### PR TITLE
Asset prototype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,12 +6,12 @@ name := "bifrost"
 lazy val commonSettings = Seq(
   scalaVersion := "2.12.7",
   organization := "co.topl",
-  version := "1.0.0"
+  version := "1.1.0"
 )
 
 scalaVersion := "2.12.7"
 organization := "co.topl"
-version := "1.0.0"
+version := "1.1.0"
 
 mainClass in assembly := Some("bifrost.BifrostApp")
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,8 @@ FROM java:8-jre
 
 RUN mkdir -p /usr/src/myapp
 
-COPY ./project-bifrost-assembly-0.2.0-alpha-public.jar /usr/src/myapp
+COPY ./bifrost-assembly-1.1.0.jar /usr/src/myapp
 
 WORKDIR /usr/src/myapp
 
-CMD ["java", "-jar", "project-bifrost-assembly-0.2.0-alpha-public.jar"]
+CMD ["java", "-jar", "bifrost-1.1.0.jar"]

--- a/docker/createDockerImage.sh
+++ b/docker/createDockerImage.sh
@@ -1,3 +1,3 @@
-cp ../target/scala-2.12/project-bifrost-assembly-0.2.0-alpha-public.jar ./
+cp ../target/scala-2.12/bifrost-assembly-1.1.0.jar ./
 
-docker build -t toplprotocol/projectbifrost:0.2.0-testnet .
+docker build -t toplprotocol/bifrost:1.2.0 .

--- a/src/main/scala/bifrost/api/http/AssetApiRoute.scala
+++ b/src/main/scala/bifrost/api/http/AssetApiRoute.scala
@@ -151,7 +151,7 @@ case class AssetApiRoute (override val settings: Settings, nodeViewHolderRef: Ac
       // Update nodeView with new TX
       AssetTransfer.validatePrototype(tx) match {
         case Success(_) =>
-          tx.json
+          tx.json.deepMerge(Map("messageToSign" -> Base58.encode(tx.messageToSign)).asJson)
         case Failure(e) => throw new Exception(s"Could not validate transaction: $e")
       }
     }
@@ -204,7 +204,7 @@ case class AssetApiRoute (override val settings: Settings, nodeViewHolderRef: Ac
       val tx = AssetTransfer(from, to, Map(), asset.proposition, asset.assetCode, fee, timestamp, data)
       AssetTransfer.validatePrototype(tx) match {
         case Success(_) =>
-          tx.json
+          tx.json.deepMerge(Map("messageToSign" -> Base58.encode(tx.messageToSign)).asJson)
         case Failure(e) => throw new Exception(s"Could not validate transaction: $e")
       }
     }
@@ -248,7 +248,7 @@ case class AssetApiRoute (override val settings: Settings, nodeViewHolderRef: Ac
 
       AssetCreation.validatePrototype(tx) match {
         case Success(_) =>
-          tx.json
+          tx.json.deepMerge(Map("messageToSign" -> Base58.encode(tx.messageToSign)).asJson)
         case Failure(e) => throw new Exception(s"Could not validate transaction: $e")
       }
     }

--- a/src/main/scala/bifrost/api/http/AssetApiRoute.scala
+++ b/src/main/scala/bifrost/api/http/AssetApiRoute.scala
@@ -151,7 +151,10 @@ case class AssetApiRoute (override val settings: Settings, nodeViewHolderRef: Ac
       // Update nodeView with new TX
       AssetTransfer.validatePrototype(tx) match {
         case Success(_) =>
-          tx.json.deepMerge(Map("messageToSign" -> Base58.encode(tx.messageToSign)).asJson)
+          Map(
+            "formattedTx" -> tx.json,
+            "messageToSign" -> Base58.encode(tx.messageToSign).asJson
+          ).asJson
         case Failure(e) => throw new Exception(s"Could not validate transaction: $e")
       }
     }
