### PR TITLE
added HasName type class #866

### DIFF
--- a/src/main/scala/co/topl/attestation/Proposition.scala
+++ b/src/main/scala/co/topl/attestation/Proposition.scala
@@ -3,6 +3,7 @@ package co.topl.attestation
 import co.topl.attestation.AddressEncoder.NetworkPrefix
 import co.topl.attestation.Evidence.{EvidenceContent, EvidenceTypePrefix}
 import co.topl.attestation.serialization.PropositionSerializer
+import co.topl.utils.HasName
 import co.topl.utils.serialization.{BifrostSerializer, BytesSerializable}
 import com.google.common.primitives.Ints
 import io.circe.syntax.EncoderOps
@@ -83,6 +84,8 @@ object PublicKeyPropositionCurve25519 {
       prop: PublicKeyPropositionCurve25519 => Evidence(typePrefix, EvidenceContent @@ Blake2b256(prop.bytes))
     }
 
+  implicit val name: HasName[PublicKeyPropositionCurve25519] = HasName.instance(() => typeString)
+
   // see circe documentation for custom encoder / decoders
   // https://circe.github.io/circe/codecs/custom-codecs.html
   implicit val jsonEncoder: Encoder[PublicKeyPropositionCurve25519] = (prop: PublicKeyPropositionCurve25519) => prop.toString.asJson
