### PR TITLE
added 128 bit class

### DIFF
--- a/src/main/scala/co/topl/consensus/Forger.scala
+++ b/src/main/scala/co/topl/consensus/Forger.scala
@@ -48,7 +48,7 @@ class Forger(settings: AppSettings, appContext: AppContext)(implicit ec: Executi
   private var rewardAddress: Option[Address] = None
 
   // a timestamp updated on each forging attempt
-  private var forgeTime: Time = appContext.timeProvider.time()
+  private var forgeTime: Time = appContext.timeProvider.time
 
   override def preStart(): Unit = {
     // determine the set of applicable protocol rules for this software version
@@ -129,7 +129,7 @@ class Forger(settings: AppSettings, appContext: AppContext)(implicit ec: Executi
   ////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////// METHOD DEFINITIONS ////////////////////////////////
   /** Updates the forging actors timestamp */
-  private def updateForgeTime(): Unit = forgeTime = appContext.timeProvider.time()
+  private def updateForgeTime(): Unit = forgeTime = appContext.timeProvider.time
 
   /** Updates the rewards address from the API */
   private def updateRewardsAddress(address: Address): String = {

--- a/src/main/scala/co/topl/consensus/genesis/PrivateTestnet.scala
+++ b/src/main/scala/co/topl/consensus/genesis/PrivateTestnet.scala
@@ -9,6 +9,7 @@ import co.topl.modifier.block.Block
 import co.topl.modifier.transaction.{ArbitTransfer, PolyTransfer}
 import co.topl.modifier.box.{ArbitBox, SimpleValue}
 import co.topl.settings.{AppSettings, Version}
+import co.topl.utils.Int128
 
 import scala.util.Try
 
@@ -38,14 +39,15 @@ case class PrivateTestnet ( keyGen  : (Int, Option[String]) => Set[PublicKeyProp
     // map the members to their balances then continue as normal
     val privateTotalStake = numberOfKeys * balance
 
-    val accts = keyGen(numberOfKeys, settings.forging.privateTestnet.flatMap(_.genesisSeed))
+    val accts: Set[PublicKeyPropositionCurve25519] =
+      keyGen(numberOfKeys, settings.forging.privateTestnet.flatMap(_.genesisSeed))
 
     val txInput = (
       IndexedSeq(),
       (genesisAcct.publicImage.address -> SimpleValue(0L)) +:
         accts.map(_.address -> SimpleValue(balance)).toIndexedSeq,
       Map(genesisAcct.publicImage -> SignatureCurve25519.genesis),
-      0L,
+      Int128(0),
       0L,
       None,
       true)

--- a/src/main/scala/co/topl/http/api/endpoints/NodeViewApiEndpoint.scala
+++ b/src/main/scala/co/topl/http/api/endpoints/NodeViewApiEndpoint.scala
@@ -10,6 +10,7 @@ import co.topl.nodeView.mempool.MemPool
 import co.topl.nodeView.state.State
 import co.topl.modifier.box._
 import co.topl.settings.{AppContext, RPCApiSettings}
+import co.topl.utils.Int128
 import io.circe.Json
 import io.circe.syntax._
 
@@ -22,6 +23,9 @@ case class NodeViewApiEndpoint(
   nodeViewHolderRef:     ActorRef
 )(implicit val context:  ActorRefFactory)
     extends ApiEndpointWithView {
+
+  import co.topl.utils.codecs.Int128Codec._
+
   type HIS = History
   type MS = State
   type MP = MemPool
@@ -109,18 +113,18 @@ case class NodeViewApiEndpoint(
             k -> orderedBoxes
           }.toMap
 
-        val balances: Map[Address, Map[String, Long]] =
+        val balances: Map[Address, Map[String, Int128]] =
           boxes.map { case (addr, assets) =>
             addr -> assets.map { case (boxType, boxes) =>
-              (boxType, boxes.map(_.value.quantity).sum)
+              (boxType, boxes.map(_.value.quantity).reduce(_ + _))
             }
           }
 
         boxes.map { case (addr, boxes) =>
           addr -> Map(
             "Balances" -> Map(
-              "Polys"  -> balances(addr).getOrElse(PolyBox.typeString, 0L),
-              "Arbits" -> balances(addr).getOrElse(ArbitBox.typeString, 0L)
+              "Polys"  -> balances(addr).getOrElse(PolyBox.typeString, Int128(0)),
+              "Arbits" -> balances(addr).getOrElse(ArbitBox.typeString, Int128(0))
             ).asJson,
             "Boxes" -> boxes.map(b => b._1 -> b._2.asJson).asJson
           )

--- a/src/main/scala/co/topl/http/api/endpoints/TransactionApiEndpoint.scala
+++ b/src/main/scala/co/topl/http/api/endpoints/TransactionApiEndpoint.scala
@@ -11,6 +11,8 @@ import co.topl.nodeView.mempool.MemPool
 import co.topl.nodeView.state.State
 import co.topl.modifier.box.{AssetValue, SimpleValue}
 import co.topl.settings.{AppContext, RPCApiSettings}
+import co.topl.utils.Int128
+import co.topl.utils.codecs.Int128Codec
 import io.circe.Json
 import io.circe.syntax._
 import scorex.util.encode.Base58
@@ -28,6 +30,8 @@ case class TransactionApiEndpoint(
   appContext:        AppContext,
   nodeViewHolderRef: ActorRef
 )(implicit val ec:   ExecutionContext) extends ApiEndpointWithView {
+
+  import Int128Codec._
 
   type HIS = History
   type MS = State
@@ -86,7 +90,7 @@ case class TransactionApiEndpoint(
         sender            <- p.get[IndexedSeq[Address]]("sender")
         changeAddr        <- p.get[Address]("changeAddress")
         consolidationAddr <- p.get[Option[Address]]("consolidationAddress")
-        fee               <- p.get[Long]("fee")
+        fee               <- p.get[Int128]("fee")(Int128Codec.jsonDecoder)
         minting           <- p.get[Boolean]("minting")
         data              <- p.get[Option[String]]("data")
       } yield {
@@ -175,10 +179,10 @@ case class TransactionApiEndpoint(
       // parse arguments from the request
       (for {
         propType   <- p.get[String]("propositionType")
-        recipients <- p.get[IndexedSeq[(Address, Long)]]("recipients")
+        recipients <- p.get[IndexedSeq[(Address, Int128)]]("recipients")
         sender     <- p.get[IndexedSeq[Address]]("sender")
         changeAddr <- p.get[Address]("changeAddress")
-        fee        <- p.get[Long]("fee")
+        fee        <- p.get[Int128]("fee")(Int128Codec.jsonDecoder)
         data       <- p.get[Option[String]]("data")
       } yield {
 
@@ -251,11 +255,11 @@ case class TransactionApiEndpoint(
       // parse arguments from the request
       (for {
         propType          <- p.get[String]("propositionType")
-        recipients        <- p.get[IndexedSeq[(Address, Long)]]("recipients")
+        recipients        <- p.get[IndexedSeq[(Address, Int128)]]("recipients")
         sender            <- p.get[IndexedSeq[Address]]("sender")
         changeAddr        <- p.get[Address]("changeAddress")
         consolidationAddr <- p.get[Option[Address]]("consolidationAddress")
-        fee               <- p.get[Long]("fee")
+        fee               <- p.get[Int128]("fee")(Int128Codec.jsonDecoder)
         data              <- p.get[Option[String]]("data")
       } yield {
 

--- a/src/main/scala/co/topl/modifier/block/Block.scala
+++ b/src/main/scala/co/topl/modifier/block/Block.scala
@@ -4,11 +4,10 @@ import co.topl.attestation.AddressEncoder.NetworkPrefix
 import co.topl.attestation.EvidenceProducer.Syntax._
 import co.topl.attestation.{PublicKeyPropositionCurve25519, SignatureCurve25519}
 import co.topl.modifier.NodeViewModifier.ModifierTypeId
-import co.topl.modifier.block.Block._
 import co.topl.modifier.block.PersistentNodeViewModifier.PNVMVersion
+import co.topl.modifier.box.ArbitBox
 import co.topl.modifier.transaction.Transaction
 import co.topl.modifier.{ModifierId, NodeViewModifier}
-import co.topl.modifier.box.ArbitBox
 import co.topl.utils.TimeProvider
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, HCursor}

--- a/src/main/scala/co/topl/modifier/block/BlockBody.scala
+++ b/src/main/scala/co/topl/modifier/block/BlockBody.scala
@@ -9,11 +9,8 @@ import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor}
 import supertagged.@@
 
-case class BlockBody(id: ModifierId,
-                     parentId: ModifierId,
-                     transactions: Seq[Transaction.TX],
-                     version: PNVMVersion
-                    ) extends TransactionCarryingPersistentNodeViewModifier[Transaction.TX] {
+case class BlockBody(id: ModifierId, parentId: ModifierId, transactions: Seq[Transaction.TX], version: PNVMVersion)
+    extends TransactionCarryingPersistentNodeViewModifier[Transaction.TX] {
 
   override lazy val modifierTypeId: ModifierTypeId = BlockBody.modifierTypeId
 
@@ -25,20 +22,18 @@ object BlockBody {
 
   implicit val jsonEncoder: Encoder[BlockBody] = { b: BlockBody ⇒
     Map(
-      "id" -> b.id.toString.asJson,
+      "id"       -> b.id.toString.asJson,
       "parentId" -> b.parentId.toString.asJson,
-      "txs" -> b.transactions.asJson,
-      "version" -> b.version.asJson,
+      "txs"      -> b.transactions.asJson,
+      "version"  -> b.version.asJson
     ).asJson
   }
 
   implicit def jsonDecoder(implicit networkPrefix: NetworkPrefix): Decoder[BlockBody] = (c: HCursor) =>
     for {
-      id <- c.downField("id").as[ModifierId]
+      id       <- c.downField("id").as[ModifierId]
       parentId <- c.downField("parentId").as[ModifierId]
-      txsSeq <- c.downField("txs").as[Seq[Transaction.TX]]
-      version <- c.downField("version").as[PNVMVersion]
-    } yield {
-      BlockBody(id, parentId, txsSeq, version)
-    }
+      txsSeq   <- c.downField("txs").as[Seq[Transaction.TX]]
+      version  <- c.downField("version").as[PNVMVersion]
+    } yield BlockBody(id, parentId, txsSeq, version)
 }

--- a/src/main/scala/co/topl/modifier/block/BlockHeader.scala
+++ b/src/main/scala/co/topl/modifier/block/BlockHeader.scala
@@ -12,18 +12,19 @@ import io.circe.{Decoder, Encoder, HCursor}
 import scorex.crypto.hash.Digest32
 import supertagged.@@
 
-case class BlockHeader(id          : ModifierId,
-                       parentId    : ModifierId,
-                       timestamp   : TimeProvider.Time,
-                       generatorBox: ArbitBox,
-                       publicKey   : PublicKeyPropositionCurve25519,
-                       signature   : SignatureCurve25519,
-                       height      : Long,
-                       difficulty  : Long,
-                       txRoot      : Digest32,
-                       bloomFilter : BloomFilter,
-                       version     : PNVMVersion
-                      ) extends PersistentNodeViewModifier {
+case class BlockHeader(
+  id:           ModifierId,
+  parentId:     ModifierId,
+  timestamp:    TimeProvider.Time,
+  generatorBox: ArbitBox,
+  publicKey:    PublicKeyPropositionCurve25519,
+  signature:    SignatureCurve25519,
+  height:       Long,
+  difficulty:   Long,
+  txRoot:       Digest32,
+  bloomFilter:  BloomFilter,
+  version:      PNVMVersion
+) extends PersistentNodeViewModifier {
 
   override lazy val modifierTypeId: ModifierTypeId = BlockHeader.modifierTypeId
 
@@ -32,49 +33,46 @@ case class BlockHeader(id          : ModifierId,
 object BlockHeader {
   val modifierTypeId: Byte @@ NodeViewModifier.ModifierTypeId.Tag = ModifierTypeId @@ (4: Byte)
 
-
   implicit val jsonEncoder: Encoder[BlockHeader] = { bh: BlockHeader ⇒
     Map(
-      "id" -> bh.id.toString.asJson,
-      "parentId" -> bh.parentId.toString.asJson,
-      "timestamp" -> bh.timestamp.asJson,
+      "id"           -> bh.id.toString.asJson,
+      "parentId"     -> bh.parentId.toString.asJson,
+      "timestamp"    -> bh.timestamp.asJson,
       "generatorBox" -> bh.generatorBox.asJson,
-      "publicKey" -> bh.publicKey.asJson,
-      "signature" -> bh.signature.asJson,
-      "height" -> bh.height.asJson,
-      "difficulty" -> bh.difficulty.asJson,
-      "txRoot" -> bh.txRoot.asJson(Digest32Ops.jsonEncoder),
-      "bloomFilter" -> bh.bloomFilter.asJson,
-      "version" -> bh.version.asJson,
+      "publicKey"    -> bh.publicKey.asJson,
+      "signature"    -> bh.signature.asJson,
+      "height"       -> bh.height.asJson,
+      "difficulty"   -> bh.difficulty.asJson,
+      "txRoot"       -> bh.txRoot.asJson(Digest32Ops.jsonEncoder),
+      "bloomFilter"  -> bh.bloomFilter.asJson,
+      "version"      -> bh.version.asJson
     ).asJson
   }
 
   implicit val jsonDecoder: Decoder[BlockHeader] = (c: HCursor) =>
     for {
-      id <- c.downField("id").as[ModifierId]
-      parentId <- c.downField("parentId").as[ModifierId]
-      timestamp <- c.downField("timestamp").as[TimeProvider.Time]
+      id           <- c.downField("id").as[ModifierId]
+      parentId     <- c.downField("parentId").as[ModifierId]
+      timestamp    <- c.downField("timestamp").as[TimeProvider.Time]
       generatorBox <- c.downField("generatorBox").as[ArbitBox]
-      publicKey <- c.downField("publicKey").as[PublicKeyPropositionCurve25519]
-      signature <- c.downField("signature").as[SignatureCurve25519]
-      height <- c.downField("height").as[Long]
-      difficulty <- c.downField("difficulty").as[Long]
-      txRoot <- c.downField("txRoot").as[Digest32](Digest32Ops.jsonDecoder)
-      bloomFilter <- c.downField("bloomFilter").as[BloomFilter]
-      version <- c.downField("version").as[Byte]
-    } yield {
-      BlockHeader(
-        id,
-        parentId,
-        timestamp,
-        generatorBox,
-        publicKey,
-        signature,
-        height,
-        difficulty,
-        txRoot,
-        bloomFilter,
-        version
-      )
-    }
+      publicKey    <- c.downField("publicKey").as[PublicKeyPropositionCurve25519]
+      signature    <- c.downField("signature").as[SignatureCurve25519]
+      height       <- c.downField("height").as[Long]
+      difficulty   <- c.downField("difficulty").as[Long]
+      txRoot       <- c.downField("txRoot").as[Digest32](Digest32Ops.jsonDecoder)
+      bloomFilter  <- c.downField("bloomFilter").as[BloomFilter]
+      version      <- c.downField("version").as[Byte]
+    } yield BlockHeader(
+      id,
+      parentId,
+      timestamp,
+      generatorBox,
+      publicKey,
+      signature,
+      height,
+      difficulty,
+      txRoot,
+      bloomFilter,
+      version
+    )
 }

--- a/src/main/scala/co/topl/modifier/block/BloomFilter.scala
+++ b/src/main/scala/co/topl/modifier/block/BloomFilter.scala
@@ -57,9 +57,9 @@ object BloomFilter extends BifrostSerializer[BloomFilter] {
   object BloomTopic extends TaggedType[Array[Byte]]
   type BloomTopic = BloomTopic.Type
 
-  val bloomSize: Int = 256 //bytes (2048 bits)
-  private val bloomSizeBit: Int = bloomSize * 8
-  private val numLongs: Int = bloomSizeBit / 64 // filter is composed of an array of longs (64 bit elements)
+  val numBytes: Int = 256 //bytes (2048 bits)
+  private val size: Int = numBytes * 8
+  private val numLongs: Int = size / 64 // filter is composed of an array of longs (64 bit elements)
 
   val empty: BloomFilter = new BloomFilter(Array.fill(numLongs)(0L)) // 2048 element bit array of zeros
 
@@ -68,9 +68,9 @@ object BloomFilter extends BifrostSerializer[BloomFilter] {
   // In the notes below only the first two bytes are shown since the other bytes are always zero.
   // NOTE - these values are highly dependent on the length of the bloom filter, manipulate carefully
   private val idxMask: Int =
-    bloomSizeBit - 1 /* 2047 -> 0000 0111 1111 1111 - mask for taking the low-order 11 bits of the byte pairs */
+    size - 1 /* 2047 -> 0000 0111 1111 1111 - mask for taking the low-order 11 bits of the byte pairs */
   private val longElemMask: Int =
-    bloomSizeBit - 64 /* 1984 -> 0000 0111 1100 0000 - mask for finding the long to modify */
+    size - 64 /* 1984 -> 0000 0111 1100 0000 - mask for finding the long to modify */
   private val bitElemMask: Int = 63 /*   63 -> 0000 0000 0011 1111 - mask for finding the bit to modify */
 
   /** Create a new Bloom filter given a sequence of topics to be hashed */

--- a/src/main/scala/co/topl/modifier/block/BloomFilter.scala
+++ b/src/main/scala/co/topl/modifier/block/BloomFilter.scala
@@ -10,34 +10,35 @@ import supertagged.TaggedType
 
 import scala.util.Try
 
-/**
- * This implementation of Bloom filter is inspired from the Ethereum Yellow Paper
- * for more information, visit: http://gavwood.com/paper.pdf (as of 2020.11.20 there is an error in footnote 3 - 2^11^ = 2048)
- * Another explanation can be found here (but he messes denoting the byte pairs, this stuff is tricky)
- * https://ethereum.stackexchange.com/questions/59203/what-exactly-does-the-m-function-in-the-formal-bloom-filter-specifications-do
- * A calculator to look at the false positivity rate can be found here
- * https://hur.st/bloomfilter/?n=100&p=&m=2048&k=4
- * The bloom filter is constructed by taking the low-order 11 bits (mod 2048) of each of the first four pairs of bytes from a Blake2b-256 hash
- * In english, the algorithm is to hash the input topic, take the first 8 bytes from the hash output, pair them up (1,2) (3,4) (5,6) (7,8),
- * then take the first 11 bits from each pair (each pair is 16 bits and we take 11 bits because 2^11^ = 2048). These bits can be
- * retrieved using a bit-wise AND operation. For each of the 11-bit numbers we construct a positive definite integer between (0 & 2047).
- * This integer is the index of the bit to flip in the bloom filter. Finally, the bloom filter is represented as a Array[Long] so
- * we must apply two additional bit-wise AND operations on each index to find which Long should be changed in the bloom filter and
- * finally which bit of the Long must be flipped.
- */
+/** This implementation of Bloom filter is inspired from the Ethereum Yellow Paper
+  * for more information, visit: http://gavwood.com/paper.pdf (as of 2020.11.20 there is an error in footnote 3 - 2^11^ = 2048)
+  * Another explanation can be found here (but he messes denoting the byte pairs, this stuff is tricky)
+  * https://ethereum.stackexchange.com/questions/59203/what-exactly-does-the-m-function-in-the-formal-bloom-filter-specifications-do
+  * A calculator to look at the false positivity rate can be found here
+  * https://hur.st/bloomfilter/?n=100&p=&m=2048&k=4
+  * The bloom filter is constructed by taking the low-order 11 bits (mod 2048) of each of the first four pairs of bytes from a Blake2b-256 hash
+  * In english, the algorithm is to hash the input topic, take the first 8 bytes from the hash output, pair them up (1,2) (3,4) (5,6) (7,8),
+  * then take the first 11 bits from each pair (each pair is 16 bits and we take 11 bits because 2^11^ = 2048). These bits can be
+  * retrieved using a bit-wise AND operation. For each of the 11-bit numbers we construct a positive definite integer between (0 & 2047).
+  * This integer is the index of the bit to flip in the bloom filter. Finally, the bloom filter is represented as a Array[Long] so
+  * we must apply two additional bit-wise AND operations on each index to find which Long should be changed in the bloom filter and
+  * finally which bit of the Long must be flipped.
+  */
 class BloomFilter private (private val value: Array[Long]) extends BytesSerializable {
 
-  require(value.length == BloomFilter.numLongs,
-    s"Invalid bloom filter length: ${value.length}. Bloom filters must be an Array[Long] of length ${BloomFilter.numLongs}")
+  require(
+    value.length == BloomFilter.numLongs,
+    s"Invalid bloom filter length: ${value.length}. Bloom filters must be an Array[Long] of length ${BloomFilter.numLongs}"
+  )
 
   override type M = BloomFilter
   lazy val serializer: BifrostSerializer[BloomFilter] = BloomFilter
 
   /** Check if a given topic is included in the Bloom filter */
-  def contains (topic: BloomTopic): Boolean = {
+  def contains(topic: BloomTopic): Boolean = {
     val indices: Set[Int] = BloomFilter.calculateIndices(topic)
-    BloomFilter.generateLongs(indices).forall {
-      case (idx, bits) => (value(idx) & bits) != 0L
+    BloomFilter.generateLongs(indices).forall { case (idx, bits) =>
+      (value(idx) & bits) != 0L
     }
   }
 
@@ -45,7 +46,7 @@ class BloomFilter private (private val value: Array[Long]) extends BytesSerializ
 
   override def equals(obj: Any): Boolean = obj match {
     case b: BloomFilter => b.value sameElements value
-    case _ => false
+    case _              => false
   }
 
   override def hashCode(): Int = super.hashCode()
@@ -66,17 +67,21 @@ object BloomFilter extends BifrostSerializer[BloomFilter] {
   // These vals are denoted as Ints (4 bytes) because we need at least 11 bits to hold a 2048 bit bloom filter
   // In the notes below only the first two bytes are shown since the other bytes are always zero.
   // NOTE - these values are highly dependent on the length of the bloom filter, manipulate carefully
-  private val idxMask: Int = bloomSizeBit - 1       /* 2047 -> 0000 0111 1111 1111 - mask for taking the low-order 11 bits of the byte pairs */
-  private val longElemMask: Int = bloomSizeBit - 64 /* 1984 -> 0000 0111 1100 0000 - mask for finding the long to modify */
-  private val bitElemMask: Int = 63                 /*   63 -> 0000 0000 0011 1111 - mask for finding the bit to modify */
+  private val idxMask: Int =
+    bloomSizeBit - 1 /* 2047 -> 0000 0111 1111 1111 - mask for taking the low-order 11 bits of the byte pairs */
+  private val longElemMask: Int =
+    bloomSizeBit - 64 /* 1984 -> 0000 0111 1100 0000 - mask for finding the long to modify */
+  private val bitElemMask: Int = 63 /*   63 -> 0000 0000 0011 1111 - mask for finding the bit to modify */
 
   /** Create a new Bloom filter given a sequence of topics to be hashed */
   def apply(topics: Set[BloomTopic]): BloomFilter = update(empty, topics)
 
   /** Returns a new Bloom filter with updated topics included in the bit array.
-   * The updated bloom filter computes the indices to be flipped and merges these changes with
-   * the input array of longs before returning a new filter */
+    * The updated bloom filter computes the indices to be flipped and merges these changes with
+    * the input array of longs before returning a new filter
+    */
   def update(inputBF: BloomFilter, topics: Set[BloomTopic]): BloomFilter = {
+
     /** Compute the indices that should be flipped in the bloom filter */
     val indices: Set[Int] = topics.flatMap(calculateIndices)
 
@@ -84,70 +89,69 @@ object BloomFilter extends BifrostSerializer[BloomFilter] {
     val longsForFilter: Map[Int, Long] = generateLongs(indices)
 
     /** Compute the fixed length Array[Long] by bit-wise OR operations
-     * with the matching index from the input BloomFilter */
+      * with the matching index from the input BloomFilter
+      */
     val longsArray =
-      inputBF
-        .value
-        .zipWithIndex
-        .map {
-          case (bits, idx) => longsForFilter.getOrElse(idx, 0L) | bits
+      inputBF.value.zipWithIndex
+        .map { case (bits, idx) =>
+          longsForFilter.getOrElse(idx, 0L) | bits
         }
 
     new BloomFilter(longsArray)
   }
 
-  /**
-   * Calculates the bit index that must be flipped.
-   * The algorithm is
-   * 1. Compute the hash of the given topic
-   * 2. Retrieve the first 4 pairs of bytes from the hash
-   * 3. Take the bit-wise AND to convert signed byte to unsigned int
-   * 4. For each pair of bytes, take the first byte bit shift it up 8 elements and bit-wise OR it to produce a 16 bit
-   *    unsigned number.
-   * 5. From the 16 bit unsigned number, apply an 11 bit mask to retrieve the lowest 11-bits. This is the index of the
-   *    bit that should be flipped in the bit array.
-   *
-   * Since Java uses signed numbers we must be careful about the mapping of the bitwise operations. See the examples
-   * below for the expected behavior.
-   * Examples
-   * 1. Byte pair (0: Byte, 0: Byte)    -> 0: Int (the zero index bit in the 2048 bit array must be flipped)
-   * 2. Byte pair (0: Byte, 1: Byte)    -> 1: Int (the one index bit in the 2048 bit array must be flipped)
-   * 3. Byte pair (0: Byte, 127: Byte)  -> 127: Int (the 127 index bit in the 2048 bit array must be flipped)
-   * 4. Byte pair (0: Byte, -128: Byte) -> 128: Int (the 128 index bit in the 2048 bit array must be flipped)
-   * 5. Byte pair (0: Byte, -127: Byte) -> 129: Int
-   * 6. Byte pair (0: Byte, -1: Byte)   -> 255: Int
-   * 7. Byte pair (1: Byte, 0: Byte)    -> 256: Int
-   * 8. Byte pair (127: Byte, 0: Byte)  -> 1792: Int
-   * 9. Byte pair (127: Byte, -1: Byte) -> 2047: Int
-   * 10. Byte pair (-1: Byte, -1: Byte) -> 2047: Int
-   * */
+  /** Calculates the bit index that must be flipped.
+    * The algorithm is
+    * 1. Compute the hash of the given topic
+    * 2. Retrieve the first 4 pairs of bytes from the hash
+    * 3. Take the bit-wise AND to convert signed byte to unsigned int
+    * 4. For each pair of bytes, take the first byte bit shift it up 8 elements and bit-wise OR it to produce a 16 bit
+    *    unsigned number.
+    * 5. From the 16 bit unsigned number, apply an 11 bit mask to retrieve the lowest 11-bits. This is the index of the
+    *    bit that should be flipped in the bit array.
+    *
+    * Since Java uses signed numbers we must be careful about the mapping of the bitwise operations. See the examples
+    * below for the expected behavior.
+    * Examples
+    * 1. Byte pair (0: Byte, 0: Byte)    -> 0: Int (the zero index bit in the 2048 bit array must be flipped)
+    * 2. Byte pair (0: Byte, 1: Byte)    -> 1: Int (the one index bit in the 2048 bit array must be flipped)
+    * 3. Byte pair (0: Byte, 127: Byte)  -> 127: Int (the 127 index bit in the 2048 bit array must be flipped)
+    * 4. Byte pair (0: Byte, -128: Byte) -> 128: Int (the 128 index bit in the 2048 bit array must be flipped)
+    * 5. Byte pair (0: Byte, -127: Byte) -> 129: Int
+    * 6. Byte pair (0: Byte, -1: Byte)   -> 255: Int
+    * 7. Byte pair (1: Byte, 0: Byte)    -> 256: Int
+    * 8. Byte pair (127: Byte, 0: Byte)  -> 1792: Int
+    * 9. Byte pair (127: Byte, -1: Byte) -> 2047: Int
+    * 10. Byte pair (-1: Byte, -1: Byte) -> 2047: Int
+    */
   private def calculateIndices(topic: BloomTopic): Set[Int] =
-  // Pair up bytes and convert signed Byte to unsigned Int
-    Set(0, 2, 4, 6).map(i => Blake2b256(topic).slice(i, i + 2).map(_ & 0xFF)).map {
-      case Array(b1, b2) => ((b1 << 8) | b2) & idxMask
+    // Pair up bytes and convert signed Byte to unsigned Int
+    Set(0, 2, 4, 6).map(i => Blake2b256(topic).slice(i, i + 2).map(_ & 0xff)).map { case Array(b1, b2) =>
+      ((b1 << 8) | b2) & idxMask
     }
 
-  /**
-   * From the set of indices, create a long (with the appropriate bits flipped) that will be inserted in the
-   * * bloom filter. This function performs bit-wise operations to split the 11 bit bit index integer into two pieces.
-   * 1. The least significant 6 bits (6 bits from the right) are used to determine how far to shift a single 1 bit
-   *    along the length of the long. This is the first element in the tuple below.
-   * 2. The most significant 5 bits and bit shifted down 6 bits to form an integer between 0 and (numLongs - 1).
-   *    This is the index of the Long in the array of longs where the long computed in step 1 will be placed.
-   * Finally, since we may update bits corresponding to the same long, we group them and fold all longs at the
-   * same index into a single value using a bit-wise OR operation. Following this the output mao should contain
-   * only unique keys between 0 -> 31. These keys are to be associated with a single Long, the value of which
-   * may range between Long.MinValue -> Long.MaxValue
-   */
+  /** From the set of indices, create a long (with the appropriate bits flipped) that will be inserted in the
+    * * bloom filter. This function performs bit-wise operations to split the 11 bit bit index integer into two pieces.
+    * 1. The least significant 6 bits (6 bits from the right) are used to determine how far to shift a single 1 bit
+    *    along the length of the long. This is the first element in the tuple below.
+    * 2. The most significant 5 bits and bit shifted down 6 bits to form an integer between 0 and (numLongs - 1).
+    *    This is the index of the Long in the array of longs where the long computed in step 1 will be placed.
+    * Finally, since we may update bits corresponding to the same long, we group them and fold all longs at the
+    * same index into a single value using a bit-wise OR operation. Following this the output mao should contain
+    * only unique keys between 0 -> 31. These keys are to be associated with a single Long, the value of which
+    * may range between Long.MinValue -> Long.MaxValue
+    */
   private def generateLongs(indices: Set[Int]): Map[Int, Long] =
-    indices.map { i =>
-      (
-        Long.MinValue >>> (i & bitElemMask), // value of the bit array as a Long
-        (i & longElemMask) >>> 6 // index of the Long that must be manipulated
-      )
-    }.groupBy(_._2) // group the tuples by the index of the long so we can accumulate the bits into a single Long
-      .map {
-        case (elem, values) => elem -> values.foldLeft(0L)((acc, bits) => acc | bits._1)
+    indices
+      .map { i =>
+        (
+          Long.MinValue >>> (i & bitElemMask), // value of the bit array as a Long
+          (i & longElemMask) >>> 6 // index of the Long that must be manipulated
+        )
+      }
+      .groupBy(_._2) // group the tuples by the index of the long so we can accumulate the bits into a single Long
+      .map { case (elem, values) =>
+        elem -> values.foldLeft(0L)((acc, bits) => acc | bits._1)
       }
 
   /** Recreate a bloom filter from a string encoding */
@@ -158,9 +162,8 @@ object BloomFilter extends BifrostSerializer[BloomFilter] {
   implicit val jsonDecoder: Decoder[BloomFilter] = Decoder.decodeString.emapTry(fromString)
   implicit val jsonKeyDecoder: KeyDecoder[BloomFilter] = (str: String) => fromString(str).toOption
 
-  override def serialize(obj: BloomFilter, w: Writer): Unit = {
+  override def serialize(obj: BloomFilter, w: Writer): Unit =
     obj.value.foreach(l => w.putLong(l))
-  }
 
   override def parse(r: Reader): BloomFilter = {
     val value: Array[Long] = (for (_ <- 0 until numLongs) yield r.getLong()).toArray

--- a/src/main/scala/co/topl/modifier/box/Box.scala
+++ b/src/main/scala/co/topl/modifier/box/Box.scala
@@ -44,9 +44,7 @@ object Box {
       evidence <- c.downField("evidence").as[Evidence]
       value    <- c.downField("value").as[T]
       nonce    <- c.downField("nonce").as[Nonce]
-    } yield {
-      (evidence, nonce, value)
-    }
+    } yield (evidence, nonce, value)
 
   def identifier(box: Box[_]): Identifier = box match {
     case _: ArbitBox     => ArbitBox.identifier.getId

--- a/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
+++ b/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
@@ -82,7 +82,7 @@ object SimpleValue extends BifrostSerializer[SimpleValue] {
     w.putBytes(obj.quantity.toByteArray)
 
   override def parse(r: Reader): SimpleValue =
-    SimpleValue(Int128(r.getBytes(Int128.bytes)))
+    SimpleValue(Int128(r.getBytes(Int128.numBytes)))
 }
 
 /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
@@ -143,7 +143,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
   }
 
   override def parse(r: Reader): AssetValue = {
-    val quantity = Int128(r.getBytes(Int128.bytes))
+    val quantity = Int128(r.getBytes(Int128.numBytes))
     val assetCode = AssetCode.parse(r)
     val securityRoot = SecurityRoot.parse(r)
     val metadata: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
+++ b/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
@@ -111,7 +111,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
   implicit val jsonEncoder: Encoder[AssetValue] = { (value: AssetValue) =>
     Map(
       "type"         -> valueTypeString.asJson,
-      "quantity"     -> Int128Codec.jsonEncoder(value.quantity),
+      "quantity"     -> value.quantity.asJson(Int128Codec.jsonEncoder),
       "assetCode"    -> value.assetCode.asJson,
       "securityRoot" -> value.securityRoot.asJson,
       "metadata"     -> value.metadata.asJson
@@ -120,7 +120,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
 
   implicit val jsonDecoder: Decoder[AssetValue] = (c: HCursor) =>
     for {
-      quantity     <- c.downField("quantity").as[Long]
+      quantity     <- c.get[Int128]("quantity")(Int128Codec.jsonDecoder)
       assetCode    <- c.downField("assetCode").as[AssetCode]
       securityRoot <- c.downField("securityRoot").as[Option[String]]
       metadata     <- c.downField("metadata").as[Option[String]]

--- a/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
+++ b/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
@@ -79,10 +79,10 @@ object SimpleValue extends BifrostSerializer[SimpleValue] {
     }
 
   override def serialize(obj: SimpleValue, w: Writer): Unit =
-    w.putBytes(obj.quantity.toByteArray)
+    w.putInt128(obj.quantity)
 
   override def parse(r: Reader): SimpleValue =
-    SimpleValue(Int128(r.getBytes(Int128.numBytes)))
+    SimpleValue(r.getInt128())
 }
 
 /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
@@ -134,7 +134,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
     }
 
   override def serialize(obj: AssetValue, w: Writer): Unit = {
-    w.putBytes(obj.quantity.toByteArray)
+    w.putInt128(obj.quantity)
     AssetCode.serialize(obj.assetCode, w)
     SecurityRoot.serialize(obj.securityRoot, w)
     w.putOption(obj.metadata) { (writer, metadata) =>
@@ -143,7 +143,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
   }
 
   override def parse(r: Reader): AssetValue = {
-    val quantity = Int128(r.getBytes(Int128.numBytes))
+    val quantity = r.getInt128()
     val assetCode = AssetCode.parse(r)
     val securityRoot = SecurityRoot.parse(r)
     val metadata: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
+++ b/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
@@ -3,11 +3,13 @@ package co.topl.modifier.box
 import java.nio.charset.StandardCharsets
 
 import co.topl.attestation.Address
+import co.topl.utils.Int128
+import co.topl.utils.codecs.Int128Codec
 import co.topl.utils.serialization.{BifrostSerializer, BytesSerializable, Reader, Writer}
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor}
 
-sealed abstract class TokenValueHolder(val quantity: Long) extends BytesSerializable {
+sealed abstract class TokenValueHolder(val quantity: Int128) extends BytesSerializable {
   override type M = TokenValueHolder
 
   override def serializer: BifrostSerializer[TokenValueHolder] = TokenValueHolder
@@ -56,7 +58,7 @@ object TokenValueHolder extends BifrostSerializer[TokenValueHolder] {
 
 /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
 
-case class SimpleValue(override val quantity: Long) extends TokenValueHolder(quantity)
+case class SimpleValue(override val quantity: Int128) extends TokenValueHolder(quantity)
 
 object SimpleValue extends BifrostSerializer[SimpleValue] {
   val valueTypePrefix: Byte = 1: Byte
@@ -65,7 +67,7 @@ object SimpleValue extends BifrostSerializer[SimpleValue] {
   implicit val jsonEncoder: Encoder[SimpleValue] = { (value: SimpleValue) =>
     Map(
       "type"     -> valueTypeString.asJson,
-      "quantity" -> value.quantity.asJson
+      "quantity" -> Int128Codec.jsonEncoder(value.quantity)
     ).asJson
   }
 
@@ -77,15 +79,15 @@ object SimpleValue extends BifrostSerializer[SimpleValue] {
     }
 
   override def serialize(obj: SimpleValue, w: Writer): Unit =
-    w.putULong(obj.quantity)
+    w.putBytes(obj.quantity.toByteArray)
 
   override def parse(r: Reader): SimpleValue =
-    SimpleValue(r.getULong())
+    SimpleValue(Int128(r.getBytes(Int128.bytes)))
 }
 
 /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
 case class AssetValue(
-  override val quantity: Long,
+  override val quantity: Int128,
   assetCode:             AssetCode,
   securityRoot:          SecurityRoot = SecurityRoot.empty,
   metadata:              Option[String] = None
@@ -109,7 +111,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
   implicit val jsonEncoder: Encoder[AssetValue] = { (value: AssetValue) =>
     Map(
       "type"         -> valueTypeString.asJson,
-      "quantity"     -> value.quantity.asJson,
+      "quantity"     -> Int128Codec.jsonEncoder(value.quantity),
       "assetCode"    -> value.assetCode.asJson,
       "securityRoot" -> value.securityRoot.asJson,
       "metadata"     -> value.metadata.asJson
@@ -132,7 +134,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
     }
 
   override def serialize(obj: AssetValue, w: Writer): Unit = {
-    w.putULong(obj.quantity)
+    w.putBytes(obj.quantity.toByteArray)
     AssetCode.serialize(obj.assetCode, w)
     SecurityRoot.serialize(obj.securityRoot, w)
     w.putOption(obj.metadata) { (writer, metadata) =>
@@ -141,7 +143,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
   }
 
   override def parse(r: Reader): AssetValue = {
-    val quantity = r.getULong()
+    val quantity = Int128(r.getBytes(Int128.bytes))
     val assetCode = AssetCode.parse(r)
     val securityRoot = SecurityRoot.parse(r)
     val metadata: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/ArbitTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/ArbitTransfer.scala
@@ -64,7 +64,7 @@ object ArbitTransfer {
     sender:               IndexedSeq[Address],
     changeAddress:        Address,
     consolidationAddress: Option[Address],
-    fee:                  Long,
+    fee:                  Int128,
     data:                 Option[String]
   ): Try[ArbitTransfer[P]] =
     TransferTransaction

--- a/src/main/scala/co/topl/modifier/transaction/ArbitTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/ArbitTransfer.scala
@@ -8,7 +8,8 @@ import co.topl.modifier.transaction.Transaction.TxType
 import co.topl.modifier.transaction.TransferTransaction.BoxParams
 import co.topl.nodeView.state.StateReader
 import co.topl.modifier.box._
-import co.topl.utils.{Identifiable, Identifier}
+import co.topl.utils.codecs.Int128Codec
+import co.topl.utils.{Identifiable, Identifier, Int128}
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor}
 
@@ -19,7 +20,7 @@ case class ArbitTransfer[
 ](override val from:        IndexedSeq[(Address, Box.Nonce)],
   override val to:          IndexedSeq[(Address, TokenValueHolder)],
   override val attestation: Map[P, Proof[P]],
-  override val fee:         Long,
+  override val fee:         Int128,
   override val timestamp:   Long,
   override val data:        Option[String] = None,
   override val minting:     Boolean = false
@@ -90,7 +91,7 @@ object ArbitTransfer {
       "from"            -> tx.from.asJson,
       "to"              -> tx.to.asJson,
       "signatures"      -> tx.attestation.asJson,
-      "fee"             -> tx.fee.asJson,
+      "fee"             -> tx.fee.asJson(Int128Codec.jsonEncoder),
       "timestamp"       -> tx.timestamp.asJson,
       "minting"         -> tx.minting.asJson,
       "data"            -> tx.data.asJson
@@ -102,7 +103,7 @@ object ArbitTransfer {
       for {
         from      <- c.downField("from").as[IndexedSeq[(Address, Box.Nonce)]]
         to        <- c.downField("to").as[IndexedSeq[(Address, SimpleValue)]]
-        fee       <- c.downField("fee").as[Long]
+        fee       <- c.get[Int128]("fee")(Int128Codec.jsonDecoder)
         timestamp <- c.downField("timestamp").as[Long]
         data      <- c.downField("data").as[Option[String]]
         propType  <- c.downField("propositionType").as[String]

--- a/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
@@ -64,7 +64,7 @@ object AssetTransfer {
     sender:               IndexedSeq[Address],
     changeAddress:        Address,
     consolidationAddress: Option[Address],
-    fee:                  Long,
+    fee:                  Int128,
     data:                 Option[String],
     minting:              Boolean
   ): Try[AssetTransfer[P]] = {

--- a/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
@@ -8,7 +8,8 @@ import co.topl.modifier.transaction.Transaction.TxType
 import co.topl.modifier.transaction.TransferTransaction.BoxParams
 import co.topl.nodeView.state.StateReader
 import co.topl.modifier.box._
-import co.topl.utils.{Identifiable, Identifier}
+import co.topl.utils.codecs.Int128Codec
+import co.topl.utils.{Identifiable, Identifier, Int128}
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, HCursor}
 
@@ -19,7 +20,7 @@ case class AssetTransfer[
 ](override val from:        IndexedSeq[(Address, Box.Nonce)],
   override val to:          IndexedSeq[(Address, TokenValueHolder)],
   override val attestation: Map[P, Proof[P]],
-  override val fee:         Long,
+  override val fee:         Int128,
   override val timestamp:   Long,
   override val data:        Option[String] = None,
   override val minting:     Boolean = false
@@ -101,7 +102,7 @@ object AssetTransfer {
       "from"            -> tx.from.asJson,
       "to"              -> tx.to.asJson,
       "signatures"      -> tx.attestation.asJson,
-      "fee"             -> tx.fee.asJson,
+      "fee"             -> tx.fee.asJson(Int128Codec.jsonEncoder),
       "timestamp"       -> tx.timestamp.asJson,
       "data"            -> tx.data.asJson,
       "minting"         -> tx.minting.asJson
@@ -113,7 +114,7 @@ object AssetTransfer {
       for {
         from      <- c.downField("from").as[IndexedSeq[(Address, Long)]]
         to        <- c.downField("to").as[IndexedSeq[(Address, TokenValueHolder)]]
-        fee       <- c.downField("fee").as[Long]
+        fee       <- c.get[Int128]("fee")(Int128Codec.jsonDecoder)
         timestamp <- c.downField("timestamp").as[Long]
         data      <- c.downField("data").as[Option[String]]
         minting   <- c.downField("minting").as[Boolean]

--- a/src/main/scala/co/topl/modifier/transaction/Transaction.scala
+++ b/src/main/scala/co/topl/modifier/transaction/Transaction.scala
@@ -7,7 +7,7 @@ import co.topl.modifier.block.BloomFilter.BloomTopic
 import co.topl.modifier.box.{Box, BoxId, ProgramId}
 import co.topl.modifier.{ModifierId, NodeViewModifier}
 import co.topl.nodeView.state.StateReader
-import co.topl.utils.{Identifiable, Identifier}
+import co.topl.utils.{Identifiable, Identifier, Int128}
 import com.google.common.primitives.Longs
 import io.circe.{Decoder, Encoder, HCursor}
 import scorex.crypto.hash.Digest32
@@ -28,7 +28,7 @@ abstract class Transaction[+T, P <: Proposition: Identifiable] extends NodeViewM
 
   val attestation: Map[P, Proof[P]]
 
-  val fee: Long
+  val fee: Int128
 
   val timestamp: Long
 
@@ -40,7 +40,7 @@ abstract class Transaction[+T, P <: Proposition: Identifiable] extends NodeViewM
     newBoxes.foldLeft(Array[Byte]())((acc, x) => acc ++ x.bytes) ++
     boxIdsToOpen.foldLeft(Array[Byte]())((acc, x) => acc ++ x.hashBytes) ++
     Longs.toByteArray(timestamp) ++
-    Longs.toByteArray(fee)
+    fee.toByteArray
 
   def getPropIdentifier: Identifier = Identifiable[P].getId
 

--- a/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
@@ -38,7 +38,7 @@ object ArbitTransferSerializer extends BifrostSerializer[ArbitTransfer[_ <: Prop
     }
 
     /* fee: Int128 */
-    w.putBytes(obj.fee.toByteArray)
+    w.putInt128(obj.fee)
 
     /* timestamp: Long */
     w.putULong(obj.timestamp)
@@ -76,7 +76,7 @@ object ArbitTransferSerializer extends BifrostSerializer[ArbitTransfer[_ <: Prop
       prop -> sig
     }: _*)
 
-    val fee: Int128 = Int128(r.getBytes(Int128.numBytes))
+    val fee: Int128 = r.getInt128()
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
@@ -4,6 +4,7 @@ import co.topl.attestation._
 import co.topl.attestation.serialization.{ProofSerializer, PropositionSerializer}
 import co.topl.modifier.transaction.ArbitTransfer
 import co.topl.modifier.box.TokenValueHolder
+import co.topl.utils.Int128
 import co.topl.utils.serialization.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
@@ -36,8 +37,8 @@ object ArbitTransferSerializer extends BifrostSerializer[ArbitTransfer[_ <: Prop
       ProofSerializer.serialize(sig, w)
     }
 
-    /* fee: Long */
-    w.putULong(obj.fee)
+    /* fee: Int128 */
+    w.putBytes(obj.fee.toByteArray)
 
     /* timestamp: Long */
     w.putULong(obj.timestamp)
@@ -75,7 +76,7 @@ object ArbitTransferSerializer extends BifrostSerializer[ArbitTransfer[_ <: Prop
       prop -> sig
     }: _*)
 
-    val fee: Long = r.getULong()
+    val fee: Int128 = Int128(r.getBytes(Int128.size))
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
@@ -76,7 +76,7 @@ object ArbitTransferSerializer extends BifrostSerializer[ArbitTransfer[_ <: Prop
       prop -> sig
     }: _*)
 
-    val fee: Int128 = Int128(r.getBytes(Int128.size))
+    val fee: Int128 = Int128(r.getBytes(Int128.numBytes))
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
@@ -76,7 +76,7 @@ object AssetTransferSerializer extends BifrostSerializer[AssetTransfer[_ <: Prop
       prop -> sig
     }: _*)
 
-    val fee: Int128 = Int128(r.getBytes(Int128.size))
+    val fee: Int128 = Int128(r.getBytes(Int128.numBytes))
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
@@ -4,6 +4,7 @@ import co.topl.attestation._
 import co.topl.attestation.serialization.{ProofSerializer, PropositionSerializer}
 import co.topl.modifier.transaction.AssetTransfer
 import co.topl.modifier.box.TokenValueHolder
+import co.topl.utils.Int128
 import co.topl.utils.serialization.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
@@ -36,8 +37,8 @@ object AssetTransferSerializer extends BifrostSerializer[AssetTransfer[_ <: Prop
       ProofSerializer.serialize(sig, w)
     }
 
-    /* fee: Long */
-    w.putULong(obj.fee)
+    /* fee: Int128 */
+    w.putBytes(obj.fee.toByteArray)
 
     /* timestamp: Long */
     w.putULong(obj.timestamp)
@@ -75,7 +76,7 @@ object AssetTransferSerializer extends BifrostSerializer[AssetTransfer[_ <: Prop
       prop -> sig
     }: _*)
 
-    val fee: Long = r.getULong()
+    val fee: Int128 = Int128(r.getBytes(Int128.size))
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
@@ -38,7 +38,7 @@ object AssetTransferSerializer extends BifrostSerializer[AssetTransfer[_ <: Prop
     }
 
     /* fee: Int128 */
-    w.putBytes(obj.fee.toByteArray)
+    w.putInt128(obj.fee)
 
     /* timestamp: Long */
     w.putULong(obj.timestamp)
@@ -76,7 +76,7 @@ object AssetTransferSerializer extends BifrostSerializer[AssetTransfer[_ <: Prop
       prop -> sig
     }: _*)
 
-    val fee: Int128 = Int128(r.getBytes(Int128.numBytes))
+    val fee: Int128 = r.getInt128()
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
@@ -76,7 +76,7 @@ object PolyTransferSerializer extends BifrostSerializer[PolyTransfer[_ <: Propos
       prop -> sig
     }: _*)
 
-    val fee: Int128 = Int128(r.getBytes(Int128.size))
+    val fee: Int128 = Int128(r.getBytes(Int128.numBytes))
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
@@ -38,7 +38,7 @@ object PolyTransferSerializer extends BifrostSerializer[PolyTransfer[_ <: Propos
     }
 
     /* fee: Int128 */
-    w.putBytes(obj.fee.toByteArray)
+    w.putInt128(obj.fee)
 
     /* timestamp: Long */
     w.putULong(obj.timestamp)
@@ -76,7 +76,7 @@ object PolyTransferSerializer extends BifrostSerializer[PolyTransfer[_ <: Propos
       prop -> sig
     }: _*)
 
-    val fee: Int128 = Int128(r.getBytes(Int128.numBytes))
+    val fee: Int128 = r.getInt128()
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
@@ -4,6 +4,7 @@ import co.topl.attestation._
 import co.topl.attestation.serialization.{ProofSerializer, PropositionSerializer}
 import co.topl.modifier.transaction.PolyTransfer
 import co.topl.modifier.box.TokenValueHolder
+import co.topl.utils.Int128
 import co.topl.utils.serialization.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
@@ -36,8 +37,8 @@ object PolyTransferSerializer extends BifrostSerializer[PolyTransfer[_ <: Propos
       ProofSerializer.serialize(sig, w)
     }
 
-    /* fee: Long */
-    w.putULong(obj.fee)
+    /* fee: Int128 */
+    w.putBytes(obj.fee.toByteArray)
 
     /* timestamp: Long */
     w.putULong(obj.timestamp)
@@ -75,7 +76,7 @@ object PolyTransferSerializer extends BifrostSerializer[PolyTransfer[_ <: Propos
       prop -> sig
     }: _*)
 
-    val fee: Long = r.getULong()
+    val fee: Int128 = Int128(r.getBytes(Int128.size))
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/network/NetworkController.scala
+++ b/src/main/scala/co/topl/network/NetworkController.scala
@@ -230,7 +230,7 @@ class NetworkController(
   ////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////// METHOD DEFINITIONS ////////////////////////////////
 
-  def networkTime(): Time = appContext.timeProvider.time()
+  def networkTime(): Time = appContext.timeProvider.time
 
   /** Schedule a periodic connection to a random known peer */
   private def scheduleConnectionToPeer(): Unit = {

--- a/src/main/scala/co/topl/network/PeerConnectionHandler.scala
+++ b/src/main/scala/co/topl/network/PeerConnectionHandler.scala
@@ -245,7 +245,7 @@ class PeerConnectionHandler(
   }
 
   private def createHandshakeMessage(): Unit = {
-    val nodeInfo = message.Handshake(localPeerSpec, appContext.timeProvider.time())
+    val nodeInfo = message.Handshake(localPeerSpec, appContext.timeProvider.time)
 
     /** create, save, and schedule a timeout option. The variable lets us cancel the timeout message
       * if a handshake is received
@@ -264,7 +264,7 @@ class PeerConnectionHandler(
 
     val peerInfo = PeerInfo(
       receivedHandshake.peerSpec,
-      appContext.timeProvider.time(),
+      appContext.timeProvider.time,
       Some(direction)
     )
     val peer = ConnectedPeer(connectionDescription.connectionId, self, Some(peerInfo))

--- a/src/main/scala/co/topl/network/SyncTracker.scala
+++ b/src/main/scala/co/topl/network/SyncTracker.scala
@@ -86,17 +86,17 @@ class SyncTracker(
   }
 
   def updateLastSyncSentTime(peer: ConnectedPeer): Unit = {
-    val currentTime = timeProvider.time()
+    val currentTime = timeProvider.time
     lastSyncSentTime(peer) = currentTime
     lastSyncInfoSentTime = currentTime
   }
 
   /** Time elapsed since last synchronization */
-  def elapsedTimeSinceLastSync(): Long = timeProvider.time() - lastSyncInfoSentTime
+  def elapsedTimeSinceLastSync(): Long = timeProvider.time - lastSyncInfoSentTime
 
   /** A peer with a lastSyncSentTime greater than the maxInterval is outdated */
   private def outdatedPeers(): Seq[ConnectedPeer] =
-    lastSyncSentTime.filter(t => (timeProvider.time() - t._2).millis > maxInterval()).keys.toSeq
+    lastSyncSentTime.filter(t => (timeProvider.time - t._2).millis > maxInterval()).keys.toSeq
 
   /** Number of peers that are older */
   private def numOfSeniors(): Int = statuses.count(_._2 == Older)
@@ -116,7 +116,7 @@ class SyncTracker(
         val elders = statuses.filter(_._2 == Older).keys.toIndexedSeq
         val nonOutdated =
           (if (elders.nonEmpty) elders(scala.util.Random.nextInt(elders.size)) +: unknowns else unknowns) ++ forks
-        nonOutdated.filter(p => (timeProvider.time() - lastSyncSentTime.getOrElse(p, 0L)).millis >= minInterval)
+        nonOutdated.filter(p => (timeProvider.time - lastSyncSentTime.getOrElse(p, 0L)).millis >= minInterval)
       }
 
     peers.foreach(updateLastSyncSentTime)

--- a/src/main/scala/co/topl/nodeView/CleanupWorker.scala
+++ b/src/main/scala/co/topl/nodeView/CleanupWorker.scala
@@ -70,7 +70,7 @@ class CleanupWorker(nodeViewHolderRef: ActorRef, settings: AppSettings, appConte
           // if any newly created box matches a box already in the UTXO set, remove the transaction
           val boxAlreadyExists = utx.tx.newBoxes.exists(b => stateReader.getBox(b.id).isDefined)
           val txTimeout =
-            (appContext.timeProvider.time() - utx.dateAdded) > settings.application.mempoolTimeout.toMillis
+            (appContext.timeProvider.time - utx.dateAdded) > settings.application.mempoolTimeout.toMillis
 
           if (boxAlreadyExists | txTimeout) (validAcc, utx.tx.id +: invalidAcc)
           else (utx.tx.id +: validAcc, invalidAcc)

--- a/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
+++ b/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
@@ -239,7 +239,7 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
   protected def txModify(tx: TX): Unit =
     tx.syntacticValidate match {
       case Success(_) =>
-        memoryPool().put(tx, appContext.timeProvider.time()) match {
+        memoryPool().put(tx, appContext.timeProvider.time) match {
           case Success(_) =>
             log.debug(s"Unconfirmed transaction $tx added to the memory pool")
             context.system.eventStream.publish(SuccessfulTransaction[TX](tx))
@@ -437,7 +437,7 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
     val appliedTxs = blocksApplied.flatMap(extractTransactions)
 
     memPool
-      .putWithoutCheck(rolledBackTxs, appContext.timeProvider.time())
+      .putWithoutCheck(rolledBackTxs, appContext.timeProvider.time)
       .filter { tx =>
         !appliedTxs.exists(t => t.id == tx.id) && {
           state.semanticValidate(tx).isSuccess

--- a/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
@@ -1,7 +1,7 @@
 package co.topl.nodeView.mempool
 
 import co.topl.modifier.transaction.Transaction
-import co.topl.modifier.{ContainsModifiers, ModifierId, NodeViewModifier}
+import co.topl.modifier.{ContainsModifiers, ModifierId}
 import co.topl.nodeView.NodeViewComponent
 import co.topl.utils.TimeProvider
 

--- a/src/main/scala/co/topl/utils/Int128.scala
+++ b/src/main/scala/co/topl/utils/Int128.scala
@@ -278,4 +278,11 @@ final class Int128(val upperLong: Long, val lowerLong: Long)
 
   /** Remainder of UInt128 */
   def %  (that: Int128): Int128 = Int128(this.bigInt % that.bigInt)
+
+  /** Returns a BigInt whose value is the negation of this BigInt */
+  def unary_- : Int128   = Int128(this.bigInt.bigInteger.negate())
+
+  /** Returns the bitwise complement of this BigInt */
+  def unary_~ : Int128 = Int128(this.bigInt.bigInteger.not())
+
 }

--- a/src/main/scala/co/topl/utils/Int128.scala
+++ b/src/main/scala/co/topl/utils/Int128.scala
@@ -32,7 +32,7 @@ import scala.util.{Failure, Success, Try}
   */
 object Int128 {
   val size = 128
-  val bytes: Int = size / java.lang.Byte.SIZE
+  val numBytes: Int = size / java.lang.Byte.SIZE
   val MinValue: Int128 = Int128(Long.MinValue, 0L)
   val MaxValue: Int128 = Int128(Long.MaxValue, -1L)
 
@@ -105,14 +105,14 @@ object Int128 {
     */
   def apply(value: BigInt): Int128 = {
     val bigIntBytes = value.toByteArray
-    val res = if (bigIntBytes.length >= Int128.bytes) {
+    val res = if (bigIntBytes.length >= Int128.numBytes) {
       bigIntBytes.takeRight(16)
     } else {
       val pad: Byte = if (bigIntBytes.head < 0) -1 else 0
       Array.fill(16 - bigIntBytes.length)(pad) ++ bigIntBytes
     }
 
-    val buf = ByteBuffer.allocate(bytes).order(ByteOrder.BIG_ENDIAN)
+    val buf = ByteBuffer.allocate(numBytes).order(ByteOrder.BIG_ENDIAN)
     buf.put(res)
     buf.flip()
     new Int128(buf.getLong(), buf.getLong())
@@ -158,13 +158,13 @@ object Int128 {
     * @param value Byte array in big-endian format.
     */
   def apply(value: Array[Byte]): Int128 = {
-    val res = if (value.length >= Int128.bytes) {
+    val res = if (value.length >= Int128.numBytes) {
       value.takeRight(16)
     } else {
       Array.fill(16 - value.length)(0: Byte) ++ value
     }
 
-    val buf = ByteBuffer.allocate(bytes).order(ByteOrder.BIG_ENDIAN)
+    val buf = ByteBuffer.allocate(numBytes).order(ByteOrder.BIG_ENDIAN)
     buf.put(res)
     buf.flip()
     new Int128(buf.getLong(), buf.getLong())
@@ -208,7 +208,7 @@ final class Int128(val upperLong: Long, val lowerLong: Long)
     * @return Byte array containing this number in big-endian format.
     */
   def toByteArray: Array[Byte] = {
-    val buf = ByteBuffer.allocate(Int128.bytes).order(ByteOrder.BIG_ENDIAN)
+    val buf = ByteBuffer.allocate(Int128.numBytes).order(ByteOrder.BIG_ENDIAN)
     buf.putLong(upperLong)
     buf.putLong(lowerLong)
     buf.array

--- a/src/main/scala/co/topl/utils/Int128.scala
+++ b/src/main/scala/co/topl/utils/Int128.scala
@@ -24,9 +24,9 @@ import scala.util.{Failure, Success, Try}
  */
 
 /** Container for a 128 bit signed integer stored in big-endian format.
- * Adopted from the original work available at
- * https://github.com/PlatformLab/TorcDB/blob/master/src/main/java/net/ellitron/torc/util/UInt128.java
- * by Jonathan Ellithorpe (jde@cs.stanford.edu)
+  * Adopted from the original work available at
+  * https://github.com/PlatformLab/TorcDB/blob/master/src/main/java/net/ellitron/torc/util/Int128.java
+  * by Jonathan Ellithorpe (jde@cs.stanford.edu)
   *
   * @author James Aman (j.aman@topl.me)
   */
@@ -36,30 +36,29 @@ object Int128 {
   val MinValue: Int128 = Int128(Long.MinValue, 0L)
   val MaxValue: Int128 = Int128(Long.MaxValue, -1L)
 
-  /** This method attempts to translate its argument into a UInt128.
+  /** This method attempts to translate its argument into a Int128.
     *
     * @param n Number to translate.
-    * @return UInt128
+    * @return Int128
     */
   def decode(n: Any): Try[Int128] = Try {
     n match {
-      case b: Byte          => Int128(b)
-      case sh: Short        => Int128(sh)
-      case integer: Integer => Int128(integer)
-      case l: Long          => Int128(l)
-      case idStr: String =>
-        if (idStr.startsWith("0x")) Int128(idStr, 16)
-        else Int128(idStr, 10)
-      case integer: BigInteger => Int128(integer)
-      case uuid: UUID          => Int128(uuid)
-      case bytes: Array[Byte]  => Int128(bytes)
-      case int12: Int128      => int12
+      case b: Byte                                 => Int128(b)
+      case sh: Short                               => Int128(sh)
+      case int: Int                                => Int128(int)
+      case l: Long                                 => Int128(l)
+      case integer: BigInteger                     => Int128(integer)
+      case uuid: UUID                              => Int128(uuid)
+      case bytes: Array[Byte]                      => Int128(bytes)
+      case int128: Int128                          => int128
+      case idStr: String if idStr.startsWith("0x") => Int128(idStr, 16)
+      case idStr: String                           => Int128(idStr, 10)
       case _ =>
         throw new NumberFormatException(String.format("Unable to decode " + "number: [%s,%s]", n.getClass, n.toString))
     }
   }
 
-  /** Constructs a UInt128 from two longs, one representing the upper 64 bits
+  /** Constructs a Int128 from two longs, one representing the upper 64 bits
     * and the other representing the lower 64 bits.
     *
     * @param upperLong Upper 64 bits.
@@ -67,36 +66,41 @@ object Int128 {
     */
   def apply(upperLong: Long, lowerLong: Long): Int128 = new Int128(upperLong, lowerLong)
 
-  /** Constructs a UInt128 from a Byte value. Value is treated as unsigned and
-    * therefore no sign extension is performed.
+  /** Constructs a Int128 from a Byte value.
     *
-    * @param value Byte, treated as 8 unsigned bits.
+    * @param value Byte
     */
-  def apply(value: Byte): Int128 = new Int128(0, value.toLong)
+  def apply(value: Byte): Int128 =
+    if (value < 0) new Int128(-1, value.toLong)
+    else new Int128(0, value.toLong)
 
-  /** Constructs a UInt128 from a Short value. Value is treated as unsigned and
-    * therefore no sign extension is performed.
+
+  /** Constructs a Int128 from a Short value.
     *
-    * @param value Short, treated as 16 unsigned bits.
+    * @param value Short
     */
-  def apply(value: Short): Int128 = new Int128(0, value.toLong)
+  def apply(value: Short): Int128 =
+    if (value < 0) new Int128(-1, value.toLong)
+    else new Int128(0, value.toLong)
 
-  /** Constructs a UInt128 from an Integer value. Value is treated as unsigned
-    * and therefore no sign extension is performed.
+  /** Constructs a Int128 from an Integer value.
     *
-    * @param value Integer, treated as 32 unsigned bits.
+    * @param value Int
     */
-  def apply(value: Integer): Int128 = new Int128(0, value.toLong)
+  def apply(value: Int): Int128 =
+    if (value< 0) new Int128(-1, value.toLong)
+    else new Int128(0, value.toLong)
 
-  /** Constructs a UInt128 from a Long value. Value is treated as unsigned and
-    * therefore no sign extension is performed.
+  /** Constructs a Int128 from a Long value.
     *
-    * @param value Long, treated as 64 unsigned bits.
+    * @param value Long
     */
-  def apply(value: Long): Int128 = new Int128(0, value)
+  def apply(value: Long): Int128 =
+    if (value< 0) new Int128(-1, value.toLong)
+    else new Int128(0, value.toLong)
 
-  /** Constructs a UInt128 from a BigInteger value. The value used to construct
-    * the UInt128 is the 128-bit two's complement representation of the
+  /** Constructs a Int128 from a BigInteger value. The value used to construct
+    * the Int128 is the 128-bit two's complement representation of the
     * BigInteger. In the case that the number of bits in the minimal
     * two's-complement representation of the BigInteger is greater than 128,
     * then the lower 128 bits are used and higher order bits are discarded.
@@ -118,40 +122,40 @@ object Int128 {
     new Int128(buf.getLong(), buf.getLong())
   }
 
-  /** Constructs a UInt128 from a String value representing a number in a
-    * specified base. The value stored in this UInt128 is the 128 bit
+  /** Constructs a Int128 from a String value representing a number in a
+    * specified base. The value stored in this Int128 is the 128 bit
     * two's-complement representation of this value. If the two's-complement
     * representation of the value requires more than 128 bits to represent, only
-    * the lower 128 bits are used to construct this UInt128.
+    * the lower 128 bits are used to construct this Int128.
     *
     * @param value   String, treated as a 128 bit signed value.
     * @param radix The base of the number represented by the string.
     */
   def apply(value: String, radix: Int): Int128 = apply(new BigInteger(value, radix))
 
-  /** Constructs a UInt128 from a String value representing a number in base 10.
-    * The value stored in this UInt128 is the 128 bit two's-complement
+  /** Constructs a Int128 from a String value representing a number in base 10.
+    * The value stored in this Int128 is the 128 bit two's-complement
     * representation of this value. If the two's-complement representation of
     * the value requires more than 128 bits to represent, only the lower 128
-    * bits are used to construct this UInt128.
+    * bits are used to construct this Int128.
     *
     * @param value Base 10 format String, treated as a 128 bit signed value.
     */
   def apply(value: String): Int128 = apply(value, 10)
 
-  /** Constructs a UInt128 from a UUID value.
-    * The value stored in this UInt128 is the 128 bit two's-complement
+  /** Constructs a Int128 from a UUID value.
+    * The value stored in this Int128 is the 128 bit two's-complement
     * representation of this value. If the two's-complement representation of
     * the value requires more than 128 bits to represent, only the lower 128
-    * bits are used to construct this UInt128.
+    * bits are used to construct this Int128.
     *
     * @param value 128-bit UUID value
     */
   def apply(value: UUID): Int128 = new Int128(value.getMostSignificantBits, value.getLeastSignificantBits)
 
-  /** Constructs a UInt128 from a byte array value. The byte array value is
+  /** Constructs a Int128 from a byte array value. The byte array value is
     * interpreted as unsigned and in big-endian format. If the byte array is
-    * less than 16 bytes, then the higher order bytes of the resulting UInt128
+    * less than 16 bytes, then the higher order bytes of the resulting Int128
     * are padded with 0s. If the byte array is greater than 16 bytes, then the
     * lower 16 bytes are used.
     *
@@ -170,8 +174,8 @@ object Int128 {
     new Int128(buf.getLong(), buf.getLong())
   }
 
-  /** Parses a UInt128 from a ByteBuffer. The ByteBuffer is expected to have at
-    * least 16 bytes at the current position, storing a UInt128 in big-endian
+  /** Parses a Int128 from a ByteBuffer. The ByteBuffer is expected to have at
+    * least 16 bytes at the current position, storing a Int128 in big-endian
     * order. This method will also advance the current position of the
     * ByteBuffer by 16 bytes.
     *
@@ -185,13 +189,13 @@ object Int128 {
   }
 
   /** Implicit conversion from `Int` to `BigInt`. */
-  implicit def int2uint128(i: Int): Int128 = apply(i)
+  implicit def int2Int128(i: Int): Int128 = apply(i)
 
   /** Implicit conversion from `Long` to `BigInt`. */
-  implicit def long2uint128(l: Long): Int128 = apply(l)
+  implicit def long2Int128(l: Long): Int128 = apply(l)
 
   /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`. */
-  implicit def javaBigInteger2uint128(x: BigInteger): Int128 = apply(x)
+  implicit def javaBigInteger2Int128(x: BigInteger): Int128 = apply(x)
 }
 
 final class Int128(val upperLong: Long, val lowerLong: Long)
@@ -219,22 +223,23 @@ final class Int128(val upperLong: Long, val lowerLong: Long)
     *
     * @return Formatted string representing this number.
     */
-  override def toString: String = BigInt(this.toByteArray).toString()
+  override def toString: String = this.bigInt.toString()
 
-  def toString(radix: Int): String = bigInt.toString(radix)
+  def toString(radix: Int): String = this.bigInt.toString(radix)
 
   override def compare(that: Int128): Int = this.bigInt.compare(that.bigInt)
 
-  /** If the supplied argument is another UInt128, tests for bit-wise equality,
-    * otherwise attempts to convert the argument to a UInt128 and then tests for
+  /** If the supplied argument is another Int128, tests for bit-wise equality,
+    * otherwise attempts to convert the argument to a Int128 and then tests for
     * equality.
     */
   override def equals(that: Any): Boolean = that match {
     case int12: Int128 => int12.upperLong == this.upperLong && int12.lowerLong == this.lowerLong
-    case _ => Int128.decode(that) match {
-      case Failure(_)    => false
-      case Success(that) => this == that
-    }
+    case _ =>
+      Int128.decode(that) match {
+        case Failure(_)    => false
+        case Success(that) => this == that
+      }
   }
 
   override def hashCode: Int = {
@@ -253,8 +258,8 @@ final class Int128(val upperLong: Long, val lowerLong: Long)
   override def isValidChar: Boolean = this >= Char.MinValue && this <= Char.MaxValue
   override def isValidInt: Boolean = this >= Int.MinValue && this <= Int.MaxValue
   def isValidLong: Boolean = this >= Long.MinValue && this <= Long.MaxValue
-  def isValidFloat: Boolean = BigInt(this.toByteArray).isValidFloat
-  def isValidDouble: Boolean = BigInt(this.toByteArray).isValidDouble
+  def isValidFloat: Boolean = this.bigInt.isValidFloat
+  def isValidDouble: Boolean = this.bigInt.isValidDouble
 
   override def intValue(): Int = this.bigInt.intValue()
 
@@ -264,23 +269,23 @@ final class Int128(val upperLong: Long, val lowerLong: Long)
 
   override def doubleValue(): Double = this.bigInt.doubleValue()
 
-  /** Subtraction of UInt128 */
-  def +  (that: Int128): Int128 = Int128(this.bigInt + that.bigInt)
+  /** Subtraction of Int128 */
+  def +(that: Int128): Int128 = Int128(this.bigInt + that.bigInt)
 
-  /** Subtraction of UInt128 */
-  def -  (that: Int128): Int128 = Int128(this.bigInt - that.bigInt)
+  /** Subtraction of Int128 */
+  def -(that: Int128): Int128 = Int128(this.bigInt - that.bigInt)
 
-  /** Multiplication of UInt128 */
-  def *  (that: Int128): Int128 = Int128(this.bigInt * that.bigInt)
+  /** Multiplication of Int128 */
+  def *(that: Int128): Int128 = Int128(this.bigInt * that.bigInt)
 
-  /** Division of UInt128 */
-  def /  (that: Int128): Int128 = Int128(this.bigInt / that.bigInt)
+  /** Division of Int128 */
+  def /(that: Int128): Int128 = Int128(this.bigInt / that.bigInt)
 
-  /** Remainder of UInt128 */
-  def %  (that: Int128): Int128 = Int128(this.bigInt % that.bigInt)
+  /** Remainder of Int128 */
+  def %(that: Int128): Int128 = Int128(this.bigInt % that.bigInt)
 
   /** Returns a BigInt whose value is the negation of this BigInt */
-  def unary_- : Int128   = Int128(this.bigInt.bigInteger.negate())
+  def unary_- : Int128 = Int128(this.bigInt.bigInteger.negate())
 
   /** Returns the bitwise complement of this BigInt */
   def unary_~ : Int128 = Int128(this.bigInt.bigInteger.not())

--- a/src/main/scala/co/topl/utils/Int128.scala
+++ b/src/main/scala/co/topl/utils/Int128.scala
@@ -1,0 +1,281 @@
+package co.topl.utils
+
+import java.math.BigInteger
+import java.nio.{ByteBuffer, ByteOrder}
+import java.util.UUID
+
+import scala.language.implicitConversions
+import scala.math.{BigInt, ScalaNumber, ScalaNumericConversions}
+import scala.util.{Failure, Success, Try}
+
+/* Copyright (c) 2015-2019 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/** Container for a 128 bit signed integer stored in big-endian format.
+ * Adopted from the original work available at
+ * https://github.com/PlatformLab/TorcDB/blob/master/src/main/java/net/ellitron/torc/util/UInt128.java
+ * by Jonathan Ellithorpe (jde@cs.stanford.edu)
+  *
+  * @author James Aman (j.aman@topl.me)
+  */
+object Int128 {
+  val size = 128
+  val bytes: Int = size / java.lang.Byte.SIZE
+  val MinValue: Int128 = Int128(Long.MinValue, 0L)
+  val MaxValue: Int128 = Int128(Long.MaxValue, -1L)
+
+  /** This method attempts to translate its argument into a UInt128.
+    *
+    * @param n Number to translate.
+    * @return UInt128
+    */
+  def decode(n: Any): Try[Int128] = Try {
+    n match {
+      case b: Byte          => Int128(b)
+      case sh: Short        => Int128(sh)
+      case integer: Integer => Int128(integer)
+      case l: Long          => Int128(l)
+      case idStr: String =>
+        if (idStr.startsWith("0x")) Int128(idStr, 16)
+        else Int128(idStr, 10)
+      case integer: BigInteger => Int128(integer)
+      case uuid: UUID          => Int128(uuid)
+      case bytes: Array[Byte]  => Int128(bytes)
+      case int12: Int128      => int12
+      case _ =>
+        throw new NumberFormatException(String.format("Unable to decode " + "number: [%s,%s]", n.getClass, n.toString))
+    }
+  }
+
+  /** Constructs a UInt128 from two longs, one representing the upper 64 bits
+    * and the other representing the lower 64 bits.
+    *
+    * @param upperLong Upper 64 bits.
+    * @param lowerLong Lower 64 bits.
+    */
+  def apply(upperLong: Long, lowerLong: Long): Int128 = new Int128(upperLong, lowerLong)
+
+  /** Constructs a UInt128 from a Byte value. Value is treated as unsigned and
+    * therefore no sign extension is performed.
+    *
+    * @param value Byte, treated as 8 unsigned bits.
+    */
+  def apply(value: Byte): Int128 = new Int128(0, value.toLong)
+
+  /** Constructs a UInt128 from a Short value. Value is treated as unsigned and
+    * therefore no sign extension is performed.
+    *
+    * @param value Short, treated as 16 unsigned bits.
+    */
+  def apply(value: Short): Int128 = new Int128(0, value.toLong)
+
+  /** Constructs a UInt128 from an Integer value. Value is treated as unsigned
+    * and therefore no sign extension is performed.
+    *
+    * @param value Integer, treated as 32 unsigned bits.
+    */
+  def apply(value: Integer): Int128 = new Int128(0, value.toLong)
+
+  /** Constructs a UInt128 from a Long value. Value is treated as unsigned and
+    * therefore no sign extension is performed.
+    *
+    * @param value Long, treated as 64 unsigned bits.
+    */
+  def apply(value: Long): Int128 = new Int128(0, value)
+
+  /** Constructs a UInt128 from a BigInteger value. The value used to construct
+    * the UInt128 is the 128-bit two's complement representation of the
+    * BigInteger. In the case that the number of bits in the minimal
+    * two's-complement representation of the BigInteger is greater than 128,
+    * then the lower 128 bits are used and higher order bits are discarded.
+    *
+    * @param value BigInteger, treated as a 128 bit signed value.
+    */
+  def apply(value: BigInt): Int128 = {
+    val bigIntBytes = value.toByteArray
+    val res = if (bigIntBytes.length >= Int128.bytes) {
+      bigIntBytes.takeRight(16)
+    } else {
+      val pad: Byte = if (bigIntBytes.head < 0) -1 else 0
+      Array.fill(16 - bigIntBytes.length)(pad) ++ bigIntBytes
+    }
+
+    val buf = ByteBuffer.allocate(bytes).order(ByteOrder.BIG_ENDIAN)
+    buf.put(res)
+    buf.flip()
+    new Int128(buf.getLong(), buf.getLong())
+  }
+
+  /** Constructs a UInt128 from a String value representing a number in a
+    * specified base. The value stored in this UInt128 is the 128 bit
+    * two's-complement representation of this value. If the two's-complement
+    * representation of the value requires more than 128 bits to represent, only
+    * the lower 128 bits are used to construct this UInt128.
+    *
+    * @param value   String, treated as a 128 bit signed value.
+    * @param radix The base of the number represented by the string.
+    */
+  def apply(value: String, radix: Int): Int128 = apply(new BigInteger(value, radix))
+
+  /** Constructs a UInt128 from a String value representing a number in base 10.
+    * The value stored in this UInt128 is the 128 bit two's-complement
+    * representation of this value. If the two's-complement representation of
+    * the value requires more than 128 bits to represent, only the lower 128
+    * bits are used to construct this UInt128.
+    *
+    * @param value Base 10 format String, treated as a 128 bit signed value.
+    */
+  def apply(value: String): Int128 = apply(value, 10)
+
+  /** Constructs a UInt128 from a UUID value.
+    * The value stored in this UInt128 is the 128 bit two's-complement
+    * representation of this value. If the two's-complement representation of
+    * the value requires more than 128 bits to represent, only the lower 128
+    * bits are used to construct this UInt128.
+    *
+    * @param value 128-bit UUID value
+    */
+  def apply(value: UUID): Int128 = new Int128(value.getMostSignificantBits, value.getLeastSignificantBits)
+
+  /** Constructs a UInt128 from a byte array value. The byte array value is
+    * interpreted as unsigned and in big-endian format. If the byte array is
+    * less than 16 bytes, then the higher order bytes of the resulting UInt128
+    * are padded with 0s. If the byte array is greater than 16 bytes, then the
+    * lower 16 bytes are used.
+    *
+    * @param value Byte array in big-endian format.
+    */
+  def apply(value: Array[Byte]): Int128 = {
+    val res = if (value.length >= Int128.bytes) {
+      value.takeRight(16)
+    } else {
+      Array.fill(16 - value.length)(0: Byte) ++ value
+    }
+
+    val buf = ByteBuffer.allocate(bytes).order(ByteOrder.BIG_ENDIAN)
+    buf.put(res)
+    buf.flip()
+    new Int128(buf.getLong(), buf.getLong())
+  }
+
+  /** Parses a UInt128 from a ByteBuffer. The ByteBuffer is expected to have at
+    * least 16 bytes at the current position, storing a UInt128 in big-endian
+    * order. This method will also advance the current position of the
+    * ByteBuffer by 16 bytes.
+    *
+    * @param buf ByteBuffer containing the value in big-endian format at the
+    *            current position of the buffer.
+    */
+  def parseFromByteBuffer(buf: ByteBuffer): Int128 = {
+    val upperLong = buf.getLong
+    val lowerLong = buf.getLong
+    new Int128(upperLong, lowerLong)
+  }
+
+  /** Implicit conversion from `Int` to `BigInt`. */
+  implicit def int2uint128(i: Int): Int128 = apply(i)
+
+  /** Implicit conversion from `Long` to `BigInt`. */
+  implicit def long2uint128(l: Long): Int128 = apply(l)
+
+  /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`. */
+  implicit def javaBigInteger2uint128(x: BigInteger): Int128 = apply(x)
+}
+
+final class Int128(val upperLong: Long, val lowerLong: Long)
+    extends ScalaNumber
+    with ScalaNumericConversions
+    with Serializable
+    with Ordered[Int128] {
+
+  private val bigInt = BigInt(this.toByteArray)
+
+  /** Returns a byte array containing this 128 bit unsigned integer in
+    * big-endian format.
+    *
+    * @return Byte array containing this number in big-endian format.
+    */
+  def toByteArray: Array[Byte] = {
+    val buf = ByteBuffer.allocate(Int128.bytes).order(ByteOrder.BIG_ENDIAN)
+    buf.putLong(upperLong)
+    buf.putLong(lowerLong)
+    buf.array
+  }
+
+  /** Returns a hexadecimal String representing this 128 bit unsigned integer
+    * with the minimum number of digits.
+    *
+    * @return Formatted string representing this number.
+    */
+  override def toString: String = BigInt(this.toByteArray).toString()
+
+  def toString(radix: Int): String = bigInt.toString(radix)
+
+  override def compare(that: Int128): Int = this.bigInt.compare(that.bigInt)
+
+  /** If the supplied argument is another UInt128, tests for bit-wise equality,
+    * otherwise attempts to convert the argument to a UInt128 and then tests for
+    * equality.
+    */
+  override def equals(that: Any): Boolean = that match {
+    case int12: Int128 => int12.upperLong == this.upperLong && int12.lowerLong == this.lowerLong
+    case _ => Int128.decode(that) match {
+      case Failure(_)    => false
+      case Success(that) => this == that
+    }
+  }
+
+  override def hashCode: Int = {
+    var hash = 7
+    hash = 83 * hash + (this.upperLong ^ (this.upperLong >>> 32)).toInt
+    hash = 83 * hash + (this.lowerLong ^ (this.lowerLong >>> 32)).toInt
+    hash
+  }
+
+  override def underlying: (Long, Long) = (this.upperLong, this.lowerLong)
+
+  override def isWhole(): Boolean = true
+
+  override def isValidByte: Boolean = this >= Byte.MinValue && this <= Byte.MaxValue
+  override def isValidShort: Boolean = this >= Short.MinValue && this <= Short.MaxValue
+  override def isValidChar: Boolean = this >= Char.MinValue && this <= Char.MaxValue
+  override def isValidInt: Boolean = this >= Int.MinValue && this <= Int.MaxValue
+  def isValidLong: Boolean = this >= Long.MinValue && this <= Long.MaxValue
+  def isValidFloat: Boolean = BigInt(this.toByteArray).isValidFloat
+  def isValidDouble: Boolean = BigInt(this.toByteArray).isValidDouble
+
+  override def intValue(): Int = this.bigInt.intValue()
+
+  override def longValue(): Long = this.bigInt.longValue()
+
+  override def floatValue(): Float = this.bigInt.floatValue()
+
+  override def doubleValue(): Double = this.bigInt.doubleValue()
+
+  /** Subtraction of UInt128 */
+  def +  (that: Int128): Int128 = Int128(this.bigInt + that.bigInt)
+
+  /** Subtraction of UInt128 */
+  def -  (that: Int128): Int128 = Int128(this.bigInt - that.bigInt)
+
+  /** Multiplication of UInt128 */
+  def *  (that: Int128): Int128 = Int128(this.bigInt * that.bigInt)
+
+  /** Division of UInt128 */
+  def /  (that: Int128): Int128 = Int128(this.bigInt / that.bigInt)
+
+  /** Remainder of UInt128 */
+  def %  (that: Int128): Int128 = Int128(this.bigInt % that.bigInt)
+}

--- a/src/main/scala/co/topl/utils/NetworkTime.scala
+++ b/src/main/scala/co/topl/utils/NetworkTime.scala
@@ -29,7 +29,7 @@ class NetworkTimeProvider(ntpSettings: NetworkTimeProviderSettings)(implicit ec:
     *
     * @return the current timestamp in milliseconds
     */
-  override def time(): TimeProvider.Time = {
+  override def time: TimeProvider.Time = {
     checkUpdateRequired()
     NetworkTime.localWithOffset(offset.get())
   }

--- a/src/main/scala/co/topl/utils/TimeProvider.scala
+++ b/src/main/scala/co/topl/utils/TimeProvider.scala
@@ -5,5 +5,5 @@ object TimeProvider {
 }
 
 trait TimeProvider {
-  def time(): TimeProvider.Time
+  def time: TimeProvider.Time
 }

--- a/src/main/scala/co/topl/utils/codecs/Int128Codec.scala
+++ b/src/main/scala/co/topl/utils/codecs/Int128Codec.scala
@@ -1,0 +1,10 @@
+package co.topl.utils.codecs
+
+import co.topl.utils.Int128
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder}
+
+object Int128Codec {
+  implicit val jsonEncoder: Encoder[Int128] = (x: Int128) => x.toString.asJson
+  implicit val jsonDecoder: Decoder[Int128] = Decoder.decodeString.map(s => Int128(s))
+}

--- a/src/main/scala/co/topl/utils/serialization/Reader.scala
+++ b/src/main/scala/co/topl/utils/serialization/Reader.scala
@@ -1,5 +1,7 @@
 package co.topl.utils.serialization
 
+import co.topl.utils.Int128
+
 trait Reader {
 
   /**

--- a/src/main/scala/co/topl/utils/serialization/Reader.scala
+++ b/src/main/scala/co/topl/utils/serialization/Reader.scala
@@ -96,6 +96,12 @@ trait Reader {
   def getULong(): Long
 
   /**
+   * Decode sign Int128
+   * @return signed Int128
+   */
+  def getInt128(): Int128
+
+  /**
     * Decode array of byte values
     * @param size expected size of decoded array
     * @return

--- a/src/main/scala/co/topl/utils/serialization/VLQReader.scala
+++ b/src/main/scala/co/topl/utils/serialization/VLQReader.scala
@@ -2,6 +2,7 @@ package co.topl.utils.serialization
 
 import java.util
 
+import co.topl.utils.Int128
 import co.topl.utils.serialization.Extensions._
 import co.topl.utils.serialization.ZigZagEncoder._
 
@@ -88,6 +89,9 @@ trait VLQReader extends Reader {
     sys.error(s"Cannot deserialize Long value. Unexpected reader $this with bytes remaining $remaining")
     // see https://rosettacode.org/wiki/Variable-length_quantity for implementations in other languages
   }
+
+  /** Retrieve the custom Int128 type that is 16 bytes (128 bits) */
+  @inline def getInt128(): Int128 = Int128(getBytes(Int128.numBytes))
 
   @inline override def getBits(size: Int): Array[Boolean] = {
     if (size == 0) return Array[Boolean]()

--- a/src/main/scala/co/topl/utils/serialization/VLQWriter.scala
+++ b/src/main/scala/co/topl/utils/serialization/VLQWriter.scala
@@ -2,6 +2,7 @@ package co.topl.utils.serialization
 
 import java.util
 
+import co.topl.utils.Int128
 import co.topl.utils.serialization.ZigZagEncoder._
 
 trait VLQWriter extends Writer {

--- a/src/main/scala/co/topl/utils/serialization/VLQWriter.scala
+++ b/src/main/scala/co/topl/utils/serialization/VLQWriter.scala
@@ -117,6 +117,9 @@ trait VLQWriter extends Writer {
     // see https://rosettacode.org/wiki/Variable-length_quantity for implementations in other languages
   }
 
+  /** Insert the custom Int128 type that is 16 bytes (128 bits) */
+  @inline def putInt128(x: Int128): this.type = putBytes(x.toByteArray)
+
   @inline override def putBits(xs: Array[Boolean]): this.type = {
     if (xs.isEmpty) return this
     val bitSet = new util.BitSet(xs.length)

--- a/src/main/scala/co/topl/utils/serialization/Writer.scala
+++ b/src/main/scala/co/topl/utils/serialization/Writer.scala
@@ -1,5 +1,7 @@
 package co.topl.utils.serialization
 
+import co.topl.utils.Int128
+
 trait Writer {
 
   /**
@@ -108,7 +110,6 @@ trait Writer {
     * @param x Long
     */
   def putULong(x: Long): this.type
-
 
   /**
     * Encode an array of bytes

--- a/src/main/scala/co/topl/utils/serialization/Writer.scala
+++ b/src/main/scala/co/topl/utils/serialization/Writer.scala
@@ -112,6 +112,12 @@ trait Writer {
   def putULong(x: Long): this.type
 
   /**
+   * Encode an Int128 value
+   * @param x - Int128
+   */
+  def putInt128(x: Int128): this.type
+
+  /**
     * Encode an array of bytes
     * @param xs value to encode
     * @return

--- a/src/main/scala/co/topl/utils/serialization/ZigZagEncoder.scala
+++ b/src/main/scala/co/topl/utils/serialization/ZigZagEncoder.scala
@@ -1,5 +1,7 @@
 package co.topl.utils.serialization
 
+import co.topl.utils.Int128
+
 object ZigZagEncoder {
 
   /**
@@ -58,4 +60,5 @@ object ZigZagEncoder {
     // source: http://github.com/google/protobuf/blob/a7252bf42df8f0841cf3a0c85fdbf1a5172adecb/java/core/src/main/java/com/google/protobuf/CodedInputStream.java#L566
     (n >>> 1) ^ -(n & 1)
   }
+
 }

--- a/src/test/scala/co/topl/api/AssetRPCSpec.scala
+++ b/src/test/scala/co/topl/api/AssetRPCSpec.scala
@@ -30,7 +30,7 @@ class AssetRPCSpec extends AnyWordSpec
            |  [
            |    "AUBDNmMJkmHtuyGXkWAB7Bg9X8T4CRDNVXmPvVcQWPMk4RdwR883",
            |      {
-           |        "quantity" : 5858200457744262097,
+           |        "quantity" : "5858200457744262097",
            |        "assetCode" : "PPsSca8fTkx4jDLUvxCoaVw3r3ZabTssC2SKFGbCdRYDNJSRm2q6tQCXYkP",
            |        "metadata" : "ApdGzs6uwKAhuKJQswBWoVAFjNA5B8enBKfxVbzlcQ8EnpxicpRcE9B9Bgn2LGv02kYUSA1h1181ZYeECvr",
            |        "type" : "Asset",
@@ -39,7 +39,7 @@ class AssetRPCSpec extends AnyWordSpec
            |     "sender": ["$address"],
            |     "changeAddress": "$address",
            |     "consolidationAddress": "$address",
-           |     "fee": 1,
+           |     "fee": "1",
            |     "minting": true,
            |     "data": ""
            |   }]

--- a/src/test/scala/co/topl/utils/ValidGenerators.scala
+++ b/src/test/scala/co/topl/utils/ValidGenerators.scala
@@ -109,10 +109,10 @@ trait ValidGenerators extends CoreGenerators {
   }
 
   def validAssetTransfer(
-    keyRing: KeyRing[PrivateKeyCurve25519, KeyfileCurve25519],
-    state: State,
-    fee: Long = 1L,
-    minting: Boolean = false
+                          keyRing: KeyRing[PrivateKeyCurve25519, KeyfileCurve25519],
+                          state: State,
+                          fee: Long = 1L,
+                          minting: Boolean = false
   ): Gen[AssetTransfer[PublicKeyPropositionCurve25519]] = {
     val sender = keyRing.addresses.head
     val prop = keyRing.lookupPublicKey(sender).get


### PR DESCRIPTION
## Summary
This PR implements a 128 bit number as the value for tokens in Bifrost. Currently we are representing this values as Longs which may present an issue of running out of room in the numbers we can represent since the 64 bit. These Long numbers are only able to represent 18 orders of magnitude (in decimal) so we would've been limited to only being able to represent numbers up to ~9.2 billion (with the lower 9 orders used for fractions of a token). While that might have been enough, it doesn't really leave a lot of room for growth if we start off by issuing 200 million coins (we only had about a factor of 20 in head room). The custom 128 bit number now lets us represent numbers up to 10^38, so with fractional tokens the maximum number is now 170 octillion (10^27). 

## Changes
- added custom fixed length 128 bit integer type
  - arthmetic for this type is implemenbted via BigInt but otherwise this number acts like Long, Int, etc.
- replaced the quantity type in AssetValue and SimpleValue to be represented by Int128
- replaced the fee typoe in Transactions to be represented by Int128
- replaced instances of `.sum` with `.reduce(_ + _)` due since sum is a trait of Numeric[T]
- refactored `.time()` to `.time` to avoid unnecessary parentheses
- updated serializers for all modified types (ArbitTransfer, PolyTransfer, AssetTransfer)
- updated JSON encoder/decoders for modified types
  - note that JSON number inputs are now assumed to be Strings in JSON that are then interpreted as Int128
- modified BlockValidator and Forger classes to correctly implement the Int128 classes
- Updated Private genesis block creation
- updated `Balance` API request to return String encoded Int128
- updated some val names in BloomFilter (shouldn't effect anything)

## Testing
- Bifrost passes all unit tests
- Able to spin up a node on a private network and query using Postman