### PR TITLE
add string extension method to enforce latin 1 valid strings

### DIFF
--- a/src/main/scala/co/topl/attestation/keyManagement/KeyfileCurve25519.scala
+++ b/src/main/scala/co/topl/attestation/keyManagement/KeyfileCurve25519.scala
@@ -3,6 +3,7 @@ package co.topl.attestation.keyManagement
 import java.nio.charset.StandardCharsets
 
 import co.topl.attestation.Address
+import co.topl.utils.Extensions.StringOps
 import co.topl.utils.NetworkType.NetworkPrefix
 import io.circe.parser.parse
 import io.circe.syntax._
@@ -105,7 +106,7 @@ object KeyfileCurve25519 extends KeyfileCompanion[PrivateKeyCurve25519, KeyfileC
     * @return
     */
   private def getDerivedKey (password: String, salt: Array[Byte]): Array[Byte] = {
-    val passwordBytes = password.getBytes(StandardCharsets.ISO_8859_1)
+    val passwordBytes = password.getValidLatin1Bytes.getOrElse(throw new Exception("String is not valid Latin-1"))
     SCrypt.generate(passwordBytes, salt, scala.math.pow(2, 18).toInt, 8, 1, 32)
   }
 

--- a/src/main/scala/co/topl/attestation/serialization/ThresholdPropositionCurve25519Serializer.scala
+++ b/src/main/scala/co/topl/attestation/serialization/ThresholdPropositionCurve25519Serializer.scala
@@ -1,7 +1,7 @@
 package co.topl.attestation.serialization
 
 import co.topl.attestation.{PublicKeyPropositionCurve25519, ThresholdPropositionCurve25519}
-import co.topl.utils.serialization.Extensions._
+import co.topl.utils.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
 import scala.collection.SortedSet

--- a/src/main/scala/co/topl/attestation/serialization/ThresholdSignatureCurve25519Serializer.scala
+++ b/src/main/scala/co/topl/attestation/serialization/ThresholdSignatureCurve25519Serializer.scala
@@ -1,7 +1,7 @@
 package co.topl.attestation.serialization
 
 import co.topl.attestation.{SignatureCurve25519, ThresholdSignatureCurve25519}
-import co.topl.utils.serialization.Extensions._
+import co.topl.utils.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
 

--- a/src/main/scala/co/topl/modifier/block/serialization/BlockBodySerializer.scala
+++ b/src/main/scala/co/topl/modifier/block/serialization/BlockBodySerializer.scala
@@ -4,7 +4,7 @@ import co.topl.modifier.ModifierId
 import co.topl.modifier.block.BlockBody
 import co.topl.modifier.transaction.Transaction
 import co.topl.modifier.transaction.serialization.TransactionSerializer
-import co.topl.utils.serialization.Extensions.LongOps
+import co.topl.utils.Extensions.LongOps
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
 object BlockBodySerializer extends BifrostSerializer[BlockBody] {

--- a/src/main/scala/co/topl/modifier/block/serialization/BlockSerializer.scala
+++ b/src/main/scala/co/topl/modifier/block/serialization/BlockSerializer.scala
@@ -8,7 +8,7 @@ import co.topl.modifier.transaction.Transaction
 import co.topl.modifier.transaction.serialization.TransactionSerializer
 import co.topl.modifier.box.ArbitBox
 import co.topl.modifier.box.serialization.ArbitBoxSerializer
-import co.topl.utils.serialization.Extensions.LongOps
+import co.topl.utils.Extensions.LongOps
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
 object BlockSerializer extends BifrostSerializer[Block] {

--- a/src/main/scala/co/topl/modifier/box/serialization/CodeBoxSerializer.scala
+++ b/src/main/scala/co/topl/modifier/box/serialization/CodeBoxSerializer.scala
@@ -1,7 +1,7 @@
 package co.topl.modifier.box.serialization
 
 import co.topl.modifier.box.CodeBox
-import co.topl.utils.serialization.Extensions._
+import co.topl.utils.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
 object CodeBoxSerializer extends BifrostSerializer[CodeBox] {

--- a/src/main/scala/co/topl/modifier/box/serialization/ExecutionBoxSerializer.scala
+++ b/src/main/scala/co/topl/modifier/box/serialization/ExecutionBoxSerializer.scala
@@ -1,7 +1,7 @@
 package co.topl.modifier.box.serialization
 
 import co.topl.modifier.box.{ExecutionBox, ProgramId}
-import co.topl.utils.serialization.Extensions._
+import co.topl.utils.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
 object ExecutionBoxSerializer extends BifrostSerializer[ExecutionBox] {

--- a/src/main/scala/co/topl/modifier/transaction/TransferTransaction.scala
+++ b/src/main/scala/co/topl/modifier/transaction/TransferTransaction.scala
@@ -1,12 +1,11 @@
 package co.topl.modifier.transaction
 
-import java.nio.charset.StandardCharsets
-
 import co.topl.attestation.EvidenceProducer.Syntax._
 import co.topl.attestation.{Evidence, _}
 import co.topl.modifier.BoxReader
 import co.topl.modifier.block.BloomFilter.BloomTopic
 import co.topl.modifier.box.{Box, _}
+import co.topl.utils.Extensions.StringOps
 import co.topl.utils.NetworkType.NetworkPrefix
 import co.topl.utils.{Identifiable, Int128}
 import com.google.common.primitives.{Ints, Longs}
@@ -240,7 +239,10 @@ object TransferTransaction {
     }
 
     require(tx.timestamp >= 0L, "Invalid timestamp")
-    require(tx.data.forall(_.getBytes(StandardCharsets.ISO_8859_1).length <= 128), "Data field must be less than 128 bytes")
+    require(
+      tx.data.forall(_.getValidLatin1Bytes.getOrElse(throw new Exception("String is not valid Latin-1")).length <= 128),
+      "Data field must be less than 128 bytes"
+    )
 
     // prototype transactions do not contain signatures at creation
     if (hasAttMap) {
@@ -295,7 +297,7 @@ object TransferTransaction {
     T <: TokenValueHolder,
     P <: Proposition: EvidenceProducer
   ](tx:            TransferTransaction[T, P], boxReader: BoxReader[ProgramId, Address])(implicit
-                                                                                        networkPrefix: NetworkPrefix
+    networkPrefix: NetworkPrefix
   ): Try[Unit] = {
 
     // check that the transaction is correctly formed before checking state

--- a/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
@@ -5,7 +5,7 @@ import co.topl.attestation.serialization.{ProofSerializer, PropositionSerializer
 import co.topl.modifier.transaction.ArbitTransfer
 import co.topl.modifier.box.TokenValueHolder
 import co.topl.utils.Int128
-import co.topl.utils.serialization.Extensions._
+import co.topl.utils.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
 import scala.language.existentials

--- a/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
@@ -5,7 +5,7 @@ import co.topl.attestation.serialization.{ProofSerializer, PropositionSerializer
 import co.topl.modifier.transaction.AssetTransfer
 import co.topl.modifier.box.TokenValueHolder
 import co.topl.utils.Int128
-import co.topl.utils.serialization.Extensions._
+import co.topl.utils.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
 import scala.language.existentials

--- a/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
+++ b/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
@@ -5,7 +5,7 @@ import co.topl.attestation.serialization.{ProofSerializer, PropositionSerializer
 import co.topl.modifier.transaction.PolyTransfer
 import co.topl.modifier.box.TokenValueHolder
 import co.topl.utils.Int128
-import co.topl.utils.serialization.Extensions._
+import co.topl.utils.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
 import scala.language.existentials

--- a/src/main/scala/co/topl/network/message/BasicMessagesRepo.scala
+++ b/src/main/scala/co/topl/network/message/BasicMessagesRepo.scala
@@ -6,7 +6,7 @@ import co.topl.network.message
 import co.topl.network.message.Message.MessageCode
 import co.topl.network.peer.{PeerFeature, PeerSpec, PeerSpecSerializer}
 import co.topl.utils.Logging
-import co.topl.utils.serialization.Extensions._
+import co.topl.utils.Extensions._
 import co.topl.utils.serialization.{Reader, Writer}
 
 /** Sequence of modifiers to send to the remote peer */

--- a/src/main/scala/co/topl/network/peer/LocalAddressPeerFeatureSerializer.scala
+++ b/src/main/scala/co/topl/network/peer/LocalAddressPeerFeatureSerializer.scala
@@ -2,7 +2,7 @@ package co.topl.network.peer
 
 import java.net.{InetAddress, InetSocketAddress}
 
-import co.topl.utils.serialization.Extensions._
+import co.topl.utils.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
 object LocalAddressPeerFeatureSerializer extends BifrostSerializer[LocalAddressPeerFeature] {

--- a/src/main/scala/co/topl/network/peer/PeerSpecSerializer.scala
+++ b/src/main/scala/co/topl/network/peer/PeerSpecSerializer.scala
@@ -3,7 +3,7 @@ package co.topl.network.peer
 import java.net.{InetAddress, InetSocketAddress}
 
 import co.topl.settings.{Version, VersionSerializer}
-import co.topl.utils.serialization.Extensions._
+import co.topl.utils.Extensions._
 import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
 
 class PeerSpecSerializer(featureSerializers: PeerFeature.Serializers) extends BifrostSerializer[PeerSpec] {

--- a/src/main/scala/co/topl/utils/serialization/VLQReader.scala
+++ b/src/main/scala/co/topl/utils/serialization/VLQReader.scala
@@ -3,7 +3,7 @@ package co.topl.utils.serialization
 import java.util
 
 import co.topl.utils.Int128
-import co.topl.utils.serialization.Extensions._
+import co.topl.utils.Extensions._
 import co.topl.utils.serialization.ZigZagEncoder._
 
 trait VLQReader extends Reader {


### PR DESCRIPTION
## Summary
Want to enforce Latin-1 encoding on strings and return an error to the user if they provide non-latin-1 characters

## Changes
* Moved Extensions object to root of utils package and refactored affected dependencies
* added StringOps extension object with a function to get the byte array assuming latin-1 encoding
* updated usages of latin-1 encoding to use the new extension method