@@ -124,6 +127,8 @@ object ThresholdPropositionCurve25519 {
     EvidenceProducer.instance[ThresholdPropositionCurve25519] {
       prop: ThresholdPropositionCurve25519 => Evidence(typePrefix, EvidenceContent @@ Blake2b256(prop.bytes))
     }
+
+  implicit val name: HasName[ThresholdPropositionCurve25519] = HasName.instance(() => typeString)
 
   // see circe documentation for custom encoder / decoders
   // https://circe.github.io/circe/codecs/custom-codecs.html

--- a/src/main/scala/co/topl/modifier/transaction/ArbitTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/ArbitTransfer.scala
@@ -1,19 +1,19 @@
 package co.topl.modifier.transaction
 
 import java.time.Instant
-
 import co.topl.attestation._
 import co.topl.modifier.transaction.Transaction.TxType
 import co.topl.modifier.transaction.TransferTransaction.BoxParams
 import co.topl.nodeView.state.StateReader
 import co.topl.nodeView.state.box.{ArbitBox, Box, PolyBox, TokenBox}
+import co.topl.utils.HasName
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor}
 
 import scala.util.Try
 
 case class ArbitTransfer[
-  P <: Proposition: EvidenceProducer
+  P <: Proposition: EvidenceProducer: HasName
 ] (override val from       : IndexedSeq[(Address, Box.Nonce)],
    override val to         : IndexedSeq[(Address, TokenBox.Value)],
    override val attestation: Map[P, Proof[P]],
@@ -49,7 +49,7 @@ object ArbitTransfer {
    * @return
    */
   def createRaw[
-    P <: Proposition: EvidenceProducer
+    P <: Proposition: EvidenceProducer: HasName
   ] (stateReader  : StateReader,
      toReceive    : IndexedSeq[(Address, TokenBox.Value)],
      sender       : IndexedSeq[Address],

--- a/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
@@ -1,19 +1,19 @@
 package co.topl.modifier.transaction
 
 import java.time.Instant
-
 import co.topl.attestation._
 import co.topl.modifier.transaction.Transaction.TxType
 import co.topl.modifier.transaction.TransferTransaction.BoxParams
 import co.topl.nodeView.state.StateReader
 import co.topl.nodeView.state.box.{AssetBox, Box, PolyBox, TokenBox}
+import co.topl.utils.HasName
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, HCursor}
 
 import scala.util.Try
 
 case class AssetTransfer[
-  P <: Proposition: EvidenceProducer
+  P <: Proposition: EvidenceProducer: HasName
 ] (override val from       : IndexedSeq[(Address, Box.Nonce)],
    override val to         : IndexedSeq[(Address, TokenBox.Value)],
    override val attestation: Map[P, Proof[P]],
@@ -59,7 +59,7 @@ object AssetTransfer {
     * @return
     */
   def createRaw[
-    P <: Proposition: EvidenceProducer
+    P <: Proposition: EvidenceProducer: HasName
   ] (stateReader  : StateReader,
      toReceive    : IndexedSeq[(Address, TokenBox.Value)],
      sender       : IndexedSeq[Address],

--- a/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
@@ -70,7 +70,7 @@ object AssetTransfer {
      data         : String,
      minting      : Boolean
     ): Try[AssetTransfer[P]] =
-    TransferTransaction.createRawTransferParams(stateReader, toReceive, sender, changeAddress, fee, "AssetTransfer", Some((issuer, assetCode))).map {
+    TransferTransaction.createRawTransferParams(stateReader, toReceive, sender, changeAddress, fee, "AssetTransfer", Some((issuer, assetCode, minting))).map {
       case (inputs, outputs) => AssetTransfer[P](inputs, outputs, Map(), issuer, assetCode, fee, Instant.now.toEpochMilli, data, minting)
     }
 

--- a/src/main/scala/co/topl/modifier/transaction/PolyTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/PolyTransfer.scala
@@ -1,19 +1,19 @@
 package co.topl.modifier.transaction
 
 import java.time.Instant
-
 import co.topl.attestation._
 import co.topl.modifier.transaction.Transaction.TxType
 import co.topl.modifier.transaction.TransferTransaction.BoxParams
 import co.topl.nodeView.state.StateReader
 import co.topl.nodeView.state.box.{Box, PolyBox, TokenBox}
+import co.topl.utils.HasName
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor}
 
 import scala.util.Try
 
 case class PolyTransfer[
-  P <: Proposition: EvidenceProducer,
+  P <: Proposition: EvidenceProducer: HasName
 ] (override val from       : IndexedSeq[(Address, Box.Nonce)],
    override val to         : IndexedSeq[(Address, TokenBox.Value)],
    override val attestation: Map[P, Proof[P]],
@@ -49,7 +49,7 @@ object PolyTransfer {
     * @return
     */
   def createRaw[
-    P <: Proposition: EvidenceProducer
+    P <: Proposition: EvidenceProducer: HasName
   ] (stateReader  : StateReader,
      toReceive    : IndexedSeq[(Address, TokenBox.Value)],
      sender       : IndexedSeq[Address],

--- a/src/main/scala/co/topl/modifier/transaction/Transaction.scala
+++ b/src/main/scala/co/topl/modifier/transaction/Transaction.scala
@@ -9,6 +9,7 @@ import co.topl.modifier.transaction.serialization.TransactionSerializer
 import co.topl.modifier.{ModifierId, NodeViewModifier}
 import co.topl.nodeView.state.StateReader
 import co.topl.nodeView.state.box.{Box, BoxId}
+import co.topl.utils.HasName
 import co.topl.utils.serialization.BifrostSerializer
 import com.google.common.primitives.Longs
 import io.circe.{Decoder, Encoder, HCursor}
@@ -16,7 +17,7 @@ import scorex.crypto.hash.{Blake2b256, Digest32}
 
 import scala.util.Try
 
-abstract class Transaction[T <: Any, P <: Proposition] extends NodeViewModifier {
+abstract class Transaction[T <: Any, P <: Proposition: HasName] extends NodeViewModifier {
 
   override lazy val id: ModifierId = ModifierId(this)
 
@@ -47,7 +48,7 @@ abstract class Transaction[T <: Any, P <: Proposition] extends NodeViewModifier 
       Longs.toByteArray(timestamp) ++
       Longs.toByteArray(fee)
 
-  def getPropTypeString: String = attestation.head._1.propTypeString
+  def getPropTypeString: String = HasName[P].name
 
   def semanticValidate (stateReader: StateReader)(implicit networkPrefix: NetworkPrefix): Try[Unit]
 

--- a/src/main/scala/co/topl/modifier/transaction/TransferTransaction.scala
+++ b/src/main/scala/co/topl/modifier/transaction/TransferTransaction.scala
@@ -5,27 +5,23 @@ import co.topl.attestation.EvidenceProducer.Syntax._
 import co.topl.attestation.{Evidence, _}
 import co.topl.modifier.block.BloomFilter.BloomTopic
 import co.topl.nodeView.state.StateReader
-import co.topl.nodeView.state.box.Box.Nonce
-import co.topl.nodeView.state.box.TokenBox.Value
 import co.topl.nodeView.state.box.{Box, _}
 import co.topl.utils.HasName
-import com.google.common.base.Utf8
 import com.google.common.primitives.{Ints, Longs}
 import scorex.crypto.hash.Blake2b256
-import scorex.util.encode.Base58
 
 import scala.util.{Failure, Success, Try}
 
 abstract class TransferTransaction[
   P <: Proposition: EvidenceProducer: HasName
-] ( val from: IndexedSeq[(Address, Box.Nonce)],
-    val to: IndexedSeq[(Address, TokenBox.Value)],
-    val attestation: Map[P, Proof[P]],
-    val fee: Long,
-    val timestamp: Long,
-    val data: String,
-    val minting: Boolean
-  ) extends Transaction[TokenBox.Value, P] {
+](val from:        IndexedSeq[(Address, Box.Nonce)],
+  val to:          IndexedSeq[(Address, TokenBox.Value)],
+  val attestation: Map[P, Proof[P]],
+  val fee:         Long,
+  val timestamp:   Long,
+  val data:        String,
+  val minting:     Boolean
+) extends Transaction[TokenBox.Value, P] {
 
   lazy val bloomTopics: IndexedSeq[BloomTopic] = to.map(x => BloomTopic.apply(x._1.bytes))
 
@@ -35,33 +31,33 @@ abstract class TransferTransaction[
 
   override def messageToSign: Array[Byte] =
     super.messageToSign ++
-      data.getBytes :+ (if (minting) 1: Byte else 0: Byte)
+    data.getBytes :+ (if (minting) 1: Byte else 0: Byte)
 
-  def semanticValidate (stateReader: StateReader)(implicit networkPrefix: NetworkPrefix): Try[Unit] =
+  def semanticValidate(stateReader: StateReader)(implicit networkPrefix: NetworkPrefix): Try[Unit] =
     TransferTransaction.semanticValidate(this, stateReader)
 
-  def syntacticValidate (implicit networkPrefix: NetworkPrefix): Try[Unit] =
+  def syntacticValidate(implicit networkPrefix: NetworkPrefix): Try[Unit] =
     TransferTransaction.syntacticValidate(this)
 
-  def rawValidate (implicit networkPrefix: NetworkPrefix): Try[Unit] =
+  def rawValidate(implicit networkPrefix: NetworkPrefix): Try[Unit] =
     TransferTransaction.syntacticValidate(this, hasAttMap = false)
 
 }
-
 
 object TransferTransaction {
 
   case class BoxParams(evidence: Evidence, nonce: Box.Nonce, value: TokenBox.Value)
 
   /** Computes a unique nonce value based on the transaction type and
-   * inputs and returns the details needed to create the output boxes for the transaction */
+    * inputs and returns the details needed to create the output boxes for the transaction
+    */
   def boxParams(tx: TransferTransaction[_]): (BoxParams, Traversable[BoxParams]) = {
     // known input data (similar to messageToSign but without newBoxes since they aren't known yet)
     val inputBytes =
       Array(tx.txTypePrefix) ++
-        tx.boxIdsToOpen.foldLeft(Array[Byte]())((acc, x) => acc ++ x.hashBytes) ++
-        Longs.toByteArray(tx.timestamp) ++
-        Longs.toByteArray(tx.fee)
+      tx.boxIdsToOpen.foldLeft(Array[Byte]())((acc, x) => acc ++ x.hashBytes) ++
+      Longs.toByteArray(tx.timestamp) ++
+      Longs.toByteArray(tx.fee)
 
     def calcNonce(index: Int): Box.Nonce = {
       val digest = Blake2b256(inputBytes ++ Ints.toByteArray(index))
@@ -80,53 +76,70 @@ object TransferTransaction {
     (feeParams, outputParams)
   }
 
-  /**
-   * Determines the input boxes needed to create a transfer transaction
-   *
-   * @param state a read-only version of the nodes current state
-   * @param toReceive the recipients of boxes
-   * @param sender the set of addresses that will contribute boxes to this transaction
-   * @param fee the fee to be paid for the transaction
-   * @param txType the type of transfer
-   * @param assetArgs a tuple of asset specific details for finding the right asset boxes to be sent in a transfer
-   * @return the input box information and output data needed to create the transaction case class
-   */
-  def createRawTransferParams(state: StateReader,
-                              toReceive: IndexedSeq[(Address, TokenBox.Value)],
-                              sender: IndexedSeq[Address],
-                              changeAddress: Address,
-                              fee: TokenBox.Value,
-                              txType: String,
-                              assetArgs: Option[(Address, String, Boolean)] = None // (issuer, assetCode)
-                          ): Try[(IndexedSeq[(Address, Box.Nonce)], IndexedSeq[(Address, TokenBox.Value)])] = Try {
-
-    // Lookup boxes for the given senders
-    val senderBoxes =
-      sender.flatMap { s =>
-        state.getTokenBoxes(s)
-          .getOrElse(throw new Exception("No boxes found to fund transaction")) // isn't this just an empty sequence instead of None?
+  /** Retrieves the boxes from state for the specified sequence of senders and filters them based on the type of transaction */
+  private def getSenderBoxesForTx(
+    state:     StateReader,
+    sender:    IndexedSeq[Address],
+    txType:    String,
+    assetArgs: Option[(Address, String, Boolean)] = None
+  ): Map[String, IndexedSeq[(String, Address, TokenBox)]] = {
+    sender
+      .flatMap { s =>
+        state
+          .getTokenBoxes(s)
+          .getOrElse(
+            throw new Exception("No boxes found to fund transaction")
+          ) // isn't this just an empty sequence instead of None?
           .filter {
             case _: PolyBox => true // always get polys because this is how fees are paid
 
             case _: ArbitBox if txType == "ArbitTransfer" => true
 
-            case bx: AssetBox if txType == "AssetTransfer" &&
-              assetArgs.forall(p => p._1 == bx.issuer && p._2 == bx.assetCode) => true
+            case bx: AssetBox
+                if txType == "AssetTransfer" &&
+                  assetArgs.forall(p => p._1 == bx.issuer && p._2 == bx.assetCode) =>
+              true
 
             case _ => false
-          }.map {
+          }
+          .map {
             case bx: PolyBox  => ("Poly", s, bx)
             case bx: ArbitBox => ("Arbit", s, bx)
             case bx: AssetBox => ("Asset", s, bx)
           }
-      }.groupBy(_._1)
+      }
+      .groupBy(_._1)
+  }
+
+  /** Determines the input boxes needed to create a transfer transaction
+    *
+    * @param state a read-only version of the nodes current state
+    * @param toReceive the recipients of boxes
+    * @param sender the set of addresses that will contribute boxes to this transaction
+    * @param fee the fee to be paid for the transaction
+    * @param txType the type of transfer
+    * @param assetArgs a tuple of asset specific details for finding the right asset boxes to be sent in a transfer
+    * @return the input box information and output data needed to create the transaction case class
+    */
+  def createRawTransferParams(
+    state:         StateReader,
+    toReceive:     IndexedSeq[(Address, TokenBox.Value)],
+    sender:        IndexedSeq[Address],
+    changeAddress: Address,
+    fee:           TokenBox.Value,
+    txType:        String,
+    assetArgs:     Option[(Address, String, Boolean)] = None // (issuer, assetCode, minting)
+  ): Try[(IndexedSeq[(Address, Box.Nonce)], IndexedSeq[(Address, TokenBox.Value)])] = Try {
+
+    // Lookup boxes for the given senders
+    val senderBoxes = getSenderBoxesForTx(state, sender, txType, assetArgs)
 
     // ensure there are enough polys to pay the fee
     require(senderBoxes("Poly").map(_._3.value).sum >= fee, s"Insufficient funds available to pay transaction fee.")
 
     // create the list of inputs and outputs (senderChangeOut & recipientOut)
     val (availableToSpend, inputs, outputs) = txType match {
-      case "PolyTransfer"  =>
+      case "PolyTransfer" =>
         (
           senderBoxes("Poly").map(_._3.value).sum - fee,
           senderBoxes("Poly").map(bxs => (bxs._2, bxs._3.nonce)),
@@ -136,11 +149,13 @@ object TransferTransaction {
       case "ArbitTransfer" =>
         (
           senderBoxes("Arbit").map(_._3.value).sum,
-          senderBoxes("Arbit").map(bxs => (bxs._2, bxs._3.nonce)) ++ senderBoxes("Poly").map(bxs => (bxs._2, bxs._3.nonce)),
+          senderBoxes("Arbit").map(bxs => (bxs._2, bxs._3.nonce)) ++ senderBoxes("Poly").map(bxs =>
+            (bxs._2, bxs._3.nonce)
+          ),
           (changeAddress, senderBoxes("Poly").map(_._3.value).sum - fee) +: toReceive
         )
 
-        // case for minting asset transfers
+      // case for minting asset transfers
       case "AssetTransfer" if assetArgs.forall(_._3) =>
         (
           Long.MaxValue,
@@ -151,7 +166,9 @@ object TransferTransaction {
       case "AssetTransfer" =>
         (
           senderBoxes("Asset").map(_._3.value).sum,
-          senderBoxes("Asset").map(bxs => (bxs._2, bxs._3.nonce)) ++ senderBoxes("Poly").map(bxs => (bxs._2, bxs._3.nonce)),
+          senderBoxes("Asset").map(bxs => (bxs._2, bxs._3.nonce)) ++ senderBoxes("Poly").map(bxs =>
+            (bxs._2, bxs._3.nonce)
+          ),
           (changeAddress, senderBoxes("Poly").map(_._3.value).sum - fee) +: toReceive
         )
     }
@@ -162,23 +179,21 @@ object TransferTransaction {
     (inputs, outputs)
   }
 
-  /**
-   * Syntactic validation of a transfer transaction
-   *
-   * @param tx an instance of a transaction to check
-   * @param hasAttMap boolean flag controlling whether signature verification should be checked or skipped
-   * @return success or failure indicating the validity of the transaction
-   */
+  /** Syntactic validation of a transfer transaction
+    *
+    * @param tx an instance of a transaction to check
+    * @param hasAttMap boolean flag controlling whether signature verification should be checked or skipped
+    * @return success or failure indicating the validity of the transaction
+    */
   def syntacticValidate[
     P <: Proposition: EvidenceProducer
-  ] (tx: TransferTransaction[P], hasAttMap: Boolean = true)
-    (implicit networkPrefix: NetworkPrefix): Try[Unit] = Try {
+  ](tx: TransferTransaction[P], hasAttMap: Boolean = true)(implicit networkPrefix: NetworkPrefix): Try[Unit] = Try {
 
     // enforce transaction specific requirements
     tx match {
       case t: ArbitTransfer[_] if t.minting => // Arbit block rewards
-      case t: PolyTransfer[_] if t.minting =>  // Poly block rewards
-      case t @ _ => require(t.from.nonEmpty, "Non-block reward transactions must specify at least one input box")
+      case t: PolyTransfer[_] if t.minting  => // Poly block rewards
+      case t @ _                            => require(t.from.nonEmpty, "Non-block reward transactions must specify at least one input box")
     }
 
     require(tx.to.forall(_._2 > 0L), "Amount sent must be greater than 0")
@@ -189,37 +204,44 @@ object TransferTransaction {
     // prototype transactions do not contain signatures at creation
     if (hasAttMap) {
       // ensure that the signatures are valid signatures with the body of the transaction
-      require(tx.attestation.forall {
-        case (prop, proof) => proof.isValid(prop, tx.messageToSign)
-      }, "The provided proposition is not satisfied by the given proof")
+      require(tx.attestation.forall { case (prop, proof) =>
+                proof.isValid(prop, tx.messageToSign)
+              },
+              "The provided proposition is not satisfied by the given proof"
+      )
 
       // ensure that the propositions match the from addresses
-      require(tx.from.forall {
-        case (addr, _) => tx.attestation.keys.map(_.generateEvidence).toSeq.contains(addr.evidence)
-      }, "The proposition(s) given do not match the evidence contained in the input boxes")
+      require(
+        tx.from.forall { case (addr, _) =>
+          tx.attestation.keys.map(_.generateEvidence).toSeq.contains(addr.evidence)
+        },
+        "The proposition(s) given do not match the evidence contained in the input boxes"
+      )
 
       tx match {
         case t: AssetTransfer[_] if tx.minting =>
-          require(t.attestation.keys.map(_.address).toSeq.contains(t.issuer), "Asset minting must include the issuers signature")
+          require(t.attestation.keys.map(_.address).toSeq.contains(t.issuer),
+                  "Asset minting must include the issuers signature"
+          )
         case _ => //skip for other transfers
       }
     }
 
     // ensure that the input and output lists of box ids are unique
-    require(tx.newBoxes.forall(b ⇒ !tx.boxIdsToOpen.contains(b.id)), "The set of input box ids contains one or more of the output ids")
+    require(tx.newBoxes.forall(b ⇒ !tx.boxIdsToOpen.contains(b.id)),
+            "The set of input box ids contains one or more of the output ids"
+    )
   }
 
-  /**
-   * Checks the stateful validity of a transaction
-   *
-   * @param tx the transaction to check
-   * @param state the state to check the validity against
-   * @return a success or failure denoting the result of this check
-   */
+  /** Checks the stateful validity of a transaction
+    *
+    * @param tx the transaction to check
+    * @param state the state to check the validity against
+    * @return a success or failure denoting the result of this check
+    */
   def semanticValidate[
     P <: Proposition: EvidenceProducer
-  ] (tx: TransferTransaction[P], state: StateReader)
-    (implicit networkPrefix: NetworkPrefix): Try[Unit] = {
+  ](tx: TransferTransaction[P], state: StateReader)(implicit networkPrefix: NetworkPrefix): Try[Unit] = {
 
     // check that the transaction is correctly formed before checking state
     syntacticValidate(tx) match {
@@ -254,11 +276,13 @@ object TransferTransaction {
         Success(Unit)
 
       case Success(sum: Long) if !tx.minting && txOutput != sum - tx.fee =>
-        Failure(new Exception(s"Tx output value does not equal input value for non-minting transaction. $txOutput != ${sum - tx.fee}"))
+        Failure(
+          new Exception(
+            s"Tx output value does not equal input value for non-minting transaction. $txOutput != ${sum - tx.fee}"
+          )
+        )
 
       case Failure(e) => Failure(e)
     }
   }
 }
-
-

--- a/src/main/scala/co/topl/modifier/transaction/TransferTransaction.scala
+++ b/src/main/scala/co/topl/modifier/transaction/TransferTransaction.scala
@@ -8,6 +8,7 @@ import co.topl.nodeView.state.StateReader
 import co.topl.nodeView.state.box.Box.Nonce
 import co.topl.nodeView.state.box.TokenBox.Value
 import co.topl.nodeView.state.box.{Box, _}
+import co.topl.utils.HasName
 import com.google.common.base.Utf8
 import com.google.common.primitives.{Ints, Longs}
 import scorex.crypto.hash.Blake2b256
@@ -16,7 +17,7 @@ import scorex.util.encode.Base58
 import scala.util.{Failure, Success, Try}
 
 abstract class TransferTransaction[
-  P <: Proposition: EvidenceProducer
+  P <: Proposition: EvidenceProducer: HasName
 ] ( val from: IndexedSeq[(Address, Box.Nonce)],
     val to: IndexedSeq[(Address, TokenBox.Value)],
     val attestation: Map[P, Proof[P]],
@@ -90,13 +91,13 @@ object TransferTransaction {
    * @param assetArgs a tuple of asset specific details for finding the right asset boxes to be sent in a transfer
    * @return the input box information and output data needed to create the transaction case class
    */
-  def createRawTransferParams ( state: StateReader,
-                                toReceive: IndexedSeq[(Address, TokenBox.Value)],
-                                sender: IndexedSeq[Address],
-                                changeAddress: Address,
-                                fee: TokenBox.Value,
-                                txType: String,
-                                assetArgs: Option[(Address, String)] = None // (issuer, assetCode)
+  def createRawTransferParams(state: StateReader,
+                              toReceive: IndexedSeq[(Address, TokenBox.Value)],
+                              sender: IndexedSeq[Address],
+                              changeAddress: Address,
+                              fee: TokenBox.Value,
+                              txType: String,
+                              assetArgs: Option[(Address, String)] = None // (issuer, assetCode)
                           ): Try[(IndexedSeq[(Address, Box.Nonce)], IndexedSeq[(Address, TokenBox.Value)])] = Try {
 
     // Lookup boxes for the given senders

--- a/src/main/scala/co/topl/utils/HasName.scala
+++ b/src/main/scala/co/topl/utils/HasName.scala
@@ -1,0 +1,13 @@
+package co.topl.utils
+
+/** Helper type class to define named methods in abstract classes */
+trait HasName[A] {
+  def name: String
+}
+
+object HasName {
+  def apply[A](implicit ev: HasName[A]): HasName[A] = ev
+  def instance[A](f: () => String): HasName[A] = new HasName[A] {
+    override def name: String = f()
+  }
+}


### PR DESCRIPTION
fixes #866 
This fixes a bug in the transaction method when creating raw transactions. Currently the `getPropTypeString` method tries to pull proposition type of the transaction by looking at the head of the attestation map. However, when creating a raw transaction, this map is empty so an error occurs since there is no head to get. I replaced this functionality with a type class that assumes a function exists that can return the name of the proposition. This allows the type argument P (defined in the Transaction) to pull the HasName type class and implicity query the name of the proposition. 

* Added HasName typeclass to allow abstract type arguments to target concrete values to return 
