### PR TITLE
Filter out reward transactions from mempool

### DIFF
--- a/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
+++ b/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
@@ -306,8 +306,8 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
 
   /**
     *
-    * @param mod
-    * @return
+    * @param mod - the block to retrieve transactions from
+    * @return the sequence of transactions from a block
     */
   protected def extractTransactions(mod: PMOD): Seq[TX] = mod match {
     case tcm: TransactionCarryingPersistentNodeViewModifier[_] => tcm.transactions
@@ -336,7 +336,7 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
 
 
   /** Below is a description of how state updates are managed */
-  /** --------------------------------------------------------------------------------------------------------------------- /
+  /** --------------------------------------------------------------------------------------------------------------- /
   Assume that history knows the following blocktree:
 
            G
@@ -345,10 +345,10 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
         /     \
        *       G
 
-    where path with G-s is about canonical chain (G means semantically valid modifier), path with * is sidechain (* means
-    that semantic validity is unknown). New modifier is coming to the sidechain, it sends rollback to the root +
-    application of the sidechain to the state. Assume that state is finding that some modifier in the sidechain is
-    incorrect:
+    where path with G-s is about canonical chain (G means semantically valid modifier), path with * is sidechain
+    (* means that semantic validity is unknown). New modifier is coming to the sidechain, it sends rollback to
+    the root + application of the sidechain to the state. Assume that state is finding that some modifier in the
+    sidechain is incorrect:
 
            G
           / \
@@ -365,7 +365,7 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
     We assume that we apply modifiers sequentially (on a single modifier coming from the network or generated locally),
     and in case of failed application of some modifier in a progressInfo, rollback point in an alternative should be not
     earlier than a rollback point of an initial progressInfo.
-  / ---------------------------------------------------------------------------------------------------------------------- **/
+  / --------------------------------------------------------------------------------------------------------------- **/
 
   @tailrec
   private def updateState(history: HIS,
@@ -432,7 +432,8 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
   //todo: this method causes delays in a block processing as it removes transactions from mempool and checks
   //todo: validity of remaining transactions in a synchronous way. Do this job async!
   protected def updateMemPool(blocksRemoved: Seq[PMOD], blocksApplied: Seq[PMOD], memPool: MP, state: MS): MP = {
-    val rolledBackTxs = blocksRemoved.flatMap(extractTransactions)
+    // drop the first two transactions, since these are the reward transactions and invalid
+    val rolledBackTxs = blocksRemoved.flatMap(b => extractTransactions(b).drop(2))
 
     val appliedTxs = blocksApplied.flatMap(extractTransactions)
 

--- a/src/test/scala/co/topl/nodeView/nodeViewHolder/NodeViewHolderSpec.scala
+++ b/src/test/scala/co/topl/nodeView/nodeViewHolder/NodeViewHolderSpec.scala
@@ -1,0 +1,34 @@
+package co.topl.nodeView.nodeViewHolder
+
+import akka.testkit.TestActorRef
+import co.topl.nodeView.NodeViewHolder
+import co.topl.nodeView.mempool.MemPool
+import co.topl.nodeView.state.MockState
+import co.topl.utils.CoreGenerators
+import org.scalatest.PrivateMethodTester
+import org.scalatest.propspec.AnyPropSpec
+
+class NodeViewHolderSpec extends AnyPropSpec
+  with PrivateMethodTester
+  with CoreGenerators
+  with MockState {
+
+  type MP = MemPool
+
+  private val nvhTestRef = TestActorRef(new NodeViewHolder(settings, appContext))
+  private val nodeView = nvhTestRef.underlyingActor
+  private val state = createState()
+
+  // TODO replace reward transactions with valid transactions
+  property("Rewards transactions are removed from transactions extracted from a block being rolled back") {
+    forAll(blockGen) { block =>
+      val polyReward = polyTransferGen.sample.get.copy(minting = true)
+      val arbitReward = arbitTransferGen.sample.get.copy(minting = true)
+      val rewardBlock = block.copy(transactions = Seq(arbitReward, polyReward))
+
+      val updateMemPool = PrivateMethod[MP]('updateMemPool)
+      val memPool = nodeView invokePrivate updateMemPool(Seq(rewardBlock), Seq(), MemPool.emptyPool, state)
+      memPool.size shouldBe 0
+    }
+  }
+}


### PR DESCRIPTION
closes #1062 

This update will drop reward transactions before they are put into the mempool whenever blocks are rolled back.