### PR TITLE
Move peer sync creation

### DIFF
--- a/src/main/scala/bifrost/BifrostApp.scala
+++ b/src/main/scala/bifrost/BifrostApp.scala
@@ -21,7 +21,6 @@ import bifrost.modifier.box.proposition.ProofOfKnowledgeProposition
 import bifrost.modifier.transaction.bifrostTransaction.Transaction
 import bifrost.network._
 import bifrost.network.message._
-import bifrost.network.peer.PeerSynchronizerRef
 import bifrost.nodeView.{NodeViewHolder, NodeViewHolderRef, NodeViewModifier}
 import bifrost.settings.{AppSettings, BifrostContext, NetworkType, StartupOpts}
 import bifrost.utils.{Logging, NetworkTimeProvider}
@@ -98,7 +97,7 @@ class BifrostApp(startupOpts: StartupOpts) extends Logging with Runnable {
 
   private val networkControllerRef: ActorRef = NetworkControllerRef("networkController", settings.network, peerManagerRef, bifrostContext)
 
-  private val peerSynchronizer: ActorRef = PeerSynchronizerRef("PeerSynchronizer", networkControllerRef, peerManagerRef, settings.network, featureSerializers)
+  private val peerSynchronizer: ActorRef = peer.PeerSynchronizerRef("PeerSynchronizer", networkControllerRef, peerManagerRef, settings.network, featureSerializers)
 
   private val nodeViewHolderRef: ActorRef = NodeViewHolderRef("nodeViewHolder", settings, timeProvider)
 

--- a/src/main/scala/bifrost/network/NetworkController.scala
+++ b/src/main/scala/bifrost/network/NetworkController.scala
@@ -12,7 +12,7 @@ import bifrost.network.peer._
 import bifrost.settings.{BifrostContext, NetworkSettings, Version}
 import bifrost.utils.{Logging, NetworkUtils}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
@@ -54,11 +54,6 @@ class NetworkController(
       log.warn(s"Restarting child actor failed with: $e")
       Restart
   }
-
-  //todo: make usage more clear, now we're relying on preStart logic in a actor which is described by a never used val
-
-
-
 
   private var messageHandlers = Map.empty[message.Message.MessageCode, ActorRef]
   private var connections = Map.empty[InetSocketAddress, ConnectedPeer]

--- a/src/main/scala/bifrost/network/NetworkController.scala
+++ b/src/main/scala/bifrost/network/NetworkController.scala
@@ -56,16 +56,9 @@ class NetworkController(
   }
 
   //todo: make usage more clear, now we're relying on preStart logic in a actor which is described by a never used val
-  private val featureSerializers: PeerFeature.Serializers =
-    bifrostContext.features.map(f => f.featureId -> f.serializer).toMap
 
-  private val peerSynchronizer: ActorRef = PeerSynchronizerRef(
-    "PeerSynchronizer",
-    self,
-    peerManagerRef,
-    settings,
-    featureSerializers
-  )
+
+
 
   private var messageHandlers = Map.empty[message.Message.MessageCode, ActorRef]
   private var connections = Map.empty[InetSocketAddress, ConnectedPeer]

--- a/src/main/scala/bifrost/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/bifrost/network/NodeViewSynchronizer.scala
@@ -103,8 +103,7 @@ class NodeViewSynchronizer[TX <: Transaction,
   protected def processDataFromPeer: Receive = {
 
     // sync info is coming from another node
-    case DataFromPeer(spec, syncInfo: SI@unchecked, remote)
-      if spec.messageCode == syncInfoSpec.messageCode =>
+    case DataFromPeer(spec, syncInfo: SI@unchecked, remote) if spec.messageCode == syncInfoSpec.messageCode =>
 
       historyReaderOpt match {
         case Some(historyReader) =>
@@ -122,8 +121,7 @@ class NodeViewSynchronizer[TX <: Transaction,
       }
 
     // Object ids coming from other node.
-    case DataFromPeer(spec, invData: InvData@unchecked, peer)
-      if spec.messageCode == InvSpec.MessageCode =>
+    case DataFromPeer(spec, invData: InvData@unchecked, peer) if spec.messageCode == InvSpec.MessageCode =>
 
       (mempoolReaderOpt, historyReaderOpt) match {
         // Filter out modifier ids that are already in process (requested, received or applied)
@@ -149,8 +147,7 @@ class NodeViewSynchronizer[TX <: Transaction,
 
 
     // other node asking for objects by their ids
-    case DataFromPeer(spec, invData: InvData@unchecked, remote)
-      if spec.messageCode == RequestModifierSpec.MessageCode =>
+    case DataFromPeer(spec, invData: InvData@unchecked, remote) if spec.messageCode == RequestModifierSpec.MessageCode =>
 
       readersOpt.foreach { readers =>
         val objs: Seq[NodeViewModifier] = invData.typeId match {
@@ -166,8 +163,7 @@ class NodeViewSynchronizer[TX <: Transaction,
       }
 
     // process modifiers received from another peer
-    case DataFromPeer(spec, data: ModifiersData@unchecked, remote)
-      if spec.messageCode == ModifiersSpec.MessageCode =>
+    case DataFromPeer(spec, data: ModifiersData@unchecked, remote) if spec.messageCode == ModifiersSpec.MessageCode =>
 
       val typeId = data.typeId
       val modifiers = data.modifiers


### PR DESCRIPTION
Peer synchronizer can be moved to the application level where it will be used. This avoids the unused val in NetworkController and thus will dissuade people from deleting it thinking it isn't needed. 