### PR TITLE
refactor state to separate out stateChanges

### DIFF
--- a/src/main/scala/bifrost/history/GenericHistory.scala
+++ b/src/main/scala/bifrost/history/GenericHistory.scala
@@ -91,6 +91,9 @@ trait GenericHistory[
     */
   def reportModifierIsInvalid(modifier: PM, progressInfo: ProgressInfo[PM]): (HT, ProgressInfo[PM])
 
+  /**
+    * @return read-only copy of this history
+    */
   def getReader: HistoryReader[PM, SI] = this
 }
 

--- a/src/main/scala/bifrost/http/api/routes/WalletApiRoute.scala
+++ b/src/main/scala/bifrost/http/api/routes/WalletApiRoute.scala
@@ -656,7 +656,7 @@ case class WalletApiRoute(override val settings: AppSettings, nodeViewHolderRef:
           throw new Exception(s"Could not find valid transaction type $txType")
       }
 
-      view.state.semanticValidity(txInstance)
+      State.syntacticValidity(txInstance)
       nodeViewHolderRef ! LocallyGeneratedTransaction[Transaction](txInstance)
       txInstance.json
     }

--- a/src/main/scala/bifrost/mempool/MemoryPool.scala
+++ b/src/main/scala/bifrost/mempool/MemoryPool.scala
@@ -41,5 +41,8 @@ trait MemoryPool[TX <: GenericTransaction[_], M <: MemoryPool[TX, M]] extends No
 
   def size: Int
 
+  /**
+    * @return read-only copy of this state
+    */
   def getReader: MemPoolReader[TX] = this
 }

--- a/src/main/scala/bifrost/state/State.scala
+++ b/src/main/scala/bifrost/state/State.scala
@@ -70,7 +70,7 @@ case class State(
       }
     }
 
