### PR TITLE
fixes #1012

### DIFF
--- a/src/main/scala/co/topl/attestation/Proposition.scala
+++ b/src/main/scala/co/topl/attestation/Proposition.scala
@@ -76,7 +76,7 @@ object PublicKeyPropositionCurve25519 {
 
   implicit val evProducer: EvidenceProducer[PublicKeyPropositionCurve25519] =
     EvidenceProducer.instance[PublicKeyPropositionCurve25519] {
-      prop: PublicKeyPropositionCurve25519 => Evidence(typePrefix, EvidenceContent @@ Blake2b256(prop.bytes))
+      prop: PublicKeyPropositionCurve25519 => Evidence(typePrefix, EvidenceContent @@ Blake2b256(prop.bytes.tail))
     }
 
   implicit val identifier: Identifiable[PublicKeyPropositionCurve25519] = Identifiable.instance { () =>
@@ -122,7 +122,7 @@ object ThresholdPropositionCurve25519 {
 
   implicit val evProducer: EvidenceProducer[ThresholdPropositionCurve25519] =
     EvidenceProducer.instance[ThresholdPropositionCurve25519] {
-      prop: ThresholdPropositionCurve25519 => Evidence(typePrefix, EvidenceContent @@ Blake2b256(prop.bytes))
+      prop: ThresholdPropositionCurve25519 => Evidence(typePrefix, EvidenceContent @@ Blake2b256(prop.bytes.tail))
     }
 
   implicit val identifier: Identifiable[ThresholdPropositionCurve25519] = Identifiable.instance { () =>

--- a/src/main/scala/co/topl/crypto/KeyfileCurve25519.scala
+++ b/src/main/scala/co/topl/crypto/KeyfileCurve25519.scala
@@ -69,7 +69,7 @@ object KeyfileCurve25519 extends KeyfileCompanion[PrivateKeyCurve25519, KeyfileC
           val privateKey = new PrivateKeyCurve25519(PrivateKey @@ skBytes, PublicKey @@ pkBytes)
           val derivedAddress = Address.from(privateKey.publicImage)
           // check that the address given in the keyfile matches the public key
-          require(encryptedKeyFile.address == derivedAddress, "PublicKey in file is invalid")
+          require(encryptedKeyFile.address == derivedAddress, "Derived address does not match that listed in the keyfile")
           privateKey
       }
     }

--- a/src/test/scala/co/topl/modifier/BloomFilterSpec.scala
+++ b/src/test/scala/co/topl/modifier/BloomFilterSpec.scala
@@ -74,6 +74,6 @@ class BloomFilterSpec
       else count
     }
 
-    falsePositives shouldEqual 12
+    falsePositives shouldEqual 15
   }
 }


### PR DESCRIPTION
There was an issue with an extra byte being added to the evidence of a proposition due to using the `.bytes` method. This has been resolved by adding `.tail` to pop off the head byte.