@@ -204,7 +207,10 @@ case class AssetApiRoute (override val settings: Settings, nodeViewHolderRef: Ac
       val tx = AssetTransfer(from, to, Map(), asset.proposition, asset.assetCode, fee, timestamp, data)
       AssetTransfer.validatePrototype(tx) match {
         case Success(_) =>
-          tx.json.deepMerge(Map("messageToSign" -> Base58.encode(tx.messageToSign)).asJson)
+          Map(
+            "formattedTx" -> tx.json,
+            "messageToSign" -> Base58.encode(tx.messageToSign).asJson
+          ).asJson
         case Failure(e) => throw new Exception(s"Could not validate transaction: $e")
       }
     }
@@ -248,7 +254,10 @@ case class AssetApiRoute (override val settings: Settings, nodeViewHolderRef: Ac
 
       AssetCreation.validatePrototype(tx) match {
         case Success(_) =>
-          tx.json.deepMerge(Map("messageToSign" -> Base58.encode(tx.messageToSign)).asJson)
+          Map(
+            "formattedTx" -> tx.json,
+            "messageToSign" -> Base58.encode(tx.messageToSign).asJson
+          ).asJson
         case Failure(e) => throw new Exception(s"Could not validate transaction: $e")
       }
     }

--- a/src/main/scala/bifrost/api/http/WalletApiRoute.scala
+++ b/src/main/scala/bifrost/api/http/WalletApiRoute.scala
@@ -41,6 +41,7 @@ case class WalletApiRoute(override val settings: Settings, nodeViewHolderRef: Ac
         postJsonRoute {
           viewAsync().map { view =>
             var reqId = ""
+            println(s"parse(body): ${parse(body)}")
             parse(body) match {
               case Left(failure) => ApiException(failure.getCause)
               case Right(request) =>
@@ -295,9 +296,9 @@ case class WalletApiRoute(override val settings: Settings, nodeViewHolderRef: Ac
         case "AssetTransfer" => tx.as[AssetTransfer].right.get
         case _ => throw new Exception(s"Could not find valid transaction type $txType")
       }
-      val signatures: Json = BifrostTransaction.signTx(wallet, props, txInstance.messageToSign).map(sig => {
+      val signatures: Json = Map("signatures" -> BifrostTransaction.signTx(wallet, props, txInstance.messageToSign).map(sig => {
         Base58.encode(sig._1.pubKeyBytes) -> Base58.encode(sig._2.signature).asJson
-      }).asJson
+      })).asJson
 
       tx.deepMerge(signatures)
     }

--- a/src/main/scala/bifrost/api/http/WalletApiRoute.scala
+++ b/src/main/scala/bifrost/api/http/WalletApiRoute.scala
@@ -41,7 +41,6 @@ case class WalletApiRoute(override val settings: Settings, nodeViewHolderRef: Ac
         postJsonRoute {
           viewAsync().map { view =>
             var reqId = ""
-            println(s"parse(body): ${parse(body)}")
             parse(body) match {
               case Left(failure) => ApiException(failure.getCause)
               case Right(request) =>
@@ -154,7 +153,6 @@ case class WalletApiRoute(override val settings: Settings, nodeViewHolderRef: Ac
         sender.foreach(key => if(!view.state.nodeKeys.contains(ByteArrayWrapper(key.pubKeyBytes))) throw new Exception("Node not set to watch for specified public key"))
       val tx = ArbitTransfer.create(view.state.tbr, wallet, IndexedSeq((recipient, amount)), sender, fee, data).get
       // Update nodeView with new TX
-      println(tx.json)
       ArbitTransfer.validate(tx) match {
         case Success(_) =>
           nodeViewHolderRef ! LocallyGeneratedTransaction[ProofOfKnowledgeProposition[PrivateKey25519], ArbitTransfer](tx)

--- a/src/main/scala/bifrost/transaction/bifrostTransaction/AssetTransfer.scala
+++ b/src/main/scala/bifrost/transaction/bifrostTransaction/AssetTransfer.scala
@@ -56,25 +56,15 @@ case class AssetTransfer(override val from: IndexedSeq[(PublicKey25519Propositio
     "newBoxes" -> newBoxes.map(b => Base58.encode(b.id).asJson).asJson,
     "boxesToRemove" -> boxIdsToOpen.map(id => Base58.encode(id).asJson).asJson,
     "from" -> from.map { s =>
-      Map(
-        "proposition" -> Base58.encode(s._1.pubKeyBytes).asJson,
-        "nonce" -> s._2.asJson
-      ).asJson
+        Base58.encode(s._1.pubKeyBytes) -> s._2
     }.asJson,
     "to" -> to.map { s =>
-      Map(
-        "proposition" -> Base58.encode(s._1.pubKeyBytes).asJson,
-        "value" -> s._2.asJson
-      ).asJson
+        Base58.encode(s._1.pubKeyBytes) -> s._2
     }.asJson,
     "issuer" -> Base58.encode(issuer.pubKeyBytes).asJson,
     "assetCode" -> assetCode.asJson,
-    "signatures" -> signatures
-      .map { s =>
-        Map(
-          "proposition" -> Base58.encode(s._1.pubKeyBytes).asJson,
-          "signature" -> Base58.encode(s._2.signature).asJson
-        ).asJson
+    "signatures" -> signatures.map { s =>
+          Base58.encode(s._1.pubKeyBytes).asJson -> Base58.encode(s._2.signature).asJson
       }.asJson,
     "fee" -> fee.asJson,
     "timestamp" -> timestamp.asJson,

--- a/src/main/scala/bifrost/transaction/bifrostTransaction/AssetTransfer.scala
+++ b/src/main/scala/bifrost/transaction/bifrostTransaction/AssetTransfer.scala
@@ -100,9 +100,10 @@ object AssetTransfer extends TransferUtil {
              fee: Long,
              issuer: PublicKey25519Proposition,
              assetCode: String,
-             data: String): Try[AssetTransfer] = Try {
+             data: String,
+             assetId: Option[String] = None): Try[AssetTransfer] = Try {
 
-    val params = parametersForCreate(tbr, w, toReceive, sender, fee, "AssetTransfer", issuer, assetCode)
+    val params = parametersForCreate(tbr, w, toReceive, sender, fee, "AssetTransfer", issuer, assetCode, assetId)
     val timestamp = Instant.now.toEpochMilli
     AssetTransfer(params._1.map(t => t._1 -> t._2), params._2, issuer, assetCode, fee, timestamp, data)
   }
@@ -113,9 +114,10 @@ object AssetTransfer extends TransferUtil {
                       issuer: PublicKey25519Proposition,
                       assetCode: String,
                       fee: Long,
-                      data: String): Try[AssetTransfer] = Try
+                      data: String,
+                      assetId: Option[String] = None): Try[AssetTransfer] = Try
   {
-    val params = parametersForCreate(tbr, toReceive, sender, fee, "AssetTransfer", issuer, assetCode)
+    val params = parametersForCreate(tbr, toReceive, sender, fee, "AssetTransfer", issuer, assetCode, assetId)
     val timestamp = Instant.now.toEpochMilli
     AssetTransfer(params._1.map(t => t._1 -> t._2), params._2, Map(), issuer, assetCode, fee, timestamp, data)
   }

--- a/src/main/scala/bifrost/transaction/bifrostTransaction/AssetTransfer.scala
+++ b/src/main/scala/bifrost/transaction/bifrostTransaction/AssetTransfer.scala
@@ -64,7 +64,7 @@ case class AssetTransfer(override val from: IndexedSeq[(PublicKey25519Propositio
     "issuer" -> Base58.encode(issuer.pubKeyBytes).asJson,
     "assetCode" -> assetCode.asJson,
     "signatures" -> signatures.map { s =>
-          Base58.encode(s._1.pubKeyBytes).asJson -> Base58.encode(s._2.signature).asJson
+          Base58.encode(s._1.pubKeyBytes) -> Base58.encode(s._2.signature)
       }.asJson,
     "fee" -> fee.asJson,
     "timestamp" -> timestamp.asJson,

--- a/src/main/scala/bifrost/transaction/bifrostTransaction/BifrostTransaction.scala
+++ b/src/main/scala/bifrost/transaction/bifrostTransaction/BifrostTransaction.scala
@@ -7,9 +7,10 @@ import bifrost.transaction.bifrostTransaction.BifrostTransaction.Nonce
 import bifrost.transaction.box._
 import bifrost.transaction.box.proposition.{ProofOfKnowledgeProposition, PublicKey25519Proposition}
 import bifrost.transaction.proof.Signature25519
-import bifrost.transaction.state.PrivateKey25519
+import bifrost.transaction.state.{PrivateKey25519, PrivateKey25519Companion}
+import bifrost.wallet.BWallet
 import com.google.common.primitives.Longs
-import io.circe.Json
+import io.circe.{Decoder, HCursor, Json}
 import io.circe.parser.parse
 import scorex.crypto.encode.Base58
 
@@ -57,4 +58,11 @@ object BifrostTransaction {
   def stringToSignature(rawString: String): Signature25519 = Signature25519(Base58.decode(rawString).get)
 
   def nonceFromDigest(digest: Array[Byte]): Nonce = Longs.fromByteArray(digest.take(Longs.BYTES))
+
+  def signTx(w: BWallet, props: IndexedSeq[PublicKey25519Proposition], message: Array[Byte]):
+  Map[PublicKey25519Proposition, Signature25519] = props.map { prop =>
+    val secret = w.secretByPublicImage(prop).get
+    val signature = PrivateKey25519Companion.sign(secret, message)
+    prop -> signature
+  }.toMap
 }

--- a/src/main/scala/bifrost/transaction/bifrostTransaction/ProgramMethodExecution.scala
+++ b/src/main/scala/bifrost/transaction/bifrostTransaction/ProgramMethodExecution.scala
@@ -57,6 +57,7 @@ case class ProgramMethodExecution(state: Seq[StateBox],
 
   lazy val boxIdsToOpen: IndexedSeq[Array[Byte]] = feeBoxIdKeyPairs.map(_._1)
 
+  //TODO deprecate timestamp once fee boxes are included in nonce generation
   lazy val hashNoNonces = FastCryptographicHash(
     executionBox.id ++
       methodName.getBytes ++

--- a/src/main/scala/bifrost/transaction/bifrostTransaction/TransferUtil.scala
+++ b/src/main/scala/bifrost/transaction/bifrostTransaction/TransferUtil.scala
@@ -8,6 +8,7 @@ import bifrost.transaction.proof.Signature25519
 import bifrost.transaction.state.{PrivateKey25519, PrivateKey25519Companion}
 import bifrost.wallet.BWallet
 import com.google.common.primitives.Longs
+import scorex.crypto.encode.Base58
 
 import scala.util.Try
 
@@ -79,14 +80,22 @@ trait TransferUtil {
                 case _ => None
               })
             case "AssetTransfer" =>
-              keyFilteredBoxes.flatMap(_ match {
-                case a: AssetBox
-                  if (a.assetCode equals extraArgs(1).asInstanceOf[String]) &&
-                    (a.issuer equals extraArgs(0)
-                      .asInstanceOf[PublicKey25519Proposition]) =>
-                  Some(a)
-                case _ => None
-              })
+              if(extraArgs(2).asInstanceOf[Option[String]].isDefined) {
+                keyFilteredBoxes.flatMap(_ match {
+                  case a: AssetBox
+                    if(Base58.encode(a.id) equals extraArgs(2).asInstanceOf[Option[String]].get) =>
+                      Some(a)
+                })
+              } else {
+                keyFilteredBoxes.flatMap(_ match {
+                  case a: AssetBox
+                    if (a.assetCode equals extraArgs(1).asInstanceOf[String]) &&
+                      (a.issuer equals extraArgs(0)
+                        .asInstanceOf[PublicKey25519Proposition]) =>
+                    Some(a)
+                  case _ => None
+                })
+              }
           }
 
           if(keyAndTypeFilteredBoxes.length < 1) throw new Exception("No boxes found to fund transaction")
@@ -151,14 +160,22 @@ trait TransferUtil {
                 case _ => None
               })
             case "AssetTransfer" =>
-              keyFilteredBoxes.flatMap(_ match {
-                case a: AssetBox
-                  if (a.assetCode equals extraArgs(1).asInstanceOf[String]) &&
-                    (a.issuer equals extraArgs(0)
-                      .asInstanceOf[PublicKey25519Proposition]) =>
-                  Some(a)
-                case _ => None
-              })
+              if(extraArgs(2).asInstanceOf[Option[String]].isDefined) {
+                keyFilteredBoxes.flatMap(_ match {
+                  case a: AssetBox
+                    if(Base58.encode(a.id) equals extraArgs(2).asInstanceOf[Option[String]].get) =>
+                    Some(a)
+                })
+              } else {
+                keyFilteredBoxes.flatMap(_ match {
+                  case a: AssetBox
+                    if (a.assetCode equals extraArgs(1).asInstanceOf[String]) &&
+                      (a.issuer equals extraArgs(0)
+                        .asInstanceOf[PublicKey25519Proposition]) =>
+                    Some(a)
+                  case _ => None
+                })
+              }
           }
 
           if(keyAndTypeFilteredBoxes.length < 1) throw new Exception("No boxes found to fund transaction")

--- a/src/test/scala/bifrost/api/AssetRPCSpec.scala
+++ b/src/test/scala/bifrost/api/AssetRPCSpec.scala
@@ -161,6 +161,31 @@ class AssetRPCSpec extends WordSpec
       }
     }
 
+    "Transfer target asset prototype" in {
+      val requestBody = ByteString(
+        s"""
+           |{
+           |   "jsonrpc": "2.0",
+           |   "id": "1",
+           |   "method": "transferTargetAssetsPrototype",
+           |   "params": [{
+           |     "recipient": "${publicKeys("producer")}",
+           |     "assetId": "${Base58.encode(asset.get.id)}",
+           |     "amount": 1,
+           |     "fee": 0,
+           |     "data": ""
+           |   }]
+           |}
+        """.stripMargin)
+
+      httpPOST(requestBody) ~> route ~> check {
+        val res = parse(responseAs[String]).right.get
+        println(res)
+        (res \\ "error").isEmpty shouldBe true
+        (res \\ "result").head.asObject.isDefined shouldBe true
+      }
+    }
+
     "Transfer a target asset" in {
       val requestBody = ByteString(
         s"""
@@ -180,6 +205,7 @@ class AssetRPCSpec extends WordSpec
 
       httpPOST(requestBody) ~> route ~> check {
         val res = parse(responseAs[String]).right.get
+        println(res)
         (res \\ "error").isEmpty shouldBe true
         (res \\ "result").head.asObject.isDefined shouldBe true
       }

--- a/src/test/scala/bifrost/api/AssetRPCSpec.scala
+++ b/src/test/scala/bifrost/api/AssetRPCSpec.scala
@@ -232,6 +232,7 @@ class AssetRPCSpec extends WordSpec
            |   "id": "1",
            |   "method": "transferTargetAssetsPrototype",
            |   "params": [{
+           |     "sender": ["${Base58.encode(asset.get.proposition.pubKeyBytes)}"],
            |     "recipient": "${publicKeys("producer")}",
            |     "assetId": "${Base58.encode(asset.get.id)}",
            |     "amount": 1,
@@ -273,21 +274,6 @@ class AssetRPCSpec extends WordSpec
         val res = parse(responseAs[String]).right.get
         (res \\ "error").isEmpty shouldBe true
         (res \\ "result").head.asObject.isDefined shouldBe true
-        val txHash = ((res \\ "result").head \\ "txHash").head.asString.get
-        val txInstance: BifrostTransaction = view().pool.getById(Base58.decode(txHash).get).get
-
-        val history = view().history
-        val tempBlock = BifrostBlock(history.bestBlockId,
-          System.currentTimeMillis(),
-          ArbitBox(PublicKey25519Proposition(history.bestBlockId), 0L, 10000L),
-          Signature25519(Array.fill(Curve25519.SignatureLength)(1: Byte)),
-          Seq(txInstance),
-          10L,
-          settings.version
-        )
-        view().state.applyModifier(tempBlock)
-        view().pool.remove(txInstance)
-        //Dont need further checks here since the subsequent tests would fail if this one did
       }
     }
 
@@ -299,6 +285,7 @@ class AssetRPCSpec extends WordSpec
            |   "id": "1",
            |   "method": "transferTargetAssets",
            |   "params": [{
+           |     "sender": ["${Base58.encode(asset.get.proposition.pubKeyBytes)}"],
            |     "recipient": "${publicKeys("producer")}",
            |     "assetId": "${Base58.encode(asset.get.id)}",
            |     "amount": 1,

--- a/src/test/scala/bifrost/api/AssetRPCSpec.scala
+++ b/src/test/scala/bifrost/api/AssetRPCSpec.scala
@@ -176,32 +176,27 @@ class AssetRPCSpec extends WordSpec
       }
     }
 
-    /*
     "Sign createAssets Prototype transaction" in {
       val requestBody = ByteString(
         s"""
            |{
            |  "jsonrpc": "2.0",
-           |  "id": "1",
+           |  "id": "3",
            |  "method": "signTx",
            |  "params": [{
-           |    "signingKeys": "${publicKeys("hub")}",
-           |    "tx": "$tx"
+           |    "signingKeys": ["${publicKeys("hub")}"],
+           |    "tx": $tx
            |  }]
            |}
           """.stripMargin)
 
-      println(requestBody.utf8String)
-
-      httpPOST(requestBody) ~> walletRoute ~> check {
+      walletHttpPOST(requestBody) ~> walletRoute ~> check {
         val res = parse(responseAs[String]).right.get
-        tx = (res \\ "result").head.asString.get
+        tx = (res \\ "result").head
         (res \\ "error").isEmpty shouldBe true
         (res \\ "result").head.asObject.isDefined shouldBe true
       }
     }
-     */
-
 
     "Broadcast createAssetsPrototype transaction" in {
       val secret = view().vault.secretByPublicImage(
@@ -257,7 +252,7 @@ class AssetRPCSpec extends WordSpec
     "Broadcast transferTargetAssetsPrototype" in {
       val prop = (tx \\ "from").head.asArray.get.head.asArray.get.head.asString.get
       val secret = view().vault.secretByPublicImage(
-        PublicKey25519Proposition(Base58.decode(prop).get))
+        PublicKey25519Proposition(Base58.decode(prop).get)).get
       val tempTx = tx.as[AssetTransfer].right.get
       val sig = PrivateKey25519Companion.sign(secret, tempTx.messageToSign)
       val signedTx = tempTx.copy(signatures = Map(PublicKey25519Proposition(Base58.decode(publicKeys("hub")).get) -> sig))
@@ -276,7 +271,6 @@ class AssetRPCSpec extends WordSpec
 
       walletHttpPOST(requestBody) ~> walletRoute ~> check {
         val res = parse(responseAs[String]).right.get
-        println(res)
         (res \\ "error").isEmpty shouldBe true
         (res \\ "result").head.asObject.isDefined shouldBe true
         val txHash = ((res \\ "result").head \\ "txHash").head.asString.get


### PR DESCRIPTION
Add the capability to target specific assets when creating an asset transfer transaction, and restructure asset transactions to work with generalized signing and broadcast transactions. The message used to sign a transaction is now included in asset prototype transactions to allow for 3rd party applications to sign transactions. Closes #241, closes #242, closes #243, closes #245, closes #246