-  private def lastVersionString =
+  private def lastVersionString: String =
     storage.lastVersionID.map(v => Base58.encode(v.data)).getOrElse("None")
 
   def validate(transaction: TX): Try[Unit] = {

--- a/src/main/scala/bifrost/state/State.scala
+++ b/src/main/scala/bifrost/state/State.scala
@@ -2,22 +2,13 @@ package bifrost.state
 
 import java.io.File
 
-import bifrost.crypto.{
-  FastCryptographicHash,
-  MultiSignature25519,
-  PrivateKey25519,
-  Signature25519
-}
+import bifrost.crypto.{FastCryptographicHash, MultiSignature25519, PrivateKey25519, Signature25519}
 import bifrost.exceptions.TransactionValidationException
 import bifrost.history.History
 import bifrost.modifier.block.Block
 import bifrost.modifier.box._
-import bifrost.modifier.box.proposition.{
-  ProofOfKnowledgeProposition,
-  PublicKey25519Proposition
-}
+import bifrost.modifier.box.proposition.{ProofOfKnowledgeProposition, PublicKey25519Proposition}
 import bifrost.modifier.transaction.bifrostTransaction._
-import bifrost.modifier.transaction.bifrostTransaction.Transaction.Nonce
 import bifrost.modifier.ModifierId
 import bifrost.nodeView.NodeViewModifier.idToBytes
 import bifrost.settings.AppSettings
@@ -29,14 +20,6 @@ import scorex.crypto.encode.Base58
 
 import scala.util.{Failure, Success, Try}
 
-case class StateChanges(
-    override val boxIdsToRemove: Set[Array[Byte]],
-    override val toAppend: Set[Box],
-    timestamp: Long
-) extends GenericStateChanges[Any, ProofOfKnowledgeProposition[
-      PrivateKey25519
-    ], Box](boxIdsToRemove, toAppend)
-
 /**
   * BifrostState is a data structure which deterministically defines whether an arbitrary transaction is valid and so
   * applicable to it or not. Also has methods to get a closed box, to apply a persistent modifier, and to roll back
@@ -47,7 +30,6 @@ case class StateChanges(
   * @param timestamp         timestamp of the block that results in this state
   * @param history           Main box storage
   */
-//noinspection ScalaStyle
 case class State(
     storage: LSMStore,
     override val version: VersionTag,
@@ -60,38 +42,37 @@ case class State(
     with Logging {
 
   override type NVCT = State
-  type P = State.P
-  type T = State.T
-  type TX = State.TX
-  type BX = State.BX
-  type BPMOD = State.BPMOD
-  type GSC = State.GSC
-  type BSC = State.BSC
+  type TX = Transaction
+  type P = ProofOfKnowledgeProposition[PrivateKey25519]
+  type BX = Box
+  type BPMOD = Block
+  type GSC = GenericStateChanges[Any, P, BX]
+  type BSC = StateChanges
 
-  override def rollbackTo(version: VersionTag): Try[NVCT] = Try {
-    if (storage.lastVersionID.exists(_.data sameElements version.hashBytes)) {
-      this
-    } else {
-      log.debug(
-        s"Rollback BifrostState to $version from version $lastVersionString"
-      )
-      storage.rollback(ByteArrayWrapper(idToBytes(version)))
-      tbr.rollbackTo(version, storage)
-      pbr.rollbackTo(version, storage)
-      val timestamp: Long = Longs.fromByteArray(
-        storage
-          .get(ByteArrayWrapper(FastCryptographicHash("timestamp".getBytes)))
-          .get
-          .data
-      )
-      State(storage, version, timestamp, history, pbr, tbr)
+  override def rollbackTo(version: VersionTag): Try[NVCT] =
+    Try {
+      if (storage.lastVersionID.exists(_.data sameElements version.hashBytes)) {
+        this
+      } else {
+        log.debug(
+          s"Rollback BifrostState to $version from version $lastVersionString"
+        )
+        storage.rollback(ByteArrayWrapper(idToBytes(version)))
+        tbr.rollbackTo(version, storage)
+        pbr.rollbackTo(version, storage)
+        val timestamp: Long = Longs.fromByteArray(
+          storage
+            .get(ByteArrayWrapper(FastCryptographicHash("timestamp".getBytes)))
+            .get
+            .data
+        )
+        State(storage, version, timestamp, history, pbr, tbr)
+      }
     }
-  }
 
   private def lastVersionString =
     storage.lastVersionID.map(v => Base58.encode(v.data)).getOrElse("None")
 
-  //noinspection ScalaStyle
   def validate(transaction: TX): Try[Unit] = {
     transaction match {
       case poT: PolyTransfer           => validatePolyTransfer(poT)
@@ -110,12 +91,61 @@ case class State(
     }
   }
 
+  private def validateArbitTransfer(arT: ArbitTransfer): Try[Unit] = {
+
+    val unlockers = generateUnlockers(arT.from, arT.signatures)
+
+    val statefulValid: Try[Unit] = {
+      val boxesSumTry: Try[Long] = {
+        unlockers.foldLeft[Try[Long]](Success(0L))((partialRes, unlocker) =>
+          partialRes.flatMap(partialSum =>
+            /* Checks if unlocker is valid and if so adds to current running total */
+            closedBox(unlocker.closedBoxId) match {
+              case Some(box: ArbitBox) =>
+                if (
+                  unlocker.boxKey
+                    .isValid(box.proposition, arT.messageToSign)
+                ) {
+                  Success(partialSum + box.value)
+                } else {
+                  Failure(new Exception("Incorrect unlocker"))
+                }
+              case None =>
+                Failure(
+                  new Exception(
+                    s"Box for unlocker $unlocker is not in the state"
+                  )
+                )
+              case _ =>
+                Failure(new Exception("Invalid Box type for this transaction"))
+            }
+          )
+        )
+      }
+      //Determine enough arbits
+      boxesSumTry flatMap { openSum =>
+        if (
+          arT.newBoxes.map {
+            case p: ArbitBox => p.value
+            case _           => 0L
+          }.sum == openSum - arT.fee
+        ) {
+          Success[Unit](Unit)
+        } else {
+          Failure(new Exception("Negative fee"))
+        }
+      }
+
+    }
+
+    statefulValid.flatMap(_ => State.syntacticValidity(arT))
+  }
+
   /**
-    *
     * @param poT : the PolyTransfer to validate
     * @return
     */
-  def validatePolyTransfer(poT: PolyTransfer): Try[Unit] = {
+  private def validatePolyTransfer(poT: PolyTransfer): Try[Unit] = {
 
     val unlockers = generateUnlockers(poT.from, poT.signatures)
 
@@ -126,8 +156,10 @@ case class State(
             /* Checks if unlocker is valid and if so adds to current running total */
             closedBox(unlocker.closedBoxId) match {
               case Some(box: PolyBox) =>
-                if (unlocker.boxKey
-                      .isValid(box.proposition, poT.messageToSign)) {
+                if (
+                  unlocker.boxKey
+                    .isValid(box.proposition, poT.messageToSign)
+                ) {
                   Success(partialSum + box.value)
                 } else {
                   Failure(new Exception("Incorrect unlocker"))
@@ -147,72 +179,10 @@ case class State(
       determineEnoughPolys(boxesSumTry: Try[Long], poT)
     }
 
-    statefulValid.flatMap(_ => semanticValidity(poT))
+    statefulValid.flatMap(_ => State.syntacticValidity(poT))
   }
 
-  private def determineEnoughPolys(
-      boxesSumTry: Try[Long],
-      tx: Transaction
-  ): Try[Unit] = {
-    boxesSumTry flatMap { openSum =>
-      if (tx.newBoxes.map {
-            case p: PolyBox => p.value
-            case _          => 0L
-          }.sum == openSum - tx.fee) {
-        Success[Unit](Unit)
-      } else {
-        Failure(new Exception("Negative fee"))
-      }
-    }
-  }
-
-  def validateArbitTransfer(arT: ArbitTransfer): Try[Unit] = {
-
-    val unlockers = generateUnlockers(arT.from, arT.signatures)
-
-    val statefulValid: Try[Unit] = {
-      val boxesSumTry: Try[Long] = {
-        unlockers.foldLeft[Try[Long]](Success(0L))((partialRes, unlocker) =>
-          partialRes.flatMap(partialSum =>
-            /* Checks if unlocker is valid and if so adds to current running total */
-            closedBox(unlocker.closedBoxId) match {
-              case Some(box: ArbitBox) =>
-                if (unlocker.boxKey
-                      .isValid(box.proposition, arT.messageToSign)) {
-                  Success(partialSum + box.value)
-                } else {
-                  Failure(new Exception("Incorrect unlocker"))
-                }
-              case None =>
-                Failure(
-                  new Exception(
-                    s"Box for unlocker $unlocker is not in the state"
-                  )
-                )
-              case _ =>
-                Failure(new Exception("Invalid Box type for this transaction"))
-            }
-          )
-        )
-      }
-      //Determine enough arbits
-      boxesSumTry flatMap { openSum =>
-        if (arT.newBoxes.map {
-              case p: ArbitBox => p.value
-              case _           => 0L
-            }.sum == openSum - arT.fee) {
-          Success[Unit](Unit)
-        } else {
-          Failure(new Exception("Negative fee"))
-        }
-      }
-
-    }
-
-    statefulValid.flatMap(_ => semanticValidity(arT))
-  }
-
-  def validateAssetTransfer(asT: AssetTransfer): Try[Unit] = {
+  private def validateAssetTransfer(asT: AssetTransfer): Try[Unit] = {
 
     val unlockers = generateUnlockers(asT.from, asT.signatures)
 
@@ -224,10 +194,12 @@ case class State(
               /* Checks if unlocker is valid and if so adds to current running total */
               closedBox(unlocker.closedBoxId) match {
                 case Some(box: AssetBox) =>
-                  if (unlocker.boxKey.isValid(
-                        box.proposition,
-                        asT.messageToSign
-                      ) && (box.issuer equals asT.issuer) && (box.assetCode equals asT.assetCode)) {
+                  if (
+                    unlocker.boxKey.isValid(
+                      box.proposition,
+                      asT.messageToSign
+                    ) && (box.issuer equals asT.issuer) && (box.assetCode equals asT.assetCode)
+                  ) {
                     Success(partialSum + box.value)
                   } else {
                     Failure(new Exception("Incorrect unlocker"))
@@ -249,26 +221,10 @@ case class State(
       determineEnoughAssets(boxesSumTry, asT)
     }
 
-    statefulValid.flatMap(_ => semanticValidity(asT))
+    statefulValid.flatMap(_ => State.syntacticValidity(asT))
   }
 
-  private def determineEnoughAssets(
-      boxesSumTry: Try[Long],
-      tx: Transaction
-  ): Try[Unit] = {
-    boxesSumTry flatMap { openSum =>
-      if (tx.newBoxes.map {
-            case a: AssetBox => a.value
-            case _           => 0L
-          }.sum <= openSum) {
-        Success[Unit](Unit)
-      } else {
-        Failure(new Exception("Not enough assets"))
-      }
-    }
-  }
-
-  def validateProgramTransfer(prT: ProgramTransfer): Try[Unit] = {
+  private def validateProgramTransfer(prT: ProgramTransfer): Try[Unit] = {
     val from = Seq((prT.from, prT.executionBox.nonce))
     val signature = Map(prT.from -> prT.signature)
     val unlocker = generateUnlockers(from, signature).head
@@ -300,41 +256,26 @@ case class State(
       }
     }
 
-    statefulValid.flatMap(_ => semanticValidity(prT))
+    statefulValid.flatMap(_ => State.syntacticValidity(prT))
   }
 
-  def generateUnlockers(
-      from: Seq[(PublicKey25519Proposition, Nonce)],
-      signatures: Map[PublicKey25519Proposition, Signature25519]
-  ): Traversable[BoxUnlocker[PublicKey25519Proposition]] = {
-    from.map {
-      case (prop, nonce) =>
-        new BoxUnlocker[PublicKey25519Proposition] {
-          override val closedBoxId: Array[Byte] =
-            PublicKeyNoncedBox.idFromBox(prop, nonce)
-          override val boxKey: Signature25519 = signatures.getOrElse(
-            prop,
-            throw new Exception("Signature not provided")
-          )
-        }
-    }
-  }
-
-  def validateAssetCreation(ac: AssetCreation): Try[Unit] = {
+  private def validateAssetCreation(ac: AssetCreation): Try[Unit] = {
     val statefulValid: Try[Unit] = {
       ac.newBoxes.size match {
         //only one box should be created
         case 1 =>
-          if (ac.newBoxes.head
-                .isInstanceOf[AssetBox]) // the new box is an asset box
-            Success[Unit](Unit)
-          else
+          if (
+            ac.newBoxes.head
+              .isInstanceOf[AssetBox]
+          ) // the new box is an asset box
+          Success[Unit](Unit)
+            else
             Failure(new Exception("Incorrect box type"))
 
         case _ => Failure(new Exception("Incorrect number of boxes created"))
       }
     }
-    statefulValid.flatMap(_ => semanticValidity(ac))
+    statefulValid.flatMap(_ => State.syntacticValidity(ac))
   }
 
   /**
@@ -344,7 +285,7 @@ case class State(
     * @param cc : CodeCreation object
     * @return
     */
-  def validateCodeCreation(cc: CodeCreation): Try[Unit] = {
+  private def validateCodeCreation(cc: CodeCreation): Try[Unit] = {
     val statefulValid: Try[Unit] = {
       cc.newBoxes.size match {
         //only one box should be created
@@ -357,7 +298,7 @@ case class State(
         case _ => Failure(new Exception("Incorrect number of boxes created"))
       }
     }
-    statefulValid.flatMap(_ => semanticValidity(cc))
+    statefulValid.flatMap(_ => State.syntacticValidity(cc))
   }
 
   /**
@@ -366,8 +307,7 @@ case class State(
     * @param pc : ProgramCreation object
     * @return
     */
-  //noinspection ScalaStyle
-  def validateProgramCreation(pc: ProgramCreation): Try[Unit] = {
+  private def validateProgramCreation(pc: ProgramCreation): Try[Unit] = {
 
     val unlockers = generateUnlockers(pc.boxIdsToOpen, pc.signatures.head._2)
 
@@ -377,8 +317,10 @@ case class State(
           .flatMap { _ =>
             closedBox(unlocker.closedBoxId) match {
               case Some(box) =>
-                if (unlocker.boxKey
-                      .isValid(box.proposition, pc.messageToSign)) {
+                if (
+                  unlocker.boxKey
+                    .isValid(box.proposition, pc.messageToSign)
+                ) {
                   Success(())
                 } else {
                   Failure(
@@ -414,11 +356,10 @@ case class State(
       }
     }
 
-    statefulValid.flatMap(_ => semanticValidity(pc))
+    statefulValid.flatMap(_ => State.syntacticValidity(pc))
   }
 
-  //noinspection ScalaStyle
-  def validateProgramMethodExecution(pme: ProgramMethodExecution): Try[Unit] = {
+  private def validateProgramMethodExecution(pme: ProgramMethodExecution): Try[Unit] = {
     //TODO get execution box from box registry using UUID before using its actual id to get it from storage
     val executionBoxBytes = storage.get(ByteArrayWrapper(pme.executionBox.id))
 
@@ -434,8 +375,10 @@ case class State(
     val programProposition: PublicKey25519Proposition = executionBox.proposition
 
     /* This person belongs to program */
-    if (!MultiSignature25519(pme.signatures.values.toSet)
-          .isValid(programProposition, pme.messageToSign)) {
+    if (
+      !MultiSignature25519(pme.signatures.values.toSet)
+        .isValid(programProposition, pme.messageToSign)
+    ) {
       throw new TransactionValidationException(
         s"Signature is invalid for ExecutionBox"
       )
@@ -449,8 +392,10 @@ case class State(
           .flatMap { _ =>
             closedBox(unlocker.closedBoxId) match {
               case Some(box) =>
-                if (unlocker.boxKey
-                      .isValid(box.proposition, pme.messageToSign)) {
+                if (
+                  unlocker.boxKey
+                    .isValid(box.proposition, pme.messageToSign)
+                ) {
                   Success(())
                 } else {
                   Failure(
@@ -487,31 +432,10 @@ case class State(
       }
     }
 
-    statefulValid.flatMap(_ => semanticValidity(pme))
+    statefulValid.flatMap(_ => State.syntacticValidity(pme))
   }
 
-  def semanticValidity(tx: Transaction): Try[Unit] = State.semanticValidity(tx)
-
-  def closedBox(boxId: Array[Byte]): Option[BX] =
-    storage
-      .get(ByteArrayWrapper(boxId))
-      .map(_.data)
-      .map(BoxSerializer.parseBytes)
-      .flatMap(_.toOption)
-
-  def generateUnlockers(
-      boxIds: Seq[Array[Byte]],
-      signature: Signature25519
-  ): Traversable[BoxUnlocker[PublicKey25519Proposition]] = {
-    boxIds.map { id =>
-      new BoxUnlocker[PublicKey25519Proposition] {
-        override val closedBoxId: Array[Byte] = id
-        override val boxKey: Signature25519 = signature
-      }
-    }
-  }
-
-  def validateCoinbaseTransaction(cb: CoinbaseTransaction): Try[Unit] = {
+  private def validateCoinbaseTransaction(cb: CoinbaseTransaction): Try[Unit] = {
     //val t = history.modifierById(cb.blockID).get
     //def helper(m: Block): Boolean = { m.id sameElements t.id }
     val validConstruction: Try[Unit] = {
@@ -529,100 +453,179 @@ case class State(
 
   }
 
-  override def applyModifier(mod: BPMOD): Try[State] = mod match {
-    case b: Block ⇒
-      changes(b).flatMap(cs ⇒ applyChanges(cs, b.id))
-    //case a: Any ⇒
-    // Failure(new Exception(s"unknown modifier $a"))
+  private def determineEnoughAssets(boxesSumTry: Try[Long], tx: Transaction): Try[Unit] = {
+    boxesSumTry flatMap { openSum =>
+      if (
+        tx.newBoxes.map {
+          case a: AssetBox => a.value
+          case _           => 0L
+        }.sum <= openSum
+      ) {
+        Success[Unit](Unit)
+      } else {
+        Failure(new Exception("Not enough assets"))
+      }
+    }
   }
 
-  def changes(mod: BPMOD): Try[GSC] = State.changes(mod)
-
-  def applyChanges(changes: GSC, newVersion: VersionTag): Try[NVCT] = Try {
-
-    //Filtering boxes pertaining to public keys specified in settings file
-    //Note YT - Need to handle MofN Proposition separately
-    val keyFilteredBoxesToAdd =
-      if (nodeKeys != null)
-        changes.toAppend
-          .filter(b => nodeKeys.contains(ByteArrayWrapper(b.proposition.bytes)))
-      else
-        changes.toAppend
-
-    val keyFilteredBoxIdsToRemove =
-      if (nodeKeys != null)
-        changes.boxIdsToRemove
-          .flatMap(closedBox)
-          .filter(b => nodeKeys.contains(ByteArrayWrapper(b.proposition.bytes)))
-          .map(b => b.id)
-      else
-        changes.boxIdsToRemove
-
-    val boxesToAdd = keyFilteredBoxesToAdd
-      .map(b => ByteArrayWrapper(b.id) -> ByteArrayWrapper(b.bytes))
-
-    /* This seeks to avoid the scenario where there is remove and then update of the same keys */
-    val boxIdsToRemove =
-      (keyFilteredBoxIdsToRemove -- boxesToAdd.map(_._1.data))
-        .map(ByteArrayWrapper.apply)
-
-    log.debug(
-      s"Update BifrostState from version $lastVersionString to version $newVersion. " +
-        s"Removing boxes with ids ${boxIdsToRemove.map(b => Base58.encode(b.data))}, " +
-        s"adding boxes ${boxesToAdd.map(b => Base58.encode(b._1.data))}"
-    )
-
-    val timestamp: Long = changes.asInstanceOf[StateChanges].timestamp
-
-    if (storage.lastVersionID.isDefined)
-      boxIdsToRemove.foreach(i => require(closedBox(i.data).isDefined))
-
-    //TokenBoxRegistry must be updated before state since it uses the boxes from state that are being removed in the update
-    if (tbr != null)
-      tbr.updateFromState(
-        newVersion,
-        keyFilteredBoxIdsToRemove,
-        keyFilteredBoxesToAdd
-      )
-    if (pbr != null)
-      pbr.updateFromState(
-        newVersion,
-        keyFilteredBoxIdsToRemove,
-        keyFilteredBoxesToAdd
-      )
-
-    storage.update(
-      ByteArrayWrapper(newVersion.hashBytes),
-      boxIdsToRemove,
-      boxesToAdd + (ByteArrayWrapper(
-        FastCryptographicHash("timestamp".getBytes)
-      ) -> ByteArrayWrapper(Longs.toByteArray(timestamp)))
-    )
-
-    val newSt =
-      State(storage, newVersion, timestamp, history, pbr, tbr, nodeKeys)
-
-    boxIdsToRemove.foreach(box =>
-      require(newSt.closedBox(box.data).isEmpty, s"Box $box is still in state")
-    )
-    newSt
+  private def determineEnoughPolys(boxesSumTry: Try[Long], tx: Transaction): Try[Unit] = {
+    boxesSumTry flatMap { openSum =>
+      if (
+        tx.newBoxes.map {
+          case p: PolyBox => p.value
+          case _          => 0L
+        }.sum == openSum - tx.fee
+      ) {
+        Success[Unit](Unit)
+      } else {
+        Failure(new Exception("Negative fee"))
+      }
+    }
   }
 
+  def closedBox(boxId: Array[Byte]): Option[BX] =
+    storage
+      .get(ByteArrayWrapper(boxId))
+      .map(_.data)
+      .map(BoxSerializer.parseBytes)
+      .flatMap(_.toOption)
+
+  private def generateUnlockers( from: Seq[(PublicKey25519Proposition, Transaction.Nonce)],
+                                 signatures: Map[PublicKey25519Proposition, Signature25519]
+                               ): Traversable[BoxUnlocker[PublicKey25519Proposition]] = {
+    from.map {
+      case (prop, nonce) =>
+        new BoxUnlocker[PublicKey25519Proposition] {
+          override val closedBoxId: Array[Byte] =
+            PublicKeyNoncedBox.idFromBox(prop, nonce)
+          override val boxKey: Signature25519 = signatures.getOrElse(
+            prop,
+            throw new Exception("Signature not provided")
+          )
+        }
+    }
+  }
+
+  private def generateUnlockers( boxIds: Seq[Array[Byte]],
+                                 signature: Signature25519
+                               ): Traversable[BoxUnlocker[PublicKey25519Proposition]] = {
+    boxIds.map { id =>
+      new BoxUnlocker[PublicKey25519Proposition] {
+        override val closedBoxId: Array[Byte] = id
+        override val boxKey: Signature25519 = signature
+      }
+    }
+  }
+
+  override def applyModifier(mod: BPMOD): Try[State] =
+    mod match {
+      case b: Block ⇒
+        StateChanges(b).flatMap(cs ⇒ applyChanges(cs, b.id))
+      //case a: Any ⇒
+      // Failure(new Exception(s"unknown modifier $a"))
+    }
+
+  // not private because of tests
+  def applyChanges(changes: GSC, newVersion: VersionTag): Try[NVCT] =
+    Try {
+
+      //Filtering boxes pertaining to public keys specified in settings file
+      //Note YT - Need to handle MofN Proposition separately
+      val keyFilteredBoxesToAdd =
+        if (nodeKeys != null)
+          changes.toAppend
+            .filter(b =>
+              nodeKeys.contains(ByteArrayWrapper(b.proposition.bytes))
+            )
+        else
+          changes.toAppend
+
+      val keyFilteredBoxIdsToRemove =
+        if (nodeKeys != null)
+          changes.boxIdsToRemove
+            .flatMap(closedBox)
+            .filter(b =>
+              nodeKeys.contains(ByteArrayWrapper(b.proposition.bytes))
+            )
+            .map(b => b.id)
+        else
+          changes.boxIdsToRemove
+
+      val boxesToAdd = keyFilteredBoxesToAdd
+        .map(b => ByteArrayWrapper(b.id) -> ByteArrayWrapper(b.bytes))
+
+      /* This seeks to avoid the scenario where there is remove and then update of the same keys */
+      val boxIdsToRemove =
+        (keyFilteredBoxIdsToRemove -- boxesToAdd.map(_._1.data))
+          .map(ByteArrayWrapper.apply)
+
+      log.debug(
+        s"Update BifrostState from version $lastVersionString to version $newVersion. " +
+          s"Removing boxes with ids ${boxIdsToRemove.map(b => Base58.encode(b.data))}, " +
+          s"adding boxes ${boxesToAdd.map(b => Base58.encode(b._1.data))}"
+      )
+
+      val timestamp: Long = changes.asInstanceOf[StateChanges].timestamp
+
+      if (storage.lastVersionID.isDefined)
+        boxIdsToRemove.foreach(i => require(closedBox(i.data).isDefined))
+
+      //TokenBoxRegistry must be updated before state since it uses the boxes from state that are being removed in the update
+      if (tbr != null)
+        tbr.updateFromState(
+          newVersion,
+          keyFilteredBoxIdsToRemove,
+          keyFilteredBoxesToAdd
+        )
+      if (pbr != null)
+        pbr.updateFromState(
+          newVersion,
+          keyFilteredBoxIdsToRemove,
+          keyFilteredBoxesToAdd
+        )
+
+      storage.update(
+        ByteArrayWrapper(newVersion.hashBytes),
+        boxIdsToRemove,
+        boxesToAdd + (ByteArrayWrapper(
+          FastCryptographicHash("timestamp".getBytes)
+        ) -> ByteArrayWrapper(Longs.toByteArray(timestamp)))
+      )
+
+      val newSt =
+        State(storage, newVersion, timestamp, history, pbr, tbr, nodeKeys)
+
+      boxIdsToRemove.foreach(box =>
+        require(
+          newSt.closedBox(box.data).isEmpty,
+          s"Box $box is still in state"
+        )
+      )
+      newSt
+    }
+
+  // todo: JAA - shouldn't this be read in from a settings file or is it even needed (can we remove it from the trait?)
   override def maxRollbackDepth: Int = 10
 }
 
 object State extends Logging {
 
-  type T = Any
-  type TX = Transaction
-  type P = ProofOfKnowledgeProposition[PrivateKey25519]
-  type BX = Box
-  type BPMOD = Block
-  type GSC = GenericStateChanges[T, P, BX]
-  type BSC = StateChanges
+  def genesisState(settings: AppSettings, initialBlocks: Seq[Block], history: History): State = {
+    initialBlocks
+      .foldLeft(readOrGenerate( settings, callFromGenesis = true, history)) {
+        (state, mod) =>
+          StateChanges(mod)
+            .flatMap(cs => state.applyChanges(cs, mod.id))
+            .get
+      }
+  }
 
-  //noinspection ScalaStyle
-  def semanticValidity(tx: TX): Try[Unit] = {
+  /**
+    * Provides a single interface for syntactically validating transactions
+    *
+    * @param tx transaction to evaluate
+    */
+  def syntacticValidity[TX](tx: TX): Try[Unit] = {
     tx match {
       case poT: PolyTransfer           => PolyTransfer.validate(poT)
       case arT: ArbitTransfer          => ArbitTransfer.validate(arT)
@@ -640,62 +643,8 @@ object State extends Logging {
     }
   }
 
-  //YT NOTE - byte array set quality is incorrectly overloaded (shallow not deep), consider using ByteArrayWrapper instead
-  //YT NOTE - LSMStore will throw error if given duplicate keys in toRemove or toAppend so this needs to be fixed
-  def changes(mod: BPMOD): Try[GSC] = Try {
-
-    val gen = mod.forgerBox.proposition
-
-    val boxDeltas: Seq[(Set[Array[Byte]], Set[BX], Long)] =
-      mod.transactions match {
-        case Some(txSeq) =>
-          txSeq.map(tx => (tx.boxIdsToOpen.toSet, tx.newBoxes.toSet, tx.fee))
-        case _ => Seq((Set[Array[Byte]](), Set[BX](), 0L))
-      }
-
-    val (toRemove: Set[Array[Byte]], toAdd: Set[BX], reward: Long) =
-      boxDeltas.foldLeft((Set[Array[Byte]](), Set[BX](), 0L))(
-        (aggregate, boxDelta) => {
-          (
-            aggregate._1 ++ boxDelta._1,
-            aggregate._2 ++ boxDelta._2,
-            aggregate._3 + boxDelta._3
-          )
-        }
-      )
-
-    val rewardNonce = Longs.fromByteArray(mod.id.hashBytes.take(Longs.BYTES))
-
-    //TODO Change to immutable val
-    var finalToAdd = toAdd
-    if (reward != 0) finalToAdd += PolyBox(gen, rewardNonce, reward)
-
-    //no reward additional to tx fees
-    StateChanges(toRemove, finalToAdd, mod.timestamp)
-  }
-
-  def genesisState(
-      settings: AppSettings,
-      initialBlocks: Seq[BPMOD],
-      history: History
-  ): State = {
-    initialBlocks
-      .foldLeft(readOrGenerate(settings, callFromGenesis = true, history)) {
-        (state, mod) =>
-          state
-            .changes(mod)
-            .flatMap(cs => state.applyChanges(cs, mod.id))
-            .get
-      }
-  }
-
-  def readOrGenerate(
-      settings: AppSettings,
-      callFromGenesis: Boolean = false,
-      history: History
-  ): State = {
-    val dataDirOpt =
-      settings.dataDir.ensuring(_.isDefined, "data dir must be specified")
+  def readOrGenerate(settings: AppSettings, callFromGenesis: Boolean = false, history: History): State = {
+    val dataDirOpt = settings.dataDir.ensuring(_.isDefined, "data dir must be specified")
     val dataDir = dataDirOpt.get
 
     new File(dataDir).mkdirs()
@@ -709,6 +658,7 @@ object State extends Logging {
         stateStorage.close()
       }
     })
+
     val version: VersionTag = ModifierId(
       stateStorage.lastVersionID
         .fold(Array.emptyByteArray)(_.data)

--- a/src/main/scala/bifrost/state/StateChanges.scala
+++ b/src/main/scala/bifrost/state/StateChanges.scala
@@ -1,0 +1,58 @@
+package bifrost.state
+
+import bifrost.crypto.PrivateKey25519
+import bifrost.modifier.block.Block
+import bifrost.modifier.box.{Box, PolyBox}
+import bifrost.modifier.box.proposition.ProofOfKnowledgeProposition
+import com.google.common.primitives.Longs
+
+import scala.util.Try
+
+case class StateChanges( override val boxIdsToRemove: Set[Array[Byte]],
+                         override val toAppend: Set[Box],
+                         timestamp: Long
+                       ) extends GenericStateChanges[Any, ProofOfKnowledgeProposition[PrivateKey25519], Box](boxIdsToRemove, toAppend)
+
+object StateChanges {
+  type P = ProofOfKnowledgeProposition[PrivateKey25519]
+  type BX = Box
+  type BPMOD = Block
+  type GSC = GenericStateChanges[Any, P, BX]
+
+
+  //todo - byte array set quality is incorrectly overloaded (shallow not deep), consider using ByteArrayWrapper instead
+  //todo - LSMStore will throw error if given duplicate keys in toRemove or toAppend so this needs to be fixed
+  def apply(mod: BPMOD): Try[GSC] =
+    Try {
+
+      val boxDeltas: Seq[(Set[Array[Byte]], Set[BX], Long)] =
+        mod.transactions match {
+          case Some(txSeq) =>
+            txSeq.map(tx => (tx.boxIdsToOpen.toSet, tx.newBoxes.toSet, tx.fee))
+          case _ => Seq((Set[Array[Byte]](), Set[BX](), 0L))
+        }
+
+      val (toRemove: Set[Array[Byte]], toAdd: Set[BX], reward: Long) =
+        boxDeltas.foldLeft((Set[Array[Byte]](), Set[BX](), 0L))(
+          (aggregate, boxDelta) => {
+            (
+              aggregate._1 ++ boxDelta._1,
+              aggregate._2 ++ boxDelta._2,
+              aggregate._3 + boxDelta._3
+            )
+          }
+        )
+
+      // compute the fees to be transferred to the validator
+      val finalToAdd =
+        if (reward != 0) {
+          val gen = mod.forgerBox.proposition
+          val rewardNonce = Longs.fromByteArray(mod.id.hashBytes.take(Longs.BYTES))
+          toAdd + PolyBox(gen, rewardNonce, reward)
+        }
+        else toAdd
+
+      // return the state changes that can be applied
+      new StateChanges(toRemove, finalToAdd, mod.timestamp)
+    }
+}

--- a/src/main/scala/bifrost/wallet/Wallet.scala
+++ b/src/main/scala/bifrost/wallet/Wallet.scala
@@ -10,7 +10,7 @@ import bifrost.modifier.box._
 import bifrost.modifier.box.proposition.{MofNProposition, ProofOfKnowledgeProposition, PublicKey25519Proposition}
 import bifrost.modifier.transaction.bifrostTransaction.Transaction
 import bifrost.settings.AppSettings
-import bifrost.state.{State, StateChanges}
+import bifrost.state.StateChanges
 import bifrost.utils.Logging
 import com.google.common.primitives.Ints
 import io.iohk.iodb.{ByteArrayWrapper, LSMStore}
@@ -25,10 +25,13 @@ case class Wallet(var secrets: Set[PrivateKey25519], store: LSMStore, defaultKey
 
   import bifrost.wallet.Wallet._
 
+  override type NVCT = Wallet
   type S = PrivateKey25519
   type PI = ProofOfKnowledgeProposition[S]
 
   private val BoxIdsKey: ByteArrayWrapper = ByteArrayWrapper(Array.fill(store.keySize)(1: Byte))
+
+  private lazy val walletBoxSerializer = new WalletBoxSerializer[Any, PI, Box](BoxSerializer)
 
   def boxIds: Seq[Array[Byte]] = store
     .get(BoxIdsKey)
@@ -37,8 +40,6 @@ case class Wallet(var secrets: Set[PrivateKey25519], store: LSMStore, defaultKey
            .grouped(store.keySize)
            .toSeq)
     .getOrElse(Seq[Array[Byte]]())
-
-  private lazy val walletBoxSerializer = new WalletBoxSerializer[Any, PI, Box](BoxSerializer)
 
   //not implemented intentionally for now
   def historyTransactions: Seq[WalletTransaction[PI, Transaction]] = ???
@@ -66,7 +67,7 @@ case class Wallet(var secrets: Set[PrivateKey25519], store: LSMStore, defaultKey
   }
 
   //Only returns asset, arbit and poly boxes by public key
-   def boxesByKey(publicKeyString: String): Seq[WalletBox[Any, PI, Box]] = {
+  def boxesByKey(publicKeyString: String): Seq[WalletBox[Any, PI, Box]] = {
     //log.debug(s"${Console.GREEN}Accessing boxes: ${boxIds.toList.map(Base58.encode)}${Console.RESET}")
     boxIds
       .flatMap(id => store.get(ByteArrayWrapper(id)))
@@ -233,9 +234,7 @@ case class Wallet(var secrets: Set[PrivateKey25519], store: LSMStore, defaultKey
       Wallet(secrets, store, defaultKeyDir)
     }
   }
-
-  override type NVCT = this.type
-
+  
 }
 
 object Wallet {

--- a/src/main/scala/bifrost/wallet/Wallet.scala
+++ b/src/main/scala/bifrost/wallet/Wallet.scala
@@ -10,7 +10,7 @@ import bifrost.modifier.box._
 import bifrost.modifier.box.proposition.{MofNProposition, ProofOfKnowledgeProposition, PublicKey25519Proposition}
 import bifrost.modifier.transaction.bifrostTransaction.Transaction
 import bifrost.settings.AppSettings
-import bifrost.state.State
+import bifrost.state.{State, StateChanges}
 import bifrost.utils.Logging
 import com.google.common.primitives.Ints
 import io.iohk.iodb.{ByteArrayWrapper, LSMStore}
@@ -184,7 +184,7 @@ case class Wallet(var secrets: Set[PrivateKey25519], store: LSMStore, defaultKey
 
   override def scanPersistent(modifier: Block): Wallet = {
     log.debug(s"Applying modifier to wallet: ${modifier.id.toString}")
-    val changes = State.changes(modifier).get
+    val changes = StateChanges(modifier).get
 
     val newBoxes = changes
       .toAppend

--- a/src/test/scala/bifrost/state/AssetCreationValidationSpec.scala
+++ b/src/test/scala/bifrost/state/AssetCreationValidationSpec.scala
@@ -38,7 +38,7 @@ class AssetCreationValidationSpec extends StateSpec {
           .get
 
         val newState = preparedState
-          .applyChanges(preparedState.changes(block).get, ModifierId(Ints.toByteArray(8)))
+          .applyChanges(StateChanges(block).get, ModifierId(Ints.toByteArray(8)))
           .get
 
         assetCreation.newBoxes.forall(b => newState.storage.get(ByteArrayWrapper(b.id)) match {

--- a/src/test/scala/bifrost/state/ProgramCreationValidationSpec.scala
+++ b/src/test/scala/bifrost/state/ProgramCreationValidationSpec.scala
@@ -129,7 +129,7 @@ class ProgramCreationValidationSpec extends ProgramSpec {
           .get
 
         val newState = preparedState
-          .applyChanges(preparedState.changes(block).get, ModifierId(Ints.toByteArray(24)))
+          .applyChanges(StateChanges(block).get, ModifierId(Ints.toByteArray(24)))
           .get
 
         require(returnedPolyBoxes
@@ -307,7 +307,7 @@ class ProgramCreationValidationSpec extends ProgramSpec {
           .applyChanges(necessaryBoxesSC, ModifierId(Ints.toByteArray(29)))
           .get
 
-        val preparedChanges = necessaryState.changes(firstCCAddBlock).get
+        val preparedChanges = StateChanges(firstCCAddBlock).get
         val preparedState = necessaryState
           .applyChanges(preparedChanges, ModifierId(Ints.toByteArray(30)))
           .get

--- a/src/test/scala/bifrost/state/TokenBoxRegistrySpec.scala
+++ b/src/test/scala/bifrost/state/TokenBoxRegistrySpec.scala
@@ -78,7 +78,7 @@ class TokenBoxRegistrySpec extends AnyPropSpec
     require(genesisState.validate(tx1).isSuccess)
 
     val newState1 = genesisState
-      .applyChanges(genesisState.changes(block1).get, block1.id)
+      .applyChanges(StateChanges(block1).get, block1.id)
       .get
 
     val newWallet1 = gw.scanPersistent(block1)
@@ -111,7 +111,7 @@ class TokenBoxRegistrySpec extends AnyPropSpec
     require(newState1.validate(tx2).isSuccess)
 
     val newState2 = newState1
-      .applyChanges(newState1.changes(block2).get, block2.id)
+      .applyChanges(StateChanges(block2).get, block2.id)
       .get
 
     val newWallet2 = newWallet1.scanPersistent(block2)
@@ -153,7 +153,7 @@ class TokenBoxRegistrySpec extends AnyPropSpec
     require(genesisState.validate(tx1).isSuccess)
 
     val newState1 = genesisState
-      .applyChanges(genesisState.changes(block1).get, block1.id)
+      .applyChanges(StateChanges(block1).get, block1.id)
       .get
 
     assert(newState1.tbr.boxesByKey(Base58.decode("6sYyiTguyQ455w2dGEaNbrwkAWAEYV1Zk6FtZMknWDKQ").get).count(_.isInstanceOf[ArbitBox]) == 1)

--- a/src/test/scala/bifrost/transaction/ArbitTransferSpec.scala
+++ b/src/test/scala/bifrost/transaction/ArbitTransferSpec.scala
@@ -16,7 +16,7 @@ class ArbitTransferSpec extends AnyPropSpec
 
   property("Randomly generated ArbitTransfer Tx should be valid") {
     forAll(validArbitTransferGen) {
-      at: ArbitTransfer => State.semanticValidity(at).isSuccess shouldBe true
+      at: ArbitTransfer => State.syntacticValidity(at).isSuccess shouldBe true
     }
   }
 }

--- a/src/test/scala/bifrost/transaction/CoinbaseTransactionSpec.scala
+++ b/src/test/scala/bifrost/transaction/CoinbaseTransactionSpec.scala
@@ -16,7 +16,7 @@ class CoinbaseTransactionSpec extends AnyPropSpec
 
   property("Generated Coinbase Tx should be valid") {
     forAll(validCoinbaseTransactionGen) {
-      cb: CoinbaseTransaction => State.semanticValidity(cb).isSuccess shouldBe true
+      cb: CoinbaseTransaction => State.syntacticValidity(cb).isSuccess shouldBe true
     }
 
     // test inflation val stuff works

--- a/src/test/scala/bifrost/transaction/PolyTransferSpec.scala
+++ b/src/test/scala/bifrost/transaction/PolyTransferSpec.scala
@@ -17,7 +17,7 @@ class PolyTransferSpec extends AnyPropSpec
   property("Generated PolyTransfer Tx should be valid") {
     forAll(validPolyTransferGen) {
       polyTransfer: PolyTransfer =>
-        State.semanticValidity(polyTransfer).isSuccess shouldBe true
+        State.syntacticValidity(polyTransfer).isSuccess shouldBe true
     }
   }
 
@@ -25,7 +25,7 @@ class PolyTransferSpec extends AnyPropSpec
     // Create invalid PolyTransfer
     // send tx to state
     forAll(polyTransferGen) { polyTransfer =>
-      State.semanticValidity(polyTransfer).isSuccess shouldBe false
+      State.syntacticValidity(polyTransfer).isSuccess shouldBe false
     }
   }
 
@@ -33,7 +33,7 @@ class PolyTransferSpec extends AnyPropSpec
     // Create invalid PolyTransfer
     // send tx to state
     forAll(arbitTransferGen) { arbitTransfer =>
-      State.semanticValidity(arbitTransfer).isSuccess shouldBe false
+      State.syntacticValidity(arbitTransfer).isSuccess shouldBe false
     }
   }
 }

--- a/src/test/scala/bifrost/transaction/ProgramCreationSpec.scala
+++ b/src/test/scala/bifrost/transaction/ProgramCreationSpec.scala
@@ -24,7 +24,7 @@ class ProgramCreationSpec extends AnyPropSpec
   property("Generated ProgramCreation Tx should be valid") {
     forAll(validProgramCreationGen) {
       programCreation: ProgramCreation =>
-        val semanticValid = State.semanticValidity(programCreation)
+        val semanticValid = State.syntacticValidity(programCreation)
         semanticValid shouldBe a[Success[_]]
     }
   }
@@ -40,7 +40,7 @@ class ProgramCreationSpec extends AnyPropSpec
           programCreation.signatures +
             (programCreation.signatures.head._1 -> Signature25519(wrongSig))
 
-        State.semanticValidity(programCreation.copy(signatures = wrongSigs)).isSuccess shouldBe false
+        State.syntacticValidity(programCreation.copy(signatures = wrongSigs)).isSuccess shouldBe false
     }
   }
 /*


### PR DESCRIPTION
Created a dedicated state changes class file instead of returning state changes from a method in an instance of state. Also reorganized State slightly.