### PR TITLE
remove repeated code from routes

### DIFF
--- a/src/main/scala/bifrost/http/api/ApiRoute.scala
+++ b/src/main/scala/bifrost/http/api/ApiRoute.scala
@@ -1,7 +1,6 @@
 package bifrost.http.api
 
 import akka.actor.ActorRefFactory
-import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
 import akka.http.scaladsl.server.{Directive0, Directives, Route}
 import akka.util.Timeout
@@ -29,16 +28,10 @@ trait ApiRoute extends Directives {
 
   def postJsonRoute(fn: ApiResponse): Route = jsonRoute(fn, post)
 
-  def postJsonRoute(fn: Future[ApiResponse]): Route = jsonRoute(Await.result(fn, timeout.duration), post)
-
   private def jsonRoute(fn: ApiResponse, method: Directive0): Route = method {
-    val resp = complete(HttpEntity(ContentTypes.`application/json`, fn.toJson.spaces2))
-    withCors(resp)
-  }
-
-  def withCors(fn: => Route): Route = {
-    if (corsAllowed) respondWithHeaders(RawHeader("Access-Control-Allow-Origin", "*"))(fn)
-    else fn
+    complete(
+      HttpEntity(ContentTypes.`application/json`, fn.toJson.spaces2)
+    )
   }
 
   def withAuth(route: => Route): Route = {

--- a/src/main/scala/bifrost/http/api/ApiRoute.scala
+++ b/src/main/scala/bifrost/http/api/ApiRoute.scala
@@ -6,11 +6,14 @@ import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
 import akka.http.scaladsl.server.{Directive0, Directives, Route}
 import akka.util.Timeout
 import bifrost.settings.AppSettings
+import io.circe.Json
+import io.circe.parser.parse
 import scorex.crypto.encode.Base58
 import scorex.crypto.hash.{Blake2b256, CryptographicHash}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import scala.util.{Failure, Success, Try}
 
 trait ApiRoute extends Directives {
   val settings: AppSettings
@@ -51,6 +54,41 @@ trait ApiRoute extends Directives {
       case (None, _) => true
       case (Some(expected), Some(passed)) => expected sameElements passed
       case _ => false
+    }
+  }
+
+
+  protected final def basicRoute( handler: (String, Vector[Json], String) => Future[Json]): Route = path("") {
+    entity(as[String]) { body =>
+      withAuth {
+        postJsonRoute {
+          var reqId = ""
+          parse(body) match {
+            case Left(failure) => ErrorResponse(failure.getCause, 400, reqId)
+            case Right(request) =>
+              val futureResponse: Try[Future[Json]] = Try {
+                val id = (request \\ "id").head.asString.get
+                reqId = id
+                require((request \\ "jsonrpc").head.asString.get == "2.0")
+
+                val params = (request \\ "params").head.asArray.get
+                require(params.size <= 1, s"size of params is ${params.size}")
+
+                val method = (request \\ "method").head.asString.get
+
+                handler(method, params, id)
+              }
+
+              // await result of future from handler
+              futureResponse map { response =>
+                Await.result(response, timeout.duration)
+              } match {
+                case Success(resp) => SuccessResponse(resp, reqId)
+                case Failure(e) => ErrorResponse(e, 500, reqId, verbose = settings.verboseAPI)
+              }
+          }
+        }
+      }
     }
   }
 }

--- a/src/main/scala/bifrost/http/api/routes/NodeViewApiRoute.scala
+++ b/src/main/scala/bifrost/http/api/routes/NodeViewApiRoute.scala
@@ -2,25 +2,21 @@ package bifrost.http.api.routes
 
 import akka.actor.{ActorRef, ActorRefFactory}
 import akka.http.scaladsl.server.Route
-import akka.pattern.ask
 import bifrost.history.History
-import bifrost.http.api.{ApiRouteWithView, ErrorResponse, SuccessResponse}
+import bifrost.http.api.ApiRouteWithView
 import bifrost.mempool.MemPool
 import bifrost.modifier.ModifierId
 import bifrost.nodeView.CurrentView
-import bifrost.nodeView.GenericNodeViewHolder.ReceivableMessages.GetDataFromCurrentView
 import bifrost.settings.AppSettings
 import bifrost.state.State
 import bifrost.wallet.Wallet
 import io.circe.Json
-import io.circe.parser.parse
 import io.circe.syntax._
 import scorex.crypto.encode.Base58
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 case class NodeViewApiRoute(override val settings: AppSettings, nodeViewHolderRef: ActorRef)
                            (implicit val context: ActorRefFactory) extends ApiRouteWithView {
@@ -28,64 +24,16 @@ case class NodeViewApiRoute(override val settings: AppSettings, nodeViewHolderRe
   type MS = State
   type VL = Wallet
   type MP = MemPool
-  override val route: Route = pathPrefix("nodeView") { nodeViewRoute }
+  type CV = CurrentView[History, State, Wallet, MemPool]
+  override val route: Route = pathPrefix("nodeView") { basicRoute(handlers) }
 
-  def nodeViewRoute: Route = path("") {
-    entity(as[String]) { body =>
-      withAuth {
-        postJsonRoute {
-          viewAsync().map { _ =>
-            var reqId = ""
-            parse(body) match {
-              case Left(failure) => ErrorResponse(failure.getCause, 400, reqId)
-              case Right(request) =>
-                val futureResponse: Try[Future[Json]] = Try {
-                  val id = (request \\ "id").head.asString.get
-                  reqId = id
-                  require((request \\ "jsonrpc").head.asString.get == "2.0")
-                  val params = (request \\ "params").head.asArray.get
-                  require(params.size <= 5, s"size of params is ${params.size}")
-
-                  (request \\ "method").head.asString.get match {
-                    case "mempool"         => mempool(params.head, id)
-                    case "transactionById" => transactionById(params.head, id)
-                    case "blockById"       => blockById(params.head, id)
-                    case "transactionFromMempool" =>
-                      transactionFromMempool(params.head, id)
-                  }
-                }
-                futureResponse map { response =>
-                  Await.result(response, timeout.duration)
-                } match {
-                  case Success(resp) => SuccessResponse(resp, reqId)
-                  case Failure(e) =>
-                    ErrorResponse(
-                      e,
-                      500,
-                      reqId,
-                      verbose = settings.verboseAPI
-                    )
-                }
-            }
-          }
-        }
-      }
+  def handlers(method: String, params: Vector[Json], id: String): Future[Json] =
+    method match {
+      case "mempool"                => mempool(params.head, id)
+      case "transactionById"        => transactionById(params.head, id)
+      case "blockById"              => blockById(params.head, id)
+      case "transactionFromMempool" => transactionFromMempool(params.head, id)
     }
-  }
-
-  private def actOnCurrentView(v: CurrentView[History, State, Wallet, MemPool]): CurrentView[History, State, Wallet, MemPool] = v
-
-  // todo: why is an async view querying the NodeViewHolder again?
-  private def getMempool: Try[MP] = Try {
-    Await
-      .result(
-        (nodeViewHolderRef ? GetDataFromCurrentView(actOnCurrentView))
-          .mapTo[CurrentView[_, _, _, _ <: MP]]
-          .map(_.pool),
-        5.seconds
-      )
-      .asInstanceOf[MP]
-  }
 
   /**  #### Summary
     *    Get the first 100 transactions in the mempool (sorted by fee amount)
@@ -102,12 +50,8 @@ case class NodeViewApiRoute(override val settings: AppSettings, nodeViewHolderRe
     * @return
     */
   private def mempool(params: Json, id: String): Future[Json] = {
-    viewAsync().map { _ =>
-      getMempool match {
-        case Success(pool: MP) => pool.take(100).map(_.json).asJson
-        case Failure(e) ⇒ ErrorResponse(e, 500, id).toJson
-        //Failure is caught by ErrorResponse in the nodeViewRoute function when the Await does not receive a response
-      }
+    viewAsync().map {
+      view => view.pool.take(100).map(_.json).asJson
     }
   }
 
@@ -144,7 +88,7 @@ case class NodeViewApiRoute(override val settings: AppSettings, nodeViewHolderRe
             .add("blockNumber", blockNumber.asJson)
             .add("blockHash", blockId.toString.asJson)
             .asJson
-        case Failure(e) ⇒ ErrorResponse(e, 500, id).toJson
+        case Failure(e) ⇒ throw e
       }
     }
   }
@@ -164,15 +108,11 @@ case class NodeViewApiRoute(override val settings: AppSettings, nodeViewHolderRe
     * @return
     */
   private def transactionFromMempool(params: Json, id: String): Future[Json] = {
-    viewAsync().map { _ =>
+    viewAsync().map { view =>
       val transactionId: String = (params \\ "transactionId").head.asString.get
       Base58.decode(transactionId) match {
-        case Success(txId) =>
-          getMempool match {
-            case Success(pool: MP) => pool.getById(ModifierId(txId)).get.json.asJson
-            case Failure(e) ⇒ ErrorResponse(e, 550, id).toJson
-          }
-        case Failure(e) => ErrorResponse(e, 500, id).toJson
+        case Success(txId) => view.pool.getById(ModifierId(txId)).get.json.asJson
+        case Failure(e) => throw e
       }
     }
   }
@@ -208,7 +148,7 @@ case class NodeViewApiRoute(override val settings: AppSettings, nodeViewHolderRe
             .add("blockNumber", blockNumber.asJson)
             .add("blockDifficulty", storage.difficultyOf(blockId).asJson)
             .asJson
-        case Failure(e) ⇒ ErrorResponse(e, 500, id).toJson
+        case Failure(e) ⇒ throw e
       }
     }
   }

--- a/src/main/scala/bifrost/http/api/routes/NodeViewApiRoute.scala
+++ b/src/main/scala/bifrost/http/api/routes/NodeViewApiRoute.scala
@@ -110,9 +110,14 @@ case class NodeViewApiRoute(override val settings: AppSettings, nodeViewHolderRe
   private def transactionFromMempool(params: Json, id: String): Future[Json] = {
     viewAsync().map { view =>
       val transactionId: String = (params \\ "transactionId").head.asString.get
-      Base58.decode(transactionId) match {
-        case Success(txId) => view.pool.getById(ModifierId(txId)).get.json.asJson
-        case Failure(e) => throw e
+      val tx = Base58.decode(transactionId) match {
+        case Success(txId) => view.pool.getById(ModifierId(txId))
+        case Failure(_) => throw new Error("Unable to parse the provided transaction id")
+      }
+
+      tx match {
+        case Some(tx) => tx.json
+        case None => throw new Error("Unable to retrieve transaction")
       }
     }
   }


### PR DESCRIPTION
The primary handling function was copied between every route. This has now been moved into the ApiRoute trait and a list of handlers is specified in each route controller for targeting the correct function to service the request.