### PR TITLE
Reject txs that have matching boxes being created and consumed

### DIFF
--- a/src/main/scala/bifrost/transaction/bifrostTransaction/ProgramTransfer.scala
+++ b/src/main/scala/bifrost/transaction/bifrostTransaction/ProgramTransfer.scala
@@ -112,5 +112,6 @@ object ProgramTransfer {
     require(tx.fee >= 0)
     require(tx.timestamp >= 0)
     require(tx.signature.isValid(tx.from, tx.messageToSign))
+    require(tx.newBoxes.forall(b ⇒ !tx.boxIdsToOpen.contains(b.id)))
   }
 }

--- a/src/main/scala/bifrost/transaction/bifrostTransaction/ProgramTransfer.scala
+++ b/src/main/scala/bifrost/transaction/bifrostTransaction/ProgramTransfer.scala
@@ -15,6 +15,7 @@ import bifrost.wallet.BWallet
 import com.google.common.primitives.{Bytes, Longs}
 import io.circe.Json
 import io.circe.syntax._
+import io.iohk.iodb.ByteArrayWrapper
 import scorex.crypto.encode.Base58
 
 import scala.util.Try
@@ -112,6 +113,7 @@ object ProgramTransfer {
     require(tx.fee >= 0)
     require(tx.timestamp >= 0)
     require(tx.signature.isValid(tx.from, tx.messageToSign))
-    require(tx.newBoxes.forall(b ⇒ !tx.boxIdsToOpen.contains(b.id)))
+    val wrappedBoxIdsToOpen = tx.boxIdsToOpen.map(b ⇒ ByteArrayWrapper(b))
+    require(tx.newBoxes.forall(b ⇒ !wrappedBoxIdsToOpen.contains(ByteArrayWrapper(b.id))))
   }
 }


### PR DESCRIPTION
LSMStore catches an edge case where a transfer transaction both consumes and creates a box with a matching Id while still being considered valid at a state validation level. This fixes the issue by enforcing that the transaction cannot even be considered valid and therefore rejected from the mempool and never allowed to be broadcasted.