### PR TITLE
Created MemPool Auditor actor

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -19,6 +19,12 @@ bifrost {
     # optional set of accounts that will be tracked by the state of this node
     nodeKeys = []
 
+    #
+    mempoolCleanupDuration = 20s
+
+    # Number of transactions from mempool to be re-broadcasted
+    rebroadcastCount = 3
+
     # ----- Cache settings (Guava) -----
     # Consider 5 sec per block for testing and 15 sec per block for toplnet
     # 15 sec * 50 blocks / 60 sec per minutes = 12.5 minutes

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -19,8 +19,8 @@ bifrost {
     # optional set of accounts that will be tracked by the state of this node
     nodeKeys = []
 
-    #
-    mempoolCleanupDuration = 20s
+    # time an unconfirmed transaction can stay in the mempool before being removed
+    mempoolTimeout = 3h
 
     # Number of transactions from mempool to be re-broadcasted
     rebroadcastCount = 3

--- a/src/main/scala/co/topl/BifrostApp.scala
+++ b/src/main/scala/co/topl/BifrostApp.scala
@@ -19,7 +19,8 @@ import co.topl.network.message.BifrostSyncInfo
 import co.topl.network.upnp.Gateway
 import co.topl.nodeView.history.History
 import co.topl.nodeView.mempool.MemPool
-import co.topl.nodeView.{NodeViewHolder, NodeViewHolderRef}
+import co.topl.nodeView.state.State
+import co.topl.nodeView.{MempoolAuditor, MempoolAuditorRef, NodeViewHolder, NodeViewHolderRef}
 import co.topl.settings._
 import co.topl.utils.Logging
 import co.topl.wallet.{WalletConnectionHandler, WalletConnectionHandlerRef}
@@ -38,6 +39,7 @@ class BifrostApp(startupOpts: StartupOpts) extends Logging with Runnable {
   type PMOD = Block
   type HIS = History
   type MP = MemPool
+  type ST = State
 
   /** Setup settings file to be passed into the application */
   private val settings: AppSettings = AppSettings.read(startupOpts)
@@ -54,11 +56,13 @@ class BifrostApp(startupOpts: StartupOpts) extends Logging with Runnable {
 
   /** save runtime environment into a variable for reference throughout the application */
   protected val appContext = new AppContext(settings, startupOpts, upnpGateway)
-  log.debug(s"${Console.MAGENTA}Runtime network parameters:" +
+  log.debug(
+    s"${Console.MAGENTA}Runtime network parameters:" +
     s"type - ${appContext.networkType.verboseName}, " +
     s"prefix - ${appContext.networkType.netPrefix}, " +
     s"forging status: ${settings.forging.forgeOnStartup}" +
-    s"${Console.RESET}")
+    s"${Console.RESET}"
+  )
 
   /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ---------------- */
   /** Create Bifrost singleton actors */
@@ -71,7 +75,11 @@ class BifrostApp(startupOpts: StartupOpts) extends Logging with Runnable {
 
   private val nodeViewHolderRef: ActorRef = NodeViewHolderRef(NodeViewHolder.actorName, settings, appContext)
 
-  private val walletConnectionHandlerRef: ActorRef = WalletConnectionHandlerRef[PMOD](WalletConnectionHandler.actorName, settings, appContext, nodeViewHolderRef)
+  private val mempoolAuditor: ActorRef =
+    MempoolAuditorRef[ST, MP](MempoolAuditor.actorName, settings, appContext, nodeViewHolderRef, networkControllerRef)
+
+  private val walletConnectionHandlerRef: ActorRef =
+    WalletConnectionHandlerRef[PMOD](WalletConnectionHandler.actorName, settings, appContext, nodeViewHolderRef)
 
   private val peerSynchronizer: ActorRef =
     PeerSynchronizerRef(PeerSynchronizer.actorName, networkControllerRef, peerManagerRef, settings, appContext)
@@ -92,13 +100,14 @@ class BifrostApp(startupOpts: StartupOpts) extends Logging with Runnable {
     nodeViewSynchronizer,
     forgerRef,
     nodeViewHolderRef,
-    walletConnectionHandlerRef
+    walletConnectionHandlerRef,
+    mempoolAuditor
   )
 
   /** hook for initiating the shutdown procedure */
   sys.addShutdownHook(BifrostApp.shutdown(actorSystem, actorsToStop))
 
-  /* ----------------- *//* ----------------- *//* ----------------- *//* ----------------- *//* ----------------- *//* ----------------- */
+  /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
   /** Create and register controllers for API routes */
   private val apiRoutes: Seq[ApiEndpoint] = Seq(
     UtilsApiEndpoint(settings.rpcApi, appContext),
@@ -199,12 +208,10 @@ object BifrostApp extends Logging {
   /** parse command line arguments */
   val argParser: Arg[StartupOpts] =
     (optional[String]("--config", "-c") and
-      optionalOneOf[NetworkType](NetworkType.all.map(x => s"--${x.verboseName}" -> x) : _*) and
-      ( optional[String]("--seed", "-s") and
-        flag("--forge", "-f") and
-        optional[String]("--apiKeyHash")
-        ).to[RuntimeOpts]
-      ).to[StartupOpts]
+      optionalOneOf[NetworkType](NetworkType.all.map(x => s"--${x.verboseName}" -> x): _*) and
+      (optional[String]("--seed", "-s") and
+      flag("--forge", "-f") and
+      optional[String]("--apiKeyHash")).to[RuntimeOpts]).to[StartupOpts]
 
   ////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////// METHOD DEFINITIONS ////////////////////////////////
@@ -218,7 +225,7 @@ object BifrostApp extends Logging {
 
   def shutdown(system: ActorSystem, actors: Seq[ActorRef]): Unit = {
     log.warn("Terminating Actors")
-    actors.foreach { _ ! PoisonPill }
+    actors.foreach(_ ! PoisonPill)
     log.warn("Terminating ActorSystem")
     val termination = system.terminate()
     Await.result(termination, 60.seconds)

--- a/src/main/scala/co/topl/consensus/BlockValidator.scala
+++ b/src/main/scala/co/topl/consensus/BlockValidator.scala
@@ -4,6 +4,7 @@ import co.topl.consensus
 import co.topl.modifier.block.Block
 import co.topl.modifier.transaction.{ArbitTransfer, PolyTransfer, Transaction}
 import co.topl.nodeView.history.{BlockProcessor, History, Storage}
+import co.topl.utils.TimeProvider
 
 import scala.util.{Failure, Try}
 
@@ -30,7 +31,7 @@ class DifficultyBlockValidator(storage: Storage, blockProcessor: BlockProcessor)
     }
   }
 
-  private def ensureHeightAndDifficulty(block: Block, parent: Block, prevTimes: Seq[Block.Timestamp]): Try[Unit] = Try {
+  private def ensureHeightAndDifficulty(block: Block, parent: Block, prevTimes: Seq[TimeProvider.Time]): Try[Unit] = Try {
     // calculate the new base difficulty
     val newHeight = parent.height + 1
     val newBaseDifficulty = consensus.calcNewBaseDifficulty(newHeight, parent.difficulty, prevTimes)
@@ -58,7 +59,7 @@ class DifficultyBlockValidator(storage: Storage, blockProcessor: BlockProcessor)
   }
 
   /** Helper function to find the source of the parent block (either storage or chain cache) */
-  private def getParentDetailsOf(block: Block): (Block, Seq[Block.Timestamp]) =
+  private def getParentDetailsOf(block: Block): (Block, Seq[TimeProvider.Time]) =
     blockProcessor.getCacheBlock(block.parentId) match {
       case Some(cacheParent) => (cacheParent.block, cacheParent.prevBlockTimes)
       case None =>

--- a/src/main/scala/co/topl/consensus/Forger.scala
+++ b/src/main/scala/co/topl/consensus/Forger.scala
@@ -308,7 +308,7 @@ class Forger(settings: AppSettings, appContext: AppContext)(implicit ec: Executi
   private def pickTransactions(memPool: MemPool, state: State, chainHeight: Long): Try[PickTransactionsResult] = Try {
 
     memPool
-      .take(numTxInBlock(chainHeight))
+      .take(numTxInBlock(chainHeight))(-_.tx.fee) // returns a sequence of transactions ordered by their fee
       .filter(_.tx.fee > 0) // default strategy ignores zero fee transactions in mempool
       .foldLeft(PickTransactionsResult(Seq(), Seq())) { case (txAcc, utx) =>
         // ensure that each transaction opens a unique box by checking that this transaction

--- a/src/main/scala/co/topl/consensus/package.scala
+++ b/src/main/scala/co/topl/consensus/package.scala
@@ -3,6 +3,7 @@ package co.topl
 import co.topl.modifier.block.Block
 import co.topl.modifier.box.ArbitBox
 import co.topl.settings.ProtocolSettings
+import co.topl.utils.TimeProvider
 import com.google.common.primitives.Longs
 import scorex.crypto.hash.Blake2b256
 
@@ -89,7 +90,7 @@ package object consensus {
     * @param prevTimes      sequence of block times to calculate the average and compare to target
     * @return the modified difficulty
     */
-  def calcNewBaseDifficulty(newHeight: Long, prevDifficulty: Long, prevTimes: Seq[Block.Timestamp]): Long = {
+  def calcNewBaseDifficulty(newHeight: Long, prevDifficulty: Long, prevTimes: Seq[TimeProvider.Time]): Long = {
 
     val averageDelay = (prevTimes drop 1, prevTimes).zipped.map(_-_).sum / (prevTimes.length - 1)
     val targetTimeMilli = targetBlockTime(newHeight).toUnit(MILLISECONDS)

--- a/src/main/scala/co/topl/http/api/endpoints/NodeViewApiEndpoint.scala
+++ b/src/main/scala/co/topl/http/api/endpoints/NodeViewApiEndpoint.scala
@@ -145,7 +145,8 @@ case class NodeViewApiEndpoint(
     * @param id request identifier
     * @return
     */
-  private def mempool(params: Json, id: String): Future[Json] = viewAsync(_.pool.take(100).asJson)
+  private def mempool(params: Json, id: String): Future[Json] =
+    viewAsync { _.pool.take(100)(-_.dateAdded).map(_.tx).asJson }
 
   /**  #### Summary
     *    Lookup a transaction by its id

--- a/src/main/scala/co/topl/modifier/block/Block.scala
+++ b/src/main/scala/co/topl/modifier/block/Block.scala
@@ -9,6 +9,7 @@ import co.topl.modifier.block.PersistentNodeViewModifier.PNVMVersion
 import co.topl.modifier.transaction.Transaction
 import co.topl.modifier.{ModifierId, NodeViewModifier}
 import co.topl.modifier.box.ArbitBox
+import co.topl.utils.TimeProvider
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, HCursor}
 import supertagged.@@
@@ -31,7 +32,7 @@ import scala.util.Try
  * - additional data: block structure version no, timestamp etc
  */
 case class Block(parentId    : ModifierId,
-                 timestamp   : Timestamp,
+                 timestamp   : TimeProvider.Time,
                  generatorBox: ArbitBox,
                  publicKey   : PublicKeyPropositionCurve25519,
                  signature   : SignatureCurve25519,
@@ -53,8 +54,6 @@ case class Block(parentId    : ModifierId,
 }
 
 object Block {
-
-  type Timestamp = Long
 
   val modifierTypeId: Byte @@ NodeViewModifier.ModifierTypeId.Tag = ModifierTypeId @@ (3: Byte)
 
@@ -117,7 +116,7 @@ object Block {
     * @return a block to be sent to the network
     */
   def createAndSign(parentId: ModifierId,
-                    timestamp: Timestamp,
+                    timestamp: TimeProvider.Time,
                     txs: Seq[Transaction.TX],
                     generatorBox: ArbitBox,
                     publicKey: PublicKeyPropositionCurve25519,

--- a/src/main/scala/co/topl/modifier/block/BlockHeader.scala
+++ b/src/main/scala/co/topl/modifier/block/BlockHeader.scala
@@ -3,10 +3,10 @@ package co.topl.modifier.block
 import co.topl.attestation.{PublicKeyPropositionCurve25519, SignatureCurve25519}
 import co.topl.crypto.Digest32Ops
 import co.topl.modifier.NodeViewModifier.ModifierTypeId
-import co.topl.modifier.block.Block.Timestamp
 import co.topl.modifier.block.PersistentNodeViewModifier.PNVMVersion
-import co.topl.modifier.{ModifierId, NodeViewModifier}
 import co.topl.modifier.box.ArbitBox
+import co.topl.modifier.{ModifierId, NodeViewModifier}
+import co.topl.utils.TimeProvider
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor}
 import scorex.crypto.hash.Digest32
@@ -14,7 +14,7 @@ import supertagged.@@
 
 case class BlockHeader(id          : ModifierId,
                        parentId    : ModifierId,
-                       timestamp   : Timestamp,
+                       timestamp   : TimeProvider.Time,
                        generatorBox: ArbitBox,
                        publicKey   : PublicKeyPropositionCurve25519,
                        signature   : SignatureCurve25519,
@@ -53,7 +53,7 @@ object BlockHeader {
     for {
       id <- c.downField("id").as[ModifierId]
       parentId <- c.downField("parentId").as[ModifierId]
-      timestamp <- c.downField("timestamp").as[Timestamp]
+      timestamp <- c.downField("timestamp").as[TimeProvider.Time]
       generatorBox <- c.downField("generatorBox").as[ArbitBox]
       publicKey <- c.downField("publicKey").as[PublicKeyPropositionCurve25519]
       signature <- c.downField("signature").as[SignatureCurve25519]

--- a/src/main/scala/co/topl/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/co/topl/network/NodeViewSynchronizer.scala
@@ -14,7 +14,7 @@ import co.topl.network.peer.{ConnectedPeer, PenaltyType}
 import co.topl.nodeView.NodeViewHolder.ReceivableMessages.{GetNodeViewChanges, ModifiersFromRemote, TransactionsFromRemote}
 import co.topl.nodeView.history.GenericHistory._
 import co.topl.nodeView.history.HistoryReader
-import co.topl.nodeView.mempool.MemPoolReader
+import co.topl.nodeView.mempool.{MemPoolReader, UnconfirmedTx}
 import co.topl.nodeView.state.StateReader
 import co.topl.settings.{AppContext, AppSettings, NodeViewReady}
 import co.topl.utils.serialization.BifrostSerializer

--- a/src/main/scala/co/topl/nodeView/CleanupWorker.scala
+++ b/src/main/scala/co/topl/nodeView/CleanupWorker.scala
@@ -4,31 +4,28 @@ import akka.actor.{Actor, ActorRef}
 import co.topl.attestation.Address
 import co.topl.attestation.AddressEncoder.NetworkPrefix
 import co.topl.modifier.ModifierId
-import co.topl.modifier.box.{BoxId, ProgramId}
+import co.topl.modifier.box.ProgramId
 import co.topl.modifier.transaction.Transaction
 import co.topl.nodeView.CleanupWorker.RunCleanup
 import co.topl.nodeView.MempoolAuditor.CleanupDone
 import co.topl.nodeView.NodeViewHolder.ReceivableMessages.EliminateTransactions
 import co.topl.nodeView.mempool.MemPoolReader
 import co.topl.nodeView.state.StateReader
-import co.topl.settings.AppSettings
+import co.topl.settings.{AppContext, AppSettings}
 import co.topl.utils.Logging
 
-import scala.annotation.tailrec
 import scala.collection.immutable.TreeSet
-import scala.reflect.ClassTag
-import scala.util.{Failure, Success}
 
-/**
- * Performs mempool validation task on demand.
- * Validation result is sent directly to `NodeViewHolder`.
- */
-class CleanupWorker[
-  TX <: Transaction.TX,
-  SR <: StateReader[ProgramId, Address]: ClassTag,
-  MR <: MemPoolReader[TX]: ClassTag
-](nodeViewHolderRef: ActorRef,
-  settings: AppSettings)(implicit networkPrefix: NetworkPrefix) extends Actor with Logging {
+/** Performs mempool validation task on demand.
+  * Validation result is sent directly to `NodeViewHolder`.
+  */
+class CleanupWorker(nodeViewHolderRef: ActorRef, settings: AppSettings, appContext: AppContext)(implicit
+  networkPrefix:                       NetworkPrefix
+) extends Actor
+    with Logging {
+
+  type SR = StateReader[ProgramId, Address]
+  type MR = MemPoolReader[Transaction.TX]
 
   // keep some number of recently validated transactions in order
   // to avoid validating the same transactions too many times.
@@ -36,72 +33,50 @@ class CleanupWorker[
   // count validation sessions in order to perform index cleanup.
   private var epochNr: Int = 0
 
-  override def preStart(): Unit = {
+  override def preStart(): Unit =
     log.info("Cleanup worker started")
-  }
 
   override def receive: Receive = {
-    case RunCleanup(state, mempool) =>
-      runCleanup(state, mempool)
-      sender() ! CleanupDone
+    case RunCleanup(state: SR, mempool: MR) =>
+      val validIds = runCleanup(state, mempool)
+        .take(settings.application.rebroadcastCount)
+      sender() ! CleanupDone(validIds)
 
     //Should not be here, if non-expected signal comes, check logic
     case a: Any => log.warn(s"Strange input: $a")
   }
 
-  private def runCleanup[S <: SR, M <: MR](state: S, mempool: M): Unit = {
-    val toEliminate = validatePool(state, mempool)
+  private def runCleanup(state: SR, mempool: MR): Seq[ModifierId] = {
+    val (validated, toEliminate) = validatePool(state, mempool)
     if (toEliminate.nonEmpty) {
       log.info(s"${toEliminate.size} transactions from mempool were invalidated")
       nodeViewHolderRef ! EliminateTransactions(toEliminate)
     }
+    validated
   }
 
-  /**
-   * Validates transactions from mempool for some specified amount of time.
-   *
-   * @return - invalidated transaction ids
-   */
-  private def validatePool(stateReader: SR, mempool: MR): Seq[ModifierId] = {
-
+  /** Checks if the outputs of unconfirmed transactions exists in state or if the transaction has become
+   *  stale (by exceeding the mempoolTimeout). If either are true, the transaction is removed from the mempool
+    * @return - a sequence of recently validated transactions id's to be rebroadcast and a sequence of ids to remove
+    */
+  private def validatePool(stateReader: SR, mempool: MR): (Seq[ModifierId], Seq[ModifierId]) = {
 
     // Check transactions sorted by priority. Parent transaction comes before its children.
-    val txsToValidate = mempool.take(100)
+    val (validatedIds, invalidatedIds) = mempool
+      .take(100)(-_.dateAdded)
+      .filterNot(utx => validatedIndex.contains(utx.tx.id))
+      .foldLeft((Seq[ModifierId](), Seq[ModifierId]()))({
+        case ((validAcc: Seq[ModifierId], invalidAcc: Seq[ModifierId]), utx) =>
+          // if any newly created box matches a box already in the UTXO set, remove the transaction
+          val boxAlreadyExists = utx.tx.newBoxes.exists(b => stateReader.getBox(b.id).isDefined)
+          val txTimeout =
+            (appContext.timeProvider.time() - utx.dateAdded) > settings.application.mempoolTimeout.toMillis
 
-    //internal loop function validating transactions, returns validated and invalidated transaction ids
-    @tailrec
-    def validationLoop(txs: Seq[TX],
-                       validated: Seq[ModifierId],
-                       invalidated: Seq[ModifierId],
-                       etAcc: Long): (Seq[ModifierId], Seq[ModifierId]) = {
-      txs match {
-        case head :: tail if etAcc < settings.application.mempoolCleanupDuration.toNanos && !validatedIndex.contains(head.id) =>
+          if (boxAlreadyExists | txTimeout) (validAcc, utx.tx.id +: invalidAcc)
+          else (utx.tx.id +: validAcc, invalidAcc)
+      })
 
-          // TODO: JAA - This should take into account previously validated transactions from the pool.
-          val t0 = System.nanoTime()
-          val validationResult = head.semanticValidate(stateReader)
-          val t1 = System.nanoTime()
-          val accumulatedTime = etAcc + (t1 - t0)
-
-          val txId = head.id
-          validationResult match {
-            case Success(_) =>
-              validationLoop(tail, validated :+ txId, invalidated, accumulatedTime)
-            case Failure(e) =>
-              log.info(s"Transaction $txId invalidated: ${e.getMessage}")
-              validationLoop(tail, validated, invalidated :+ txId, accumulatedTime)
-          }
-        case _ :: tail if etAcc < settings.mempoolCleanupDuration.toNanos =>
-          // this transaction was validated earlier, skip it
-          validationLoop(tail, validated, invalidated, etAcc)
-        case _ =>
-          validated -> invalidated
-      }
-    }
-
-    val (validatedIds, invalidatedIds) = validationLoop(txsToValidate, Seq.empty, Seq.empty, 0L)
-
-    epochNr += 1
+    if (epochNr < Int.MaxValue) epochNr += 1 else epochNr = 0
     if (epochNr % CleanupWorker.RevisionInterval == 0) {
       // drop old index in order to check potentially outdated transactions again.
       validatedIndex = TreeSet(validatedIds: _*)
@@ -109,29 +84,25 @@ class CleanupWorker[
       validatedIndex ++= validatedIds
     }
 
-    invalidatedIds
+    validatedIds -> invalidatedIds
   }
 
 }
 
 object CleanupWorker {
 
-  /**
-   * Constant which shows on how many cleanup operations (called when a new block arrives) a transaction
-   * re-check happens.
-   *
-   * If transactions set is large and stable, then about (1/RevisionInterval)-th of the pool is checked
-   *
-   */
+  /** Constant which shows on how many cleanup operations (called when a new block arrives) a transaction
+    * re-check happens.
+    *
+    * If transactions set is large and stable, then about (1/RevisionInterval)-th of the pool is checked
+    */
   val RevisionInterval: Int = 4
 
-  /**
-   *
-   * A command to run (partial) memory pool cleanup
-   *
-   * @param validator - a state implementation which provides transaction validation
-   * @param mempool - mempool reader instance
-   */
+  /** A command to run (partial) memory pool cleanup
+    *
+    * @param stateReader - a state implementation which provides transaction validation
+    * @param mempool - mempool reader instance
+    */
   case class RunCleanup(stateReader: StateReader[ProgramId, Address], mempool: MemPoolReader[Transaction.TX])
 
 }

--- a/src/main/scala/co/topl/nodeView/CleanupWorker.scala
+++ b/src/main/scala/co/topl/nodeView/CleanupWorker.scala
@@ -1,0 +1,137 @@
+package co.topl.nodeView
+
+import akka.actor.{Actor, ActorRef}
+import co.topl.attestation.Address
+import co.topl.attestation.AddressEncoder.NetworkPrefix
+import co.topl.modifier.ModifierId
+import co.topl.modifier.box.{BoxId, ProgramId}
+import co.topl.modifier.transaction.Transaction
+import co.topl.nodeView.CleanupWorker.RunCleanup
+import co.topl.nodeView.MempoolAuditor.CleanupDone
+import co.topl.nodeView.NodeViewHolder.ReceivableMessages.EliminateTransactions
+import co.topl.nodeView.mempool.MemPoolReader
+import co.topl.nodeView.state.StateReader
+import co.topl.settings.AppSettings
+import co.topl.utils.Logging
+
+import scala.annotation.tailrec
+import scala.collection.immutable.TreeSet
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success}
+
+/**
+ * Performs mempool validation task on demand.
+ * Validation result is sent directly to `NodeViewHolder`.
+ */
+class CleanupWorker[
+  TX <: Transaction.TX,
+  SR <: StateReader[ProgramId, Address]: ClassTag,
+  MR <: MemPoolReader[TX]: ClassTag
+](nodeViewHolderRef: ActorRef,
+  settings: AppSettings)(implicit networkPrefix: NetworkPrefix) extends Actor with Logging {
+
+  // keep some number of recently validated transactions in order
+  // to avoid validating the same transactions too many times.
+  private var validatedIndex: TreeSet[ModifierId] = TreeSet.empty[ModifierId]
+  // count validation sessions in order to perform index cleanup.
+  private var epochNr: Int = 0
+
+  override def preStart(): Unit = {
+    log.info("Cleanup worker started")
+  }
+
+  override def receive: Receive = {
+    case RunCleanup(state, mempool) =>
+      runCleanup(state, mempool)
+      sender() ! CleanupDone
+
+    //Should not be here, if non-expected signal comes, check logic
+    case a: Any => log.warn(s"Strange input: $a")
+  }
+
+  private def runCleanup[S <: SR, M <: MR](state: S, mempool: M): Unit = {
+    val toEliminate = validatePool(state, mempool)
+    if (toEliminate.nonEmpty) {
+      log.info(s"${toEliminate.size} transactions from mempool were invalidated")
+      nodeViewHolderRef ! EliminateTransactions(toEliminate)
+    }
+  }
+
+  /**
+   * Validates transactions from mempool for some specified amount of time.
+   *
+   * @return - invalidated transaction ids
+   */
+  private def validatePool(stateReader: SR, mempool: MR): Seq[ModifierId] = {
+
+
+    // Check transactions sorted by priority. Parent transaction comes before its children.
+    val txsToValidate = mempool.take(100)
+
+    //internal loop function validating transactions, returns validated and invalidated transaction ids
+    @tailrec
+    def validationLoop(txs: Seq[TX],
+                       validated: Seq[ModifierId],
+                       invalidated: Seq[ModifierId],
+                       etAcc: Long): (Seq[ModifierId], Seq[ModifierId]) = {
+      txs match {
+        case head :: tail if etAcc < settings.application.mempoolCleanupDuration.toNanos && !validatedIndex.contains(head.id) =>
+
+          // TODO: JAA - This should take into account previously validated transactions from the pool.
+          val t0 = System.nanoTime()
+          val validationResult = head.semanticValidate(stateReader)
+          val t1 = System.nanoTime()
+          val accumulatedTime = etAcc + (t1 - t0)
+
+          val txId = head.id
+          validationResult match {
+            case Success(_) =>
+              validationLoop(tail, validated :+ txId, invalidated, accumulatedTime)
+            case Failure(e) =>
+              log.info(s"Transaction $txId invalidated: ${e.getMessage}")
+              validationLoop(tail, validated, invalidated :+ txId, accumulatedTime)
+          }
+        case _ :: tail if etAcc < settings.mempoolCleanupDuration.toNanos =>
+          // this transaction was validated earlier, skip it
+          validationLoop(tail, validated, invalidated, etAcc)
+        case _ =>
+          validated -> invalidated
+      }
+    }
+
+    val (validatedIds, invalidatedIds) = validationLoop(txsToValidate, Seq.empty, Seq.empty, 0L)
+
+    epochNr += 1
+    if (epochNr % CleanupWorker.RevisionInterval == 0) {
+      // drop old index in order to check potentially outdated transactions again.
+      validatedIndex = TreeSet(validatedIds: _*)
+    } else {
+      validatedIndex ++= validatedIds
+    }
+
+    invalidatedIds
+  }
+
+}
+
+object CleanupWorker {
+
+  /**
+   * Constant which shows on how many cleanup operations (called when a new block arrives) a transaction
+   * re-check happens.
+   *
+   * If transactions set is large and stable, then about (1/RevisionInterval)-th of the pool is checked
+   *
+   */
+  val RevisionInterval: Int = 4
+
+  /**
+   *
+   * A command to run (partial) memory pool cleanup
+   *
+   * @param validator - a state implementation which provides transaction validation
+   * @param mempool - mempool reader instance
+   */
+  case class RunCleanup(stateReader: StateReader[ProgramId, Address], mempool: MemPoolReader[Transaction.TX])
+
+}

--- a/src/main/scala/co/topl/nodeView/MemPoolAuditor.scala
+++ b/src/main/scala/co/topl/nodeView/MemPoolAuditor.scala
@@ -1,50 +1,53 @@
 package co.topl.nodeView
 
 import akka.actor.SupervisorStrategy.{Restart, Stop}
-import akka.actor.{Actor, ActorInitializationException, ActorKilledException, ActorRef, ActorRefFactory, DeathPactException, OneForOneStrategy, Props}
+import akka.actor.{
+  Actor,
+  ActorInitializationException,
+  ActorKilledException,
+  ActorRef,
+  ActorRefFactory,
+  DeathPactException,
+  OneForOneStrategy,
+  Props
+}
+import co.topl.attestation.Address
 import co.topl.attestation.AddressEncoder.NetworkPrefix
+import co.topl.modifier.ModifierId
 import co.topl.modifier.block.{Block, BlockHeader}
-import co.topl.modifier.box.{BoxId, ProgramId}
+import co.topl.modifier.box.ProgramId
 import co.topl.modifier.transaction.Transaction
 import co.topl.network.Broadcast
 import co.topl.network.NetworkController.ReceivableMessages.SendToNetwork
-import co.topl.network.NodeViewSynchronizer.ReceivableMessages.{ChangedMempool, ChangedState, SemanticallySuccessfulModifier}
+import co.topl.network.NodeViewSynchronizer.ReceivableMessages.{
+  ChangedMempool,
+  ChangedState,
+  SemanticallySuccessfulModifier
+}
 import co.topl.network.message.{InvData, InvSpec, Message}
 import co.topl.nodeView.CleanupWorker.RunCleanup
 import co.topl.nodeView.MempoolAuditor.CleanupDone
 import co.topl.nodeView.NodeViewHolder.ReceivableMessages.GetNodeViewChanges
 import co.topl.nodeView.mempool.MemPoolReader
 import co.topl.nodeView.state.StateReader
-import co.topl.settings.AppSettings
+import co.topl.settings.{AppContext, AppSettings, NodeViewReady}
 import co.topl.utils.Logging
 
-import scala.reflect.ClassTag
-
-// need to add comments, node ready commands, name of actor in object,
-
 import scala.concurrent.duration._
+import scala.reflect.ClassTag
 
 /** Controls mempool cleanup workflow. Watches NodeView events and delegates
   * mempool cleanup task to [[CleanupWorker]] when needed.
   * Adapted from ErgoPlatform available at https://github.com/ergoplatform/ergo
   */
 class MempoolAuditor[
-  SR <: StateReader[ProgramId, BoxId]: ClassTag,
+  SR <: StateReader[ProgramId, Address]: ClassTag,
   MR <: MemPoolReader[Transaction.TX]: ClassTag
-](nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings)(implicit
-  networkPrefix:     NetworkPrefix
-) extends Actor
+](nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings, appContext: AppContext)
+    extends Actor
     with Logging {
 
-  override def postRestart(reason: Throwable): Unit = {
-    log.error(s"Mempool auditor actor restarted due to ${reason.getMessage}", reason)
-    super.postRestart(reason)
-  }
-
-  override def postStop(): Unit = {
-    logger.info("Mempool auditor stopped")
-    super.postStop()
-  }
+  implicit val networkPrefix: NetworkPrefix = appContext.networkType.netPrefix
 
   override val supervisorStrategy: OneForOneStrategy =
     OneForOneStrategy(maxNrOfRetries = 5, withinTimeRange = 1.minute) {
@@ -63,12 +66,36 @@ class MempoolAuditor[
   private var poolReaderOpt: Option[MR] = None
 
   private val worker: ActorRef =
-    context.actorOf(Props(new CleanupWorker(nodeViewHolderRef, settings)))
+    context.actorOf(Props(new CleanupWorker(nodeViewHolderRef, settings, appContext)))
 
-  override def preStart(): Unit =
+  override def preStart(): Unit = {
     context.system.eventStream.subscribe(self, classOf[SemanticallySuccessfulModifier[_]])
+    context.system.eventStream.subscribe(self, classOf[NodeViewReady])
+  }
 
-  override def receive: Receive = awaiting
+  override def postRestart(reason: Throwable): Unit = {
+    log.error(s"Mempool auditor actor restarted due to ${reason.getMessage}", reason)
+    super.postRestart(reason)
+  }
+
+  override def postStop(): Unit = {
+    logger.info("Mempool auditor stopped")
+    super.postStop()
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////// ACTOR MESSAGE HANDLING //////////////////////////////
+
+  override def receive: Receive =
+    initialization orElse
+    nonsense
+
+  private def initialization: Receive = {
+    /** wait to start processing until the NodeViewHolder is ready * */
+    case NodeViewReady(_) =>
+      log.info(s"${Console.YELLOW}MemPool Auditor transitioning to the operational state${Console.RESET}")
+      context become awaiting
+  }
 
   private def awaiting: Receive = {
     case SemanticallySuccessfulModifier(_: Block) | SemanticallySuccessfulModifier(_: BlockHeader) =>
@@ -85,18 +112,27 @@ class MempoolAuditor[
       poolReaderOpt.foreach(mp => initiateCleanup(st, mp))
 
     case ChangedState(_) | ChangedMempool(_) => // do nothing
+
+    case _ => nonsense
   }
 
   private def working: Receive = {
-    case CleanupDone =>
+    case CleanupDone(ids) =>
       log.info("Cleanup done. Switching to awaiting mode")
-      rebroadcastTransactions()
+      rebroadcastTransactions(ids)
       stateReaderOpt = None
       poolReaderOpt = None
       context become awaiting
 
-    case _ => // ignore other triggers until work is done
+    case _ => nonsense
   }
+
+  private def nonsense: Receive = { case nonsense: Any =>
+    log.warn(s"Got unexpected input $nonsense from ${sender()}")
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////
+  //////////////////////////////// METHOD DEFINITIONS ////////////////////////////////
 
   private def initiateCleanup(state: SR, mempool: MR): Unit = {
     log.info("Initiating cleanup. Switching to working mode")
@@ -104,41 +140,58 @@ class MempoolAuditor[
     context become working // ignore other triggers until work is done
   }
 
-  private def rebroadcastTransactions(): Unit = {
+  private def rebroadcastTransactions(ids: Seq[ModifierId]): Unit = {
     log.debug("Rebroadcasting transactions")
     poolReaderOpt.foreach { pr =>
-      pr.take(settings.application.rebroadcastCount).foreach { tx =>
+      pr.getAll(ids).foreach { tx =>
         log.info(s"Rebroadcasting $tx")
         val msg = Message(
           new InvSpec(settings.network.maxInvObjects),
           Right(InvData(Transaction.modifierTypeId, Seq(tx.id))),
           None
         )
+
         networkControllerRef ! SendToNetwork(msg, Broadcast)
       }
 
     }
-
   }
 }
 
+////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////// COMPANION SINGLETON ////////////////////////////////
+
 object MempoolAuditor {
 
-  case object CleanupDone
+  val actorName = "mempoolAuditor"
+
+  case class CleanupDone(toBeBroadcast: Seq[ModifierId])
 
 }
 
+////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////// ACTOR REF HELPER //////////////////////////////////
+
 object MempoolAuditorRef {
 
-  def props(nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings)(implicit
-    networkPrefix:             NetworkPrefix
-  ): Props =
-    Props(new MempoolAuditor(nodeViewHolderRef, networkControllerRef, settings))
+  def props[
+    SR <: StateReader[ProgramId, Address]: ClassTag,
+    MR <: MemPoolReader[Transaction.TX]: ClassTag
+  ](settings: AppSettings, appContext: AppContext, nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef): Props =
+    Props(new MempoolAuditor(nodeViewHolderRef, networkControllerRef, settings, appContext))
 
-  def apply(nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings)(implicit
-    context:                   ActorRefFactory,
-    networkPrefix:             NetworkPrefix
+  def apply[
+    SR <: StateReader[ProgramId, Address]: ClassTag,
+    MR <: MemPoolReader[Transaction.TX]: ClassTag
+  ](
+    name:                 String,
+    settings:             AppSettings,
+    appContext:           AppContext,
+    nodeViewHolderRef:    ActorRef,
+    networkControllerRef: ActorRef
+  )(implicit
+    context: ActorRefFactory
   ): ActorRef =
-    context.actorOf(props(nodeViewHolderRef, networkControllerRef, settings))
+    context.actorOf(props(settings, appContext, nodeViewHolderRef, networkControllerRef), name)
 
 }

--- a/src/main/scala/co/topl/nodeView/MemPoolAuditor.scala
+++ b/src/main/scala/co/topl/nodeView/MemPoolAuditor.scala
@@ -1,0 +1,144 @@
+package co.topl.nodeView
+
+import akka.actor.SupervisorStrategy.{Restart, Stop}
+import akka.actor.{Actor, ActorInitializationException, ActorKilledException, ActorRef, ActorRefFactory, DeathPactException, OneForOneStrategy, Props}
+import co.topl.attestation.AddressEncoder.NetworkPrefix
+import co.topl.modifier.block.{Block, BlockHeader}
+import co.topl.modifier.box.{BoxId, ProgramId}
+import co.topl.modifier.transaction.Transaction
+import co.topl.network.Broadcast
+import co.topl.network.NetworkController.ReceivableMessages.SendToNetwork
+import co.topl.network.NodeViewSynchronizer.ReceivableMessages.{ChangedMempool, ChangedState, SemanticallySuccessfulModifier}
+import co.topl.network.message.{InvData, InvSpec, Message}
+import co.topl.nodeView.CleanupWorker.RunCleanup
+import co.topl.nodeView.MempoolAuditor.CleanupDone
+import co.topl.nodeView.NodeViewHolder.ReceivableMessages.GetNodeViewChanges
+import co.topl.nodeView.mempool.MemPoolReader
+import co.topl.nodeView.state.StateReader
+import co.topl.settings.AppSettings
+import co.topl.utils.Logging
+
+import scala.reflect.ClassTag
+
+// need to add comments, node ready commands, name of actor in object,
+
+import scala.concurrent.duration._
+
+/** Controls mempool cleanup workflow. Watches NodeView events and delegates
+  * mempool cleanup task to [[CleanupWorker]] when needed.
+  * Adapted from ErgoPlatform available at https://github.com/ergoplatform/ergo
+  */
+class MempoolAuditor[
+  SR <: StateReader[ProgramId, BoxId]: ClassTag,
+  MR <: MemPoolReader[Transaction.TX]: ClassTag
+](nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings)(implicit
+  networkPrefix:     NetworkPrefix
+) extends Actor
+    with Logging {
+
+  override def postRestart(reason: Throwable): Unit = {
+    log.error(s"Mempool auditor actor restarted due to ${reason.getMessage}", reason)
+    super.postRestart(reason)
+  }
+
+  override def postStop(): Unit = {
+    logger.info("Mempool auditor stopped")
+    super.postStop()
+  }
+
+  override val supervisorStrategy: OneForOneStrategy =
+    OneForOneStrategy(maxNrOfRetries = 5, withinTimeRange = 1.minute) {
+      case _: ActorKilledException => Stop
+      case _: DeathPactException   => Stop
+      case e: ActorInitializationException =>
+        log.warn(s"Cleanup worker failed during initialization with: $e")
+        Stop
+      case e: Exception =>
+        log.warn(s"Cleanup worker failed with: $e")
+        context become awaiting // turn ctx into awaiting mode if worker failed
+        Restart
+    }
+
+  private var stateReaderOpt: Option[SR] = None
+  private var poolReaderOpt: Option[MR] = None
+
+  private val worker: ActorRef =
+    context.actorOf(Props(new CleanupWorker(nodeViewHolderRef, settings)))
+
+  override def preStart(): Unit =
+    context.system.eventStream.subscribe(self, classOf[SemanticallySuccessfulModifier[_]])
+
+  override def receive: Receive = awaiting
+
+  private def awaiting: Receive = {
+    case SemanticallySuccessfulModifier(_: Block) | SemanticallySuccessfulModifier(_: BlockHeader) =>
+      stateReaderOpt = None
+      poolReaderOpt = None
+      nodeViewHolderRef ! GetNodeViewChanges(history = false, state = true, mempool = true)
+
+    case ChangedMempool(mp: MR) =>
+      poolReaderOpt = Some(mp)
+      stateReaderOpt.foreach(st => initiateCleanup(st, mp))
+
+    case ChangedState(st: SR) =>
+      stateReaderOpt = Some(st)
+      poolReaderOpt.foreach(mp => initiateCleanup(st, mp))
+
+    case ChangedState(_) | ChangedMempool(_) => // do nothing
+  }
+
+  private def working: Receive = {
+    case CleanupDone =>
+      log.info("Cleanup done. Switching to awaiting mode")
+      rebroadcastTransactions()
+      stateReaderOpt = None
+      poolReaderOpt = None
+      context become awaiting
+
+    case _ => // ignore other triggers until work is done
+  }
+
+  private def initiateCleanup(state: SR, mempool: MR): Unit = {
+    log.info("Initiating cleanup. Switching to working mode")
+    worker ! RunCleanup(state, mempool)
+    context become working // ignore other triggers until work is done
+  }
+
+  private def rebroadcastTransactions(): Unit = {
+    log.debug("Rebroadcasting transactions")
+    poolReaderOpt.foreach { pr =>
+      pr.take(settings.application.rebroadcastCount).foreach { tx =>
+        log.info(s"Rebroadcasting $tx")
+        val msg = Message(
+          new InvSpec(settings.network.maxInvObjects),
+          Right(InvData(Transaction.modifierTypeId, Seq(tx.id))),
+          None
+        )
+        networkControllerRef ! SendToNetwork(msg, Broadcast)
+      }
+
+    }
+
+  }
+}
+
+object MempoolAuditor {
+
+  case object CleanupDone
+
+}
+
+object MempoolAuditorRef {
+
+  def props(nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings)(implicit
+    networkPrefix:             NetworkPrefix
+  ): Props =
+    Props(new MempoolAuditor(nodeViewHolderRef, networkControllerRef, settings))
+
+  def apply(nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings)(implicit
+    context:                   ActorRefFactory,
+    networkPrefix:             NetworkPrefix
+  ): ActorRef =
+    context.actorOf(props(nodeViewHolderRef, networkControllerRef, settings))
+
+}

--- a/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
+++ b/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
@@ -34,7 +34,7 @@ import scala.util.{Failure, Success, Try}
   * The instances are read-only for external world.
   * Updates of the composite view(the instances are to be performed atomically.
   */
-class NodeViewHolder ( settings: AppSettings )
+class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
                      ( implicit ec: ExecutionContext, np: NetworkPrefix ) extends Actor with Logging {
 
   // Import the types of messages this actor can RECEIVE
@@ -236,10 +236,10 @@ class NodeViewHolder ( settings: AppSettings )
     *
     * @param tx
     */
-  protected def txModify(tx: TX): Unit = {
+  protected def txModify(tx: TX): Unit =
     tx.syntacticValidate match {
       case Success(_) =>
-        memoryPool().put(tx) match {
+        memoryPool().put(tx, appContext.timeProvider.time()) match {
           case Success(_) =>
             log.debug(s"Unconfirmed transaction $tx added to the memory pool")
             context.system.eventStream.publish(SuccessfulTransaction[TX](tx))
@@ -251,7 +251,6 @@ class NodeViewHolder ( settings: AppSettings )
       case Failure(e) =>
         context.system.eventStream.publish(FailedTransaction(tx.id, e, immediateFailure = true))
     }
-  }
 
   //todo: update state in async way?
   /**
@@ -438,7 +437,7 @@ class NodeViewHolder ( settings: AppSettings )
     val appliedTxs = blocksApplied.flatMap(extractTransactions)
 
     memPool
-      .putWithoutCheck(rolledBackTxs)
+      .putWithoutCheck(rolledBackTxs, appContext.timeProvider.time())
       .filter { tx =>
         !appliedTxs.exists(t => t.id == tx.id) && {
           state.semanticValidate(tx).isSuccess
@@ -527,7 +526,7 @@ object NodeViewHolderRef {
 
   def props ( settings: AppSettings, appContext: AppContext )
             ( implicit ec: ExecutionContext ): Props =
-    Props(new NodeViewHolder(settings)(ec, appContext.networkType.netPrefix))
+    Props(new NodeViewHolder(settings, appContext)(ec, appContext.networkType.netPrefix))
 
   def apply ( name: String, settings: AppSettings, appContext: AppContext )
             ( implicit system: ActorSystem, ec: ExecutionContext ): ActorRef =

--- a/src/main/scala/co/topl/nodeView/history/BlockProcessor.scala
+++ b/src/main/scala/co/topl/nodeView/history/BlockProcessor.scala
@@ -5,7 +5,7 @@ import co.topl.modifier.ModifierId
 import co.topl.modifier.block.Block
 import co.topl.nodeView.history.BlockProcessor.ChainCache
 import co.topl.nodeView.history.GenericHistory.ProgressInfo
-import co.topl.utils.Logging
+import co.topl.utils.{Logging, TimeProvider}
 
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeMap
@@ -120,7 +120,7 @@ object BlockProcessor extends Logging {
   def emptyCache: ChainCache = ChainCache(TreeMap.empty)
 
   /** Wrapper for storing a block and its height in the chain cache */
-  case class CacheBlock(block: Block, prevBlockTimes: Seq[Block.Timestamp])
+  case class CacheBlock(block: Block, prevBlockTimes: Seq[TimeProvider.Time])
 
   /** Stores links mapping ((id, height) -> parentId) of blocks that could possibly be applied. */
   case class ChainCache(cache: TreeMap[CacheBlock, ModifierId]) {
@@ -139,7 +139,7 @@ object BlockProcessor extends Logging {
     def getHeight(id: ModifierId): Option[Long] =
       cache.keys.find(k ⇒ k.block.id == id).map(_.block.height)
 
-    def add(block: Block, prevTimes: Seq[Block.Timestamp]): ChainCache = {
+    def add(block: Block, prevTimes: Seq[TimeProvider.Time]): ChainCache = {
       val cacheBlock = CacheBlock(block, prevTimes)
 
       log.debug(s"Added new block to chain cache: ${cacheBlock.block.id.toString}")

--- a/src/main/scala/co/topl/nodeView/history/History.scala
+++ b/src/main/scala/co/topl/nodeView/history/History.scala
@@ -484,7 +484,7 @@ object History extends Logging {
   /** Gets the timestamps for 'count' number of blocks prior to (and including) the startBlock */
   def getTimestamps(storage: Storage, count: Long, startBlock: Block): Vector[TimeProvider.Time] = {
     @tailrec
-    def loop(id: ModifierId, acc: Vector[Block.Timestamp] = Vector()): Vector[TimeProvider.Time] = {
+    def loop(id: ModifierId, acc: Vector[TimeProvider.Time] = Vector()): Vector[TimeProvider.Time] = {
       if (acc.length > count) acc
       else storage.parentIdOf(id) match {
         case Some(parentId: ModifierId) =>

--- a/src/main/scala/co/topl/nodeView/history/History.scala
+++ b/src/main/scala/co/topl/nodeView/history/History.scala
@@ -11,7 +11,7 @@ import co.topl.network.message.BifrostSyncInfo
 import co.topl.nodeView.history.GenericHistory._
 import co.topl.nodeView.history.History.GenesisParentId
 import co.topl.settings.AppSettings
-import co.topl.utils.Logging
+import co.topl.utils.{Logging, TimeProvider}
 import io.iohk.iodb.LSMStore
 
 import scala.annotation.tailrec
@@ -237,7 +237,7 @@ class History ( val storage: Storage, //todo: JAA - make this private[history]
     else Option(loop(startBlock, Seq(startBlock)).map(_.id).reverse)
   }
 
-  def getTimestampsFrom(startBlock: Block, count: Long): Vector[Block.Timestamp] =
+  def getTimestampsFrom(startBlock: Block, count: Long): Vector[TimeProvider.Time] =
     History.getTimestamps(storage, count, startBlock)
 
   /** Retrieve a sequence of blocks until the given filter is satisifed
@@ -482,9 +482,9 @@ object History extends Logging {
   }
 
   /** Gets the timestamps for 'count' number of blocks prior to (and including) the startBlock */
-  def getTimestamps(storage: Storage, count: Long, startBlock: Block): Vector[Block.Timestamp] = {
+  def getTimestamps(storage: Storage, count: Long, startBlock: Block): Vector[TimeProvider.Time] = {
     @tailrec
-    def loop(id: ModifierId, acc: Vector[Block.Timestamp] = Vector()): Vector[Block.Timestamp] = {
+    def loop(id: ModifierId, acc: Vector[Block.Timestamp] = Vector()): Vector[TimeProvider.Time] = {
       if (acc.length > count) acc
       else storage.parentIdOf(id) match {
         case Some(parentId: ModifierId) =>

--- a/src/main/scala/co/topl/nodeView/mempool/MemPool.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPool.scala
@@ -8,7 +8,7 @@ import co.topl.utils.Logging
 import scala.collection.concurrent.TrieMap
 import scala.util.Try
 
-case class MemPool(unconfirmed: TrieMap[ModifierId, Transaction.TX])
+case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
   extends MemoryPool[Transaction.TX, MemPool] with Logging {
 
   override type NVCT = MemPool

--- a/src/main/scala/co/topl/nodeView/mempool/MemPool.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPool.scala
@@ -6,6 +6,7 @@ import co.topl.modifier.transaction.Transaction
 import co.topl.utils.{Logging, TimeProvider}
 
 import scala.collection.concurrent.TrieMap
+import scala.math.Ordering
 import scala.util.Try
 
 case class MemPool(private val unconfirmed: TrieMap[ModifierId, UnconfirmedTx[Transaction.TX]])
@@ -77,8 +78,8 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, UnconfirmedTx[Tr
    * @param limit
    * @return
    */
-  override def take(limit: Int): Iterable[UnconfirmedTx[TX]] =
-    unconfirmed.values.toSeq.sortBy(-_.tx.fee).take(limit)
+  override def take[A](limit: Int)(f: UnconfirmedTx[TX] => A)(implicit ord: Ordering[A]): Iterable[UnconfirmedTx[TX]] =
+    unconfirmed.values.toSeq.sortBy(f).take(limit)
 
   /**
    *

--- a/src/main/scala/co/topl/nodeView/mempool/MemPool.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPool.scala
@@ -1,14 +1,14 @@
 package co.topl.nodeView.mempool
 
 import co.topl.modifier.ModifierId
-import co.topl.modifier.transaction.Transaction
 import co.topl.modifier.box.BoxId
-import co.topl.utils.Logging
+import co.topl.modifier.transaction.Transaction
+import co.topl.utils.{Logging, TimeProvider}
 
 import scala.collection.concurrent.TrieMap
 import scala.util.Try
 
-case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
+case class MemPool(private val unconfirmed: TrieMap[ModifierId, UnconfirmedTx[Transaction.TX]])
   extends MemoryPool[Transaction.TX, MemPool] with Logging {
 
   override type NVCT = MemPool
@@ -17,7 +17,7 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
   private val boxesInMempool = new TrieMap[BoxId, BoxId]()
 
   //getters
-  override def modifierById(id: ModifierId): Option[TX] = unconfirmed.get(id)
+  override def modifierById(id: ModifierId): Option[TX] = unconfirmed.get(id).map(_.tx)
 
   override def contains(id: ModifierId): Boolean = unconfirmed.contains(id)
 
@@ -26,8 +26,8 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
   override def size: Int = unconfirmed.size
 
   //modifiers
-  override def put(tx: TX): Try[MemPool] = Try {
-    unconfirmed.put(tx.id, tx)
+  override def put(tx: TX, time: TimeProvider.Time): Try[MemPool] = Try {
+    unconfirmed.put(tx.id, UnconfirmedTx(tx, time))
     tx.boxIdsToOpen.foreach(boxId => require(!boxesInMempool.contains(boxId)))
     tx.boxIdsToOpen.foreach(boxId => boxesInMempool.put(boxId, boxId))
     this
@@ -38,8 +38,8 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
    * @param txs
    * @return
    */
-  override def put(txs: Iterable[TX]): Try[MemPool] = Try {
-    txs.foreach(tx => unconfirmed.put(tx.id, tx))
+  override def put(txs: Iterable[TX], time: TimeProvider.Time): Try[MemPool] = Try {
+    txs.foreach(tx => unconfirmed.put(tx.id, UnconfirmedTx(tx, time)))
     txs.foreach(tx => tx.boxIdsToOpen.foreach {
       boxId => require(!boxesInMempool.contains(boxId))
     })
@@ -54,8 +54,8 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
    * @param txs
    * @return
    */
-  override def putWithoutCheck(txs: Iterable[TX]): MemPool = {
-    txs.foreach(tx => unconfirmed.put(tx.id, tx))
+  override def putWithoutCheck(txs: Iterable[TX], time: TimeProvider.Time): MemPool = {
+    txs.foreach(tx => unconfirmed.put(tx.id, UnconfirmedTx(tx, time)))
     txs.foreach(tx => tx.boxIdsToOpen.map {
       boxId => boxesInMempool.put(boxId, boxId)
     })
@@ -77,8 +77,8 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
    * @param limit
    * @return
    */
-  override def take(limit: Int): Iterable[TX] =
-    unconfirmed.values.toSeq.sortBy(-_.fee).take(limit)
+  override def take(limit: Int): Iterable[UnconfirmedTx[TX]] =
+    unconfirmed.values.toSeq.sortBy(-_.tx.fee).take(limit)
 
   /**
    *
@@ -87,10 +87,10 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
    */
   override def filter(condition: TX => Boolean): MemPool = {
     unconfirmed.retain { (_, v) =>
-      if (condition(v)) {
+      if (condition(v.tx)) {
         true
       } else {
-        v.boxIdsToOpen.foreach(boxId => {
+        v.tx.boxIdsToOpen.foreach(boxId => {
           boxesInMempool -= (boxId: BoxId)
         })
         false
@@ -104,4 +104,5 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
 
 object MemPool {
   lazy val emptyPool: MemPool = MemPool(TrieMap())
+
 }

--- a/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
@@ -1,12 +1,18 @@
 package co.topl.nodeView.mempool
 
+import co.topl.modifier.transaction.Transaction
 import co.topl.modifier.{ContainsModifiers, ModifierId, NodeViewModifier}
 import co.topl.nodeView.NodeViewComponent
+import co.topl.utils.TimeProvider
+
+import scala.math.Ordering
+
+case class UnconfirmedTx[TX <: Transaction.TX](tx: TX, dateAdded: TimeProvider.Time)
 
 /**
   * Unconfirmed transactions pool
   */
-trait MemPoolReader[TX <: NodeViewModifier]
+trait MemPoolReader[TX <: Transaction.TX]
   extends NodeViewComponent with ContainsModifiers[TX] {
 
   //getters
@@ -21,6 +27,6 @@ trait MemPoolReader[TX <: NodeViewModifier]
 
   def size: Int
 
-  def take(limit: Int): Iterable[UnconfirmedTx[TX]]
+  def take[A](limit: Int)(f: UnconfirmedTx[TX] => A)(implicit ord: Ordering[A]): Iterable[UnconfirmedTx[TX]]
 
 }

--- a/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
@@ -21,6 +21,6 @@ trait MemPoolReader[TX <: NodeViewModifier]
 
   def size: Int
 
-  def take(limit: Int): Iterable[TX]
+  def take(limit: Int): Iterable[UnconfirmedTx[TX]]
 
 }

--- a/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
@@ -21,6 +21,6 @@ trait MemPoolReader[TX <: NodeViewModifier]
 
   def size: Int
 
-  def take( limit: Int): Iterable[TX]
+  def take(limit: Int): Iterable[TX]
 
 }

--- a/src/main/scala/co/topl/nodeView/mempool/MemoryPool.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemoryPool.scala
@@ -16,17 +16,8 @@ import scala.util.Try
 trait MemoryPool[TX <: Transaction.TX, M <: MemoryPool[TX, M]]
   extends NodeViewComponent with MemPoolReader[TX] {
 
-//  //getters
-//  def modifierById(id: ModifierId): Option[TX]
-//
-//  def contains(id: ModifierId): Boolean
-
   //get ids from Seq, not presenting in mempool
   override def notIn(ids: Seq[ModifierId]): Seq[ModifierId] = ids.filter(id => !contains(id))
-//
-//  def getAll(ids: Seq[ModifierId]): Seq[TX]
-//
-//  def take[A](limit: Int)(f: UnconfirmedTx[TX] => A)(implicit ord: Ordering[A]): Iterable[UnconfirmedTx[TX]]
 
   //modifiers
   def put(tx: TX, time: TimeProvider.Time): Try[M]

--- a/src/main/scala/co/topl/nodeView/mempool/MemoryPool.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemoryPool.scala
@@ -3,8 +3,11 @@ package co.topl.nodeView.mempool
 import co.topl.modifier.ModifierId
 import co.topl.modifier.transaction.Transaction
 import co.topl.nodeView.NodeViewComponent
+import co.topl.utils.TimeProvider
 
 import scala.util.Try
+
+case class UnconfirmedTx[TX <: Transaction[_,_]](tx: TX, dateAdded: TimeProvider.Time)
 
 /**
   * Unconfirmed transactions pool
@@ -24,16 +27,16 @@ trait MemoryPool[TX <: Transaction[_,_], M <: MemoryPool[TX, M]]
 
   def getAll(ids: Seq[ModifierId]): Seq[TX]
 
+  def take(limit: Int): Iterable[UnconfirmedTx[TX]]
+
   //modifiers
-  def put(tx: TX): Try[M]
+  def put(tx: TX, time: TimeProvider.Time): Try[M]
 
-  def put(txs: Iterable[TX]): Try[M]
+  def put(txs: Iterable[TX], time: TimeProvider.Time): Try[M]
 
-  def putWithoutCheck(txs: Iterable[TX]): M
+  def putWithoutCheck(txs: Iterable[TX], time: TimeProvider.Time): M
 
   def remove(tx: TX): M
-
-  def take(limit: Int): Iterable[TX]
 
   def filter(txs: Seq[TX]): M = filter(t => !txs.exists(_.id == t.id))
 
@@ -46,3 +49,4 @@ trait MemoryPool[TX <: Transaction[_,_], M <: MemoryPool[TX, M]]
     */
   def getReader: MemPoolReader[TX] = this
 }
+

--- a/src/main/scala/co/topl/nodeView/mempool/MemoryPool.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemoryPool.scala
@@ -5,29 +5,28 @@ import co.topl.modifier.transaction.Transaction
 import co.topl.nodeView.NodeViewComponent
 import co.topl.utils.TimeProvider
 
+import scala.math.Ordering
 import scala.util.Try
-
-case class UnconfirmedTx[TX <: Transaction[_,_]](tx: TX, dateAdded: TimeProvider.Time)
 
 /**
   * Unconfirmed transactions pool
   *
   * @tparam M -type of this memory pool
   */
-trait MemoryPool[TX <: Transaction[_,_], M <: MemoryPool[TX, M]]
+trait MemoryPool[TX <: Transaction.TX, M <: MemoryPool[TX, M]]
   extends NodeViewComponent with MemPoolReader[TX] {
 
-  //getters
-  def modifierById(id: ModifierId): Option[TX]
-
-  def contains(id: ModifierId): Boolean
+//  //getters
+//  def modifierById(id: ModifierId): Option[TX]
+//
+//  def contains(id: ModifierId): Boolean
 
   //get ids from Seq, not presenting in mempool
   override def notIn(ids: Seq[ModifierId]): Seq[ModifierId] = ids.filter(id => !contains(id))
-
-  def getAll(ids: Seq[ModifierId]): Seq[TX]
-
-  def take(limit: Int): Iterable[UnconfirmedTx[TX]]
+//
+//  def getAll(ids: Seq[ModifierId]): Seq[TX]
+//
+//  def take[A](limit: Int)(f: UnconfirmedTx[TX] => A)(implicit ord: Ordering[A]): Iterable[UnconfirmedTx[TX]]
 
   //modifiers
   def put(tx: TX, time: TimeProvider.Time): Try[M]
@@ -41,8 +40,6 @@ trait MemoryPool[TX <: Transaction[_,_], M <: MemoryPool[TX, M]]
   def filter(txs: Seq[TX]): M = filter(t => !txs.exists(_.id == t.id))
 
   def filter(condition: TX => Boolean): M
-
-  def size: Int
 
   /**
     * @return read-only copy of this state

--- a/src/main/scala/co/topl/settings/AppSettings.scala
+++ b/src/main/scala/co/topl/settings/AppSettings.scala
@@ -20,7 +20,7 @@ case class ApplicationSettings(
   version:     Version,
   cacheExpire: Int,
   cacheSize:   Int,
-  mempoolCleanupDuration: FiniteDuration,
+  mempoolTimeout: FiniteDuration,
   rebroadcastCount: Int
 )
 

--- a/src/main/scala/co/topl/settings/AppSettings.scala
+++ b/src/main/scala/co/topl/settings/AppSettings.scala
@@ -19,7 +19,9 @@ case class ApplicationSettings(
   nodeKeys:    Option[Set[String]],
   version:     Version,
   cacheExpire: Int,
-  cacheSize:   Int
+  cacheSize:   Int,
+  mempoolCleanupDuration: FiniteDuration,
+  rebroadcastCount: Int
 )
 
 case class RPCApiSettings(

--- a/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
+++ b/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
@@ -17,7 +17,7 @@ class NodeViewRPCSpec extends AnyWordSpec
   val block: Block = blockGen.sample.get.copy(transactions = txs)
 
   view().history.storage.update(block, isBest = false)
-  view().pool.putWithoutCheck(txs)
+  view().pool.putWithoutCheck(txs, block.timestamp)
 
   "NodeView RPC" should {
     "Get first 100 transactions in mempool" in {


### PR DESCRIPTION
## Summary
A mempool auditor is needed to allow non-forging nodes to have a method to clear their mempools. Currently, forging and the receipt of blocks are the only way to remove transactions from a mempool. However, due to network latency, a transaction may get rebraodcast between two nodes while a block is in transit. This will result in a node hearing about a transaction that was previously included in a block but having no way to remove the transaction from their mempool (unless they are a forging node). This auditor helps to alleviate this issue as it has become troublesome of Monon

## Changes
- changed timestamp to use type defined in Timeprovider
- refacotred mempool filter to expose the sort function that sorts the returned result
- added an unconfirmed class to wrap mempool transactions, this class addes dateAdded to so we can expire transactions
- added a mempool auditor and cleanup worker actor that periodically check for outdated and invalid transactions
- included the pattern matching refactor done by Nick in an alternate branch for the pickTransactions function in Forger
- nodeView Api endpoint method 'topl_mempool' now returns the 100 most recently added transactions
- removed unneeded functions in MemoryPool trait (they are already defined in it's parent)
- added mempoolTimeout and reBroadcastCount to AppSettings. These are settings for the mempool auditor

## Testing
Tested by hand using BramblSc and a modified version of the mempool auditor. This was done by turning on a node without forging and with the mempool timeout lowered to 30 seconds. I then used BramblSc to submit a transaction that showed up in the Mempool and was later validated by the Auditor (using a forced query). After the timeout expired I then saw the auditor remove the transaction from the mempool. 

The screen shot below shows the transaction coming in, being queried and eventually being removed from the mempool.
![image](https://user-images.githubusercontent.com/1753335/107326234-ee74c700-6a5f-11eb-8652-0a8c3d1d6f2a.png)
