### PR TITLE
add execution implicit to nodeview holder and peer manager

### DIFF
--- a/src/main/scala/bifrost/network/NetworkController.scala
+++ b/src/main/scala/bifrost/network/NetworkController.scala
@@ -12,7 +12,7 @@ import bifrost.network.peer._
 import bifrost.settings.{BifrostContext, NetworkSettings, Version}
 import bifrost.utils.{Logging, NetworkUtils}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
@@ -151,8 +151,7 @@ class NetworkController(
   private def peerCommands: Receive = {
     case ConnectTo(peer) =>
       connectTo(peer)
-
-
+      
     case DisconnectFrom(peer) =>
       log.info(s"Disconnected from ${peer.connectionId}")
       peer.handlerRef ! CloseConnection

--- a/src/main/scala/bifrost/network/peer/PeerManager.scala
+++ b/src/main/scala/bifrost/network/peer/PeerManager.scala
@@ -9,13 +9,14 @@ import bifrost.settings.AppSettings
 import bifrost.utils.NetworkUtils
 import bifrost.utils.Logging
 
+import scala.concurrent.ExecutionContext
 import scala.util.Random
 
 /**
   * Peer manager takes care of peers connected and in process, and also chooses a random peer to connect
   * Must be singleton
   */
-class PeerManager(settings: AppSettings, bifrostContext: BifrostContext) extends Actor with Logging {
+class PeerManager(settings: AppSettings, bifrostContext: BifrostContext)(implicit ec: ExecutionContext) extends Actor with Logging {
 
   // Import the types of messages this actor can RECEIVE
   import PeerManager.ReceivableMessages._
@@ -197,17 +198,17 @@ object PeerManager {
 
 object PeerManagerRef {
 
-  def props(settings: AppSettings, bifrostContext: BifrostContext): Props = {
+  def props(settings: AppSettings, bifrostContext: BifrostContext)(implicit ec: ExecutionContext): Props = {
     Props(new PeerManager(settings, bifrostContext))
   }
 
   def apply(settings: AppSettings, bifrostContext: BifrostContext)
-           (implicit system: ActorSystem): ActorRef = {
+           (implicit system: ActorSystem, ec: ExecutionContext): ActorRef = {
     system.actorOf(props(settings, bifrostContext))
   }
 
   def apply(name: String, settings: AppSettings, bifrostContext: BifrostContext)
-           (implicit system: ActorSystem): ActorRef = {
+           (implicit system: ActorSystem, ec: ExecutionContext): ActorRef = {
     system.actorOf(props(settings, bifrostContext), name)
   }
 

--- a/src/main/scala/bifrost/nodeView/NodeViewHolder.scala
+++ b/src/main/scala/bifrost/nodeView/NodeViewHolder.scala
@@ -19,7 +19,9 @@ import bifrost.utils.serialization.BifrostSerializer
 import bifrost.wallet.Wallet
 import scorex.crypto.encode.Base58
 
-class NodeViewHolder(appSettings: AppSettings, timeProvider: NetworkTimeProvider)
+import scala.concurrent.ExecutionContext
+
+class NodeViewHolder(appSettings: AppSettings, timeProvider: NetworkTimeProvider)(implicit ec: ExecutionContext)
   extends GenericNodeViewHolder[Transaction, Block] {
 
   override lazy val settings: AppSettings = appSettings
@@ -150,14 +152,14 @@ object NodeViewHolder extends Logging {
 object NodeViewHolderRef {
 
   def props(settings: AppSettings,
-            timeProvider: NetworkTimeProvider): Props = Props(new NodeViewHolder(settings, timeProvider))
+            timeProvider: NetworkTimeProvider)(implicit ec: ExecutionContext): Props = Props(new NodeViewHolder(settings, timeProvider))
 
   def apply(settings: AppSettings,
-            timeProvider: NetworkTimeProvider)(implicit system: ActorSystem): ActorRef =
+            timeProvider: NetworkTimeProvider)(implicit system: ActorSystem, ec: ExecutionContext): ActorRef =
     system.actorOf(props(settings, timeProvider))
 
   def apply(name: String,
             settings: AppSettings,
-            timeProvider: NetworkTimeProvider)(implicit system: ActorSystem): ActorRef =
+            timeProvider: NetworkTimeProvider)(implicit system: ActorSystem, ec: ExecutionContext): ActorRef =
     system.actorOf(props(settings, timeProvider), name)
 }


### PR DESCRIPTION
I don't think it'll make a substantial difference but just want to use the same execution context for all bifrost actors