### PR TITLE
TransferTransaction RPC raw and broadcast tests

### DIFF
--- a/src/main/scala/co/topl/modifier/box/Box.scala
+++ b/src/main/scala/co/topl/modifier/box/Box.scala
@@ -24,6 +24,11 @@ sealed abstract class Box[+T](val evidence: Evidence, val value: T, val nonce: N
     Box.identifier(this).typeString + Box.jsonEncoder(this).noSpaces
 
   override def hashCode(): Int = Ints.fromByteArray(bytes)
+
+  override def equals(obj: Any): Boolean = obj match {
+    case box: Box[_] => bytes sameElements box.bytes
+    case _ => false
+  }
 }
 
 object Box {
@@ -81,7 +86,7 @@ object Box {
   }
 }
 
-/* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
+/* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
 
 abstract class TokenBox[
   +T <: TokenValueHolder
@@ -92,7 +97,7 @@ object TokenBox {
   implicit def jsonEncoder[T <: TokenValueHolder]: Encoder[TokenBox[T]] = (bx: TokenBox[_]) => Box.jsonEncoder(bx)
 }
 
-/* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
+/* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
 
 abstract class ProgramBox(
   override val evidence: Evidence,

--- a/src/test/scala/co/topl/api/transaction/ArbitTransferRPCSpec.scala
+++ b/src/test/scala/co/topl/api/transaction/ArbitTransferRPCSpec.scala
@@ -1,0 +1,83 @@
+package co.topl.api.transaction
+
+import akka.util.ByteString
+import co.topl.api.RPCMockState
+import co.topl.attestation.Address
+import io.circe.Json
+import io.circe.parser.parse
+import io.circe.syntax._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import scorex.util.encode.Base58
+
+class ArbitTransferRPCSpec extends AnyWordSpec
+  with Matchers
+  with RPCMockState {
+
+  val address: Address = keyRing.addresses.head
+  var tx = ""
+
+  "ArbitTransfer RPC" should {
+    "Create new arbit transfer raw transaction" in {
+      val requestBody = ByteString(
+        s"""
+           |{
+           |   "jsonrpc": "2.0",
+           |   "id": "2",
+           |   "method": "topl_rawArbitTransfer",
+           |   "params": [{
+           |     "propositionType": "PublicKeyCurve25519",
+           |     "recipients": [["$address", "1"]],
+           |     "sender": ["$address"],
+           |     "changeAddress": "$address",
+           |     "fee": "1",
+           |     "data": ""
+           |   }]
+           |}
+        """.stripMargin)
+
+      httpPOST(requestBody) ~> route ~> check {
+        val res = parse(responseAs[String]) match {
+          case Right(re) => re;
+          case Left(ex) => throw ex
+        }
+
+        val sigTx = for {
+          rawTx <- res.hcursor.downField("result").get[Json]("rawTx")
+          message <- res.hcursor.downField("result").get[String]("messageToSign")
+        } yield {
+          val sig = keyRing.generateAttestation(address)(Base58.decode(message).get)
+          val signatures: Json = Map(
+            "signatures" -> sig.asJson
+          ).asJson
+          rawTx.deepMerge(signatures)
+        }
+
+        tx = sigTx.right.get.toString
+
+        (res \\ "error").isEmpty shouldBe true
+        (res \\ "result").head.asObject.isDefined shouldBe true
+      }
+    }
+
+    "Broadcast signed ArbitTransfer transaction" in {
+      val requestBody = ByteString(
+        s"""
+           |{
+           |   "jsonrpc": "2.0",
+           |   "id": "2",
+           |   "method": "topl_broadcastTx",
+           |   "params": [{
+           |     "tx": $tx
+           |   }]
+           |}
+           |""".stripMargin)
+
+      httpPOST(requestBody) ~> route ~> check {
+        val res = parse(responseAs[String]) match { case Right(re) => re; case Left(ex) => throw ex }
+        (res \\ "error").isEmpty shouldBe true
+        (res \\ "result").head.asObject.isDefined shouldBe true
+      }
+    }
+  }
+}

--- a/src/test/scala/co/topl/api/transaction/AssetRPCSpec.scala
+++ b/src/test/scala/co/topl/api/transaction/AssetRPCSpec.scala
@@ -1,6 +1,7 @@
-package co.topl.api
+package co.topl.api.transaction
 
 import akka.util.ByteString
+import co.topl.api.RPCMockState
 import co.topl.attestation.Address
 import co.topl.modifier.box.AssetCode
 import io.circe.Json
@@ -19,8 +20,7 @@ class AssetRPCSpec extends AnyWordSpec
   val assetCode: AssetCode = AssetCode(1: Byte, address, "test")
   var tx = ""
 
-  "Asset RPC" should {
-
+  "AssetTransfer RPC" should {
     "Create new assets raw transaction" in {
       val requestBody = ByteString(
         s"""
@@ -72,8 +72,7 @@ class AssetRPCSpec extends AnyWordSpec
       }
     }
 
-    "broadcast signed AssetTransfer transaction" in {
-
+    "Broadcast signed AssetTransfer transaction" in {
       val requestBody = ByteString(
         s"""
           |{

--- a/src/test/scala/co/topl/api/transaction/PolyTransferRPCSpec.scala
+++ b/src/test/scala/co/topl/api/transaction/PolyTransferRPCSpec.scala
@@ -1,0 +1,83 @@
+package co.topl.api.transaction
+
+import akka.util.ByteString
+import co.topl.api.RPCMockState
+import co.topl.attestation.Address
+import io.circe.Json
+import io.circe.parser.parse
+import io.circe.syntax._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import scorex.util.encode.Base58
+
+class PolyTransferRPCSpec extends AnyWordSpec
+  with Matchers
+  with RPCMockState {
+
+  val address: Address = keyRing.addresses.head
+  var tx = ""
+
+  "PolyTransfer RPC" should {
+    "Create new poly transfer raw transaction" in {
+      val requestBody = ByteString(
+        s"""
+           |{
+           |   "jsonrpc": "2.0",
+           |   "id": "2",
+           |   "method": "topl_rawPolyTransfer",
+           |   "params": [{
+           |     "propositionType": "PublicKeyCurve25519",
+           |     "recipients": [["$address", "1"]],
+           |     "sender": ["$address"],
+           |     "changeAddress": "$address",
+           |     "fee": "1",
+           |     "data": ""
+           |   }]
+           |}
+        """.stripMargin)
+
+      httpPOST(requestBody) ~> route ~> check {
+        val res = parse(responseAs[String]) match {
+          case Right(re) => re;
+          case Left(ex) => throw ex
+        }
+
+        val sigTx = for {
+          rawTx <- res.hcursor.downField("result").get[Json]("rawTx")
+          message <- res.hcursor.downField("result").get[String]("messageToSign")
+        } yield {
+          val sig = keyRing.generateAttestation(address)(Base58.decode(message).get)
+          val signatures: Json = Map(
+            "signatures" -> sig.asJson
+          ).asJson
+          rawTx.deepMerge(signatures)
+        }
+
+        tx = sigTx.right.get.toString
+
+        (res \\ "error").isEmpty shouldBe true
+        (res \\ "result").head.asObject.isDefined shouldBe true
+      }
+    }
+
+    "Broadcast signed PolyTransfer transaction" in {
+      val requestBody = ByteString(
+        s"""
+           |{
+           |   "jsonrpc": "2.0",
+           |   "id": "2",
+           |   "method": "topl_broadcastTx",
+           |   "params": [{
+           |     "tx": $tx
+           |   }]
+           |}
+           |""".stripMargin)
+
+      httpPOST(requestBody) ~> route ~> check {
+        val res = parse(responseAs[String]) match { case Right(re) => re; case Left(ex) => throw ex }
+        (res \\ "error").isEmpty shouldBe true
+        (res \\ "result").head.asObject.isDefined shouldBe true
+      }
+    }
+  }
+}


### PR DESCRIPTION
These are tests for creating raw transactions, signing the transactions internally, then testing that the signed transaction can be broadcast using the `topl_broadcastTx` RPC endpoint.

closes #1020 
closes #1097 