### PR TITLE
abstract box reader from state reader to separate defintions

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -19,6 +19,12 @@ bifrost {
     # optional set of accounts that will be tracked by the state of this node
     nodeKeys = []
 
+    #
+    mempoolCleanupDuration = 20s
+
+    # Number of transactions from mempool to be re-broadcasted
+    rebroadcastCount = 3
+
     # ----- Cache settings (Guava) -----
     # Consider 5 sec per block for testing and 15 sec per block for toplnet
     # 15 sec * 50 blocks / 60 sec per minutes = 12.5 minutes

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -19,8 +19,8 @@ bifrost {
     # optional set of accounts that will be tracked by the state of this node
     nodeKeys = []
 
-    #
-    mempoolCleanupDuration = 20s
+    # time an unconfirmed transaction can stay in the mempool before being removed
+    mempoolTimeout = 3h
 
     # Number of transactions from mempool to be re-broadcasted
     rebroadcastCount = 3

--- a/src/main/scala/co/topl/BifrostApp.scala
+++ b/src/main/scala/co/topl/BifrostApp.scala
@@ -19,7 +19,8 @@ import co.topl.network.message.BifrostSyncInfo
 import co.topl.network.upnp.Gateway
 import co.topl.nodeView.history.History
 import co.topl.nodeView.mempool.MemPool
-import co.topl.nodeView.{NodeViewHolder, NodeViewHolderRef}
+import co.topl.nodeView.state.State
+import co.topl.nodeView.{MempoolAuditor, MempoolAuditorRef, NodeViewHolder, NodeViewHolderRef}
 import co.topl.settings._
 import co.topl.utils.Logging
 import co.topl.wallet.{WalletConnectionHandler, WalletConnectionHandlerRef}
@@ -38,6 +39,7 @@ class BifrostApp(startupOpts: StartupOpts) extends Logging with Runnable {
   type PMOD = Block
   type HIS = History
   type MP = MemPool
+  type ST = State
 
   /** Setup settings file to be passed into the application */
   private val settings: AppSettings = AppSettings.read(startupOpts)
@@ -54,11 +56,13 @@ class BifrostApp(startupOpts: StartupOpts) extends Logging with Runnable {
 
   /** save runtime environment into a variable for reference throughout the application */
   protected val appContext = new AppContext(settings, startupOpts, upnpGateway)
-  log.debug(s"${Console.MAGENTA}Runtime network parameters:" +
+  log.debug(
+    s"${Console.MAGENTA}Runtime network parameters:" +
     s"type - ${appContext.networkType.verboseName}, " +
     s"prefix - ${appContext.networkType.netPrefix}, " +
     s"forging status: ${settings.forging.forgeOnStartup}" +
-    s"${Console.RESET}")
+    s"${Console.RESET}"
+  )
 
   /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ---------------- */
   /** Create Bifrost singleton actors */
@@ -71,7 +75,11 @@ class BifrostApp(startupOpts: StartupOpts) extends Logging with Runnable {
 
   private val nodeViewHolderRef: ActorRef = NodeViewHolderRef(NodeViewHolder.actorName, settings, appContext)
 
-  private val walletConnectionHandlerRef: ActorRef = WalletConnectionHandlerRef[PMOD](WalletConnectionHandler.actorName, settings, appContext, nodeViewHolderRef)
+  private val mempoolAuditor: ActorRef =
+    MempoolAuditorRef[ST, MP](MempoolAuditor.actorName, settings, appContext, nodeViewHolderRef, networkControllerRef)
+
+  private val walletConnectionHandlerRef: ActorRef =
+    WalletConnectionHandlerRef[PMOD](WalletConnectionHandler.actorName, settings, appContext, nodeViewHolderRef)
 
   private val peerSynchronizer: ActorRef =
     PeerSynchronizerRef(PeerSynchronizer.actorName, networkControllerRef, peerManagerRef, settings, appContext)
@@ -92,13 +100,14 @@ class BifrostApp(startupOpts: StartupOpts) extends Logging with Runnable {
     nodeViewSynchronizer,
     forgerRef,
     nodeViewHolderRef,
-    walletConnectionHandlerRef
+    walletConnectionHandlerRef,
+    mempoolAuditor
   )
 
   /** hook for initiating the shutdown procedure */
   sys.addShutdownHook(BifrostApp.shutdown(actorSystem, actorsToStop))
 
-  /* ----------------- *//* ----------------- *//* ----------------- *//* ----------------- *//* ----------------- *//* ----------------- */
+  /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
   /** Create and register controllers for API routes */
   private val apiRoutes: Seq[ApiEndpoint] = Seq(
     UtilsApiEndpoint(settings.rpcApi, appContext),
@@ -199,12 +208,10 @@ object BifrostApp extends Logging {
   /** parse command line arguments */
   val argParser: Arg[StartupOpts] =
     (optional[String]("--config", "-c") and
-      optionalOneOf[NetworkType](NetworkType.all.map(x => s"--${x.verboseName}" -> x) : _*) and
-      ( optional[String]("--seed", "-s") and
-        flag("--forge", "-f") and
-        optional[String]("--apiKeyHash")
-        ).to[RuntimeOpts]
-      ).to[StartupOpts]
+      optionalOneOf[NetworkType](NetworkType.all.map(x => s"--${x.verboseName}" -> x): _*) and
+      (optional[String]("--seed", "-s") and
+      flag("--forge", "-f") and
+      optional[String]("--apiKeyHash")).to[RuntimeOpts]).to[StartupOpts]
 
   ////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////// METHOD DEFINITIONS ////////////////////////////////
@@ -218,7 +225,7 @@ object BifrostApp extends Logging {
 
   def shutdown(system: ActorSystem, actors: Seq[ActorRef]): Unit = {
     log.warn("Terminating Actors")
-    actors.foreach { _ ! PoisonPill }
+    actors.foreach(_ ! PoisonPill)
     log.warn("Terminating ActorSystem")
     val termination = system.terminate()
     Await.result(termination, 60.seconds)

--- a/src/main/scala/co/topl/attestation/Proposition.scala
+++ b/src/main/scala/co/topl/attestation/Proposition.scala
@@ -76,7 +76,7 @@ object PublicKeyPropositionCurve25519 {
 
   implicit val evProducer: EvidenceProducer[PublicKeyPropositionCurve25519] =
     EvidenceProducer.instance[PublicKeyPropositionCurve25519] {
-      prop: PublicKeyPropositionCurve25519 => Evidence(typePrefix, EvidenceContent @@ Blake2b256(prop.bytes))
+      prop: PublicKeyPropositionCurve25519 => Evidence(typePrefix, EvidenceContent @@ Blake2b256(prop.bytes.tail))
     }
 
   implicit val identifier: Identifiable[PublicKeyPropositionCurve25519] = Identifiable.instance { () =>
@@ -122,7 +122,7 @@ object ThresholdPropositionCurve25519 {
 
   implicit val evProducer: EvidenceProducer[ThresholdPropositionCurve25519] =
     EvidenceProducer.instance[ThresholdPropositionCurve25519] {
-      prop: ThresholdPropositionCurve25519 => Evidence(typePrefix, EvidenceContent @@ Blake2b256(prop.bytes))
+      prop: ThresholdPropositionCurve25519 => Evidence(typePrefix, EvidenceContent @@ Blake2b256(prop.bytes.tail))
     }
 
   implicit val identifier: Identifiable[ThresholdPropositionCurve25519] = Identifiable.instance { () =>

--- a/src/main/scala/co/topl/consensus/BlockValidator.scala
+++ b/src/main/scala/co/topl/consensus/BlockValidator.scala
@@ -4,6 +4,7 @@ import co.topl.consensus
 import co.topl.modifier.block.Block
 import co.topl.modifier.transaction.{ArbitTransfer, PolyTransfer, Transaction}
 import co.topl.nodeView.history.{BlockProcessor, History, Storage}
+import co.topl.utils.TimeProvider
 
 import scala.util.{Failure, Try}
 
@@ -30,7 +31,7 @@ class DifficultyBlockValidator(storage: Storage, blockProcessor: BlockProcessor)
     }
   }
 
-  private def ensureHeightAndDifficulty(block: Block, parent: Block, prevTimes: Seq[Block.Timestamp]): Try[Unit] = Try {
+  private def ensureHeightAndDifficulty(block: Block, parent: Block, prevTimes: Seq[TimeProvider.Time]): Try[Unit] = Try {
     // calculate the new base difficulty
     val newHeight = parent.height + 1
     val newBaseDifficulty = consensus.calcNewBaseDifficulty(newHeight, parent.difficulty, prevTimes)
@@ -58,7 +59,7 @@ class DifficultyBlockValidator(storage: Storage, blockProcessor: BlockProcessor)
   }
 
   /** Helper function to find the source of the parent block (either storage or chain cache) */
-  private def getParentDetailsOf(block: Block): (Block, Seq[Block.Timestamp]) =
+  private def getParentDetailsOf(block: Block): (Block, Seq[TimeProvider.Time]) =
     blockProcessor.getCacheBlock(block.parentId) match {
       case Some(cacheParent) => (cacheParent.block, cacheParent.prevBlockTimes)
       case None =>

--- a/src/main/scala/co/topl/consensus/Forger.scala
+++ b/src/main/scala/co/topl/consensus/Forger.scala
@@ -308,7 +308,7 @@ class Forger(settings: AppSettings, appContext: AppContext)(implicit ec: Executi
   private def pickTransactions(memPool: MemPool, state: State, chainHeight: Long): Try[PickTransactionsResult] = Try {
 
     memPool
-      .take(numTxInBlock(chainHeight))
+      .take(numTxInBlock(chainHeight))(-_.tx.fee) // returns a sequence of transactions ordered by their fee
       .filter(_.tx.fee > 0) // default strategy ignores zero fee transactions in mempool
       .foldLeft(PickTransactionsResult(Seq(), Seq())) { case (txAcc, utx) =>
         // ensure that each transaction opens a unique box by checking that this transaction

--- a/src/main/scala/co/topl/consensus/Forger.scala
+++ b/src/main/scala/co/topl/consensus/Forger.scala
@@ -48,7 +48,7 @@ class Forger(settings: AppSettings, appContext: AppContext)(implicit ec: Executi
   private var rewardAddress: Option[Address] = None
 
   // a timestamp updated on each forging attempt
-  private var forgeTime: Time = appContext.timeProvider.time()
+  private var forgeTime: Time = appContext.timeProvider.time
 
   override def preStart(): Unit = {
     // determine the set of applicable protocol rules for this software version
@@ -129,7 +129,7 @@ class Forger(settings: AppSettings, appContext: AppContext)(implicit ec: Executi
   ////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////// METHOD DEFINITIONS ////////////////////////////////
   /** Updates the forging actors timestamp */
-  private def updateForgeTime(): Unit = forgeTime = appContext.timeProvider.time()
+  private def updateForgeTime(): Unit = forgeTime = appContext.timeProvider.time
 
   /** Updates the rewards address from the API */
   private def updateRewardsAddress(address: Address): String = {

--- a/src/main/scala/co/topl/consensus/genesis/PrivateTestnet.scala
+++ b/src/main/scala/co/topl/consensus/genesis/PrivateTestnet.scala
@@ -9,6 +9,7 @@ import co.topl.modifier.block.Block
 import co.topl.modifier.transaction.{ArbitTransfer, PolyTransfer}
 import co.topl.modifier.box.{ArbitBox, SimpleValue}
 import co.topl.settings.{AppSettings, Version}
+import co.topl.utils.Int128
 
 import scala.util.Try
 
@@ -38,14 +39,15 @@ case class PrivateTestnet ( keyGen  : (Int, Option[String]) => Set[PublicKeyProp
     // map the members to their balances then continue as normal
     val privateTotalStake = numberOfKeys * balance
 
-    val accts = keyGen(numberOfKeys, settings.forging.privateTestnet.flatMap(_.genesisSeed))
+    val accts: Set[PublicKeyPropositionCurve25519] =
+      keyGen(numberOfKeys, settings.forging.privateTestnet.flatMap(_.genesisSeed))
 
     val txInput = (
       IndexedSeq(),
       (genesisAcct.publicImage.address -> SimpleValue(0L)) +:
         accts.map(_.address -> SimpleValue(balance)).toIndexedSeq,
       Map(genesisAcct.publicImage -> SignatureCurve25519.genesis),
-      0L,
+      Int128(0),
       0L,
       None,
       true)

--- a/src/main/scala/co/topl/consensus/package.scala
+++ b/src/main/scala/co/topl/consensus/package.scala
@@ -3,6 +3,7 @@ package co.topl
 import co.topl.modifier.block.Block
 import co.topl.modifier.box.ArbitBox
 import co.topl.settings.ProtocolSettings
+import co.topl.utils.TimeProvider
 import com.google.common.primitives.Longs
 import scorex.crypto.hash.Blake2b256
 
@@ -89,7 +90,7 @@ package object consensus {
     * @param prevTimes      sequence of block times to calculate the average and compare to target
     * @return the modified difficulty
     */
-  def calcNewBaseDifficulty(newHeight: Long, prevDifficulty: Long, prevTimes: Seq[Block.Timestamp]): Long = {
+  def calcNewBaseDifficulty(newHeight: Long, prevDifficulty: Long, prevTimes: Seq[TimeProvider.Time]): Long = {
 
     val averageDelay = (prevTimes drop 1, prevTimes).zipped.map(_-_).sum / (prevTimes.length - 1)
     val targetTimeMilli = targetBlockTime(newHeight).toUnit(MILLISECONDS)

--- a/src/main/scala/co/topl/crypto/KeyfileCurve25519.scala
+++ b/src/main/scala/co/topl/crypto/KeyfileCurve25519.scala
@@ -69,7 +69,7 @@ object KeyfileCurve25519 extends KeyfileCompanion[PrivateKeyCurve25519, KeyfileC
           val privateKey = new PrivateKeyCurve25519(PrivateKey @@ skBytes, PublicKey @@ pkBytes)
           val derivedAddress = Address.from(privateKey.publicImage)
           // check that the address given in the keyfile matches the public key
-          require(encryptedKeyFile.address == derivedAddress, "PublicKey in file is invalid")
+          require(encryptedKeyFile.address == derivedAddress, "Derived address does not match that listed in the keyfile")
           privateKey
       }
     }

--- a/src/main/scala/co/topl/http/api/ApiEndpoint.scala
+++ b/src/main/scala/co/topl/http/api/ApiEndpoint.scala
@@ -3,7 +3,7 @@ package co.topl.http.api
 import akka.util.Timeout
 import co.topl.attestation.AddressEncoder.NetworkPrefix
 import co.topl.settings.{AppContext, RPCApiSettings}
-import io.circe.{Decoder, Json}
+import io.circe.{Decoder, DecodingFailure, Json}
 
 import scala.concurrent.Future
 
@@ -20,17 +20,15 @@ trait ApiEndpoint {
   // these are the case statements for identifying the api services
   val handlers: PartialFunction[(String, Vector[Json], String), Future[Json]]
 
-  /**
-   * Helper function to parse optional parameters from the request
-   * @param key optional key to be looked for
-   * @param default default return value
-   * @tparam A type of the value expected to be retrieved
-   * @return the provided value or the default
-   */
-  def parseOptional[A](key: String, default: A)(implicit params: Json, decode: Decoder[A]): A = {
+  /** Helper function to parse optional parameters from the request
+    * @param key optional key to be looked for
+    * @param default default return value
+    * @tparam A type of the value expected to be retrieved
+    * @return the provided value or the default
+    */
+  def parseOptional[A](key: String, default: A)(implicit params: Json, decode: Decoder[A]): Either[DecodingFailure, A] =
     params.hcursor.downField(key).as[A] match {
-      case Right(value) => value
-      case Left(_)      => default
+      case Right(value) => Right(value)
+      case Left(_)      => Right(default)
     }
-  }
 }

--- a/src/main/scala/co/topl/http/api/endpoints/AdminApiEndpoint.scala
+++ b/src/main/scala/co/topl/http/api/endpoints/AdminApiEndpoint.scala
@@ -2,21 +2,21 @@ package co.topl.http.api.endpoints
 
 import akka.actor.{ActorRef, ActorRefFactory}
 import akka.pattern.ask
-import co.topl.attestation.Address
 import co.topl.attestation.AddressEncoder.NetworkPrefix
+import co.topl.attestation.{Address, PublicKeyPropositionCurve25519}
 import co.topl.consensus.Forger.ReceivableMessages._
 import co.topl.http.api.{AdminNamespace, ApiEndpoint, Namespace}
 import co.topl.settings.{AppContext, RPCApiSettings}
-import io.circe.{DecodingFailure, Json}
+import io.circe.Json
 import io.circe.syntax.EncoderOps
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
-case class AdminApiEndpoint(override val settings: RPCApiSettings, appContext: AppContext, keyHolderRef: ActorRef )
-                           ( implicit val context: ActorRefFactory ) extends ApiEndpoint {
-
+case class AdminApiEndpoint(override val settings: RPCApiSettings, appContext: AppContext, keyHolderRef: ActorRef)(
+  implicit val context:                            ActorRefFactory
+) extends ApiEndpoint {
 
   // Establish the expected network prefix for addresses
   implicit val networkPrefix: NetworkPrefix = appContext.networkType.netPrefix
@@ -26,69 +26,71 @@ case class AdminApiEndpoint(override val settings: RPCApiSettings, appContext: A
 
   // partial function for identifying local method handlers exposed by the api
   val handlers: PartialFunction[(String, Vector[Json], String), Future[Json]] = {
-    case (method, params, id) if method == s"${namespace.name}_unlockKeyfile"    => unlockKeyfile(params.head, id)
-    case (method, params, id) if method == s"${namespace.name}_lockKeyfile"      => lockKeyfile(params.head, id)
-    case (method, params, id) if method == s"${namespace.name}_generateKeyfile"  => generateKeyfile(params.head, id)
-    case (method, params, id) if method == s"${namespace.name}_importSeedPhrase" => importKeyfile(params.head, id)
-    case (method, params, id) if method == s"${namespace.name}_listOpenKeyfiles" => listOpenKeyfiles(params.head, id)
-    case (method, params, id) if method == s"${namespace.name}_startForging"     => startForging(params.head, id)
-    case (method, params, id) if method == s"${namespace.name}_stopForging"      => stopForging(params.head, id)
+    case (method, params, id) if method == s"${namespace.name}_unlockKeyfile"        => unlockKeyfile(params.head, id)
+    case (method, params, id) if method == s"${namespace.name}_lockKeyfile"          => lockKeyfile(params.head, id)
+    case (method, params, id) if method == s"${namespace.name}_generateKeyfile"      => generateKeyfile(params.head, id)
+    case (method, params, id) if method == s"${namespace.name}_importSeedPhrase"     => importKeyfile(params.head, id)
+    case (method, params, id) if method == s"${namespace.name}_listOpenKeyfiles"     => listOpenKeyfiles(params.head, id)
+    case (method, params, id) if method == s"${namespace.name}_startForging"         => startForging(params.head, id)
+    case (method, params, id) if method == s"${namespace.name}_stopForging"          => stopForging(params.head, id)
+    case (method, params, id) if method == s"${namespace.name}_updateRewardsAddress" => updateRewardsAddress(params.head, id)
+    case (method, params, id) if method == s"${namespace.name}_getRewardsAddress"    => getRewardsAddress(params.head, id)
   }
 
   /** #### Summary
-   * Unlock keyfile
-   *
-   * #### Type
-   * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
-   *
-   * #### Description
-   * Unlock an encrypted keyfile which exists in your keyfile directory. This will add the secret key to wallet and allow signing of transactions on behalf of that key
-   * ---
-   * #### Params
-   *
-   * | Fields | Data type | Required / Optional | Description |
-   * | ---| ---	| --- | --- |
-   * | publicKey | String	| Required | Public key corresponding to an encrypted keyfile in your wallet directory |
-   * | password  | String	| Required | String used to encrypt the private keyfile that is stored locally |
-   *
-   * @param params input parameters as specified above
-   * @param id     request identifier
-   * @return
-   */
-  private def unlockKeyfile ( params: Json, id: String ): Future[Json] = {
+    * Unlock keyfile
+    *
+    * #### Type
+    * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
+    *
+    * #### Description
+    * Unlock an encrypted keyfile which exists in your keyfile directory. This will add the secret key to wallet and allow signing of transactions on behalf of that key
+    * ---
+    * #### Params
+    *
+    * | Fields | Data type | Required / Optional | Description |
+    * | ---| ---	| --- | --- |
+    * | publicKey | String	| Required | Public key corresponding to an encrypted keyfile in your wallet directory |
+    * | password  | String	| Required | String used to encrypt the private keyfile that is stored locally |
+    *
+    * @param params input parameters as specified above
+    * @param id     request identifier
+    * @return
+    */
+  private def unlockKeyfile(params: Json, id: String): Future[Json] = {
     val publicKey: String = (params \\ "address").head.asString.get
     val password: String = (params \\ "password").head.asString.get
 
     (keyHolderRef ? UnlockKey(publicKey, password)).mapTo[Try[Unit]].map {
-      case Success(_)  => Map( publicKey -> "unlocked".asJson).asJson
+      case Success(_)  => Map(publicKey -> "unlocked".asJson).asJson
       case Failure(ex) => throw new Error(s"An error occurred while trying to unlock the keyfile. $ex")
     }
   }
 
   /** #### Summary
-   * Lock keyfile
-   *
-   * #### Type
-   * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
-   *
-   * #### Description
-   * Lock a previously unlocked keyfile in your wallet.
-   * ---
-   * #### Params
-   * | Fields                  	| Data type 	| Required / Optional 	| Description                                                            	  |
-   * |-------------------------	|-----------	|---------------------	|------------------------------------------------------------------------	  |
-   * | publicKey               	| String    	| Required            	| Public key corresponding to an encrypted keyfile in your wallet directory |
-   * | password                	| String    	| Required            	| String used to encrypt the private keyfile that is stored locally         |
-   *
-   * @param params input parameters as specified above
-   * @param id     request identifier
-   * @return
-   */
-  private def lockKeyfile ( params: Json, id: String ): Future[Json] =
+    * Lock keyfile
+    *
+    * #### Type
+    * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
+    *
+    * #### Description
+    * Lock a previously unlocked keyfile in your wallet.
+    * ---
+    * #### Params
+    * | Fields                  	| Data type 	| Required / Optional 	| Description                                                            	  |
+    * |-------------------------	|-----------	|---------------------	|------------------------------------------------------------------------	  |
+    * | publicKey               	| String    	| Required            	| Public key corresponding to an encrypted keyfile in your wallet directory |
+    * | password                	| String    	| Required            	| String used to encrypt the private keyfile that is stored locally         |
+    *
+    * @param params input parameters as specified above
+    * @param id     request identifier
+    * @return
+    */
+  private def lockKeyfile(params: Json, id: String): Future[Json] =
     (for {
       addr <- params.hcursor.get[Address]("address")
     } yield (keyHolderRef ? LockKey(addr)).mapTo[Try[Unit]].map {
-      case Success(_) => Map(addr -> "locked".asJson).asJson
+      case Success(_)  => Map(addr -> "locked".asJson).asJson
       case Failure(ex) => throw new Exception(s"An error occurred while trying to lock the keyfile. $ex")
     }) match {
       case Right(json) => json
@@ -96,24 +98,24 @@ case class AdminApiEndpoint(override val settings: RPCApiSettings, appContext: A
     }
 
   /** #### Summary
-   * Generate a new keyfile in local storage
-   *
-   * #### Type
-   * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
-   *
-   * #### Description
-   * Generate and save a new encrypted private keyfile using Curve25519 key pairs.
-   * ---
-   * #### Params
-   * | Fields                  	| Data type 	| Required / Optional 	| Description                                                            	  |
-   * |-------------------------	|-----------	|---------------------	|------------------------------------------------------------------------	  |
-   * | password                	| String    	| Required            	| String used to encrypt the private keyfile that is stored locally        	|
-   *
-   * @param params input parameters as specified above
-   * @param id     request identifier
-   * @return
-   */
-  private def generateKeyfile ( params: Json, id: String ): Future[Json] = {
+    * Generate a new keyfile in local storage
+    *
+    * #### Type
+    * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
+    *
+    * #### Description
+    * Generate and save a new encrypted private keyfile using Curve25519 key pairs.
+    * ---
+    * #### Params
+    * | Fields                  	| Data type 	| Required / Optional 	| Description                                                            	  |
+    * |-------------------------	|-----------	|---------------------	|------------------------------------------------------------------------	  |
+    * | password                	| String    	| Required            	| String used to encrypt the private keyfile that is stored locally        	|
+    *
+    * @param params input parameters as specified above
+    * @param id     request identifier
+    * @return
+    */
+  private def generateKeyfile(params: Json, id: String): Future[Json] = {
     val password: String = (params \\ "password").head.asString.get
 
     (keyHolderRef ? CreateKey(password)).mapTo[Try[Address]].map {
@@ -123,26 +125,26 @@ case class AdminApiEndpoint(override val settings: RPCApiSettings, appContext: A
   }
 
   /** #### Summary
-   * Import key from mnemonic
-   *
-   * #### Type
-   * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
-   *
-   * #### Description
-   * Allows a user to import a 12, 15, 18, 21, or 24 word mnemonic (seed phrase) and generate an encrypted Keyfile
-   * ---
-   * #### Params
-   * | Fields                  	| Data type 	| Required / Optional 	| Description                                                            	  |
-   * |-------------------------	|-----------	|---------------------	|------------------------------------------------------------------------	  |
-   * | password                	| String    	| Required            	| String used to encrypt the private keyfile that is stored locally         |
-   * | seedPhrase              	| String    	| Required            	| 12, 15, 18, 21, or 24 word mnemonic							         	                |
-   * | seddPhraseLang         	| String    	| Optional            	| Defaults to 'en'. Valid options are ["zh-hans", "zh-hant", "en", "fr", "it", "ja", "ko", "es"] |
-   *
-   * @param params input parameters as specified above
-   * @param id     request identifier
-   * @return
-   */
-  private def importKeyfile ( implicit params: Json, id: String ): Future[Json] = {
+    * Import key from mnemonic
+    *
+    * #### Type
+    * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
+    *
+    * #### Description
+    * Allows a user to import a 12, 15, 18, 21, or 24 word mnemonic (seed phrase) and generate an encrypted Keyfile
+    * ---
+    * #### Params
+    * | Fields                  	| Data type 	| Required / Optional 	| Description                                                            	  |
+    * |-------------------------	|-----------	|---------------------	|------------------------------------------------------------------------	  |
+    * | password                	| String    	| Required            	| String used to encrypt the private keyfile that is stored locally         |
+    * | seedPhrase              	| String    	| Required            	| 12, 15, 18, 21, or 24 word mnemonic							         	                |
+    * | seddPhraseLang         	| String    	| Optional            	| Defaults to 'en'. Valid options are ["zh-hans", "zh-hant", "en", "fr", "it", "ja", "ko", "es"] |
+    *
+    * @param params input parameters as specified above
+    * @param id     request identifier
+    * @return
+    */
+  private def importKeyfile(implicit params: Json, id: String): Future[Json] = {
     val password: String = (params \\ "password").head.asString.get
     val seedPhrase: String = (params \\ "seedPhrase").head.asString.get
     val seedPhraseLang: String = parseOptional("seedPhraseLang", "en")
@@ -153,74 +155,100 @@ case class AdminApiEndpoint(override val settings: RPCApiSettings, appContext: A
     }
   }
 
-  /** #### Summary
-   * Return list of open keyfiles
-   *
-   * #### Type
-   * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
-   *
-   * #### Description
-   * Check which keyfiles are currently unlocked in your wallet. This method takes no input arguments.
-   * ---
-   * #### Params
-   * | Fields                  	| Data type 	| Required / Optional 	| Description                                                            	  |
-   * | ------------------------	| ----------	| --------------------	| -----------------------------------------------------------------------	  |
-   * | --None specified--       |           	|                     	|                                                                         |
-   *
-   * @param params input parameters as specified above
-   * @param id     request identifier
+  /** Allows the user to retrieve the PublicKey address to receive block rewards
    * @return
    */
-  private def listOpenKeyfiles ( params: Json, id: String ): Future[Json] = {
+  private def getRewardsAddress(params: Json, id: String): Future[Json] =
+    (keyHolderRef ? GetRewardsAddress).mapTo[String].map { a =>
+        Map("rewardsAddress" -> a).asJson
+      }
+
+  /** Allows the user to specify a new PublicKey address to receive block rewards
+    * @return
+    */
+  private def updateRewardsAddress(params: Json, id: String): Future[Json] =
+    (for {
+      addr <- params.hcursor.get[Address]("address")
+    } yield {
+      require(
+        addr.evidence.bytes.head == PublicKeyPropositionCurve25519.typePrefix,
+        s"Invalid rewards address. Only" +
+        s"PublicKeyCurve25519 addresses are supported at this time"
+      )
+
+      (keyHolderRef ? UpdateRewardsAddress(addr)).mapTo[String].map { a =>
+        Map("rewardsAddress" -> a).asJson
+      }
+    }) match {
+      case Right(json) => json
+      case Left(ex)    => throw ex
+    }
+
+  /** #### Summary
+    * Return list of open keyfiles
+    *
+    * #### Type
+    * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
+    *
+    * #### Description
+    * Check which keyfiles are currently unlocked in your wallet. This method takes no input arguments.
+    * ---
+    * #### Params
+    * | Fields                  	| Data type 	| Required / Optional 	| Description                                                            	  |
+    * | ------------------------	| ----------	| --------------------	| -----------------------------------------------------------------------	  |
+    * | --None specified--       |           	|                     	|                                                                         |
+    *
+    * @param params input parameters as specified above
+    * @param id     request identifier
+    * @return
+    */
+  private def listOpenKeyfiles(params: Json, id: String): Future[Json] =
     (keyHolderRef ? ListKeys).mapTo[Set[Address]].map { b =>
       Map("unlocked" -> b.map(_.toString).asJson).asJson
     }
-  }
-
 
   /** #### Summary
-   * Send the start forging signal
-   *
-   * #### Type
-   * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
-   *
-   * #### Description
-   * Attempt to forge blocks using any unlocked keyfiles available on the node
-   * ---
-   * #### Params
-   * | Fields                  	| Data type 	| Required / Optional 	| Description                                                            	  |
-   * | ------------------------	| ----------	| --------------------	| -----------------------------------------------------------------------	  |
-   * | --None specified--       |           	|                     	|                                                                         |
-   *
-   * @param params input parameters as specified above
-   * @param id     request identifier
-   * @return
-   */
-  private def startForging ( params: Json, id: String ): Future[Json] = Future {
+    * Send the start forging signal
+    *
+    * #### Type
+    * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
+    *
+    * #### Description
+    * Attempt to forge blocks using any unlocked keyfiles available on the node
+    * ---
+    * #### Params
+    * | Fields                  	| Data type 	| Required / Optional 	| Description                                                            	  |
+    * | ------------------------	| ----------	| --------------------	| -----------------------------------------------------------------------	  |
+    * | --None specified--       |           	|                     	|                                                                         |
+    *
+    * @param params input parameters as specified above
+    * @param id     request identifier
+    * @return
+    */
+  private def startForging(params: Json, id: String): Future[Json] = Future {
     keyHolderRef ! StartForging
     Map("msg" -> "START forging signal sent".asJson).asJson
   }
 
-
   /** #### Summary
-   * Send the stop forging signal
-   *
-   * #### Type
-   * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
-   *
-   * #### Description
-   * Attempt to stop forging blocks
-   * ---
-   * #### Params
-   * | Fields                  	| Data type 	| Required / Optional 	| Description                                                            	  |
-   * | ------------------------	| ----------	| --------------------	| -----------------------------------------------------------------------	  |
-   * | --None specified--       |           	|                     	|                                                                         |
-   *
-   * @param params input parameters as specified above
-   * @param id     request identifier
-   * @return
-   */
-  private def stopForging ( params: Json, id: String ): Future[Json] = Future {
+    * Send the stop forging signal
+    *
+    * #### Type
+    * Local Only -- An unlocked keyfile must be accessible (in local storage) to fulfill this request
+    *
+    * #### Description
+    * Attempt to stop forging blocks
+    * ---
+    * #### Params
+    * | Fields                  	| Data type 	| Required / Optional 	| Description                                                            	  |
+    * | ------------------------	| ----------	| --------------------	| -----------------------------------------------------------------------	  |
+    * | --None specified--       |           	|                     	|                                                                         |
+    *
+    * @param params input parameters as specified above
+    * @param id     request identifier
+    * @return
+    */
+  private def stopForging(params: Json, id: String): Future[Json] = Future {
     keyHolderRef ! StopForging
     Map("msg" -> "STOP forging signal sent".asJson).asJson
   }

--- a/src/main/scala/co/topl/http/api/endpoints/NodeViewApiEndpoint.scala
+++ b/src/main/scala/co/topl/http/api/endpoints/NodeViewApiEndpoint.scala
@@ -145,7 +145,8 @@ case class NodeViewApiEndpoint(
     * @param id request identifier
     * @return
     */
-  private def mempool(params: Json, id: String): Future[Json] = viewAsync(_.pool.take(100).asJson)
+  private def mempool(params: Json, id: String): Future[Json] =
+    viewAsync { _.pool.take(100)(-_.dateAdded).map(_.tx).asJson }
 
   /**  #### Summary
     *    Lookup a transaction by its id

--- a/src/main/scala/co/topl/http/api/endpoints/NodeViewApiEndpoint.scala
+++ b/src/main/scala/co/topl/http/api/endpoints/NodeViewApiEndpoint.scala
@@ -10,6 +10,7 @@ import co.topl.nodeView.mempool.MemPool
 import co.topl.nodeView.state.State
 import co.topl.modifier.box._
 import co.topl.settings.{AppContext, RPCApiSettings}
+import co.topl.utils.Int128
 import io.circe.Json
 import io.circe.syntax._
 
@@ -22,6 +23,9 @@ case class NodeViewApiEndpoint(
   nodeViewHolderRef:     ActorRef
 )(implicit val context:  ActorRefFactory)
     extends ApiEndpointWithView {
+
+  import co.topl.utils.codecs.Int128Codec._
+
   type HIS = History
   type MS = State
   type MP = MemPool
@@ -109,18 +113,18 @@ case class NodeViewApiEndpoint(
             k -> orderedBoxes
           }.toMap
 
-        val balances: Map[Address, Map[String, Long]] =
+        val balances: Map[Address, Map[String, Int128]] =
           boxes.map { case (addr, assets) =>
             addr -> assets.map { case (boxType, boxes) =>
-              (boxType, boxes.map(_.value.quantity).sum)
+              (boxType, boxes.map(_.value.quantity).reduce(_ + _))
             }
           }
 
         boxes.map { case (addr, boxes) =>
           addr -> Map(
             "Balances" -> Map(
-              "Polys"  -> balances(addr).getOrElse(PolyBox.typeString, 0L),
-              "Arbits" -> balances(addr).getOrElse(ArbitBox.typeString, 0L)
+              "Polys"  -> balances(addr).getOrElse(PolyBox.typeString, Int128(0)),
+              "Arbits" -> balances(addr).getOrElse(ArbitBox.typeString, Int128(0))
             ).asJson,
             "Boxes" -> boxes.map(b => b._1 -> b._2.asJson).asJson
           )

--- a/src/main/scala/co/topl/http/api/endpoints/TransactionApiEndpoint.scala
+++ b/src/main/scala/co/topl/http/api/endpoints/TransactionApiEndpoint.scala
@@ -11,6 +11,8 @@ import co.topl.nodeView.mempool.MemPool
 import co.topl.nodeView.state.State
 import co.topl.modifier.box.{AssetValue, SimpleValue}
 import co.topl.settings.{AppContext, RPCApiSettings}
+import co.topl.utils.Int128
+import co.topl.utils.codecs.Int128Codec
 import io.circe.Json
 import io.circe.syntax._
 import scorex.util.encode.Base58
@@ -28,6 +30,8 @@ case class TransactionApiEndpoint(
   appContext:        AppContext,
   nodeViewHolderRef: ActorRef
 )(implicit val ec:   ExecutionContext) extends ApiEndpointWithView {
+
+  import Int128Codec._
 
   type HIS = History
   type MS = State
@@ -86,7 +90,7 @@ case class TransactionApiEndpoint(
         sender            <- p.get[IndexedSeq[Address]]("sender")
         changeAddr        <- p.get[Address]("changeAddress")
         consolidationAddr <- p.get[Option[Address]]("consolidationAddress")
-        fee               <- p.get[Long]("fee")
+        fee               <- p.get[Int128]("fee")(Int128Codec.jsonDecoder)
         minting           <- p.get[Boolean]("minting")
         data              <- p.get[Option[String]]("data")
       } yield {
@@ -175,10 +179,10 @@ case class TransactionApiEndpoint(
       // parse arguments from the request
       (for {
         propType   <- p.get[String]("propositionType")
-        recipients <- p.get[IndexedSeq[(Address, Long)]]("recipients")
+        recipients <- p.get[IndexedSeq[(Address, Int128)]]("recipients")
         sender     <- p.get[IndexedSeq[Address]]("sender")
         changeAddr <- p.get[Address]("changeAddress")
-        fee        <- p.get[Long]("fee")
+        fee        <- p.get[Int128]("fee")(Int128Codec.jsonDecoder)
         data       <- p.get[Option[String]]("data")
       } yield {
 
@@ -251,11 +255,11 @@ case class TransactionApiEndpoint(
       // parse arguments from the request
       (for {
         propType          <- p.get[String]("propositionType")
-        recipients        <- p.get[IndexedSeq[(Address, Long)]]("recipients")
+        recipients        <- p.get[IndexedSeq[(Address, Int128)]]("recipients")
         sender            <- p.get[IndexedSeq[Address]]("sender")
         changeAddr        <- p.get[Address]("changeAddress")
         consolidationAddr <- p.get[Option[Address]]("consolidationAddress")
-        fee               <- p.get[Long]("fee")
+        fee               <- p.get[Int128]("fee")(Int128Codec.jsonDecoder)
         data              <- p.get[Option[String]]("data")
       } yield {
 

--- a/src/main/scala/co/topl/modifier/BoxReader.scala
+++ b/src/main/scala/co/topl/modifier/BoxReader.scala
@@ -1,0 +1,15 @@
+package co.topl.modifier
+
+import co.topl.modifier.box._
+
+import scala.reflect.ClassTag
+
+trait BoxReader[KP, KT]  {
+
+    def getBox(id: BoxId): Option[Box[_]]
+
+    def getProgramBox[PBX <: ProgramBox: ClassTag](key: KP): Option[PBX]
+
+    def getTokenBoxes(key: KT): Option[Seq[TokenBox[TokenValueHolder]]]
+
+  }

--- a/src/main/scala/co/topl/modifier/block/Block.scala
+++ b/src/main/scala/co/topl/modifier/block/Block.scala
@@ -4,11 +4,10 @@ import co.topl.attestation.AddressEncoder.NetworkPrefix
 import co.topl.attestation.EvidenceProducer.Syntax._
 import co.topl.attestation.{PublicKeyPropositionCurve25519, SignatureCurve25519}
 import co.topl.modifier.NodeViewModifier.ModifierTypeId
-import co.topl.modifier.block.Block._
 import co.topl.modifier.block.PersistentNodeViewModifier.PNVMVersion
+import co.topl.modifier.box.ArbitBox
 import co.topl.modifier.transaction.Transaction
 import co.topl.modifier.{ModifierId, NodeViewModifier}
-import co.topl.modifier.box.ArbitBox
 import co.topl.utils.TimeProvider
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, HCursor}

--- a/src/main/scala/co/topl/modifier/block/Block.scala
+++ b/src/main/scala/co/topl/modifier/block/Block.scala
@@ -9,6 +9,7 @@ import co.topl.modifier.block.PersistentNodeViewModifier.PNVMVersion
 import co.topl.modifier.transaction.Transaction
 import co.topl.modifier.{ModifierId, NodeViewModifier}
 import co.topl.modifier.box.ArbitBox
+import co.topl.utils.TimeProvider
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, HCursor}
 import supertagged.@@
@@ -31,7 +32,7 @@ import scala.util.Try
  * - additional data: block structure version no, timestamp etc
  */
 case class Block(parentId    : ModifierId,
-                 timestamp   : Timestamp,
+                 timestamp   : TimeProvider.Time,
                  generatorBox: ArbitBox,
                  publicKey   : PublicKeyPropositionCurve25519,
                  signature   : SignatureCurve25519,
@@ -53,8 +54,6 @@ case class Block(parentId    : ModifierId,
 }
 
 object Block {
-
-  type Timestamp = Long
 
   val modifierTypeId: Byte @@ NodeViewModifier.ModifierTypeId.Tag = ModifierTypeId @@ (3: Byte)
 
@@ -117,7 +116,7 @@ object Block {
     * @return a block to be sent to the network
     */
   def createAndSign(parentId: ModifierId,
-                    timestamp: Timestamp,
+                    timestamp: TimeProvider.Time,
                     txs: Seq[Transaction.TX],
                     generatorBox: ArbitBox,
                     publicKey: PublicKeyPropositionCurve25519,

--- a/src/main/scala/co/topl/modifier/block/BlockBody.scala
+++ b/src/main/scala/co/topl/modifier/block/BlockBody.scala
@@ -9,11 +9,8 @@ import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor}
 import supertagged.@@
 
-case class BlockBody(id: ModifierId,
-                     parentId: ModifierId,
-                     transactions: Seq[Transaction.TX],
-                     version: PNVMVersion
-                    ) extends TransactionCarryingPersistentNodeViewModifier[Transaction.TX] {
+case class BlockBody(id: ModifierId, parentId: ModifierId, transactions: Seq[Transaction.TX], version: PNVMVersion)
+    extends TransactionCarryingPersistentNodeViewModifier[Transaction.TX] {
 
   override lazy val modifierTypeId: ModifierTypeId = BlockBody.modifierTypeId
 
@@ -25,20 +22,18 @@ object BlockBody {
 
   implicit val jsonEncoder: Encoder[BlockBody] = { b: BlockBody ⇒
     Map(
-      "id" -> b.id.toString.asJson,
+      "id"       -> b.id.toString.asJson,
       "parentId" -> b.parentId.toString.asJson,
-      "txs" -> b.transactions.asJson,
-      "version" -> b.version.asJson,
+      "txs"      -> b.transactions.asJson,
+      "version"  -> b.version.asJson
     ).asJson
   }
 
   implicit def jsonDecoder(implicit networkPrefix: NetworkPrefix): Decoder[BlockBody] = (c: HCursor) =>
     for {
-      id <- c.downField("id").as[ModifierId]
+      id       <- c.downField("id").as[ModifierId]
       parentId <- c.downField("parentId").as[ModifierId]
-      txsSeq <- c.downField("txs").as[Seq[Transaction.TX]]
-      version <- c.downField("version").as[PNVMVersion]
-    } yield {
-      BlockBody(id, parentId, txsSeq, version)
-    }
+      txsSeq   <- c.downField("txs").as[Seq[Transaction.TX]]
+      version  <- c.downField("version").as[PNVMVersion]
+    } yield BlockBody(id, parentId, txsSeq, version)
 }

--- a/src/main/scala/co/topl/modifier/block/BlockHeader.scala
+++ b/src/main/scala/co/topl/modifier/block/BlockHeader.scala
@@ -3,10 +3,10 @@ package co.topl.modifier.block
 import co.topl.attestation.{PublicKeyPropositionCurve25519, SignatureCurve25519}
 import co.topl.crypto.Digest32Ops
 import co.topl.modifier.NodeViewModifier.ModifierTypeId
-import co.topl.modifier.block.Block.Timestamp
 import co.topl.modifier.block.PersistentNodeViewModifier.PNVMVersion
-import co.topl.modifier.{ModifierId, NodeViewModifier}
 import co.topl.modifier.box.ArbitBox
+import co.topl.modifier.{ModifierId, NodeViewModifier}
+import co.topl.utils.TimeProvider
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor}
 import scorex.crypto.hash.Digest32
@@ -14,7 +14,7 @@ import supertagged.@@
 
 case class BlockHeader(id          : ModifierId,
                        parentId    : ModifierId,
-                       timestamp   : Timestamp,
+                       timestamp   : TimeProvider.Time,
                        generatorBox: ArbitBox,
                        publicKey   : PublicKeyPropositionCurve25519,
                        signature   : SignatureCurve25519,
@@ -53,7 +53,7 @@ object BlockHeader {
     for {
       id <- c.downField("id").as[ModifierId]
       parentId <- c.downField("parentId").as[ModifierId]
-      timestamp <- c.downField("timestamp").as[Timestamp]
+      timestamp <- c.downField("timestamp").as[TimeProvider.Time]
       generatorBox <- c.downField("generatorBox").as[ArbitBox]
       publicKey <- c.downField("publicKey").as[PublicKeyPropositionCurve25519]
       signature <- c.downField("signature").as[SignatureCurve25519]

--- a/src/main/scala/co/topl/modifier/block/BlockHeader.scala
+++ b/src/main/scala/co/topl/modifier/block/BlockHeader.scala
@@ -12,18 +12,19 @@ import io.circe.{Decoder, Encoder, HCursor}
 import scorex.crypto.hash.Digest32
 import supertagged.@@
 
-case class BlockHeader(id          : ModifierId,
-                       parentId    : ModifierId,
-                       timestamp   : TimeProvider.Time,
-                       generatorBox: ArbitBox,
-                       publicKey   : PublicKeyPropositionCurve25519,
-                       signature   : SignatureCurve25519,
-                       height      : Long,
-                       difficulty  : Long,
-                       txRoot      : Digest32,
-                       bloomFilter : BloomFilter,
-                       version     : PNVMVersion
-                      ) extends PersistentNodeViewModifier {
+case class BlockHeader(
+  id:           ModifierId,
+  parentId:     ModifierId,
+  timestamp:    TimeProvider.Time,
+  generatorBox: ArbitBox,
+  publicKey:    PublicKeyPropositionCurve25519,
+  signature:    SignatureCurve25519,
+  height:       Long,
+  difficulty:   Long,
+  txRoot:       Digest32,
+  bloomFilter:  BloomFilter,
+  version:      PNVMVersion
+) extends PersistentNodeViewModifier {
 
   override lazy val modifierTypeId: ModifierTypeId = BlockHeader.modifierTypeId
 
@@ -32,49 +33,46 @@ case class BlockHeader(id          : ModifierId,
 object BlockHeader {
   val modifierTypeId: Byte @@ NodeViewModifier.ModifierTypeId.Tag = ModifierTypeId @@ (4: Byte)
 
-
   implicit val jsonEncoder: Encoder[BlockHeader] = { bh: BlockHeader ⇒
     Map(
-      "id" -> bh.id.toString.asJson,
-      "parentId" -> bh.parentId.toString.asJson,
-      "timestamp" -> bh.timestamp.asJson,
+      "id"           -> bh.id.toString.asJson,
+      "parentId"     -> bh.parentId.toString.asJson,
+      "timestamp"    -> bh.timestamp.asJson,
       "generatorBox" -> bh.generatorBox.asJson,
-      "publicKey" -> bh.publicKey.asJson,
-      "signature" -> bh.signature.asJson,
-      "height" -> bh.height.asJson,
-      "difficulty" -> bh.difficulty.asJson,
-      "txRoot" -> bh.txRoot.asJson(Digest32Ops.jsonEncoder),
-      "bloomFilter" -> bh.bloomFilter.asJson,
-      "version" -> bh.version.asJson,
+      "publicKey"    -> bh.publicKey.asJson,
+      "signature"    -> bh.signature.asJson,
+      "height"       -> bh.height.asJson,
+      "difficulty"   -> bh.difficulty.asJson,
+      "txRoot"       -> bh.txRoot.asJson(Digest32Ops.jsonEncoder),
+      "bloomFilter"  -> bh.bloomFilter.asJson,
+      "version"      -> bh.version.asJson
     ).asJson
   }
 
   implicit val jsonDecoder: Decoder[BlockHeader] = (c: HCursor) =>
     for {
-      id <- c.downField("id").as[ModifierId]
-      parentId <- c.downField("parentId").as[ModifierId]
-      timestamp <- c.downField("timestamp").as[TimeProvider.Time]
+      id           <- c.downField("id").as[ModifierId]
+      parentId     <- c.downField("parentId").as[ModifierId]
+      timestamp    <- c.downField("timestamp").as[TimeProvider.Time]
       generatorBox <- c.downField("generatorBox").as[ArbitBox]
-      publicKey <- c.downField("publicKey").as[PublicKeyPropositionCurve25519]
-      signature <- c.downField("signature").as[SignatureCurve25519]
-      height <- c.downField("height").as[Long]
-      difficulty <- c.downField("difficulty").as[Long]
-      txRoot <- c.downField("txRoot").as[Digest32](Digest32Ops.jsonDecoder)
-      bloomFilter <- c.downField("bloomFilter").as[BloomFilter]
-      version <- c.downField("version").as[Byte]
-    } yield {
-      BlockHeader(
-        id,
-        parentId,
-        timestamp,
-        generatorBox,
-        publicKey,
-        signature,
-        height,
-        difficulty,
-        txRoot,
-        bloomFilter,
-        version
-      )
-    }
+      publicKey    <- c.downField("publicKey").as[PublicKeyPropositionCurve25519]
+      signature    <- c.downField("signature").as[SignatureCurve25519]
+      height       <- c.downField("height").as[Long]
+      difficulty   <- c.downField("difficulty").as[Long]
+      txRoot       <- c.downField("txRoot").as[Digest32](Digest32Ops.jsonDecoder)
+      bloomFilter  <- c.downField("bloomFilter").as[BloomFilter]
+      version      <- c.downField("version").as[Byte]
+    } yield BlockHeader(
+      id,
+      parentId,
+      timestamp,
+      generatorBox,
+      publicKey,
+      signature,
+      height,
+      difficulty,
+      txRoot,
+      bloomFilter,
+      version
+    )
 }

--- a/src/main/scala/co/topl/modifier/block/BloomFilter.scala
+++ b/src/main/scala/co/topl/modifier/block/BloomFilter.scala
@@ -57,9 +57,9 @@ object BloomFilter extends BifrostSerializer[BloomFilter] {
   object BloomTopic extends TaggedType[Array[Byte]]
   type BloomTopic = BloomTopic.Type
 
-  val bloomSize: Int = 256 //bytes (2048 bits)
-  private val bloomSizeBit: Int = bloomSize * 8
-  private val numLongs: Int = bloomSizeBit / 64 // filter is composed of an array of longs (64 bit elements)
+  val numBytes: Int = 256 //bytes (2048 bits)
+  private val size: Int = numBytes * 8
+  private val numLongs: Int = size / 64 // filter is composed of an array of longs (64 bit elements)
 
   val empty: BloomFilter = new BloomFilter(Array.fill(numLongs)(0L)) // 2048 element bit array of zeros
 
@@ -68,9 +68,9 @@ object BloomFilter extends BifrostSerializer[BloomFilter] {
   // In the notes below only the first two bytes are shown since the other bytes are always zero.
   // NOTE - these values are highly dependent on the length of the bloom filter, manipulate carefully
   private val idxMask: Int =
-    bloomSizeBit - 1 /* 2047 -> 0000 0111 1111 1111 - mask for taking the low-order 11 bits of the byte pairs */
+    size - 1 /* 2047 -> 0000 0111 1111 1111 - mask for taking the low-order 11 bits of the byte pairs */
   private val longElemMask: Int =
-    bloomSizeBit - 64 /* 1984 -> 0000 0111 1100 0000 - mask for finding the long to modify */
+    size - 64 /* 1984 -> 0000 0111 1100 0000 - mask for finding the long to modify */
   private val bitElemMask: Int = 63 /*   63 -> 0000 0000 0011 1111 - mask for finding the bit to modify */
 
   /** Create a new Bloom filter given a sequence of topics to be hashed */

--- a/src/main/scala/co/topl/modifier/block/BloomFilter.scala
+++ b/src/main/scala/co/topl/modifier/block/BloomFilter.scala
@@ -10,34 +10,35 @@ import supertagged.TaggedType
 
 import scala.util.Try
 
-/**
- * This implementation of Bloom filter is inspired from the Ethereum Yellow Paper
- * for more information, visit: http://gavwood.com/paper.pdf (as of 2020.11.20 there is an error in footnote 3 - 2^11^ = 2048)
- * Another explanation can be found here (but he messes denoting the byte pairs, this stuff is tricky)
- * https://ethereum.stackexchange.com/questions/59203/what-exactly-does-the-m-function-in-the-formal-bloom-filter-specifications-do
- * A calculator to look at the false positivity rate can be found here
- * https://hur.st/bloomfilter/?n=100&p=&m=2048&k=4
- * The bloom filter is constructed by taking the low-order 11 bits (mod 2048) of each of the first four pairs of bytes from a Blake2b-256 hash
- * In english, the algorithm is to hash the input topic, take the first 8 bytes from the hash output, pair them up (1,2) (3,4) (5,6) (7,8),
- * then take the first 11 bits from each pair (each pair is 16 bits and we take 11 bits because 2^11^ = 2048). These bits can be
- * retrieved using a bit-wise AND operation. For each of the 11-bit numbers we construct a positive definite integer between (0 & 2047).
- * This integer is the index of the bit to flip in the bloom filter. Finally, the bloom filter is represented as a Array[Long] so
- * we must apply two additional bit-wise AND operations on each index to find which Long should be changed in the bloom filter and
- * finally which bit of the Long must be flipped.
- */
+/** This implementation of Bloom filter is inspired from the Ethereum Yellow Paper
+  * for more information, visit: http://gavwood.com/paper.pdf (as of 2020.11.20 there is an error in footnote 3 - 2^11^ = 2048)
+  * Another explanation can be found here (but he messes denoting the byte pairs, this stuff is tricky)
+  * https://ethereum.stackexchange.com/questions/59203/what-exactly-does-the-m-function-in-the-formal-bloom-filter-specifications-do
+  * A calculator to look at the false positivity rate can be found here
+  * https://hur.st/bloomfilter/?n=100&p=&m=2048&k=4
+  * The bloom filter is constructed by taking the low-order 11 bits (mod 2048) of each of the first four pairs of bytes from a Blake2b-256 hash
+  * In english, the algorithm is to hash the input topic, take the first 8 bytes from the hash output, pair them up (1,2) (3,4) (5,6) (7,8),
+  * then take the first 11 bits from each pair (each pair is 16 bits and we take 11 bits because 2^11^ = 2048). These bits can be
+  * retrieved using a bit-wise AND operation. For each of the 11-bit numbers we construct a positive definite integer between (0 & 2047).
+  * This integer is the index of the bit to flip in the bloom filter. Finally, the bloom filter is represented as a Array[Long] so
+  * we must apply two additional bit-wise AND operations on each index to find which Long should be changed in the bloom filter and
+  * finally which bit of the Long must be flipped.
+  */
 class BloomFilter private (private val value: Array[Long]) extends BytesSerializable {
 
-  require(value.length == BloomFilter.numLongs,
-    s"Invalid bloom filter length: ${value.length}. Bloom filters must be an Array[Long] of length ${BloomFilter.numLongs}")
+  require(
+    value.length == BloomFilter.numLongs,
+    s"Invalid bloom filter length: ${value.length}. Bloom filters must be an Array[Long] of length ${BloomFilter.numLongs}"
+  )
 
   override type M = BloomFilter
   lazy val serializer: BifrostSerializer[BloomFilter] = BloomFilter
 
   /** Check if a given topic is included in the Bloom filter */
-  def contains (topic: BloomTopic): Boolean = {
+  def contains(topic: BloomTopic): Boolean = {
     val indices: Set[Int] = BloomFilter.calculateIndices(topic)
-    BloomFilter.generateLongs(indices).forall {
-      case (idx, bits) => (value(idx) & bits) != 0L
+    BloomFilter.generateLongs(indices).forall { case (idx, bits) =>
+      (value(idx) & bits) != 0L
     }
   }
 
@@ -45,7 +46,7 @@ class BloomFilter private (private val value: Array[Long]) extends BytesSerializ
 
   override def equals(obj: Any): Boolean = obj match {
     case b: BloomFilter => b.value sameElements value
-    case _ => false
+    case _              => false
   }
 
   override def hashCode(): Int = super.hashCode()
@@ -66,17 +67,21 @@ object BloomFilter extends BifrostSerializer[BloomFilter] {
   // These vals are denoted as Ints (4 bytes) because we need at least 11 bits to hold a 2048 bit bloom filter
   // In the notes below only the first two bytes are shown since the other bytes are always zero.
   // NOTE - these values are highly dependent on the length of the bloom filter, manipulate carefully
-  private val idxMask: Int = bloomSizeBit - 1       /* 2047 -> 0000 0111 1111 1111 - mask for taking the low-order 11 bits of the byte pairs */
-  private val longElemMask: Int = bloomSizeBit - 64 /* 1984 -> 0000 0111 1100 0000 - mask for finding the long to modify */
-  private val bitElemMask: Int = 63                 /*   63 -> 0000 0000 0011 1111 - mask for finding the bit to modify */
+  private val idxMask: Int =
+    bloomSizeBit - 1 /* 2047 -> 0000 0111 1111 1111 - mask for taking the low-order 11 bits of the byte pairs */
+  private val longElemMask: Int =
+    bloomSizeBit - 64 /* 1984 -> 0000 0111 1100 0000 - mask for finding the long to modify */
+  private val bitElemMask: Int = 63 /*   63 -> 0000 0000 0011 1111 - mask for finding the bit to modify */
 
   /** Create a new Bloom filter given a sequence of topics to be hashed */
   def apply(topics: Set[BloomTopic]): BloomFilter = update(empty, topics)
 
   /** Returns a new Bloom filter with updated topics included in the bit array.
-   * The updated bloom filter computes the indices to be flipped and merges these changes with
-   * the input array of longs before returning a new filter */
+    * The updated bloom filter computes the indices to be flipped and merges these changes with
+    * the input array of longs before returning a new filter
+    */
   def update(inputBF: BloomFilter, topics: Set[BloomTopic]): BloomFilter = {
+
     /** Compute the indices that should be flipped in the bloom filter */
     val indices: Set[Int] = topics.flatMap(calculateIndices)
 
@@ -84,70 +89,69 @@ object BloomFilter extends BifrostSerializer[BloomFilter] {
     val longsForFilter: Map[Int, Long] = generateLongs(indices)
 
     /** Compute the fixed length Array[Long] by bit-wise OR operations
-     * with the matching index from the input BloomFilter */
+      * with the matching index from the input BloomFilter
+      */
     val longsArray =
-      inputBF
-        .value
-        .zipWithIndex
-        .map {
-          case (bits, idx) => longsForFilter.getOrElse(idx, 0L) | bits
+      inputBF.value.zipWithIndex
+        .map { case (bits, idx) =>
+          longsForFilter.getOrElse(idx, 0L) | bits
         }
 
     new BloomFilter(longsArray)
   }
 
-  /**
-   * Calculates the bit index that must be flipped.
-   * The algorithm is
-   * 1. Compute the hash of the given topic
-   * 2. Retrieve the first 4 pairs of bytes from the hash
-   * 3. Take the bit-wise AND to convert signed byte to unsigned int
-   * 4. For each pair of bytes, take the first byte bit shift it up 8 elements and bit-wise OR it to produce a 16 bit
-   *    unsigned number.
-   * 5. From the 16 bit unsigned number, apply an 11 bit mask to retrieve the lowest 11-bits. This is the index of the
-   *    bit that should be flipped in the bit array.
-   *
-   * Since Java uses signed numbers we must be careful about the mapping of the bitwise operations. See the examples
-   * below for the expected behavior.
-   * Examples
-   * 1. Byte pair (0: Byte, 0: Byte)    -> 0: Int (the zero index bit in the 2048 bit array must be flipped)
-   * 2. Byte pair (0: Byte, 1: Byte)    -> 1: Int (the one index bit in the 2048 bit array must be flipped)
-   * 3. Byte pair (0: Byte, 127: Byte)  -> 127: Int (the 127 index bit in the 2048 bit array must be flipped)
-   * 4. Byte pair (0: Byte, -128: Byte) -> 128: Int (the 128 index bit in the 2048 bit array must be flipped)
-   * 5. Byte pair (0: Byte, -127: Byte) -> 129: Int
-   * 6. Byte pair (0: Byte, -1: Byte)   -> 255: Int
-   * 7. Byte pair (1: Byte, 0: Byte)    -> 256: Int
-   * 8. Byte pair (127: Byte, 0: Byte)  -> 1792: Int
-   * 9. Byte pair (127: Byte, -1: Byte) -> 2047: Int
-   * 10. Byte pair (-1: Byte, -1: Byte) -> 2047: Int
-   * */
+  /** Calculates the bit index that must be flipped.
+    * The algorithm is
+    * 1. Compute the hash of the given topic
+    * 2. Retrieve the first 4 pairs of bytes from the hash
+    * 3. Take the bit-wise AND to convert signed byte to unsigned int
+    * 4. For each pair of bytes, take the first byte bit shift it up 8 elements and bit-wise OR it to produce a 16 bit
+    *    unsigned number.
+    * 5. From the 16 bit unsigned number, apply an 11 bit mask to retrieve the lowest 11-bits. This is the index of the
+    *    bit that should be flipped in the bit array.
+    *
+    * Since Java uses signed numbers we must be careful about the mapping of the bitwise operations. See the examples
+    * below for the expected behavior.
+    * Examples
+    * 1. Byte pair (0: Byte, 0: Byte)    -> 0: Int (the zero index bit in the 2048 bit array must be flipped)
+    * 2. Byte pair (0: Byte, 1: Byte)    -> 1: Int (the one index bit in the 2048 bit array must be flipped)
+    * 3. Byte pair (0: Byte, 127: Byte)  -> 127: Int (the 127 index bit in the 2048 bit array must be flipped)
+    * 4. Byte pair (0: Byte, -128: Byte) -> 128: Int (the 128 index bit in the 2048 bit array must be flipped)
+    * 5. Byte pair (0: Byte, -127: Byte) -> 129: Int
+    * 6. Byte pair (0: Byte, -1: Byte)   -> 255: Int
+    * 7. Byte pair (1: Byte, 0: Byte)    -> 256: Int
+    * 8. Byte pair (127: Byte, 0: Byte)  -> 1792: Int
+    * 9. Byte pair (127: Byte, -1: Byte) -> 2047: Int
+    * 10. Byte pair (-1: Byte, -1: Byte) -> 2047: Int
+    */
   private def calculateIndices(topic: BloomTopic): Set[Int] =
-  // Pair up bytes and convert signed Byte to unsigned Int
-    Set(0, 2, 4, 6).map(i => Blake2b256(topic).slice(i, i + 2).map(_ & 0xFF)).map {
-      case Array(b1, b2) => ((b1 << 8) | b2) & idxMask
+    // Pair up bytes and convert signed Byte to unsigned Int
+    Set(0, 2, 4, 6).map(i => Blake2b256(topic).slice(i, i + 2).map(_ & 0xff)).map { case Array(b1, b2) =>
+      ((b1 << 8) | b2) & idxMask
     }
 
-  /**
-   * From the set of indices, create a long (with the appropriate bits flipped) that will be inserted in the
-   * * bloom filter. This function performs bit-wise operations to split the 11 bit bit index integer into two pieces.
-   * 1. The least significant 6 bits (6 bits from the right) are used to determine how far to shift a single 1 bit
-   *    along the length of the long. This is the first element in the tuple below.
-   * 2. The most significant 5 bits and bit shifted down 6 bits to form an integer between 0 and (numLongs - 1).
-   *    This is the index of the Long in the array of longs where the long computed in step 1 will be placed.
-   * Finally, since we may update bits corresponding to the same long, we group them and fold all longs at the
-   * same index into a single value using a bit-wise OR operation. Following this the output mao should contain
-   * only unique keys between 0 -> 31. These keys are to be associated with a single Long, the value of which
-   * may range between Long.MinValue -> Long.MaxValue
-   */
+  /** From the set of indices, create a long (with the appropriate bits flipped) that will be inserted in the
+    * * bloom filter. This function performs bit-wise operations to split the 11 bit bit index integer into two pieces.
+    * 1. The least significant 6 bits (6 bits from the right) are used to determine how far to shift a single 1 bit
+    *    along the length of the long. This is the first element in the tuple below.
+    * 2. The most significant 5 bits and bit shifted down 6 bits to form an integer between 0 and (numLongs - 1).
+    *    This is the index of the Long in the array of longs where the long computed in step 1 will be placed.
+    * Finally, since we may update bits corresponding to the same long, we group them and fold all longs at the
+    * same index into a single value using a bit-wise OR operation. Following this the output mao should contain
+    * only unique keys between 0 -> 31. These keys are to be associated with a single Long, the value of which
+    * may range between Long.MinValue -> Long.MaxValue
+    */
   private def generateLongs(indices: Set[Int]): Map[Int, Long] =
-    indices.map { i =>
-      (
-        Long.MinValue >>> (i & bitElemMask), // value of the bit array as a Long
-        (i & longElemMask) >>> 6 // index of the Long that must be manipulated
-      )
-    }.groupBy(_._2) // group the tuples by the index of the long so we can accumulate the bits into a single Long
-      .map {
-        case (elem, values) => elem -> values.foldLeft(0L)((acc, bits) => acc | bits._1)
+    indices
+      .map { i =>
+        (
+          Long.MinValue >>> (i & bitElemMask), // value of the bit array as a Long
+          (i & longElemMask) >>> 6 // index of the Long that must be manipulated
+        )
+      }
+      .groupBy(_._2) // group the tuples by the index of the long so we can accumulate the bits into a single Long
+      .map { case (elem, values) =>
+        elem -> values.foldLeft(0L)((acc, bits) => acc | bits._1)
       }
 
   /** Recreate a bloom filter from a string encoding */
@@ -158,9 +162,8 @@ object BloomFilter extends BifrostSerializer[BloomFilter] {
   implicit val jsonDecoder: Decoder[BloomFilter] = Decoder.decodeString.emapTry(fromString)
   implicit val jsonKeyDecoder: KeyDecoder[BloomFilter] = (str: String) => fromString(str).toOption
 
-  override def serialize(obj: BloomFilter, w: Writer): Unit = {
+  override def serialize(obj: BloomFilter, w: Writer): Unit =
     obj.value.foreach(l => w.putLong(l))
-  }
 
   override def parse(r: Reader): BloomFilter = {
     val value: Array[Long] = (for (_ <- 0 until numLongs) yield r.getLong()).toArray

--- a/src/main/scala/co/topl/modifier/box/Box.scala
+++ b/src/main/scala/co/topl/modifier/box/Box.scala
@@ -44,9 +44,7 @@ object Box {
       evidence <- c.downField("evidence").as[Evidence]
       value    <- c.downField("value").as[T]
       nonce    <- c.downField("nonce").as[Nonce]
-    } yield {
-      (evidence, nonce, value)
-    }
+    } yield (evidence, nonce, value)
 
   def identifier(box: Box[_]): Identifier = box match {
     case _: ArbitBox     => ArbitBox.identifier.getId

--- a/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
+++ b/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
@@ -82,7 +82,7 @@ object SimpleValue extends BifrostSerializer[SimpleValue] {
     w.putBytes(obj.quantity.toByteArray)
 
   override def parse(r: Reader): SimpleValue =
-    SimpleValue(Int128(r.getBytes(Int128.bytes)))
+    SimpleValue(Int128(r.getBytes(Int128.numBytes)))
 }
 
 /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
@@ -143,7 +143,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
   }
 
   override def parse(r: Reader): AssetValue = {
-    val quantity = Int128(r.getBytes(Int128.bytes))
+    val quantity = Int128(r.getBytes(Int128.numBytes))
     val assetCode = AssetCode.parse(r)
     val securityRoot = SecurityRoot.parse(r)
     val metadata: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
+++ b/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
@@ -111,7 +111,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
   implicit val jsonEncoder: Encoder[AssetValue] = { (value: AssetValue) =>
     Map(
       "type"         -> valueTypeString.asJson,
-      "quantity"     -> Int128Codec.jsonEncoder(value.quantity),
+      "quantity"     -> value.quantity.asJson(Int128Codec.jsonEncoder),
       "assetCode"    -> value.assetCode.asJson,
       "securityRoot" -> value.securityRoot.asJson,
       "metadata"     -> value.metadata.asJson
@@ -120,7 +120,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
 
   implicit val jsonDecoder: Decoder[AssetValue] = (c: HCursor) =>
     for {
-      quantity     <- c.downField("quantity").as[Long]
+      quantity     <- c.get[Int128]("quantity")(Int128Codec.jsonDecoder)
       assetCode    <- c.downField("assetCode").as[AssetCode]
       securityRoot <- c.downField("securityRoot").as[Option[String]]
       metadata     <- c.downField("metadata").as[Option[String]]

--- a/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
+++ b/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
@@ -79,10 +79,10 @@ object SimpleValue extends BifrostSerializer[SimpleValue] {
     }
 
   override def serialize(obj: SimpleValue, w: Writer): Unit =
-    w.putBytes(obj.quantity.toByteArray)
+    w.putInt128(obj.quantity)
 
   override def parse(r: Reader): SimpleValue =
-    SimpleValue(Int128(r.getBytes(Int128.numBytes)))
+    SimpleValue(r.getInt128())
 }
 
 /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
@@ -134,7 +134,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
     }
 
   override def serialize(obj: AssetValue, w: Writer): Unit = {
-    w.putBytes(obj.quantity.toByteArray)
+    w.putInt128(obj.quantity)
     AssetCode.serialize(obj.assetCode, w)
     SecurityRoot.serialize(obj.securityRoot, w)
     w.putOption(obj.metadata) { (writer, metadata) =>
@@ -143,7 +143,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
   }
 
   override def parse(r: Reader): AssetValue = {
-    val quantity = Int128(r.getBytes(Int128.numBytes))
+    val quantity = r.getInt128()
     val assetCode = AssetCode.parse(r)
     val securityRoot = SecurityRoot.parse(r)
     val metadata: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
+++ b/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
@@ -3,11 +3,13 @@ package co.topl.modifier.box
 import java.nio.charset.StandardCharsets
 
 import co.topl.attestation.Address
+import co.topl.utils.Int128
+import co.topl.utils.codecs.Int128Codec
 import co.topl.utils.serialization.{BifrostSerializer, BytesSerializable, Reader, Writer}
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor}
 
-sealed abstract class TokenValueHolder(val quantity: Long) extends BytesSerializable {
+sealed abstract class TokenValueHolder(val quantity: Int128) extends BytesSerializable {
   override type M = TokenValueHolder
 
   override def serializer: BifrostSerializer[TokenValueHolder] = TokenValueHolder
@@ -56,7 +58,7 @@ object TokenValueHolder extends BifrostSerializer[TokenValueHolder] {
 
 /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
 
-case class SimpleValue(override val quantity: Long) extends TokenValueHolder(quantity)
+case class SimpleValue(override val quantity: Int128) extends TokenValueHolder(quantity)
 
 object SimpleValue extends BifrostSerializer[SimpleValue] {
   val valueTypePrefix: Byte = 1: Byte
@@ -65,7 +67,7 @@ object SimpleValue extends BifrostSerializer[SimpleValue] {
   implicit val jsonEncoder: Encoder[SimpleValue] = { (value: SimpleValue) =>
     Map(
       "type"     -> valueTypeString.asJson,
-      "quantity" -> value.quantity.asJson
+      "quantity" -> Int128Codec.jsonEncoder(value.quantity)
     ).asJson
   }
 
@@ -77,15 +79,15 @@ object SimpleValue extends BifrostSerializer[SimpleValue] {
     }
 
   override def serialize(obj: SimpleValue, w: Writer): Unit =
-    w.putULong(obj.quantity)
+    w.putBytes(obj.quantity.toByteArray)
 
   override def parse(r: Reader): SimpleValue =
-    SimpleValue(r.getULong())
+    SimpleValue(Int128(r.getBytes(Int128.bytes)))
 }
 
 /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
 case class AssetValue(
-  override val quantity: Long,
+  override val quantity: Int128,
   assetCode:             AssetCode,
   securityRoot:          SecurityRoot = SecurityRoot.empty,
   metadata:              Option[String] = None
@@ -109,7 +111,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
   implicit val jsonEncoder: Encoder[AssetValue] = { (value: AssetValue) =>
     Map(
       "type"         -> valueTypeString.asJson,
-      "quantity"     -> value.quantity.asJson,
+      "quantity"     -> Int128Codec.jsonEncoder(value.quantity),
       "assetCode"    -> value.assetCode.asJson,
       "securityRoot" -> value.securityRoot.asJson,
       "metadata"     -> value.metadata.asJson
@@ -132,7 +134,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
     }
 
   override def serialize(obj: AssetValue, w: Writer): Unit = {
-    w.putULong(obj.quantity)
+    w.putBytes(obj.quantity.toByteArray)
     AssetCode.serialize(obj.assetCode, w)
     SecurityRoot.serialize(obj.securityRoot, w)
     w.putOption(obj.metadata) { (writer, metadata) =>
@@ -141,7 +143,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
   }
 
   override def parse(r: Reader): AssetValue = {
-    val quantity = r.getULong()
+    val quantity = Int128(r.getBytes(Int128.bytes))
     val assetCode = AssetCode.parse(r)
     val securityRoot = SecurityRoot.parse(r)
     val metadata: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/ArbitTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/ArbitTransfer.scala
@@ -64,7 +64,7 @@ object ArbitTransfer {
     sender:               IndexedSeq[Address],
     changeAddress:        Address,
     consolidationAddress: Option[Address],
-    fee:                  Long,
+    fee:                  Int128,
     data:                 Option[String]
   ): Try[ArbitTransfer[P]] =
     TransferTransaction

--- a/src/main/scala/co/topl/modifier/transaction/ArbitTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/ArbitTransfer.scala
@@ -8,7 +8,8 @@ import co.topl.modifier.transaction.Transaction.TxType
 import co.topl.modifier.transaction.TransferTransaction.BoxParams
 import co.topl.nodeView.state.StateReader
 import co.topl.modifier.box._
-import co.topl.utils.{Identifiable, Identifier}
+import co.topl.utils.codecs.Int128Codec
+import co.topl.utils.{Identifiable, Identifier, Int128}
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor}
 
@@ -19,7 +20,7 @@ case class ArbitTransfer[
 ](override val from:        IndexedSeq[(Address, Box.Nonce)],
   override val to:          IndexedSeq[(Address, TokenValueHolder)],
   override val attestation: Map[P, Proof[P]],
-  override val fee:         Long,
+  override val fee:         Int128,
   override val timestamp:   Long,
   override val data:        Option[String] = None,
   override val minting:     Boolean = false
@@ -90,7 +91,7 @@ object ArbitTransfer {
       "from"            -> tx.from.asJson,
       "to"              -> tx.to.asJson,
       "signatures"      -> tx.attestation.asJson,
-      "fee"             -> tx.fee.asJson,
+      "fee"             -> tx.fee.asJson(Int128Codec.jsonEncoder),
       "timestamp"       -> tx.timestamp.asJson,
       "minting"         -> tx.minting.asJson,
       "data"            -> tx.data.asJson
@@ -102,7 +103,7 @@ object ArbitTransfer {
       for {
         from      <- c.downField("from").as[IndexedSeq[(Address, Box.Nonce)]]
         to        <- c.downField("to").as[IndexedSeq[(Address, SimpleValue)]]
-        fee       <- c.downField("fee").as[Long]
+        fee       <- c.get[Int128]("fee")(Int128Codec.jsonDecoder)
         timestamp <- c.downField("timestamp").as[Long]
         data      <- c.downField("data").as[Option[String]]
         propType  <- c.downField("propositionType").as[String]

--- a/src/main/scala/co/topl/modifier/transaction/ArbitTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/ArbitTransfer.scala
@@ -4,10 +4,10 @@ import java.time.Instant
 
 import co.topl.attestation.AddressEncoder.NetworkPrefix
 import co.topl.attestation._
+import co.topl.modifier.BoxReader
+import co.topl.modifier.box._
 import co.topl.modifier.transaction.Transaction.TxType
 import co.topl.modifier.transaction.TransferTransaction.BoxParams
-import co.topl.nodeView.state.StateReader
-import co.topl.modifier.box._
 import co.topl.utils.codecs.Int128Codec
 import co.topl.utils.{Identifiable, Identifier, Int128}
 import io.circe.syntax.EncoderOps
@@ -17,7 +17,8 @@ import scala.util.Try
 
 case class ArbitTransfer[
   P <: Proposition: EvidenceProducer: Identifiable
-](override val from:        IndexedSeq[(Address, Box.Nonce)],
+](
+  override val from:        IndexedSeq[(Address, Box.Nonce)],
   override val to:          IndexedSeq[(Address, TokenValueHolder)],
   override val attestation: Map[P, Proof[P]],
   override val fee:         Int128,
@@ -50,7 +51,7 @@ object ArbitTransfer {
     Identifier(typeString, typePrefix)
   }
 
-  /** @param stateReader
+  /** @param boxReader
     * @param toReceive
     * @param sender
     * @param fee
@@ -59,7 +60,8 @@ object ArbitTransfer {
     */
   def createRaw[
     P <: Proposition: EvidenceProducer: Identifiable
-  ](stateReader:          StateReader[ProgramId, Address],
+  ](
+    boxReader:            BoxReader[ProgramId, Address],
     toReceive:            IndexedSeq[(Address, SimpleValue)],
     sender:               IndexedSeq[Address],
     changeAddress:        Address,
@@ -69,7 +71,7 @@ object ArbitTransfer {
   ): Try[ArbitTransfer[P]] =
     TransferTransaction
       .createRawTransferParams(
-        stateReader,
+        boxReader,
         toReceive,
         sender,
         changeAddress,
@@ -107,20 +109,18 @@ object ArbitTransfer {
         timestamp <- c.downField("timestamp").as[Long]
         data      <- c.downField("data").as[Option[String]]
         propType  <- c.downField("propositionType").as[String]
-      } yield {
-        (propType match {
-          case PublicKeyPropositionCurve25519.`typeString` =>
-            c.downField("signatures").as[Map[PublicKeyPropositionCurve25519, SignatureCurve25519]].map {
-              new ArbitTransfer[PublicKeyPropositionCurve25519](from, to, _, fee, timestamp, data)
-            }
+      } yield (propType match {
+        case PublicKeyPropositionCurve25519.`typeString` =>
+          c.downField("signatures").as[Map[PublicKeyPropositionCurve25519, SignatureCurve25519]].map {
+            new ArbitTransfer[PublicKeyPropositionCurve25519](from, to, _, fee, timestamp, data)
+          }
 
-          case ThresholdPropositionCurve25519.`typeString` =>
-            c.downField("signatures").as[Map[ThresholdPropositionCurve25519, ThresholdSignatureCurve25519]].map {
-              new ArbitTransfer[ThresholdPropositionCurve25519](from, to, _, fee, timestamp, data)
-            }
-        }) match {
-          case Right(tx) => tx
-          case Left(ex)  => throw ex
-        }
+        case ThresholdPropositionCurve25519.`typeString` =>
+          c.downField("signatures").as[Map[ThresholdPropositionCurve25519, ThresholdSignatureCurve25519]].map {
+            new ArbitTransfer[ThresholdPropositionCurve25519](from, to, _, fee, timestamp, data)
+          }
+      }) match {
+        case Right(tx) => tx
+        case Left(ex)  => throw ex
       }
 }

--- a/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
@@ -64,7 +64,7 @@ object AssetTransfer {
     sender:               IndexedSeq[Address],
     changeAddress:        Address,
     consolidationAddress: Option[Address],
-    fee:                  Long,
+    fee:                  Int128,
     data:                 Option[String],
     minting:              Boolean
   ): Try[AssetTransfer[P]] = {

--- a/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
@@ -4,10 +4,10 @@ import java.time.Instant
 
 import co.topl.attestation.AddressEncoder.NetworkPrefix
 import co.topl.attestation._
+import co.topl.modifier.BoxReader
+import co.topl.modifier.box._
 import co.topl.modifier.transaction.Transaction.TxType
 import co.topl.modifier.transaction.TransferTransaction.BoxParams
-import co.topl.nodeView.state.StateReader
-import co.topl.modifier.box._
 import co.topl.utils.codecs.Int128Codec
 import co.topl.utils.{Identifiable, Identifier, Int128}
 import io.circe.syntax._
@@ -17,7 +17,8 @@ import scala.util.Try
 
 case class AssetTransfer[
   P <: Proposition: EvidenceProducer: Identifiable
-](override val from:        IndexedSeq[(Address, Box.Nonce)],
+](
+  override val from:        IndexedSeq[(Address, Box.Nonce)],
   override val to:          IndexedSeq[(Address, TokenValueHolder)],
   override val attestation: Map[P, Proof[P]],
   override val fee:         Int128,
@@ -50,7 +51,7 @@ object AssetTransfer {
     Identifier(typeString, typePrefix)
   }
 
-  /** @param stateReader
+  /** @param boxReader
     * @param toReceive
     * @param sender
     * @param fee
@@ -59,7 +60,8 @@ object AssetTransfer {
     */
   def createRaw[
     P <: Proposition: EvidenceProducer: Identifiable
-  ](stateReader:          StateReader[ProgramId, Address],
+  ](
+    boxReader:            BoxReader[ProgramId, Address],
     toReceive:            IndexedSeq[(Address, AssetValue)],
     sender:               IndexedSeq[Address],
     changeAddress:        Address,
@@ -78,7 +80,7 @@ object AssetTransfer {
 
     TransferTransaction
       .createRawTransferParams(
-        stateReader,
+        boxReader,
         toReceive,
         sender,
         changeAddress,
@@ -119,20 +121,18 @@ object AssetTransfer {
         data      <- c.downField("data").as[Option[String]]
         minting   <- c.downField("minting").as[Boolean]
         propType  <- c.downField("propositionType").as[String]
-      } yield {
-        (propType match {
-          case PublicKeyPropositionCurve25519.`typeString` =>
-            c.downField("signatures").as[Map[PublicKeyPropositionCurve25519, SignatureCurve25519]].map {
-              new AssetTransfer[PublicKeyPropositionCurve25519](from, to, _, fee, timestamp, data, minting)
-            }
+      } yield (propType match {
+        case PublicKeyPropositionCurve25519.`typeString` =>
+          c.downField("signatures").as[Map[PublicKeyPropositionCurve25519, SignatureCurve25519]].map {
+            new AssetTransfer[PublicKeyPropositionCurve25519](from, to, _, fee, timestamp, data, minting)
+          }
 
-          case ThresholdPropositionCurve25519.`typeString` =>
-            c.downField("signatures").as[Map[ThresholdPropositionCurve25519, ThresholdSignatureCurve25519]].map {
-              new AssetTransfer[ThresholdPropositionCurve25519](from, to, _, fee, timestamp, data, minting)
-            }
-        }) match {
-          case Right(tx) => tx
-          case Left(ex)  => throw ex
-        }
+        case ThresholdPropositionCurve25519.`typeString` =>
+          c.downField("signatures").as[Map[ThresholdPropositionCurve25519, ThresholdSignatureCurve25519]].map {
+            new AssetTransfer[ThresholdPropositionCurve25519](from, to, _, fee, timestamp, data, minting)
+          }
+      }) match {
+        case Right(tx) => tx
+        case Left(ex)  => throw ex
       }
 }

--- a/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/AssetTransfer.scala
@@ -8,7 +8,8 @@ import co.topl.modifier.transaction.Transaction.TxType
 import co.topl.modifier.transaction.TransferTransaction.BoxParams
 import co.topl.nodeView.state.StateReader
 import co.topl.modifier.box._
-import co.topl.utils.{Identifiable, Identifier}
+import co.topl.utils.codecs.Int128Codec
+import co.topl.utils.{Identifiable, Identifier, Int128}
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, HCursor}
 
@@ -19,7 +20,7 @@ case class AssetTransfer[
 ](override val from:        IndexedSeq[(Address, Box.Nonce)],
   override val to:          IndexedSeq[(Address, TokenValueHolder)],
   override val attestation: Map[P, Proof[P]],
-  override val fee:         Long,
+  override val fee:         Int128,
   override val timestamp:   Long,
   override val data:        Option[String] = None,
   override val minting:     Boolean = false
@@ -101,7 +102,7 @@ object AssetTransfer {
       "from"            -> tx.from.asJson,
       "to"              -> tx.to.asJson,
       "signatures"      -> tx.attestation.asJson,
-      "fee"             -> tx.fee.asJson,
+      "fee"             -> tx.fee.asJson(Int128Codec.jsonEncoder),
       "timestamp"       -> tx.timestamp.asJson,
       "data"            -> tx.data.asJson,
       "minting"         -> tx.minting.asJson
@@ -113,7 +114,7 @@ object AssetTransfer {
       for {
         from      <- c.downField("from").as[IndexedSeq[(Address, Long)]]
         to        <- c.downField("to").as[IndexedSeq[(Address, TokenValueHolder)]]
-        fee       <- c.downField("fee").as[Long]
+        fee       <- c.get[Int128]("fee")(Int128Codec.jsonDecoder)
         timestamp <- c.downField("timestamp").as[Long]
         data      <- c.downField("data").as[Option[String]]
         minting   <- c.downField("minting").as[Boolean]

--- a/src/main/scala/co/topl/modifier/transaction/PolyTransfer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/PolyTransfer.scala
@@ -4,10 +4,10 @@ import java.time.Instant
 
 import co.topl.attestation.AddressEncoder.NetworkPrefix
 import co.topl.attestation._
+import co.topl.modifier.BoxReader
+import co.topl.modifier.box._
 import co.topl.modifier.transaction.Transaction.TxType
 import co.topl.modifier.transaction.TransferTransaction.BoxParams
-import co.topl.nodeView.state.StateReader
-import co.topl.modifier.box._
 import co.topl.utils.codecs.Int128Codec
 import co.topl.utils.{Identifiable, Identifier, Int128}
 import io.circe.syntax.EncoderOps
@@ -17,7 +17,8 @@ import scala.util.Try
 
 case class PolyTransfer[
   P <: Proposition: EvidenceProducer: Identifiable
-](override val from:        IndexedSeq[(Address, Box.Nonce)],
+](
+  override val from:        IndexedSeq[(Address, Box.Nonce)],
   override val to:          IndexedSeq[(Address, TokenValueHolder)],
   override val attestation: Map[P, Proof[P]],
   override val fee:         Int128,
@@ -50,7 +51,7 @@ object PolyTransfer {
     Identifier(typeString, typePrefix)
   }
 
-  /** @param stateReader
+  /** @param boxReader
     * @param toReceive
     * @param sender
     * @param fee
@@ -59,7 +60,8 @@ object PolyTransfer {
     */
   def createRaw[
     P <: Proposition: EvidenceProducer: Identifiable
-  ](stateReader:          StateReader[ProgramId, Address],
+  ](
+    boxReader:            BoxReader[ProgramId, Address],
     toReceive:            IndexedSeq[(Address, SimpleValue)],
     sender:               IndexedSeq[Address],
     changeAddress:        Address,
@@ -68,7 +70,7 @@ object PolyTransfer {
     data:                 Option[String]
   ): Try[PolyTransfer[P]] =
     TransferTransaction
-      .createRawTransferParams(stateReader, toReceive, sender, changeAddress, consolidationAddress, fee, "PolyTransfer")
+      .createRawTransferParams(boxReader, toReceive, sender, changeAddress, consolidationAddress, fee, "PolyTransfer")
       .map { case (inputs, outputs) =>
         PolyTransfer[P](inputs, outputs, Map(), fee, Instant.now.toEpochMilli, data)
       }
@@ -99,20 +101,18 @@ object PolyTransfer {
         timestamp <- c.downField("timestamp").as[Long]
         data      <- c.downField("data").as[Option[String]]
         propType  <- c.downField("propositionType").as[String]
-      } yield {
-        (propType match {
-          case PublicKeyPropositionCurve25519.`typeString` =>
-            c.downField("signatures").as[Map[PublicKeyPropositionCurve25519, SignatureCurve25519]].map {
-              new PolyTransfer[PublicKeyPropositionCurve25519](from, to, _, fee, timestamp, data)
-            }
+      } yield (propType match {
+        case PublicKeyPropositionCurve25519.`typeString` =>
+          c.downField("signatures").as[Map[PublicKeyPropositionCurve25519, SignatureCurve25519]].map {
+            new PolyTransfer[PublicKeyPropositionCurve25519](from, to, _, fee, timestamp, data)
+          }
 
-          case ThresholdPropositionCurve25519.`typeString` =>
-            c.downField("signatures").as[Map[ThresholdPropositionCurve25519, ThresholdSignatureCurve25519]].map {
-              new PolyTransfer[ThresholdPropositionCurve25519](from, to, _, fee, timestamp, data)
-            }
-        }) match {
-          case Right(tx) => tx
-          case Left(ex)  => throw ex
-        }
+        case ThresholdPropositionCurve25519.`typeString` =>
+          c.downField("signatures").as[Map[ThresholdPropositionCurve25519, ThresholdSignatureCurve25519]].map {
+            new PolyTransfer[ThresholdPropositionCurve25519](from, to, _, fee, timestamp, data)
+          }
+      }) match {
+        case Right(tx) => tx
+        case Left(ex)  => throw ex
       }
 }

--- a/src/main/scala/co/topl/modifier/transaction/Transaction.scala
+++ b/src/main/scala/co/topl/modifier/transaction/Transaction.scala
@@ -7,7 +7,7 @@ import co.topl.modifier.block.BloomFilter.BloomTopic
 import co.topl.modifier.box.{Box, BoxId, ProgramId}
 import co.topl.modifier.{ModifierId, NodeViewModifier}
 import co.topl.nodeView.state.StateReader
-import co.topl.utils.{Identifiable, Identifier}
+import co.topl.utils.{Identifiable, Identifier, Int128}
 import com.google.common.primitives.Longs
 import io.circe.{Decoder, Encoder, HCursor}
 import scorex.crypto.hash.Digest32
@@ -28,7 +28,7 @@ abstract class Transaction[+T, P <: Proposition: Identifiable] extends NodeViewM
 
   val attestation: Map[P, Proof[P]]
 
-  val fee: Long
+  val fee: Int128
 
   val timestamp: Long
 
@@ -40,7 +40,7 @@ abstract class Transaction[+T, P <: Proposition: Identifiable] extends NodeViewM
     newBoxes.foldLeft(Array[Byte]())((acc, x) => acc ++ x.bytes) ++
     boxIdsToOpen.foldLeft(Array[Byte]())((acc, x) => acc ++ x.hashBytes) ++
     Longs.toByteArray(timestamp) ++
-    Longs.toByteArray(fee)
+    fee.toByteArray
 
   def getPropIdentifier: Identifier = Identifiable[P].getId
 

--- a/src/main/scala/co/topl/modifier/transaction/Transaction.scala
+++ b/src/main/scala/co/topl/modifier/transaction/Transaction.scala
@@ -5,8 +5,7 @@ import co.topl.attestation.{Address, Proof, Proposition}
 import co.topl.modifier.NodeViewModifier.ModifierTypeId
 import co.topl.modifier.block.BloomFilter.BloomTopic
 import co.topl.modifier.box.{Box, BoxId, ProgramId}
-import co.topl.modifier.{ModifierId, NodeViewModifier}
-import co.topl.nodeView.state.StateReader
+import co.topl.modifier.{BoxReader, ModifierId, NodeViewModifier}
 import co.topl.utils.{Identifiable, Identifier, Int128}
 import com.google.common.primitives.Longs
 import io.circe.{Decoder, Encoder, HCursor}
@@ -44,7 +43,7 @@ abstract class Transaction[+T, P <: Proposition: Identifiable] extends NodeViewM
 
   def getPropIdentifier: Identifier = Identifiable[P].getId
 
-  def semanticValidate(stateReader: StateReader[ProgramId, Address])(implicit networkPrefix: NetworkPrefix): Try[Unit]
+  def semanticValidate(boxReader: BoxReader[ProgramId, Address])(implicit networkPrefix: NetworkPrefix): Try[Unit]
 
   def syntacticValidate(implicit networkPrefix: NetworkPrefix): Try[Unit]
 

--- a/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
@@ -38,7 +38,7 @@ object ArbitTransferSerializer extends BifrostSerializer[ArbitTransfer[_ <: Prop
     }
 
     /* fee: Int128 */
-    w.putBytes(obj.fee.toByteArray)
+    w.putInt128(obj.fee)
 
     /* timestamp: Long */
     w.putULong(obj.timestamp)
@@ -76,7 +76,7 @@ object ArbitTransferSerializer extends BifrostSerializer[ArbitTransfer[_ <: Prop
       prop -> sig
     }: _*)
 
-    val fee: Int128 = Int128(r.getBytes(Int128.numBytes))
+    val fee: Int128 = r.getInt128()
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
@@ -4,6 +4,7 @@ import co.topl.attestation._
 import co.topl.attestation.serialization.{ProofSerializer, PropositionSerializer}
 import co.topl.modifier.transaction.ArbitTransfer
 import co.topl.modifier.box.TokenValueHolder
+import co.topl.utils.Int128
 import co.topl.utils.serialization.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
@@ -36,8 +37,8 @@ object ArbitTransferSerializer extends BifrostSerializer[ArbitTransfer[_ <: Prop
       ProofSerializer.serialize(sig, w)
     }
 
-    /* fee: Long */
-    w.putULong(obj.fee)
+    /* fee: Int128 */
+    w.putBytes(obj.fee.toByteArray)
 
     /* timestamp: Long */
     w.putULong(obj.timestamp)
@@ -75,7 +76,7 @@ object ArbitTransferSerializer extends BifrostSerializer[ArbitTransfer[_ <: Prop
       prop -> sig
     }: _*)
 
-    val fee: Long = r.getULong()
+    val fee: Int128 = Int128(r.getBytes(Int128.size))
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
@@ -76,7 +76,7 @@ object ArbitTransferSerializer extends BifrostSerializer[ArbitTransfer[_ <: Prop
       prop -> sig
     }: _*)
 
-    val fee: Int128 = Int128(r.getBytes(Int128.size))
+    val fee: Int128 = Int128(r.getBytes(Int128.numBytes))
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
@@ -76,7 +76,7 @@ object AssetTransferSerializer extends BifrostSerializer[AssetTransfer[_ <: Prop
       prop -> sig
     }: _*)
 
-    val fee: Int128 = Int128(r.getBytes(Int128.size))
+    val fee: Int128 = Int128(r.getBytes(Int128.numBytes))
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
@@ -4,6 +4,7 @@ import co.topl.attestation._
 import co.topl.attestation.serialization.{ProofSerializer, PropositionSerializer}
 import co.topl.modifier.transaction.AssetTransfer
 import co.topl.modifier.box.TokenValueHolder
+import co.topl.utils.Int128
 import co.topl.utils.serialization.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
@@ -36,8 +37,8 @@ object AssetTransferSerializer extends BifrostSerializer[AssetTransfer[_ <: Prop
       ProofSerializer.serialize(sig, w)
     }
 
-    /* fee: Long */
-    w.putULong(obj.fee)
+    /* fee: Int128 */
+    w.putBytes(obj.fee.toByteArray)
 
     /* timestamp: Long */
     w.putULong(obj.timestamp)
@@ -75,7 +76,7 @@ object AssetTransferSerializer extends BifrostSerializer[AssetTransfer[_ <: Prop
       prop -> sig
     }: _*)
 
-    val fee: Long = r.getULong()
+    val fee: Int128 = Int128(r.getBytes(Int128.size))
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
@@ -38,7 +38,7 @@ object AssetTransferSerializer extends BifrostSerializer[AssetTransfer[_ <: Prop
     }
 
     /* fee: Int128 */
-    w.putBytes(obj.fee.toByteArray)
+    w.putInt128(obj.fee)
 
     /* timestamp: Long */
     w.putULong(obj.timestamp)
@@ -76,7 +76,7 @@ object AssetTransferSerializer extends BifrostSerializer[AssetTransfer[_ <: Prop
       prop -> sig
     }: _*)
 
-    val fee: Int128 = Int128(r.getBytes(Int128.numBytes))
+    val fee: Int128 = r.getInt128()
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
@@ -76,7 +76,7 @@ object PolyTransferSerializer extends BifrostSerializer[PolyTransfer[_ <: Propos
       prop -> sig
     }: _*)
 
-    val fee: Int128 = Int128(r.getBytes(Int128.size))
+    val fee: Int128 = Int128(r.getBytes(Int128.numBytes))
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
@@ -38,7 +38,7 @@ object PolyTransferSerializer extends BifrostSerializer[PolyTransfer[_ <: Propos
     }
 
     /* fee: Int128 */
-    w.putBytes(obj.fee.toByteArray)
+    w.putInt128(obj.fee)
 
     /* timestamp: Long */
     w.putULong(obj.timestamp)
@@ -76,7 +76,7 @@ object PolyTransferSerializer extends BifrostSerializer[PolyTransfer[_ <: Propos
       prop -> sig
     }: _*)
 
-    val fee: Int128 = Int128(r.getBytes(Int128.numBytes))
+    val fee: Int128 = r.getInt128()
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
@@ -4,6 +4,7 @@ import co.topl.attestation._
 import co.topl.attestation.serialization.{ProofSerializer, PropositionSerializer}
 import co.topl.modifier.transaction.PolyTransfer
 import co.topl.modifier.box.TokenValueHolder
+import co.topl.utils.Int128
 import co.topl.utils.serialization.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
@@ -36,8 +37,8 @@ object PolyTransferSerializer extends BifrostSerializer[PolyTransfer[_ <: Propos
       ProofSerializer.serialize(sig, w)
     }
 
-    /* fee: Long */
-    w.putULong(obj.fee)
+    /* fee: Int128 */
+    w.putBytes(obj.fee.toByteArray)
 
     /* timestamp: Long */
     w.putULong(obj.timestamp)
@@ -75,7 +76,7 @@ object PolyTransferSerializer extends BifrostSerializer[PolyTransfer[_ <: Propos
       prop -> sig
     }: _*)
 
-    val fee: Long = r.getULong()
+    val fee: Int128 = Int128(r.getBytes(Int128.size))
     val timestamp: Long = r.getULong()
 
     val data: Option[String] = r.getOption {

--- a/src/main/scala/co/topl/network/NetworkController.scala
+++ b/src/main/scala/co/topl/network/NetworkController.scala
@@ -230,7 +230,7 @@ class NetworkController(
   ////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////// METHOD DEFINITIONS ////////////////////////////////
 
-  def networkTime(): Time = appContext.timeProvider.time()
+  def networkTime(): Time = appContext.timeProvider.time
 
   /** Schedule a periodic connection to a random known peer */
   private def scheduleConnectionToPeer(): Unit = {

--- a/src/main/scala/co/topl/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/co/topl/network/NodeViewSynchronizer.scala
@@ -14,7 +14,7 @@ import co.topl.network.peer.{ConnectedPeer, PenaltyType}
 import co.topl.nodeView.NodeViewHolder.ReceivableMessages.{GetNodeViewChanges, ModifiersFromRemote, TransactionsFromRemote}
 import co.topl.nodeView.history.GenericHistory._
 import co.topl.nodeView.history.HistoryReader
-import co.topl.nodeView.mempool.MemPoolReader
+import co.topl.nodeView.mempool.{MemPoolReader, UnconfirmedTx}
 import co.topl.nodeView.state.StateReader
 import co.topl.settings.{AppContext, AppSettings, NodeViewReady}
 import co.topl.utils.serialization.BifrostSerializer

--- a/src/main/scala/co/topl/network/PeerConnectionHandler.scala
+++ b/src/main/scala/co/topl/network/PeerConnectionHandler.scala
@@ -245,7 +245,7 @@ class PeerConnectionHandler(
   }
 
   private def createHandshakeMessage(): Unit = {
-    val nodeInfo = message.Handshake(localPeerSpec, appContext.timeProvider.time())
+    val nodeInfo = message.Handshake(localPeerSpec, appContext.timeProvider.time)
 
     /** create, save, and schedule a timeout option. The variable lets us cancel the timeout message
       * if a handshake is received
@@ -264,7 +264,7 @@ class PeerConnectionHandler(
 
     val peerInfo = PeerInfo(
       receivedHandshake.peerSpec,
-      appContext.timeProvider.time(),
+      appContext.timeProvider.time,
       Some(direction)
     )
     val peer = ConnectedPeer(connectionDescription.connectionId, self, Some(peerInfo))

--- a/src/main/scala/co/topl/network/SyncTracker.scala
+++ b/src/main/scala/co/topl/network/SyncTracker.scala
@@ -86,17 +86,17 @@ class SyncTracker(
   }
 
   def updateLastSyncSentTime(peer: ConnectedPeer): Unit = {
-    val currentTime = timeProvider.time()
+    val currentTime = timeProvider.time
     lastSyncSentTime(peer) = currentTime
     lastSyncInfoSentTime = currentTime
   }
 
   /** Time elapsed since last synchronization */
-  def elapsedTimeSinceLastSync(): Long = timeProvider.time() - lastSyncInfoSentTime
+  def elapsedTimeSinceLastSync(): Long = timeProvider.time - lastSyncInfoSentTime
 
   /** A peer with a lastSyncSentTime greater than the maxInterval is outdated */
   private def outdatedPeers(): Seq[ConnectedPeer] =
-    lastSyncSentTime.filter(t => (timeProvider.time() - t._2).millis > maxInterval()).keys.toSeq
+    lastSyncSentTime.filter(t => (timeProvider.time - t._2).millis > maxInterval()).keys.toSeq
 
   /** Number of peers that are older */
   private def numOfSeniors(): Int = statuses.count(_._2 == Older)
@@ -116,7 +116,7 @@ class SyncTracker(
         val elders = statuses.filter(_._2 == Older).keys.toIndexedSeq
         val nonOutdated =
           (if (elders.nonEmpty) elders(scala.util.Random.nextInt(elders.size)) +: unknowns else unknowns) ++ forks
-        nonOutdated.filter(p => (timeProvider.time() - lastSyncSentTime.getOrElse(p, 0L)).millis >= minInterval)
+        nonOutdated.filter(p => (timeProvider.time - lastSyncSentTime.getOrElse(p, 0L)).millis >= minInterval)
       }
 
     peers.foreach(updateLastSyncSentTime)

--- a/src/main/scala/co/topl/nodeView/CleanupWorker.scala
+++ b/src/main/scala/co/topl/nodeView/CleanupWorker.scala
@@ -70,7 +70,7 @@ class CleanupWorker(nodeViewHolderRef: ActorRef, settings: AppSettings, appConte
           // if any newly created box matches a box already in the UTXO set, remove the transaction
           val boxAlreadyExists = utx.tx.newBoxes.exists(b => stateReader.getBox(b.id).isDefined)
           val txTimeout =
-            (appContext.timeProvider.time() - utx.dateAdded) > settings.application.mempoolTimeout.toMillis
+            (appContext.timeProvider.time - utx.dateAdded) > settings.application.mempoolTimeout.toMillis
 
           if (boxAlreadyExists | txTimeout) (validAcc, utx.tx.id +: invalidAcc)
           else (utx.tx.id +: validAcc, invalidAcc)

--- a/src/main/scala/co/topl/nodeView/CleanupWorker.scala
+++ b/src/main/scala/co/topl/nodeView/CleanupWorker.scala
@@ -4,31 +4,28 @@ import akka.actor.{Actor, ActorRef}
 import co.topl.attestation.Address
 import co.topl.attestation.AddressEncoder.NetworkPrefix
 import co.topl.modifier.ModifierId
-import co.topl.modifier.box.{BoxId, ProgramId}
+import co.topl.modifier.box.ProgramId
 import co.topl.modifier.transaction.Transaction
 import co.topl.nodeView.CleanupWorker.RunCleanup
 import co.topl.nodeView.MempoolAuditor.CleanupDone
 import co.topl.nodeView.NodeViewHolder.ReceivableMessages.EliminateTransactions
 import co.topl.nodeView.mempool.MemPoolReader
 import co.topl.nodeView.state.StateReader
-import co.topl.settings.AppSettings
+import co.topl.settings.{AppContext, AppSettings}
 import co.topl.utils.Logging
 
-import scala.annotation.tailrec
 import scala.collection.immutable.TreeSet
-import scala.reflect.ClassTag
-import scala.util.{Failure, Success}
 
-/**
- * Performs mempool validation task on demand.
- * Validation result is sent directly to `NodeViewHolder`.
- */
-class CleanupWorker[
-  TX <: Transaction.TX,
-  SR <: StateReader[ProgramId, Address]: ClassTag,
-  MR <: MemPoolReader[TX]: ClassTag
-](nodeViewHolderRef: ActorRef,
-  settings: AppSettings)(implicit networkPrefix: NetworkPrefix) extends Actor with Logging {
+/** Performs mempool validation task on demand.
+  * Validation result is sent directly to `NodeViewHolder`.
+  */
+class CleanupWorker(nodeViewHolderRef: ActorRef, settings: AppSettings, appContext: AppContext)(implicit
+  networkPrefix:                       NetworkPrefix
+) extends Actor
+    with Logging {
+
+  type SR = StateReader[ProgramId, Address]
+  type MR = MemPoolReader[Transaction.TX]
 
   // keep some number of recently validated transactions in order
   // to avoid validating the same transactions too many times.
@@ -36,72 +33,50 @@ class CleanupWorker[
   // count validation sessions in order to perform index cleanup.
   private var epochNr: Int = 0
 
-  override def preStart(): Unit = {
+  override def preStart(): Unit =
     log.info("Cleanup worker started")
-  }
 
   override def receive: Receive = {
-    case RunCleanup(state, mempool) =>
-      runCleanup(state, mempool)
-      sender() ! CleanupDone
+    case RunCleanup(state: SR, mempool: MR) =>
+      val validIds = runCleanup(state, mempool)
+        .take(settings.application.rebroadcastCount)
+      sender() ! CleanupDone(validIds)
 
     //Should not be here, if non-expected signal comes, check logic
     case a: Any => log.warn(s"Strange input: $a")
   }
 
-  private def runCleanup[S <: SR, M <: MR](state: S, mempool: M): Unit = {
-    val toEliminate = validatePool(state, mempool)
+  private def runCleanup(state: SR, mempool: MR): Seq[ModifierId] = {
+    val (validated, toEliminate) = validatePool(state, mempool)
     if (toEliminate.nonEmpty) {
       log.info(s"${toEliminate.size} transactions from mempool were invalidated")
       nodeViewHolderRef ! EliminateTransactions(toEliminate)
     }
+    validated
   }
 
-  /**
-   * Validates transactions from mempool for some specified amount of time.
-   *
-   * @return - invalidated transaction ids
-   */
-  private def validatePool(stateReader: SR, mempool: MR): Seq[ModifierId] = {
-
+  /** Checks if the outputs of unconfirmed transactions exists in state or if the transaction has become
+   *  stale (by exceeding the mempoolTimeout). If either are true, the transaction is removed from the mempool
+    * @return - a sequence of recently validated transactions id's to be rebroadcast and a sequence of ids to remove
+    */
+  private def validatePool(stateReader: SR, mempool: MR): (Seq[ModifierId], Seq[ModifierId]) = {
 
     // Check transactions sorted by priority. Parent transaction comes before its children.
-    val txsToValidate = mempool.take(100)
+    val (validatedIds, invalidatedIds) = mempool
+      .take(100)(-_.dateAdded)
+      .filterNot(utx => validatedIndex.contains(utx.tx.id))
+      .foldLeft((Seq[ModifierId](), Seq[ModifierId]()))({
+        case ((validAcc: Seq[ModifierId], invalidAcc: Seq[ModifierId]), utx) =>
+          // if any newly created box matches a box already in the UTXO set, remove the transaction
+          val boxAlreadyExists = utx.tx.newBoxes.exists(b => stateReader.getBox(b.id).isDefined)
+          val txTimeout =
+            (appContext.timeProvider.time() - utx.dateAdded) > settings.application.mempoolTimeout.toMillis
 
-    //internal loop function validating transactions, returns validated and invalidated transaction ids
-    @tailrec
-    def validationLoop(txs: Seq[TX],
-                       validated: Seq[ModifierId],
-                       invalidated: Seq[ModifierId],
-                       etAcc: Long): (Seq[ModifierId], Seq[ModifierId]) = {
-      txs match {
-        case head :: tail if etAcc < settings.application.mempoolCleanupDuration.toNanos && !validatedIndex.contains(head.id) =>
+          if (boxAlreadyExists | txTimeout) (validAcc, utx.tx.id +: invalidAcc)
+          else (utx.tx.id +: validAcc, invalidAcc)
+      })
 
-          // TODO: JAA - This should take into account previously validated transactions from the pool.
-          val t0 = System.nanoTime()
-          val validationResult = head.semanticValidate(stateReader)
-          val t1 = System.nanoTime()
-          val accumulatedTime = etAcc + (t1 - t0)
-
-          val txId = head.id
-          validationResult match {
-            case Success(_) =>
-              validationLoop(tail, validated :+ txId, invalidated, accumulatedTime)
-            case Failure(e) =>
-              log.info(s"Transaction $txId invalidated: ${e.getMessage}")
-              validationLoop(tail, validated, invalidated :+ txId, accumulatedTime)
-          }
-        case _ :: tail if etAcc < settings.mempoolCleanupDuration.toNanos =>
-          // this transaction was validated earlier, skip it
-          validationLoop(tail, validated, invalidated, etAcc)
-        case _ =>
-          validated -> invalidated
-      }
-    }
-
-    val (validatedIds, invalidatedIds) = validationLoop(txsToValidate, Seq.empty, Seq.empty, 0L)
-
-    epochNr += 1
+    if (epochNr < Int.MaxValue) epochNr += 1 else epochNr = 0
     if (epochNr % CleanupWorker.RevisionInterval == 0) {
       // drop old index in order to check potentially outdated transactions again.
       validatedIndex = TreeSet(validatedIds: _*)
@@ -109,29 +84,25 @@ class CleanupWorker[
       validatedIndex ++= validatedIds
     }
 
-    invalidatedIds
+    validatedIds -> invalidatedIds
   }
 
 }
 
 object CleanupWorker {
 
-  /**
-   * Constant which shows on how many cleanup operations (called when a new block arrives) a transaction
-   * re-check happens.
-   *
-   * If transactions set is large and stable, then about (1/RevisionInterval)-th of the pool is checked
-   *
-   */
+  /** Constant which shows on how many cleanup operations (called when a new block arrives) a transaction
+    * re-check happens.
+    *
+    * If transactions set is large and stable, then about (1/RevisionInterval)-th of the pool is checked
+    */
   val RevisionInterval: Int = 4
 
-  /**
-   *
-   * A command to run (partial) memory pool cleanup
-   *
-   * @param validator - a state implementation which provides transaction validation
-   * @param mempool - mempool reader instance
-   */
+  /** A command to run (partial) memory pool cleanup
+    *
+    * @param stateReader - a state implementation which provides transaction validation
+    * @param mempool - mempool reader instance
+    */
   case class RunCleanup(stateReader: StateReader[ProgramId, Address], mempool: MemPoolReader[Transaction.TX])
 
 }

--- a/src/main/scala/co/topl/nodeView/CleanupWorker.scala
+++ b/src/main/scala/co/topl/nodeView/CleanupWorker.scala
@@ -1,0 +1,137 @@
+package co.topl.nodeView
+
+import akka.actor.{Actor, ActorRef}
+import co.topl.attestation.Address
+import co.topl.attestation.AddressEncoder.NetworkPrefix
+import co.topl.modifier.ModifierId
+import co.topl.modifier.box.{BoxId, ProgramId}
+import co.topl.modifier.transaction.Transaction
+import co.topl.nodeView.CleanupWorker.RunCleanup
+import co.topl.nodeView.MempoolAuditor.CleanupDone
+import co.topl.nodeView.NodeViewHolder.ReceivableMessages.EliminateTransactions
+import co.topl.nodeView.mempool.MemPoolReader
+import co.topl.nodeView.state.StateReader
+import co.topl.settings.AppSettings
+import co.topl.utils.Logging
+
+import scala.annotation.tailrec
+import scala.collection.immutable.TreeSet
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success}
+
+/**
+ * Performs mempool validation task on demand.
+ * Validation result is sent directly to `NodeViewHolder`.
+ */
+class CleanupWorker[
+  TX <: Transaction.TX,
+  SR <: StateReader[ProgramId, Address]: ClassTag,
+  MR <: MemPoolReader[TX]: ClassTag
+](nodeViewHolderRef: ActorRef,
+  settings: AppSettings)(implicit networkPrefix: NetworkPrefix) extends Actor with Logging {
+
+  // keep some number of recently validated transactions in order
+  // to avoid validating the same transactions too many times.
+  private var validatedIndex: TreeSet[ModifierId] = TreeSet.empty[ModifierId]
+  // count validation sessions in order to perform index cleanup.
+  private var epochNr: Int = 0
+
+  override def preStart(): Unit = {
+    log.info("Cleanup worker started")
+  }
+
+  override def receive: Receive = {
+    case RunCleanup(state, mempool) =>
+      runCleanup(state, mempool)
+      sender() ! CleanupDone
+
+    //Should not be here, if non-expected signal comes, check logic
+    case a: Any => log.warn(s"Strange input: $a")
+  }
+
+  private def runCleanup[S <: SR, M <: MR](state: S, mempool: M): Unit = {
+    val toEliminate = validatePool(state, mempool)
+    if (toEliminate.nonEmpty) {
+      log.info(s"${toEliminate.size} transactions from mempool were invalidated")
+      nodeViewHolderRef ! EliminateTransactions(toEliminate)
+    }
+  }
+
+  /**
+   * Validates transactions from mempool for some specified amount of time.
+   *
+   * @return - invalidated transaction ids
+   */
+  private def validatePool(stateReader: SR, mempool: MR): Seq[ModifierId] = {
+
+
+    // Check transactions sorted by priority. Parent transaction comes before its children.
+    val txsToValidate = mempool.take(100)
+
+    //internal loop function validating transactions, returns validated and invalidated transaction ids
+    @tailrec
+    def validationLoop(txs: Seq[TX],
+                       validated: Seq[ModifierId],
+                       invalidated: Seq[ModifierId],
+                       etAcc: Long): (Seq[ModifierId], Seq[ModifierId]) = {
+      txs match {
+        case head :: tail if etAcc < settings.application.mempoolCleanupDuration.toNanos && !validatedIndex.contains(head.id) =>
+
+          // TODO: JAA - This should take into account previously validated transactions from the pool.
+          val t0 = System.nanoTime()
+          val validationResult = head.semanticValidate(stateReader)
+          val t1 = System.nanoTime()
+          val accumulatedTime = etAcc + (t1 - t0)
+
+          val txId = head.id
+          validationResult match {
+            case Success(_) =>
+              validationLoop(tail, validated :+ txId, invalidated, accumulatedTime)
+            case Failure(e) =>
+              log.info(s"Transaction $txId invalidated: ${e.getMessage}")
+              validationLoop(tail, validated, invalidated :+ txId, accumulatedTime)
+          }
+        case _ :: tail if etAcc < settings.mempoolCleanupDuration.toNanos =>
+          // this transaction was validated earlier, skip it
+          validationLoop(tail, validated, invalidated, etAcc)
+        case _ =>
+          validated -> invalidated
+      }
+    }
+
+    val (validatedIds, invalidatedIds) = validationLoop(txsToValidate, Seq.empty, Seq.empty, 0L)
+
+    epochNr += 1
+    if (epochNr % CleanupWorker.RevisionInterval == 0) {
+      // drop old index in order to check potentially outdated transactions again.
+      validatedIndex = TreeSet(validatedIds: _*)
+    } else {
+      validatedIndex ++= validatedIds
+    }
+
+    invalidatedIds
+  }
+
+}
+
+object CleanupWorker {
+
+  /**
+   * Constant which shows on how many cleanup operations (called when a new block arrives) a transaction
+   * re-check happens.
+   *
+   * If transactions set is large and stable, then about (1/RevisionInterval)-th of the pool is checked
+   *
+   */
+  val RevisionInterval: Int = 4
+
+  /**
+   *
+   * A command to run (partial) memory pool cleanup
+   *
+   * @param validator - a state implementation which provides transaction validation
+   * @param mempool - mempool reader instance
+   */
+  case class RunCleanup(stateReader: StateReader[ProgramId, Address], mempool: MemPoolReader[Transaction.TX])
+
+}

--- a/src/main/scala/co/topl/nodeView/MemPoolAuditor.scala
+++ b/src/main/scala/co/topl/nodeView/MemPoolAuditor.scala
@@ -1,50 +1,53 @@
 package co.topl.nodeView
 
 import akka.actor.SupervisorStrategy.{Restart, Stop}
-import akka.actor.{Actor, ActorInitializationException, ActorKilledException, ActorRef, ActorRefFactory, DeathPactException, OneForOneStrategy, Props}
+import akka.actor.{
+  Actor,
+  ActorInitializationException,
+  ActorKilledException,
+  ActorRef,
+  ActorRefFactory,
+  DeathPactException,
+  OneForOneStrategy,
+  Props
+}
+import co.topl.attestation.Address
 import co.topl.attestation.AddressEncoder.NetworkPrefix
+import co.topl.modifier.ModifierId
 import co.topl.modifier.block.{Block, BlockHeader}
-import co.topl.modifier.box.{BoxId, ProgramId}
+import co.topl.modifier.box.ProgramId
 import co.topl.modifier.transaction.Transaction
 import co.topl.network.Broadcast
 import co.topl.network.NetworkController.ReceivableMessages.SendToNetwork
-import co.topl.network.NodeViewSynchronizer.ReceivableMessages.{ChangedMempool, ChangedState, SemanticallySuccessfulModifier}
+import co.topl.network.NodeViewSynchronizer.ReceivableMessages.{
+  ChangedMempool,
+  ChangedState,
+  SemanticallySuccessfulModifier
+}
 import co.topl.network.message.{InvData, InvSpec, Message}
 import co.topl.nodeView.CleanupWorker.RunCleanup
 import co.topl.nodeView.MempoolAuditor.CleanupDone
 import co.topl.nodeView.NodeViewHolder.ReceivableMessages.GetNodeViewChanges
 import co.topl.nodeView.mempool.MemPoolReader
 import co.topl.nodeView.state.StateReader
-import co.topl.settings.AppSettings
+import co.topl.settings.{AppContext, AppSettings, NodeViewReady}
 import co.topl.utils.Logging
 
-import scala.reflect.ClassTag
-
-// need to add comments, node ready commands, name of actor in object,
-
 import scala.concurrent.duration._
+import scala.reflect.ClassTag
 
 /** Controls mempool cleanup workflow. Watches NodeView events and delegates
   * mempool cleanup task to [[CleanupWorker]] when needed.
   * Adapted from ErgoPlatform available at https://github.com/ergoplatform/ergo
   */
 class MempoolAuditor[
-  SR <: StateReader[ProgramId, BoxId]: ClassTag,
+  SR <: StateReader[ProgramId, Address]: ClassTag,
   MR <: MemPoolReader[Transaction.TX]: ClassTag
-](nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings)(implicit
-  networkPrefix:     NetworkPrefix
-) extends Actor
+](nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings, appContext: AppContext)
+    extends Actor
     with Logging {
 
-  override def postRestart(reason: Throwable): Unit = {
-    log.error(s"Mempool auditor actor restarted due to ${reason.getMessage}", reason)
-    super.postRestart(reason)
-  }
-
-  override def postStop(): Unit = {
-    logger.info("Mempool auditor stopped")
-    super.postStop()
-  }
+  implicit val networkPrefix: NetworkPrefix = appContext.networkType.netPrefix
 
   override val supervisorStrategy: OneForOneStrategy =
     OneForOneStrategy(maxNrOfRetries = 5, withinTimeRange = 1.minute) {
@@ -63,12 +66,36 @@ class MempoolAuditor[
   private var poolReaderOpt: Option[MR] = None
 
   private val worker: ActorRef =
-    context.actorOf(Props(new CleanupWorker(nodeViewHolderRef, settings)))
+    context.actorOf(Props(new CleanupWorker(nodeViewHolderRef, settings, appContext)))
 
-  override def preStart(): Unit =
+  override def preStart(): Unit = {
     context.system.eventStream.subscribe(self, classOf[SemanticallySuccessfulModifier[_]])
+    context.system.eventStream.subscribe(self, classOf[NodeViewReady])
+  }
 
-  override def receive: Receive = awaiting
+  override def postRestart(reason: Throwable): Unit = {
+    log.error(s"Mempool auditor actor restarted due to ${reason.getMessage}", reason)
+    super.postRestart(reason)
+  }
+
+  override def postStop(): Unit = {
+    logger.info("Mempool auditor stopped")
+    super.postStop()
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////// ACTOR MESSAGE HANDLING //////////////////////////////
+
+  override def receive: Receive =
+    initialization orElse
+    nonsense
+
+  private def initialization: Receive = {
+    /** wait to start processing until the NodeViewHolder is ready * */
+    case NodeViewReady(_) =>
+      log.info(s"${Console.YELLOW}MemPool Auditor transitioning to the operational state${Console.RESET}")
+      context become awaiting
+  }
 
   private def awaiting: Receive = {
     case SemanticallySuccessfulModifier(_: Block) | SemanticallySuccessfulModifier(_: BlockHeader) =>
@@ -85,18 +112,27 @@ class MempoolAuditor[
       poolReaderOpt.foreach(mp => initiateCleanup(st, mp))
 
     case ChangedState(_) | ChangedMempool(_) => // do nothing
+
+    case _ => nonsense
   }
 
   private def working: Receive = {
-    case CleanupDone =>
+    case CleanupDone(ids) =>
       log.info("Cleanup done. Switching to awaiting mode")
-      rebroadcastTransactions()
+      rebroadcastTransactions(ids)
       stateReaderOpt = None
       poolReaderOpt = None
       context become awaiting
 
-    case _ => // ignore other triggers until work is done
+    case _ => nonsense
   }
+
+  private def nonsense: Receive = { case nonsense: Any =>
+    log.warn(s"Got unexpected input $nonsense from ${sender()}")
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////
+  //////////////////////////////// METHOD DEFINITIONS ////////////////////////////////
 
   private def initiateCleanup(state: SR, mempool: MR): Unit = {
     log.info("Initiating cleanup. Switching to working mode")
@@ -104,41 +140,58 @@ class MempoolAuditor[
     context become working // ignore other triggers until work is done
   }
 
-  private def rebroadcastTransactions(): Unit = {
+  private def rebroadcastTransactions(ids: Seq[ModifierId]): Unit = {
     log.debug("Rebroadcasting transactions")
     poolReaderOpt.foreach { pr =>
-      pr.take(settings.application.rebroadcastCount).foreach { tx =>
+      pr.getAll(ids).foreach { tx =>
         log.info(s"Rebroadcasting $tx")
         val msg = Message(
           new InvSpec(settings.network.maxInvObjects),
           Right(InvData(Transaction.modifierTypeId, Seq(tx.id))),
           None
         )
+
         networkControllerRef ! SendToNetwork(msg, Broadcast)
       }
 
     }
-
   }
 }
 
+////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////// COMPANION SINGLETON ////////////////////////////////
+
 object MempoolAuditor {
 
-  case object CleanupDone
+  val actorName = "mempoolAuditor"
+
+  case class CleanupDone(toBeBroadcast: Seq[ModifierId])
 
 }
 
+////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////// ACTOR REF HELPER //////////////////////////////////
+
 object MempoolAuditorRef {
 
-  def props(nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings)(implicit
-    networkPrefix:             NetworkPrefix
-  ): Props =
-    Props(new MempoolAuditor(nodeViewHolderRef, networkControllerRef, settings))
+  def props[
+    SR <: StateReader[ProgramId, Address]: ClassTag,
+    MR <: MemPoolReader[Transaction.TX]: ClassTag
+  ](settings: AppSettings, appContext: AppContext, nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef): Props =
+    Props(new MempoolAuditor(nodeViewHolderRef, networkControllerRef, settings, appContext))
 
-  def apply(nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings)(implicit
-    context:                   ActorRefFactory,
-    networkPrefix:             NetworkPrefix
+  def apply[
+    SR <: StateReader[ProgramId, Address]: ClassTag,
+    MR <: MemPoolReader[Transaction.TX]: ClassTag
+  ](
+    name:                 String,
+    settings:             AppSettings,
+    appContext:           AppContext,
+    nodeViewHolderRef:    ActorRef,
+    networkControllerRef: ActorRef
+  )(implicit
+    context: ActorRefFactory
   ): ActorRef =
-    context.actorOf(props(nodeViewHolderRef, networkControllerRef, settings))
+    context.actorOf(props(settings, appContext, nodeViewHolderRef, networkControllerRef), name)
 
 }

--- a/src/main/scala/co/topl/nodeView/MemPoolAuditor.scala
+++ b/src/main/scala/co/topl/nodeView/MemPoolAuditor.scala
@@ -1,0 +1,144 @@
+package co.topl.nodeView
+
+import akka.actor.SupervisorStrategy.{Restart, Stop}
+import akka.actor.{Actor, ActorInitializationException, ActorKilledException, ActorRef, ActorRefFactory, DeathPactException, OneForOneStrategy, Props}
+import co.topl.attestation.AddressEncoder.NetworkPrefix
+import co.topl.modifier.block.{Block, BlockHeader}
+import co.topl.modifier.box.{BoxId, ProgramId}
+import co.topl.modifier.transaction.Transaction
+import co.topl.network.Broadcast
+import co.topl.network.NetworkController.ReceivableMessages.SendToNetwork
+import co.topl.network.NodeViewSynchronizer.ReceivableMessages.{ChangedMempool, ChangedState, SemanticallySuccessfulModifier}
+import co.topl.network.message.{InvData, InvSpec, Message}
+import co.topl.nodeView.CleanupWorker.RunCleanup
+import co.topl.nodeView.MempoolAuditor.CleanupDone
+import co.topl.nodeView.NodeViewHolder.ReceivableMessages.GetNodeViewChanges
+import co.topl.nodeView.mempool.MemPoolReader
+import co.topl.nodeView.state.StateReader
+import co.topl.settings.AppSettings
+import co.topl.utils.Logging
+
+import scala.reflect.ClassTag
+
+// need to add comments, node ready commands, name of actor in object,
+
+import scala.concurrent.duration._
+
+/** Controls mempool cleanup workflow. Watches NodeView events and delegates
+  * mempool cleanup task to [[CleanupWorker]] when needed.
+  * Adapted from ErgoPlatform available at https://github.com/ergoplatform/ergo
+  */
+class MempoolAuditor[
+  SR <: StateReader[ProgramId, BoxId]: ClassTag,
+  MR <: MemPoolReader[Transaction.TX]: ClassTag
+](nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings)(implicit
+  networkPrefix:     NetworkPrefix
+) extends Actor
+    with Logging {
+
+  override def postRestart(reason: Throwable): Unit = {
+    log.error(s"Mempool auditor actor restarted due to ${reason.getMessage}", reason)
+    super.postRestart(reason)
+  }
+
+  override def postStop(): Unit = {
+    logger.info("Mempool auditor stopped")
+    super.postStop()
+  }
+
+  override val supervisorStrategy: OneForOneStrategy =
+    OneForOneStrategy(maxNrOfRetries = 5, withinTimeRange = 1.minute) {
+      case _: ActorKilledException => Stop
+      case _: DeathPactException   => Stop
+      case e: ActorInitializationException =>
+        log.warn(s"Cleanup worker failed during initialization with: $e")
+        Stop
+      case e: Exception =>
+        log.warn(s"Cleanup worker failed with: $e")
+        context become awaiting // turn ctx into awaiting mode if worker failed
+        Restart
+    }
+
+  private var stateReaderOpt: Option[SR] = None
+  private var poolReaderOpt: Option[MR] = None
+
+  private val worker: ActorRef =
+    context.actorOf(Props(new CleanupWorker(nodeViewHolderRef, settings)))
+
+  override def preStart(): Unit =
+    context.system.eventStream.subscribe(self, classOf[SemanticallySuccessfulModifier[_]])
+
+  override def receive: Receive = awaiting
+
+  private def awaiting: Receive = {
+    case SemanticallySuccessfulModifier(_: Block) | SemanticallySuccessfulModifier(_: BlockHeader) =>
+      stateReaderOpt = None
+      poolReaderOpt = None
+      nodeViewHolderRef ! GetNodeViewChanges(history = false, state = true, mempool = true)
+
+    case ChangedMempool(mp: MR) =>
+      poolReaderOpt = Some(mp)
+      stateReaderOpt.foreach(st => initiateCleanup(st, mp))
+
+    case ChangedState(st: SR) =>
+      stateReaderOpt = Some(st)
+      poolReaderOpt.foreach(mp => initiateCleanup(st, mp))
+
+    case ChangedState(_) | ChangedMempool(_) => // do nothing
+  }
+
+  private def working: Receive = {
+    case CleanupDone =>
+      log.info("Cleanup done. Switching to awaiting mode")
+      rebroadcastTransactions()
+      stateReaderOpt = None
+      poolReaderOpt = None
+      context become awaiting
+
+    case _ => // ignore other triggers until work is done
+  }
+
+  private def initiateCleanup(state: SR, mempool: MR): Unit = {
+    log.info("Initiating cleanup. Switching to working mode")
+    worker ! RunCleanup(state, mempool)
+    context become working // ignore other triggers until work is done
+  }
+
+  private def rebroadcastTransactions(): Unit = {
+    log.debug("Rebroadcasting transactions")
+    poolReaderOpt.foreach { pr =>
+      pr.take(settings.application.rebroadcastCount).foreach { tx =>
+        log.info(s"Rebroadcasting $tx")
+        val msg = Message(
+          new InvSpec(settings.network.maxInvObjects),
+          Right(InvData(Transaction.modifierTypeId, Seq(tx.id))),
+          None
+        )
+        networkControllerRef ! SendToNetwork(msg, Broadcast)
+      }
+
+    }
+
+  }
+}
+
+object MempoolAuditor {
+
+  case object CleanupDone
+
+}
+
+object MempoolAuditorRef {
+
+  def props(nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings)(implicit
+    networkPrefix:             NetworkPrefix
+  ): Props =
+    Props(new MempoolAuditor(nodeViewHolderRef, networkControllerRef, settings))
+
+  def apply(nodeViewHolderRef: ActorRef, networkControllerRef: ActorRef, settings: AppSettings)(implicit
+    context:                   ActorRefFactory,
+    networkPrefix:             NetworkPrefix
+  ): ActorRef =
+    context.actorOf(props(nodeViewHolderRef, networkControllerRef, settings))
+
+}

--- a/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
+++ b/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
@@ -239,7 +239,7 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
   protected def txModify(tx: TX): Unit =
     tx.syntacticValidate match {
       case Success(_) =>
-        memoryPool().put(tx, appContext.timeProvider.time()) match {
+        memoryPool().put(tx, appContext.timeProvider.time) match {
           case Success(_) =>
             log.debug(s"Unconfirmed transaction $tx added to the memory pool")
             context.system.eventStream.publish(SuccessfulTransaction[TX](tx))
@@ -437,7 +437,7 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
     val appliedTxs = blocksApplied.flatMap(extractTransactions)
 
     memPool
-      .putWithoutCheck(rolledBackTxs, appContext.timeProvider.time())
+      .putWithoutCheck(rolledBackTxs, appContext.timeProvider.time)
       .filter { tx =>
         !appliedTxs.exists(t => t.id == tx.id) && {
           state.semanticValidate(tx).isSuccess

--- a/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
+++ b/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
@@ -34,7 +34,7 @@ import scala.util.{Failure, Success, Try}
   * The instances are read-only for external world.
   * Updates of the composite view(the instances are to be performed atomically.
   */
-class NodeViewHolder ( settings: AppSettings )
+class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
                      ( implicit ec: ExecutionContext, np: NetworkPrefix ) extends Actor with Logging {
 
   // Import the types of messages this actor can RECEIVE
@@ -236,10 +236,10 @@ class NodeViewHolder ( settings: AppSettings )
     *
     * @param tx
     */
-  protected def txModify(tx: TX): Unit = {
+  protected def txModify(tx: TX): Unit =
     tx.syntacticValidate match {
       case Success(_) =>
-        memoryPool().put(tx) match {
+        memoryPool().put(tx, appContext.timeProvider.time()) match {
           case Success(_) =>
             log.debug(s"Unconfirmed transaction $tx added to the memory pool")
             context.system.eventStream.publish(SuccessfulTransaction[TX](tx))
@@ -251,7 +251,6 @@ class NodeViewHolder ( settings: AppSettings )
       case Failure(e) =>
         context.system.eventStream.publish(FailedTransaction(tx.id, e, immediateFailure = true))
     }
-  }
 
   //todo: update state in async way?
   /**
@@ -438,7 +437,7 @@ class NodeViewHolder ( settings: AppSettings )
     val appliedTxs = blocksApplied.flatMap(extractTransactions)
 
     memPool
-      .putWithoutCheck(rolledBackTxs)
+      .putWithoutCheck(rolledBackTxs, appContext.timeProvider.time())
       .filter { tx =>
         !appliedTxs.exists(t => t.id == tx.id) && {
           state.semanticValidate(tx).isSuccess
@@ -527,7 +526,7 @@ object NodeViewHolderRef {
 
   def props ( settings: AppSettings, appContext: AppContext )
             ( implicit ec: ExecutionContext ): Props =
-    Props(new NodeViewHolder(settings)(ec, appContext.networkType.netPrefix))
+    Props(new NodeViewHolder(settings, appContext)(ec, appContext.networkType.netPrefix))
 
   def apply ( name: String, settings: AppSettings, appContext: AppContext )
             ( implicit system: ActorSystem, ec: ExecutionContext ): ActorRef =

--- a/src/main/scala/co/topl/nodeView/history/BlockProcessor.scala
+++ b/src/main/scala/co/topl/nodeView/history/BlockProcessor.scala
@@ -5,7 +5,7 @@ import co.topl.modifier.ModifierId
 import co.topl.modifier.block.Block
 import co.topl.nodeView.history.BlockProcessor.ChainCache
 import co.topl.nodeView.history.GenericHistory.ProgressInfo
-import co.topl.utils.Logging
+import co.topl.utils.{Logging, TimeProvider}
 
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeMap
@@ -120,7 +120,7 @@ object BlockProcessor extends Logging {
   def emptyCache: ChainCache = ChainCache(TreeMap.empty)
 
   /** Wrapper for storing a block and its height in the chain cache */
-  case class CacheBlock(block: Block, prevBlockTimes: Seq[Block.Timestamp])
+  case class CacheBlock(block: Block, prevBlockTimes: Seq[TimeProvider.Time])
 
   /** Stores links mapping ((id, height) -> parentId) of blocks that could possibly be applied. */
   case class ChainCache(cache: TreeMap[CacheBlock, ModifierId]) {
@@ -139,7 +139,7 @@ object BlockProcessor extends Logging {
     def getHeight(id: ModifierId): Option[Long] =
       cache.keys.find(k ⇒ k.block.id == id).map(_.block.height)
 
-    def add(block: Block, prevTimes: Seq[Block.Timestamp]): ChainCache = {
+    def add(block: Block, prevTimes: Seq[TimeProvider.Time]): ChainCache = {
       val cacheBlock = CacheBlock(block, prevTimes)
 
       log.debug(s"Added new block to chain cache: ${cacheBlock.block.id.toString}")

--- a/src/main/scala/co/topl/nodeView/history/History.scala
+++ b/src/main/scala/co/topl/nodeView/history/History.scala
@@ -484,7 +484,7 @@ object History extends Logging {
   /** Gets the timestamps for 'count' number of blocks prior to (and including) the startBlock */
   def getTimestamps(storage: Storage, count: Long, startBlock: Block): Vector[TimeProvider.Time] = {
     @tailrec
-    def loop(id: ModifierId, acc: Vector[Block.Timestamp] = Vector()): Vector[TimeProvider.Time] = {
+    def loop(id: ModifierId, acc: Vector[TimeProvider.Time] = Vector()): Vector[TimeProvider.Time] = {
       if (acc.length > count) acc
       else storage.parentIdOf(id) match {
         case Some(parentId: ModifierId) =>

--- a/src/main/scala/co/topl/nodeView/history/History.scala
+++ b/src/main/scala/co/topl/nodeView/history/History.scala
@@ -11,7 +11,7 @@ import co.topl.network.message.BifrostSyncInfo
 import co.topl.nodeView.history.GenericHistory._
 import co.topl.nodeView.history.History.GenesisParentId
 import co.topl.settings.AppSettings
-import co.topl.utils.Logging
+import co.topl.utils.{Logging, TimeProvider}
 import io.iohk.iodb.LSMStore
 
 import scala.annotation.tailrec
@@ -237,7 +237,7 @@ class History ( val storage: Storage, //todo: JAA - make this private[history]
     else Option(loop(startBlock, Seq(startBlock)).map(_.id).reverse)
   }
 
-  def getTimestampsFrom(startBlock: Block, count: Long): Vector[Block.Timestamp] =
+  def getTimestampsFrom(startBlock: Block, count: Long): Vector[TimeProvider.Time] =
     History.getTimestamps(storage, count, startBlock)
 
   /** Retrieve a sequence of blocks until the given filter is satisifed
@@ -482,9 +482,9 @@ object History extends Logging {
   }
 
   /** Gets the timestamps for 'count' number of blocks prior to (and including) the startBlock */
-  def getTimestamps(storage: Storage, count: Long, startBlock: Block): Vector[Block.Timestamp] = {
+  def getTimestamps(storage: Storage, count: Long, startBlock: Block): Vector[TimeProvider.Time] = {
     @tailrec
-    def loop(id: ModifierId, acc: Vector[Block.Timestamp] = Vector()): Vector[Block.Timestamp] = {
+    def loop(id: ModifierId, acc: Vector[Block.Timestamp] = Vector()): Vector[TimeProvider.Time] = {
       if (acc.length > count) acc
       else storage.parentIdOf(id) match {
         case Some(parentId: ModifierId) =>

--- a/src/main/scala/co/topl/nodeView/mempool/MemPool.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPool.scala
@@ -8,7 +8,7 @@ import co.topl.utils.Logging
 import scala.collection.concurrent.TrieMap
 import scala.util.Try
 
-case class MemPool(unconfirmed: TrieMap[ModifierId, Transaction.TX])
+case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
   extends MemoryPool[Transaction.TX, MemPool] with Logging {
 
   override type NVCT = MemPool

--- a/src/main/scala/co/topl/nodeView/mempool/MemPool.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPool.scala
@@ -6,6 +6,7 @@ import co.topl.modifier.transaction.Transaction
 import co.topl.utils.{Logging, TimeProvider}
 
 import scala.collection.concurrent.TrieMap
+import scala.math.Ordering
 import scala.util.Try
 
 case class MemPool(private val unconfirmed: TrieMap[ModifierId, UnconfirmedTx[Transaction.TX]])
@@ -77,8 +78,8 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, UnconfirmedTx[Tr
    * @param limit
    * @return
    */
-  override def take(limit: Int): Iterable[UnconfirmedTx[TX]] =
-    unconfirmed.values.toSeq.sortBy(-_.tx.fee).take(limit)
+  override def take[A](limit: Int)(f: UnconfirmedTx[TX] => A)(implicit ord: Ordering[A]): Iterable[UnconfirmedTx[TX]] =
+    unconfirmed.values.toSeq.sortBy(f).take(limit)
 
   /**
    *

--- a/src/main/scala/co/topl/nodeView/mempool/MemPool.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPool.scala
@@ -1,14 +1,14 @@
 package co.topl.nodeView.mempool
 
 import co.topl.modifier.ModifierId
-import co.topl.modifier.transaction.Transaction
 import co.topl.modifier.box.BoxId
-import co.topl.utils.Logging
+import co.topl.modifier.transaction.Transaction
+import co.topl.utils.{Logging, TimeProvider}
 
 import scala.collection.concurrent.TrieMap
 import scala.util.Try
 
-case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
+case class MemPool(private val unconfirmed: TrieMap[ModifierId, UnconfirmedTx[Transaction.TX]])
   extends MemoryPool[Transaction.TX, MemPool] with Logging {
 
   override type NVCT = MemPool
@@ -17,7 +17,7 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
   private val boxesInMempool = new TrieMap[BoxId, BoxId]()
 
   //getters
-  override def modifierById(id: ModifierId): Option[TX] = unconfirmed.get(id)
+  override def modifierById(id: ModifierId): Option[TX] = unconfirmed.get(id).map(_.tx)
 
   override def contains(id: ModifierId): Boolean = unconfirmed.contains(id)
 
@@ -26,8 +26,8 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
   override def size: Int = unconfirmed.size
 
   //modifiers
-  override def put(tx: TX): Try[MemPool] = Try {
-    unconfirmed.put(tx.id, tx)
+  override def put(tx: TX, time: TimeProvider.Time): Try[MemPool] = Try {
+    unconfirmed.put(tx.id, UnconfirmedTx(tx, time))
     tx.boxIdsToOpen.foreach(boxId => require(!boxesInMempool.contains(boxId)))
     tx.boxIdsToOpen.foreach(boxId => boxesInMempool.put(boxId, boxId))
     this
@@ -38,8 +38,8 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
    * @param txs
    * @return
    */
-  override def put(txs: Iterable[TX]): Try[MemPool] = Try {
-    txs.foreach(tx => unconfirmed.put(tx.id, tx))
+  override def put(txs: Iterable[TX], time: TimeProvider.Time): Try[MemPool] = Try {
+    txs.foreach(tx => unconfirmed.put(tx.id, UnconfirmedTx(tx, time)))
     txs.foreach(tx => tx.boxIdsToOpen.foreach {
       boxId => require(!boxesInMempool.contains(boxId))
     })
@@ -54,8 +54,8 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
    * @param txs
    * @return
    */
-  override def putWithoutCheck(txs: Iterable[TX]): MemPool = {
-    txs.foreach(tx => unconfirmed.put(tx.id, tx))
+  override def putWithoutCheck(txs: Iterable[TX], time: TimeProvider.Time): MemPool = {
+    txs.foreach(tx => unconfirmed.put(tx.id, UnconfirmedTx(tx, time)))
     txs.foreach(tx => tx.boxIdsToOpen.map {
       boxId => boxesInMempool.put(boxId, boxId)
     })
@@ -77,8 +77,8 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
    * @param limit
    * @return
    */
-  override def take(limit: Int): Iterable[TX] =
-    unconfirmed.values.toSeq.sortBy(-_.fee).take(limit)
+  override def take(limit: Int): Iterable[UnconfirmedTx[TX]] =
+    unconfirmed.values.toSeq.sortBy(-_.tx.fee).take(limit)
 
   /**
    *
@@ -87,10 +87,10 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
    */
   override def filter(condition: TX => Boolean): MemPool = {
     unconfirmed.retain { (_, v) =>
-      if (condition(v)) {
+      if (condition(v.tx)) {
         true
       } else {
-        v.boxIdsToOpen.foreach(boxId => {
+        v.tx.boxIdsToOpen.foreach(boxId => {
           boxesInMempool -= (boxId: BoxId)
         })
         false
@@ -104,4 +104,5 @@ case class MemPool(private val unconfirmed: TrieMap[ModifierId, Transaction.TX])
 
 object MemPool {
   lazy val emptyPool: MemPool = MemPool(TrieMap())
+
 }

--- a/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
@@ -1,12 +1,18 @@
 package co.topl.nodeView.mempool
 
+import co.topl.modifier.transaction.Transaction
 import co.topl.modifier.{ContainsModifiers, ModifierId, NodeViewModifier}
 import co.topl.nodeView.NodeViewComponent
+import co.topl.utils.TimeProvider
+
+import scala.math.Ordering
+
+case class UnconfirmedTx[TX <: Transaction.TX](tx: TX, dateAdded: TimeProvider.Time)
 
 /**
   * Unconfirmed transactions pool
   */
-trait MemPoolReader[TX <: NodeViewModifier]
+trait MemPoolReader[TX <: Transaction.TX]
   extends NodeViewComponent with ContainsModifiers[TX] {
 
   //getters
@@ -21,6 +27,6 @@ trait MemPoolReader[TX <: NodeViewModifier]
 
   def size: Int
 
-  def take(limit: Int): Iterable[UnconfirmedTx[TX]]
+  def take[A](limit: Int)(f: UnconfirmedTx[TX] => A)(implicit ord: Ordering[A]): Iterable[UnconfirmedTx[TX]]
 
 }

--- a/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
@@ -21,6 +21,6 @@ trait MemPoolReader[TX <: NodeViewModifier]
 
   def size: Int
 
-  def take(limit: Int): Iterable[TX]
+  def take(limit: Int): Iterable[UnconfirmedTx[TX]]
 
 }

--- a/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
@@ -1,7 +1,7 @@
 package co.topl.nodeView.mempool
 
 import co.topl.modifier.transaction.Transaction
-import co.topl.modifier.{ContainsModifiers, ModifierId, NodeViewModifier}
+import co.topl.modifier.{ContainsModifiers, ModifierId}
 import co.topl.nodeView.NodeViewComponent
 import co.topl.utils.TimeProvider
 

--- a/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemPoolReader.scala
@@ -21,6 +21,6 @@ trait MemPoolReader[TX <: NodeViewModifier]
 
   def size: Int
 
-  def take( limit: Int): Iterable[TX]
+  def take(limit: Int): Iterable[TX]
 
 }

--- a/src/main/scala/co/topl/nodeView/mempool/MemoryPool.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemoryPool.scala
@@ -16,17 +16,8 @@ import scala.util.Try
 trait MemoryPool[TX <: Transaction.TX, M <: MemoryPool[TX, M]]
   extends NodeViewComponent with MemPoolReader[TX] {
 
-//  //getters
-//  def modifierById(id: ModifierId): Option[TX]
-//
-//  def contains(id: ModifierId): Boolean
-
   //get ids from Seq, not presenting in mempool
   override def notIn(ids: Seq[ModifierId]): Seq[ModifierId] = ids.filter(id => !contains(id))
-//
-//  def getAll(ids: Seq[ModifierId]): Seq[TX]
-//
-//  def take[A](limit: Int)(f: UnconfirmedTx[TX] => A)(implicit ord: Ordering[A]): Iterable[UnconfirmedTx[TX]]
 
   //modifiers
   def put(tx: TX, time: TimeProvider.Time): Try[M]

--- a/src/main/scala/co/topl/nodeView/mempool/MemoryPool.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemoryPool.scala
@@ -3,8 +3,11 @@ package co.topl.nodeView.mempool
 import co.topl.modifier.ModifierId
 import co.topl.modifier.transaction.Transaction
 import co.topl.nodeView.NodeViewComponent
+import co.topl.utils.TimeProvider
 
 import scala.util.Try
+
+case class UnconfirmedTx[TX <: Transaction[_,_]](tx: TX, dateAdded: TimeProvider.Time)
 
 /**
   * Unconfirmed transactions pool
@@ -24,16 +27,16 @@ trait MemoryPool[TX <: Transaction[_,_], M <: MemoryPool[TX, M]]
 
   def getAll(ids: Seq[ModifierId]): Seq[TX]
 
+  def take(limit: Int): Iterable[UnconfirmedTx[TX]]
+
   //modifiers
-  def put(tx: TX): Try[M]
+  def put(tx: TX, time: TimeProvider.Time): Try[M]
 
-  def put(txs: Iterable[TX]): Try[M]
+  def put(txs: Iterable[TX], time: TimeProvider.Time): Try[M]
 
-  def putWithoutCheck(txs: Iterable[TX]): M
+  def putWithoutCheck(txs: Iterable[TX], time: TimeProvider.Time): M
 
   def remove(tx: TX): M
-
-  def take(limit: Int): Iterable[TX]
 
   def filter(txs: Seq[TX]): M = filter(t => !txs.exists(_.id == t.id))
 
@@ -46,3 +49,4 @@ trait MemoryPool[TX <: Transaction[_,_], M <: MemoryPool[TX, M]]
     */
   def getReader: MemPoolReader[TX] = this
 }
+

--- a/src/main/scala/co/topl/nodeView/mempool/MemoryPool.scala
+++ b/src/main/scala/co/topl/nodeView/mempool/MemoryPool.scala
@@ -5,29 +5,28 @@ import co.topl.modifier.transaction.Transaction
 import co.topl.nodeView.NodeViewComponent
 import co.topl.utils.TimeProvider
 
+import scala.math.Ordering
 import scala.util.Try
-
-case class UnconfirmedTx[TX <: Transaction[_,_]](tx: TX, dateAdded: TimeProvider.Time)
 
 /**
   * Unconfirmed transactions pool
   *
   * @tparam M -type of this memory pool
   */
-trait MemoryPool[TX <: Transaction[_,_], M <: MemoryPool[TX, M]]
+trait MemoryPool[TX <: Transaction.TX, M <: MemoryPool[TX, M]]
   extends NodeViewComponent with MemPoolReader[TX] {
 
-  //getters
-  def modifierById(id: ModifierId): Option[TX]
-
-  def contains(id: ModifierId): Boolean
+//  //getters
+//  def modifierById(id: ModifierId): Option[TX]
+//
+//  def contains(id: ModifierId): Boolean
 
   //get ids from Seq, not presenting in mempool
   override def notIn(ids: Seq[ModifierId]): Seq[ModifierId] = ids.filter(id => !contains(id))
-
-  def getAll(ids: Seq[ModifierId]): Seq[TX]
-
-  def take(limit: Int): Iterable[UnconfirmedTx[TX]]
+//
+//  def getAll(ids: Seq[ModifierId]): Seq[TX]
+//
+//  def take[A](limit: Int)(f: UnconfirmedTx[TX] => A)(implicit ord: Ordering[A]): Iterable[UnconfirmedTx[TX]]
 
   //modifiers
   def put(tx: TX, time: TimeProvider.Time): Try[M]
@@ -41,8 +40,6 @@ trait MemoryPool[TX <: Transaction[_,_], M <: MemoryPool[TX, M]]
   def filter(txs: Seq[TX]): M = filter(t => !txs.exists(_.id == t.id))
 
   def filter(condition: TX => Boolean): M
-
-  def size: Int
 
   /**
     * @return read-only copy of this state

--- a/src/main/scala/co/topl/nodeView/state/StateReader.scala
+++ b/src/main/scala/co/topl/nodeView/state/StateReader.scala
@@ -1,12 +1,13 @@
 package co.topl.nodeView.state
 
+import co.topl.modifier.BoxReader
 import co.topl.nodeView.NodeViewComponent
 import co.topl.nodeView.state.MinimalState.VersionTag
 import co.topl.modifier.box._
 
 import scala.reflect.ClassTag
 
-trait StateReader[KP, KT] extends NodeViewComponent {
+trait StateReader[KP, KT] extends BoxReader[KP, KT] with NodeViewComponent {
 
   type ProgramKey = KP
   type TokenKey = KT

--- a/src/main/scala/co/topl/settings/AppSettings.scala
+++ b/src/main/scala/co/topl/settings/AppSettings.scala
@@ -20,7 +20,7 @@ case class ApplicationSettings(
   version:     Version,
   cacheExpire: Int,
   cacheSize:   Int,
-  mempoolCleanupDuration: FiniteDuration,
+  mempoolTimeout: FiniteDuration,
   rebroadcastCount: Int
 )
 

--- a/src/main/scala/co/topl/settings/AppSettings.scala
+++ b/src/main/scala/co/topl/settings/AppSettings.scala
@@ -19,7 +19,9 @@ case class ApplicationSettings(
   nodeKeys:    Option[Set[String]],
   version:     Version,
   cacheExpire: Int,
-  cacheSize:   Int
+  cacheSize:   Int,
+  mempoolCleanupDuration: FiniteDuration,
+  rebroadcastCount: Int
 )
 
 case class RPCApiSettings(

--- a/src/main/scala/co/topl/utils/Int128.scala
+++ b/src/main/scala/co/topl/utils/Int128.scala
@@ -278,4 +278,11 @@ final class Int128(val upperLong: Long, val lowerLong: Long)
 
   /** Remainder of UInt128 */
   def %  (that: Int128): Int128 = Int128(this.bigInt % that.bigInt)
+
+  /** Returns a BigInt whose value is the negation of this BigInt */
+  def unary_- : Int128   = Int128(this.bigInt.bigInteger.negate())
+
+  /** Returns the bitwise complement of this BigInt */
+  def unary_~ : Int128 = Int128(this.bigInt.bigInteger.not())
+
 }

--- a/src/main/scala/co/topl/utils/Int128.scala
+++ b/src/main/scala/co/topl/utils/Int128.scala
@@ -32,7 +32,7 @@ import scala.util.{Failure, Success, Try}
   */
 object Int128 {
   val size = 128
-  val bytes: Int = size / java.lang.Byte.SIZE
+  val numBytes: Int = size / java.lang.Byte.SIZE
   val MinValue: Int128 = Int128(Long.MinValue, 0L)
   val MaxValue: Int128 = Int128(Long.MaxValue, -1L)
 
@@ -105,14 +105,14 @@ object Int128 {
     */
   def apply(value: BigInt): Int128 = {
     val bigIntBytes = value.toByteArray
-    val res = if (bigIntBytes.length >= Int128.bytes) {
+    val res = if (bigIntBytes.length >= Int128.numBytes) {
       bigIntBytes.takeRight(16)
     } else {
       val pad: Byte = if (bigIntBytes.head < 0) -1 else 0
       Array.fill(16 - bigIntBytes.length)(pad) ++ bigIntBytes
     }
 
-    val buf = ByteBuffer.allocate(bytes).order(ByteOrder.BIG_ENDIAN)
+    val buf = ByteBuffer.allocate(numBytes).order(ByteOrder.BIG_ENDIAN)
     buf.put(res)
     buf.flip()
     new Int128(buf.getLong(), buf.getLong())
@@ -158,13 +158,13 @@ object Int128 {
     * @param value Byte array in big-endian format.
     */
   def apply(value: Array[Byte]): Int128 = {
-    val res = if (value.length >= Int128.bytes) {
+    val res = if (value.length >= Int128.numBytes) {
       value.takeRight(16)
     } else {
       Array.fill(16 - value.length)(0: Byte) ++ value
     }
 
-    val buf = ByteBuffer.allocate(bytes).order(ByteOrder.BIG_ENDIAN)
+    val buf = ByteBuffer.allocate(numBytes).order(ByteOrder.BIG_ENDIAN)
     buf.put(res)
     buf.flip()
     new Int128(buf.getLong(), buf.getLong())
@@ -208,7 +208,7 @@ final class Int128(val upperLong: Long, val lowerLong: Long)
     * @return Byte array containing this number in big-endian format.
     */
   def toByteArray: Array[Byte] = {
-    val buf = ByteBuffer.allocate(Int128.bytes).order(ByteOrder.BIG_ENDIAN)
+    val buf = ByteBuffer.allocate(Int128.numBytes).order(ByteOrder.BIG_ENDIAN)
     buf.putLong(upperLong)
     buf.putLong(lowerLong)
     buf.array

--- a/src/main/scala/co/topl/utils/Int128.scala
+++ b/src/main/scala/co/topl/utils/Int128.scala
@@ -24,9 +24,9 @@ import scala.util.{Failure, Success, Try}
  */
 
 /** Container for a 128 bit signed integer stored in big-endian format.
- * Adopted from the original work available at
- * https://github.com/PlatformLab/TorcDB/blob/master/src/main/java/net/ellitron/torc/util/UInt128.java
- * by Jonathan Ellithorpe (jde@cs.stanford.edu)
+  * Adopted from the original work available at
+  * https://github.com/PlatformLab/TorcDB/blob/master/src/main/java/net/ellitron/torc/util/Int128.java
+  * by Jonathan Ellithorpe (jde@cs.stanford.edu)
   *
   * @author James Aman (j.aman@topl.me)
   */
@@ -36,30 +36,29 @@ object Int128 {
   val MinValue: Int128 = Int128(Long.MinValue, 0L)
   val MaxValue: Int128 = Int128(Long.MaxValue, -1L)
 
-  /** This method attempts to translate its argument into a UInt128.
+  /** This method attempts to translate its argument into a Int128.
     *
     * @param n Number to translate.
-    * @return UInt128
+    * @return Int128
     */
   def decode(n: Any): Try[Int128] = Try {
     n match {
-      case b: Byte          => Int128(b)
-      case sh: Short        => Int128(sh)
-      case integer: Integer => Int128(integer)
-      case l: Long          => Int128(l)
-      case idStr: String =>
-        if (idStr.startsWith("0x")) Int128(idStr, 16)
-        else Int128(idStr, 10)
-      case integer: BigInteger => Int128(integer)
-      case uuid: UUID          => Int128(uuid)
-      case bytes: Array[Byte]  => Int128(bytes)
-      case int12: Int128      => int12
+      case b: Byte                                 => Int128(b)
+      case sh: Short                               => Int128(sh)
+      case int: Int                                => Int128(int)
+      case l: Long                                 => Int128(l)
+      case integer: BigInteger                     => Int128(integer)
+      case uuid: UUID                              => Int128(uuid)
+      case bytes: Array[Byte]                      => Int128(bytes)
+      case int128: Int128                          => int128
+      case idStr: String if idStr.startsWith("0x") => Int128(idStr, 16)
+      case idStr: String                           => Int128(idStr, 10)
       case _ =>
         throw new NumberFormatException(String.format("Unable to decode " + "number: [%s,%s]", n.getClass, n.toString))
     }
   }
 
-  /** Constructs a UInt128 from two longs, one representing the upper 64 bits
+  /** Constructs a Int128 from two longs, one representing the upper 64 bits
     * and the other representing the lower 64 bits.
     *
     * @param upperLong Upper 64 bits.
@@ -67,36 +66,41 @@ object Int128 {
     */
   def apply(upperLong: Long, lowerLong: Long): Int128 = new Int128(upperLong, lowerLong)
 
-  /** Constructs a UInt128 from a Byte value. Value is treated as unsigned and
-    * therefore no sign extension is performed.
+  /** Constructs a Int128 from a Byte value.
     *
-    * @param value Byte, treated as 8 unsigned bits.
+    * @param value Byte
     */
-  def apply(value: Byte): Int128 = new Int128(0, value.toLong)
+  def apply(value: Byte): Int128 =
+    if (value < 0) new Int128(-1, value.toLong)
+    else new Int128(0, value.toLong)
 
-  /** Constructs a UInt128 from a Short value. Value is treated as unsigned and
-    * therefore no sign extension is performed.
+
+  /** Constructs a Int128 from a Short value.
     *
-    * @param value Short, treated as 16 unsigned bits.
+    * @param value Short
     */
-  def apply(value: Short): Int128 = new Int128(0, value.toLong)
+  def apply(value: Short): Int128 =
+    if (value < 0) new Int128(-1, value.toLong)
+    else new Int128(0, value.toLong)
 
-  /** Constructs a UInt128 from an Integer value. Value is treated as unsigned
-    * and therefore no sign extension is performed.
+  /** Constructs a Int128 from an Integer value.
     *
-    * @param value Integer, treated as 32 unsigned bits.
+    * @param value Int
     */
-  def apply(value: Integer): Int128 = new Int128(0, value.toLong)
+  def apply(value: Int): Int128 =
+    if (value< 0) new Int128(-1, value.toLong)
+    else new Int128(0, value.toLong)
 
-  /** Constructs a UInt128 from a Long value. Value is treated as unsigned and
-    * therefore no sign extension is performed.
+  /** Constructs a Int128 from a Long value.
     *
-    * @param value Long, treated as 64 unsigned bits.
+    * @param value Long
     */
-  def apply(value: Long): Int128 = new Int128(0, value)
+  def apply(value: Long): Int128 =
+    if (value< 0) new Int128(-1, value.toLong)
+    else new Int128(0, value.toLong)
 
-  /** Constructs a UInt128 from a BigInteger value. The value used to construct
-    * the UInt128 is the 128-bit two's complement representation of the
+  /** Constructs a Int128 from a BigInteger value. The value used to construct
+    * the Int128 is the 128-bit two's complement representation of the
     * BigInteger. In the case that the number of bits in the minimal
     * two's-complement representation of the BigInteger is greater than 128,
     * then the lower 128 bits are used and higher order bits are discarded.
@@ -118,40 +122,40 @@ object Int128 {
     new Int128(buf.getLong(), buf.getLong())
   }
 
-  /** Constructs a UInt128 from a String value representing a number in a
-    * specified base. The value stored in this UInt128 is the 128 bit
+  /** Constructs a Int128 from a String value representing a number in a
+    * specified base. The value stored in this Int128 is the 128 bit
     * two's-complement representation of this value. If the two's-complement
     * representation of the value requires more than 128 bits to represent, only
-    * the lower 128 bits are used to construct this UInt128.
+    * the lower 128 bits are used to construct this Int128.
     *
     * @param value   String, treated as a 128 bit signed value.
     * @param radix The base of the number represented by the string.
     */
   def apply(value: String, radix: Int): Int128 = apply(new BigInteger(value, radix))
 
-  /** Constructs a UInt128 from a String value representing a number in base 10.
-    * The value stored in this UInt128 is the 128 bit two's-complement
+  /** Constructs a Int128 from a String value representing a number in base 10.
+    * The value stored in this Int128 is the 128 bit two's-complement
     * representation of this value. If the two's-complement representation of
     * the value requires more than 128 bits to represent, only the lower 128
-    * bits are used to construct this UInt128.
+    * bits are used to construct this Int128.
     *
     * @param value Base 10 format String, treated as a 128 bit signed value.
     */
   def apply(value: String): Int128 = apply(value, 10)
 
-  /** Constructs a UInt128 from a UUID value.
-    * The value stored in this UInt128 is the 128 bit two's-complement
+  /** Constructs a Int128 from a UUID value.
+    * The value stored in this Int128 is the 128 bit two's-complement
     * representation of this value. If the two's-complement representation of
     * the value requires more than 128 bits to represent, only the lower 128
-    * bits are used to construct this UInt128.
+    * bits are used to construct this Int128.
     *
     * @param value 128-bit UUID value
     */
   def apply(value: UUID): Int128 = new Int128(value.getMostSignificantBits, value.getLeastSignificantBits)
 
-  /** Constructs a UInt128 from a byte array value. The byte array value is
+  /** Constructs a Int128 from a byte array value. The byte array value is
     * interpreted as unsigned and in big-endian format. If the byte array is
-    * less than 16 bytes, then the higher order bytes of the resulting UInt128
+    * less than 16 bytes, then the higher order bytes of the resulting Int128
     * are padded with 0s. If the byte array is greater than 16 bytes, then the
     * lower 16 bytes are used.
     *
@@ -170,8 +174,8 @@ object Int128 {
     new Int128(buf.getLong(), buf.getLong())
   }
 
-  /** Parses a UInt128 from a ByteBuffer. The ByteBuffer is expected to have at
-    * least 16 bytes at the current position, storing a UInt128 in big-endian
+  /** Parses a Int128 from a ByteBuffer. The ByteBuffer is expected to have at
+    * least 16 bytes at the current position, storing a Int128 in big-endian
     * order. This method will also advance the current position of the
     * ByteBuffer by 16 bytes.
     *
@@ -185,13 +189,13 @@ object Int128 {
   }
 
   /** Implicit conversion from `Int` to `BigInt`. */
-  implicit def int2uint128(i: Int): Int128 = apply(i)
+  implicit def int2Int128(i: Int): Int128 = apply(i)
 
   /** Implicit conversion from `Long` to `BigInt`. */
-  implicit def long2uint128(l: Long): Int128 = apply(l)
+  implicit def long2Int128(l: Long): Int128 = apply(l)
 
   /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`. */
-  implicit def javaBigInteger2uint128(x: BigInteger): Int128 = apply(x)
+  implicit def javaBigInteger2Int128(x: BigInteger): Int128 = apply(x)
 }
 
 final class Int128(val upperLong: Long, val lowerLong: Long)
@@ -219,22 +223,23 @@ final class Int128(val upperLong: Long, val lowerLong: Long)
     *
     * @return Formatted string representing this number.
     */
-  override def toString: String = BigInt(this.toByteArray).toString()
+  override def toString: String = this.bigInt.toString()
 
-  def toString(radix: Int): String = bigInt.toString(radix)
+  def toString(radix: Int): String = this.bigInt.toString(radix)
 
   override def compare(that: Int128): Int = this.bigInt.compare(that.bigInt)
 
-  /** If the supplied argument is another UInt128, tests for bit-wise equality,
-    * otherwise attempts to convert the argument to a UInt128 and then tests for
+  /** If the supplied argument is another Int128, tests for bit-wise equality,
+    * otherwise attempts to convert the argument to a Int128 and then tests for
     * equality.
     */
   override def equals(that: Any): Boolean = that match {
     case int12: Int128 => int12.upperLong == this.upperLong && int12.lowerLong == this.lowerLong
-    case _ => Int128.decode(that) match {
-      case Failure(_)    => false
-      case Success(that) => this == that
-    }
+    case _ =>
+      Int128.decode(that) match {
+        case Failure(_)    => false
+        case Success(that) => this == that
+      }
   }
 
   override def hashCode: Int = {
@@ -253,8 +258,8 @@ final class Int128(val upperLong: Long, val lowerLong: Long)
   override def isValidChar: Boolean = this >= Char.MinValue && this <= Char.MaxValue
   override def isValidInt: Boolean = this >= Int.MinValue && this <= Int.MaxValue
   def isValidLong: Boolean = this >= Long.MinValue && this <= Long.MaxValue
-  def isValidFloat: Boolean = BigInt(this.toByteArray).isValidFloat
-  def isValidDouble: Boolean = BigInt(this.toByteArray).isValidDouble
+  def isValidFloat: Boolean = this.bigInt.isValidFloat
+  def isValidDouble: Boolean = this.bigInt.isValidDouble
 
   override def intValue(): Int = this.bigInt.intValue()
 
@@ -264,23 +269,23 @@ final class Int128(val upperLong: Long, val lowerLong: Long)
 
   override def doubleValue(): Double = this.bigInt.doubleValue()
 
-  /** Subtraction of UInt128 */
-  def +  (that: Int128): Int128 = Int128(this.bigInt + that.bigInt)
+  /** Subtraction of Int128 */
+  def +(that: Int128): Int128 = Int128(this.bigInt + that.bigInt)
 
-  /** Subtraction of UInt128 */
-  def -  (that: Int128): Int128 = Int128(this.bigInt - that.bigInt)
+  /** Subtraction of Int128 */
+  def -(that: Int128): Int128 = Int128(this.bigInt - that.bigInt)
 
-  /** Multiplication of UInt128 */
-  def *  (that: Int128): Int128 = Int128(this.bigInt * that.bigInt)
+  /** Multiplication of Int128 */
+  def *(that: Int128): Int128 = Int128(this.bigInt * that.bigInt)
 
-  /** Division of UInt128 */
-  def /  (that: Int128): Int128 = Int128(this.bigInt / that.bigInt)
+  /** Division of Int128 */
+  def /(that: Int128): Int128 = Int128(this.bigInt / that.bigInt)
 
-  /** Remainder of UInt128 */
-  def %  (that: Int128): Int128 = Int128(this.bigInt % that.bigInt)
+  /** Remainder of Int128 */
+  def %(that: Int128): Int128 = Int128(this.bigInt % that.bigInt)
 
   /** Returns a BigInt whose value is the negation of this BigInt */
-  def unary_- : Int128   = Int128(this.bigInt.bigInteger.negate())
+  def unary_- : Int128 = Int128(this.bigInt.bigInteger.negate())
 
   /** Returns the bitwise complement of this BigInt */
   def unary_~ : Int128 = Int128(this.bigInt.bigInteger.not())

--- a/src/main/scala/co/topl/utils/Int128.scala
+++ b/src/main/scala/co/topl/utils/Int128.scala
@@ -1,0 +1,281 @@
+package co.topl.utils
+
+import java.math.BigInteger
+import java.nio.{ByteBuffer, ByteOrder}
+import java.util.UUID
+
+import scala.language.implicitConversions
+import scala.math.{BigInt, ScalaNumber, ScalaNumericConversions}
+import scala.util.{Failure, Success, Try}
+
+/* Copyright (c) 2015-2019 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/** Container for a 128 bit signed integer stored in big-endian format.
+ * Adopted from the original work available at
+ * https://github.com/PlatformLab/TorcDB/blob/master/src/main/java/net/ellitron/torc/util/UInt128.java
+ * by Jonathan Ellithorpe (jde@cs.stanford.edu)
+  *
+  * @author James Aman (j.aman@topl.me)
+  */
+object Int128 {
+  val size = 128
+  val bytes: Int = size / java.lang.Byte.SIZE
+  val MinValue: Int128 = Int128(Long.MinValue, 0L)
+  val MaxValue: Int128 = Int128(Long.MaxValue, -1L)
+
+  /** This method attempts to translate its argument into a UInt128.
+    *
+    * @param n Number to translate.
+    * @return UInt128
+    */
+  def decode(n: Any): Try[Int128] = Try {
+    n match {
+      case b: Byte          => Int128(b)
+      case sh: Short        => Int128(sh)
+      case integer: Integer => Int128(integer)
+      case l: Long          => Int128(l)
+      case idStr: String =>
+        if (idStr.startsWith("0x")) Int128(idStr, 16)
+        else Int128(idStr, 10)
+      case integer: BigInteger => Int128(integer)
+      case uuid: UUID          => Int128(uuid)
+      case bytes: Array[Byte]  => Int128(bytes)
+      case int12: Int128      => int12
+      case _ =>
+        throw new NumberFormatException(String.format("Unable to decode " + "number: [%s,%s]", n.getClass, n.toString))
+    }
+  }
+
+  /** Constructs a UInt128 from two longs, one representing the upper 64 bits
+    * and the other representing the lower 64 bits.
+    *
+    * @param upperLong Upper 64 bits.
+    * @param lowerLong Lower 64 bits.
+    */
+  def apply(upperLong: Long, lowerLong: Long): Int128 = new Int128(upperLong, lowerLong)
+
+  /** Constructs a UInt128 from a Byte value. Value is treated as unsigned and
+    * therefore no sign extension is performed.
+    *
+    * @param value Byte, treated as 8 unsigned bits.
+    */
+  def apply(value: Byte): Int128 = new Int128(0, value.toLong)
+
+  /** Constructs a UInt128 from a Short value. Value is treated as unsigned and
+    * therefore no sign extension is performed.
+    *
+    * @param value Short, treated as 16 unsigned bits.
+    */
+  def apply(value: Short): Int128 = new Int128(0, value.toLong)
+
+  /** Constructs a UInt128 from an Integer value. Value is treated as unsigned
+    * and therefore no sign extension is performed.
+    *
+    * @param value Integer, treated as 32 unsigned bits.
+    */
+  def apply(value: Integer): Int128 = new Int128(0, value.toLong)
+
+  /** Constructs a UInt128 from a Long value. Value is treated as unsigned and
+    * therefore no sign extension is performed.
+    *
+    * @param value Long, treated as 64 unsigned bits.
+    */
+  def apply(value: Long): Int128 = new Int128(0, value)
+
+  /** Constructs a UInt128 from a BigInteger value. The value used to construct
+    * the UInt128 is the 128-bit two's complement representation of the
+    * BigInteger. In the case that the number of bits in the minimal
+    * two's-complement representation of the BigInteger is greater than 128,
+    * then the lower 128 bits are used and higher order bits are discarded.
+    *
+    * @param value BigInteger, treated as a 128 bit signed value.
+    */
+  def apply(value: BigInt): Int128 = {
+    val bigIntBytes = value.toByteArray
+    val res = if (bigIntBytes.length >= Int128.bytes) {
+      bigIntBytes.takeRight(16)
+    } else {
+      val pad: Byte = if (bigIntBytes.head < 0) -1 else 0
+      Array.fill(16 - bigIntBytes.length)(pad) ++ bigIntBytes
+    }
+
+    val buf = ByteBuffer.allocate(bytes).order(ByteOrder.BIG_ENDIAN)
+    buf.put(res)
+    buf.flip()
+    new Int128(buf.getLong(), buf.getLong())
+  }
+
+  /** Constructs a UInt128 from a String value representing a number in a
+    * specified base. The value stored in this UInt128 is the 128 bit
+    * two's-complement representation of this value. If the two's-complement
+    * representation of the value requires more than 128 bits to represent, only
+    * the lower 128 bits are used to construct this UInt128.
+    *
+    * @param value   String, treated as a 128 bit signed value.
+    * @param radix The base of the number represented by the string.
+    */
+  def apply(value: String, radix: Int): Int128 = apply(new BigInteger(value, radix))
+
+  /** Constructs a UInt128 from a String value representing a number in base 10.
+    * The value stored in this UInt128 is the 128 bit two's-complement
+    * representation of this value. If the two's-complement representation of
+    * the value requires more than 128 bits to represent, only the lower 128
+    * bits are used to construct this UInt128.
+    *
+    * @param value Base 10 format String, treated as a 128 bit signed value.
+    */
+  def apply(value: String): Int128 = apply(value, 10)
+
+  /** Constructs a UInt128 from a UUID value.
+    * The value stored in this UInt128 is the 128 bit two's-complement
+    * representation of this value. If the two's-complement representation of
+    * the value requires more than 128 bits to represent, only the lower 128
+    * bits are used to construct this UInt128.
+    *
+    * @param value 128-bit UUID value
+    */
+  def apply(value: UUID): Int128 = new Int128(value.getMostSignificantBits, value.getLeastSignificantBits)
+
+  /** Constructs a UInt128 from a byte array value. The byte array value is
+    * interpreted as unsigned and in big-endian format. If the byte array is
+    * less than 16 bytes, then the higher order bytes of the resulting UInt128
+    * are padded with 0s. If the byte array is greater than 16 bytes, then the
+    * lower 16 bytes are used.
+    *
+    * @param value Byte array in big-endian format.
+    */
+  def apply(value: Array[Byte]): Int128 = {
+    val res = if (value.length >= Int128.bytes) {
+      value.takeRight(16)
+    } else {
+      Array.fill(16 - value.length)(0: Byte) ++ value
+    }
+
+    val buf = ByteBuffer.allocate(bytes).order(ByteOrder.BIG_ENDIAN)
+    buf.put(res)
+    buf.flip()
+    new Int128(buf.getLong(), buf.getLong())
+  }
+
+  /** Parses a UInt128 from a ByteBuffer. The ByteBuffer is expected to have at
+    * least 16 bytes at the current position, storing a UInt128 in big-endian
+    * order. This method will also advance the current position of the
+    * ByteBuffer by 16 bytes.
+    *
+    * @param buf ByteBuffer containing the value in big-endian format at the
+    *            current position of the buffer.
+    */
+  def parseFromByteBuffer(buf: ByteBuffer): Int128 = {
+    val upperLong = buf.getLong
+    val lowerLong = buf.getLong
+    new Int128(upperLong, lowerLong)
+  }
+
+  /** Implicit conversion from `Int` to `BigInt`. */
+  implicit def int2uint128(i: Int): Int128 = apply(i)
+
+  /** Implicit conversion from `Long` to `BigInt`. */
+  implicit def long2uint128(l: Long): Int128 = apply(l)
+
+  /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`. */
+  implicit def javaBigInteger2uint128(x: BigInteger): Int128 = apply(x)
+}
+
+final class Int128(val upperLong: Long, val lowerLong: Long)
+    extends ScalaNumber
+    with ScalaNumericConversions
+    with Serializable
+    with Ordered[Int128] {
+
+  private val bigInt = BigInt(this.toByteArray)
+
+  /** Returns a byte array containing this 128 bit unsigned integer in
+    * big-endian format.
+    *
+    * @return Byte array containing this number in big-endian format.
+    */
+  def toByteArray: Array[Byte] = {
+    val buf = ByteBuffer.allocate(Int128.bytes).order(ByteOrder.BIG_ENDIAN)
+    buf.putLong(upperLong)
+    buf.putLong(lowerLong)
+    buf.array
+  }
+
+  /** Returns a hexadecimal String representing this 128 bit unsigned integer
+    * with the minimum number of digits.
+    *
+    * @return Formatted string representing this number.
+    */
+  override def toString: String = BigInt(this.toByteArray).toString()
+
+  def toString(radix: Int): String = bigInt.toString(radix)
+
+  override def compare(that: Int128): Int = this.bigInt.compare(that.bigInt)
+
+  /** If the supplied argument is another UInt128, tests for bit-wise equality,
+    * otherwise attempts to convert the argument to a UInt128 and then tests for
+    * equality.
+    */
+  override def equals(that: Any): Boolean = that match {
+    case int12: Int128 => int12.upperLong == this.upperLong && int12.lowerLong == this.lowerLong
+    case _ => Int128.decode(that) match {
+      case Failure(_)    => false
+      case Success(that) => this == that
+    }
+  }
+
+  override def hashCode: Int = {
+    var hash = 7
+    hash = 83 * hash + (this.upperLong ^ (this.upperLong >>> 32)).toInt
+    hash = 83 * hash + (this.lowerLong ^ (this.lowerLong >>> 32)).toInt
+    hash
+  }
+
+  override def underlying: (Long, Long) = (this.upperLong, this.lowerLong)
+
+  override def isWhole(): Boolean = true
+
+  override def isValidByte: Boolean = this >= Byte.MinValue && this <= Byte.MaxValue
+  override def isValidShort: Boolean = this >= Short.MinValue && this <= Short.MaxValue
+  override def isValidChar: Boolean = this >= Char.MinValue && this <= Char.MaxValue
+  override def isValidInt: Boolean = this >= Int.MinValue && this <= Int.MaxValue
+  def isValidLong: Boolean = this >= Long.MinValue && this <= Long.MaxValue
+  def isValidFloat: Boolean = BigInt(this.toByteArray).isValidFloat
+  def isValidDouble: Boolean = BigInt(this.toByteArray).isValidDouble
+
+  override def intValue(): Int = this.bigInt.intValue()
+
+  override def longValue(): Long = this.bigInt.longValue()
+
+  override def floatValue(): Float = this.bigInt.floatValue()
+
+  override def doubleValue(): Double = this.bigInt.doubleValue()
+
+  /** Subtraction of UInt128 */
+  def +  (that: Int128): Int128 = Int128(this.bigInt + that.bigInt)
+
+  /** Subtraction of UInt128 */
+  def -  (that: Int128): Int128 = Int128(this.bigInt - that.bigInt)
+
+  /** Multiplication of UInt128 */
+  def *  (that: Int128): Int128 = Int128(this.bigInt * that.bigInt)
+
+  /** Division of UInt128 */
+  def /  (that: Int128): Int128 = Int128(this.bigInt / that.bigInt)
+
+  /** Remainder of UInt128 */
+  def %  (that: Int128): Int128 = Int128(this.bigInt % that.bigInt)
+}

--- a/src/main/scala/co/topl/utils/NetworkTime.scala
+++ b/src/main/scala/co/topl/utils/NetworkTime.scala
@@ -29,7 +29,7 @@ class NetworkTimeProvider(ntpSettings: NetworkTimeProviderSettings)(implicit ec:
     *
     * @return the current timestamp in milliseconds
     */
-  override def time(): TimeProvider.Time = {
+  override def time: TimeProvider.Time = {
     checkUpdateRequired()
     NetworkTime.localWithOffset(offset.get())
   }

--- a/src/main/scala/co/topl/utils/TimeProvider.scala
+++ b/src/main/scala/co/topl/utils/TimeProvider.scala
@@ -5,5 +5,5 @@ object TimeProvider {
 }
 
 trait TimeProvider {
-  def time(): TimeProvider.Time
+  def time: TimeProvider.Time
 }

--- a/src/main/scala/co/topl/utils/codecs/Int128Codec.scala
+++ b/src/main/scala/co/topl/utils/codecs/Int128Codec.scala
@@ -1,0 +1,10 @@
+package co.topl.utils.codecs
+
+import co.topl.utils.Int128
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder}
+
+object Int128Codec {
+  implicit val jsonEncoder: Encoder[Int128] = (x: Int128) => x.toString.asJson
+  implicit val jsonDecoder: Decoder[Int128] = Decoder.decodeString.map(s => Int128(s))
+}

--- a/src/main/scala/co/topl/utils/serialization/Reader.scala
+++ b/src/main/scala/co/topl/utils/serialization/Reader.scala
@@ -1,5 +1,7 @@
 package co.topl.utils.serialization
 
+import co.topl.utils.Int128
+
 trait Reader {
 
   /**

--- a/src/main/scala/co/topl/utils/serialization/Reader.scala
+++ b/src/main/scala/co/topl/utils/serialization/Reader.scala
@@ -96,6 +96,12 @@ trait Reader {
   def getULong(): Long
 
   /**
+   * Decode sign Int128
+   * @return signed Int128
+   */
+  def getInt128(): Int128
+
+  /**
     * Decode array of byte values
     * @param size expected size of decoded array
     * @return

--- a/src/main/scala/co/topl/utils/serialization/VLQReader.scala
+++ b/src/main/scala/co/topl/utils/serialization/VLQReader.scala
@@ -2,6 +2,7 @@ package co.topl.utils.serialization
 
 import java.util
 
+import co.topl.utils.Int128
 import co.topl.utils.serialization.Extensions._
 import co.topl.utils.serialization.ZigZagEncoder._
 
@@ -88,6 +89,9 @@ trait VLQReader extends Reader {
     sys.error(s"Cannot deserialize Long value. Unexpected reader $this with bytes remaining $remaining")
     // see https://rosettacode.org/wiki/Variable-length_quantity for implementations in other languages
   }
+
+  /** Retrieve the custom Int128 type that is 16 bytes (128 bits) */
+  @inline def getInt128(): Int128 = Int128(getBytes(Int128.numBytes))
 
   @inline override def getBits(size: Int): Array[Boolean] = {
     if (size == 0) return Array[Boolean]()

--- a/src/main/scala/co/topl/utils/serialization/VLQWriter.scala
+++ b/src/main/scala/co/topl/utils/serialization/VLQWriter.scala
@@ -2,6 +2,7 @@ package co.topl.utils.serialization
 
 import java.util
 
+import co.topl.utils.Int128
 import co.topl.utils.serialization.ZigZagEncoder._
 
 trait VLQWriter extends Writer {

--- a/src/main/scala/co/topl/utils/serialization/VLQWriter.scala
+++ b/src/main/scala/co/topl/utils/serialization/VLQWriter.scala
@@ -117,6 +117,9 @@ trait VLQWriter extends Writer {
     // see https://rosettacode.org/wiki/Variable-length_quantity for implementations in other languages
   }
 
+  /** Insert the custom Int128 type that is 16 bytes (128 bits) */
+  @inline def putInt128(x: Int128): this.type = putBytes(x.toByteArray)
+
   @inline override def putBits(xs: Array[Boolean]): this.type = {
     if (xs.isEmpty) return this
     val bitSet = new util.BitSet(xs.length)

--- a/src/main/scala/co/topl/utils/serialization/Writer.scala
+++ b/src/main/scala/co/topl/utils/serialization/Writer.scala
@@ -1,5 +1,7 @@
 package co.topl.utils.serialization
 
+import co.topl.utils.Int128
+
 trait Writer {
 
   /**
@@ -108,7 +110,6 @@ trait Writer {
     * @param x Long
     */
   def putULong(x: Long): this.type
-
 
   /**
     * Encode an array of bytes

--- a/src/main/scala/co/topl/utils/serialization/Writer.scala
+++ b/src/main/scala/co/topl/utils/serialization/Writer.scala
@@ -112,6 +112,12 @@ trait Writer {
   def putULong(x: Long): this.type
 
   /**
+   * Encode an Int128 value
+   * @param x - Int128
+   */
+  def putInt128(x: Int128): this.type
+
+  /**
     * Encode an array of bytes
     * @param xs value to encode
     * @return

--- a/src/main/scala/co/topl/utils/serialization/ZigZagEncoder.scala
+++ b/src/main/scala/co/topl/utils/serialization/ZigZagEncoder.scala
@@ -1,5 +1,7 @@
 package co.topl.utils.serialization
 
+import co.topl.utils.Int128
+
 object ZigZagEncoder {
 
   /**
@@ -58,4 +60,5 @@ object ZigZagEncoder {
     // source: http://github.com/google/protobuf/blob/a7252bf42df8f0841cf3a0c85fdbf1a5172adecb/java/core/src/main/java/com/google/protobuf/CodedInputStream.java#L566
     (n >>> 1) ^ -(n & 1)
   }
+
 }

--- a/src/test/scala/co/topl/api/AssetRPCSpec.scala
+++ b/src/test/scala/co/topl/api/AssetRPCSpec.scala
@@ -30,7 +30,7 @@ class AssetRPCSpec extends AnyWordSpec
            |  [
            |    "AUBDNmMJkmHtuyGXkWAB7Bg9X8T4CRDNVXmPvVcQWPMk4RdwR883",
            |      {
-           |        "quantity" : 5858200457744262097,
+           |        "quantity" : "5858200457744262097",
            |        "assetCode" : "PPsSca8fTkx4jDLUvxCoaVw3r3ZabTssC2SKFGbCdRYDNJSRm2q6tQCXYkP",
            |        "metadata" : "ApdGzs6uwKAhuKJQswBWoVAFjNA5B8enBKfxVbzlcQ8EnpxicpRcE9B9Bgn2LGv02kYUSA1h1181ZYeECvr",
            |        "type" : "Asset",
@@ -39,7 +39,7 @@ class AssetRPCSpec extends AnyWordSpec
            |     "sender": ["$address"],
            |     "changeAddress": "$address",
            |     "consolidationAddress": "$address",
-           |     "fee": 1,
+           |     "fee": "1",
            |     "minting": true,
            |     "data": ""
            |   }]

--- a/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
+++ b/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
@@ -17,7 +17,7 @@ class NodeViewRPCSpec extends AnyWordSpec
   val block: Block = blockGen.sample.get.copy(transactions = txs)
 
   view().history.storage.update(block, isBest = false)
-  view().pool.putWithoutCheck(txs)
+  view().pool.putWithoutCheck(txs, block.timestamp)
 
   "NodeView RPC" should {
     "Get first 100 transactions in mempool" in {

--- a/src/test/scala/co/topl/modifier/BloomFilterSpec.scala
+++ b/src/test/scala/co/topl/modifier/BloomFilterSpec.scala
@@ -32,7 +32,6 @@ class BloomFilterSpec
   property("Bloomfilter should be able to tell if an address is likely not in the block(false positives)") {
     forAll(validBifrostTransactionSeqGen) { txs =>
       val bloomfilter: BloomFilter = TransactionsCarryingPersistentNodeViewModifier.createBloom(txs.dropRight(1))
-      val addressCount = txs.foldLeft(0)(_ + _.bloomTopics.size)
       val addressInBloom: Int = txs.dropRight(1).foldLeft(0)(_ + _.bloomTopics.size)
       val numAddressLastTx: Int = txs.last.bloomTopics.size
 
@@ -42,9 +41,9 @@ class BloomFilterSpec
       }
 
       /** Sometimes there's very few addresses in the last transaction, we only test here to make sure we don't get too
-        * many false positives. There's a very slight chance that this will break
+        * many false positives. There's a very slight chance that this will break (if it does this is probably an issue)
         */
-      (falsePositives <= numAddressLastTx / 2) shouldBe true
+      (falsePositives <= addressInBloom / 3) shouldBe true
     }
   }
 

--- a/src/test/scala/co/topl/utils/ValidGenerators.scala
+++ b/src/test/scala/co/topl/utils/ValidGenerators.scala
@@ -109,10 +109,10 @@ trait ValidGenerators extends CoreGenerators {
   }
 
   def validAssetTransfer(
-    keyRing: KeyRing[PrivateKeyCurve25519, KeyfileCurve25519],
-    state: State,
-    fee: Long = 1L,
-    minting: Boolean = false
+                          keyRing: KeyRing[PrivateKeyCurve25519, KeyfileCurve25519],
+                          state: State,
+                          fee: Long = 1L,
+                          minting: Boolean = false
   ): Gen[AssetTransfer[PublicKeyPropositionCurve25519]] = {
     val sender = keyRing.addresses.head
     val prop = keyRing.lookupPublicKey(sender).get


### PR DESCRIPTION
Separated the stateReader functionality to a more generic trait that I placed under modifier so that I can remove the `state` package in BramblSc. This cleans up the interface and should help us separate out the `topl-definitions` more readily