### PR TITLE
Remove CurrentView

### DIFF
--- a/src/main/scala/co/topl/BifrostApp.scala
+++ b/src/main/scala/co/topl/BifrostApp.scala
@@ -74,7 +74,7 @@ class BifrostApp(startupOpts: StartupOpts) extends Logging with Runnable {
   private val keyManagerRef = KeyManagerRef(KeyManager.actorName, settings, appContext)
 
   private val forgerRef: ActorRef =
-    ForgerRef[BSI, PMOD, HIS, ST, MP](Forger.actorName, settings, appContext, keyManagerRef)
+    ForgerRef[HIS, ST, MP](Forger.actorName, settings, appContext, keyManagerRef)
 
   private val nodeViewHolderRef: ActorRef = NodeViewHolderRef(NodeViewHolder.actorName, settings, appContext)
 

--- a/src/main/scala/co/topl/consensus/Forger.scala
+++ b/src/main/scala/co/topl/consensus/Forger.scala
@@ -12,7 +12,7 @@ import co.topl.modifier.block.{Block, PersistentNodeViewModifier}
 import co.topl.modifier.box.{ArbitBox, ProgramId}
 import co.topl.modifier.transaction.{ArbitTransfer, PolyTransfer, Transaction}
 import co.topl.network.NodeViewSynchronizer.ReceivableMessages.{ChangedHistory, ChangedMempool, ChangedState}
-import co.topl.network.message.SyncInfo
+import co.topl.network.message.{BifrostSyncInfo, SyncInfo}
 import co.topl.nodeView.NodeViewHolder.ReceivableMessages._
 import co.topl.nodeView.history.HistoryReader
 import co.topl.nodeView.mempool.MemPoolReader
@@ -30,9 +30,7 @@ import scala.util.{Failure, Success, Try}
   * Must be singleton
   */
 class Forger[
-  SI <: SyncInfo,
-  PMOD <: PersistentNodeViewModifier,
-  HR <: HistoryReader[PMOD, SI]: ClassTag,
+  HR <: HistoryReader[Block, BifrostSyncInfo]: ClassTag,
   SR <: StateReader[ProgramId, Address]: ClassTag,
   MR <: MemPoolReader[Transaction.TX]: ClassTag
 ](settings: AppSettings, appContext: AppContext, keyManager: ActorRef)(implicit ec: ExecutionContext, np: NetworkPrefix)
@@ -484,21 +482,17 @@ object Forger {
 object ForgerRef {
 
   def props[
-    SI <: SyncInfo,
-    PMOD <: PersistentNodeViewModifier,
-    HR <: HistoryReader[PMOD, SI]: ClassTag,
+    HR <: HistoryReader[Block, BifrostSyncInfo]: ClassTag,
     SR <: StateReader[ProgramId, Address]: ClassTag,
     MR <: MemPoolReader[Transaction.TX]: ClassTag
   ](settings: AppSettings, appContext: AppContext, keyManager: ActorRef)(implicit
     ec:       ExecutionContext,
     np:       NetworkPrefix
   ): Props =
-    Props(new Forger[SI, PMOD, HR, SR, MR](settings, appContext, keyManager))
+    Props(new Forger[HR, SR, MR](settings, appContext, keyManager))
 
   def apply[
-    SI <: SyncInfo,
-    PMOD <: PersistentNodeViewModifier,
-    HR <: HistoryReader[PMOD, SI]: ClassTag,
+    HR <: HistoryReader[Block, BifrostSyncInfo]: ClassTag,
     SR <: StateReader[ProgramId, Address]: ClassTag,
     MR <: MemPoolReader[Transaction.TX]: ClassTag
   ](name:   String, settings: AppSettings, appContext: AppContext, keyManager: ActorRef)(implicit
@@ -506,7 +500,7 @@ object ForgerRef {
     ec:     ExecutionContext
   ): ActorRef = {
     implicit val np: NetworkPrefix = appContext.networkType.netPrefix
-    system.actorOf(props[SI, PMOD, HR, SR, MR](settings, appContext, keyManager), name)
+    system.actorOf(props[HR, SR, MR](settings, appContext, keyManager), name)
   }
 
 }

--- a/src/main/scala/co/topl/consensus/KeyManager.scala
+++ b/src/main/scala/co/topl/consensus/KeyManager.scala
@@ -11,7 +11,10 @@ import co.topl.utils.NetworkType._
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
 
-class KeyManager(implicit network: NetworkPrefix, settings: AppSettings, appContext: AppContext)
+class KeyManager(
+  settings:    AppSettings,
+  appContext:  AppContext
+)(implicit ec: ExecutionContext, np: NetworkPrefix)
     extends Actor
     with Logging {
 
@@ -129,7 +132,7 @@ class KeyManager(implicit network: NetworkPrefix, settings: AppSettings, appCont
 ////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// COMPANION SINGLETON ////////////////////////////////
 
-object KeyManager extends Logging {
+object KeyManager {
 
   val actorName = "keyManager"
 
@@ -173,7 +176,7 @@ object KeyManagerRef {
 
   def props(settings: AppSettings, appContext: AppContext)(implicit ec: ExecutionContext, np: NetworkPrefix): Props =
     Props(
-      new KeyManager()(np, settings, appContext)
+      new KeyManager(settings, appContext)
     )
 
   def apply(name: String, settings: AppSettings, appContext: AppContext)(implicit

--- a/src/main/scala/co/topl/http/api/ApiEndpointWithView.scala
+++ b/src/main/scala/co/topl/http/api/ApiEndpointWithView.scala
@@ -7,7 +7,6 @@ import co.topl.modifier.block.{Block, PersistentNodeViewModifier}
 import co.topl.modifier.box.ProgramId
 import co.topl.modifier.transaction.Transaction
 import co.topl.network.message.{BifrostSyncInfo, SyncInfo}
-import co.topl.nodeView.CurrentView
 import co.topl.nodeView.NodeViewHolder.ReceivableMessages.{GetDataFromCurrentView, GetNodeViewChanges}
 import co.topl.nodeView.history.{History, HistoryReader}
 import co.topl.nodeView.mempool.{MemPool, MemPoolReader}

--- a/src/main/scala/co/topl/http/api/ApiEndpointWithView.scala
+++ b/src/main/scala/co/topl/http/api/ApiEndpointWithView.scala
@@ -3,11 +3,15 @@ package co.topl.http.api
 import akka.actor.ActorRef
 import akka.pattern.ask
 import co.topl.attestation.Address
+import co.topl.modifier.block.{Block, PersistentNodeViewModifier}
+import co.topl.modifier.box.ProgramId
+import co.topl.modifier.transaction.Transaction
+import co.topl.network.message.{BifrostSyncInfo, SyncInfo}
 import co.topl.nodeView.CurrentView
-import co.topl.nodeView.NodeViewHolder.ReceivableMessages.GetDataFromCurrentView
-import co.topl.nodeView.history.History
-import co.topl.nodeView.mempool.MemPool
-import co.topl.nodeView.state.State
+import co.topl.nodeView.NodeViewHolder.ReceivableMessages.{GetDataFromCurrentView, GetNodeViewChanges}
+import co.topl.nodeView.history.{History, HistoryReader}
+import co.topl.nodeView.mempool.{MemPool, MemPoolReader}
+import co.topl.nodeView.state.{State, StateReader}
 import io.circe.Json
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,18 +20,26 @@ trait ApiEndpointWithView extends ApiEndpoint {
 
   val nodeViewHolderRef: ActorRef
 
-  type CV = CurrentView[History, State, MemPool]
+  type HR = HistoryReader[Block, BifrostSyncInfo]
+  type SR = StateReader[ProgramId, Address]
+  type MR = MemPoolReader[Transaction.TX]
 
-  protected def viewAsync(f: CV => Json)(implicit ec: ExecutionContext): Future[Json] =
-    (nodeViewHolderRef ? GetDataFromCurrentView).mapTo[CV].map(f)
+  protected def asyncHistory(f: HR => Json)(implicit ec: ExecutionContext): Future[Json] =
+    (nodeViewHolderRef ? GetNodeViewChanges(history = true, state = false, mempool = false)).mapTo[HR].map(f)
+
+  protected def asyncState(f: SR => Json)(implicit ec: ExecutionContext): Future[Json] =
+    (nodeViewHolderRef ? GetNodeViewChanges(history = false, state = true, mempool = false)).mapTo[SR].map(f)
+
+  protected def asyncMempool(f: MR => Json)(implicit ec: ExecutionContext): Future[Json] =
+    (nodeViewHolderRef ? GetNodeViewChanges(history = false, state = false, mempool = true)).mapTo[MR].map(f)
 
   /** Helper function to ensure this node has the appropriate state to create a request raw transaction */
-  protected def checkAddress(keys: Seq[Address], view: CV): Unit = {
-    if (!view.state.hasTBR)
+  protected def checkAddress(keys: Seq[Address], sr: SR): Unit = {
+    if (!sr.hasTBR)
       throw new Exception("TokenBoxRegistry not defined for node")
 
     //YT NOTE - if nodeKeys not defined in settings file then node watches for all keys in a state update
-    if (view.state.nodeKeys.isDefined && !keys.forall(key => view.state.nodeKeys.contains(key)))
+    if (sr.nodeKeys.isDefined && !keys.forall(key => sr.nodeKeys.contains(key)))
       throw new Exception("Node not set to watch for specified public key")
   }
 }

--- a/src/main/scala/co/topl/http/api/endpoints/DebugApiEndpoint.scala
+++ b/src/main/scala/co/topl/http/api/endpoints/DebugApiEndpoint.scala
@@ -6,8 +6,10 @@ import co.topl.attestation.Address
 import co.topl.consensus.KeyManager.ReceivableMessages._
 import co.topl.http.api.{ApiEndpointWithView, DebugNamespace, Namespace}
 import co.topl.modifier.ModifierId
-import co.topl.nodeView.NodeViewHolder.ReceivableMessages.GetDataFromCurrentView
-import co.topl.nodeView.history.{History, HistoryDebug}
+import co.topl.modifier.block.Block
+import co.topl.network.message.SyncInfo
+import co.topl.nodeView.NodeViewHolder.ReceivableMessages.{GetDataFromCurrentView, GetNodeViewChanges}
+import co.topl.nodeView.history.{History, HistoryDebug, HistoryReader}
 import co.topl.nodeView.mempool.MemPool
 import co.topl.nodeView.state.State
 import co.topl.settings.{AppContext, RPCApiSettings}
@@ -62,11 +64,11 @@ case class DebugApiEndpoint(
     * @return
     */
   private def delay(params: Json, id: String): Future[Json] =
-    viewAsync { view =>
+    asyncHistory { hr =>
       (for {
         blockId <- params.hcursor.get[ModifierId]("blockId")
         count   <- params.hcursor.get[Int]("numBlocks")
-      } yield new HistoryDebug(view.history).averageDelay(blockId, count)) match {
+      } yield new HistoryDebug(hr).averageDelay(blockId, count)) match {
         case Right(Success(delay)) => Map("delay" -> s"$delay milliseconds").asJson
         case Right(Failure(ex))    => throw ex
         case Left(ex)              => throw ex
@@ -89,9 +91,11 @@ case class DebugApiEndpoint(
     * @return
     */
   private def myBlocks(params: Json, id: String): Future[Json] =
-    (nodeViewHolderRef ? GetDataFromCurrentView).mapTo[CV].flatMap { view =>
+    (nodeViewHolderRef ? GetNodeViewChanges(history = true, state = false, mempool = false))
+      .mapTo[HistoryReader[Block, _ <: SyncInfo]]
+      .flatMap { hr =>
       (keyManagerRef ? ListKeys).mapTo[Set[Address]].map { myKeys =>
-        val blockNum = new HistoryDebug(view.history).count { b =>
+        val blockNum = new HistoryDebug(hr).count { b =>
           myKeys.map(_.evidence).contains(b.generatorBox.evidence)
         }
 
@@ -115,8 +119,8 @@ case class DebugApiEndpoint(
     * @return
     */
   private def generators(params: Json, id: String): Future[Json] =
-    viewAsync { view =>
-      new HistoryDebug(view.history)
+    asyncHistory { hr =>
+      new HistoryDebug(hr)
         .forgerDistribution()
         .map(d => d._1.address -> d._2)
         .asJson

--- a/src/main/scala/co/topl/http/api/endpoints/NodeViewApiEndpoint.scala
+++ b/src/main/scala/co/topl/http/api/endpoints/NodeViewApiEndpoint.scala
@@ -64,12 +64,12 @@ case class NodeViewApiEndpoint(
     * @return
     */
   private def getBestBlock(params: Json, id: String): Future[Json] =
-    viewAsync { view =>
+    asyncHistory { hr =>
       Map(
-        "height"      -> view.history.height.toString.asJson,
-        "score"       -> view.history.score.asJson,
-        "bestBlockId" -> view.history.bestBlockId.toString.asJson,
-        "bestBlock"   -> view.history.bestBlock.asJson
+        "height"      -> hr.height.toString.asJson,
+        "score"       -> hr.score.asJson,
+        "bestBlockId" -> hr.bestBlockId.toString.asJson,
+        "bestBlock"   -> hr.bestBlock.asJson
       ).asJson
     }
 
@@ -95,17 +95,17 @@ case class NodeViewApiEndpoint(
     * @return
     */
   private def balances(params: Json, id: String): Future[Json] =
-    viewAsync { view =>
+    asyncState { hr =>
       // parse arguments from the request
       (for {
         addresses <- params.hcursor.get[Seq[Address]]("addresses")
       } yield {
         // ensure we have the state being asked about
-        checkAddress(addresses, view)
+        checkAddress(addresses, hr)
 
         val boxes: Map[Address, Map[String, Seq[TokenBox[TokenValueHolder]]]] =
           addresses.map { k =>
-            val orderedBoxes = view.state.getTokenBoxes(k) match {
+            val orderedBoxes = hr.getTokenBoxes(k) match {
               case Some(boxes) => boxes.groupBy[String](Box.identifier(_).typeString)
               case _           => Map[String, Seq[TokenBox[TokenValueHolder]]]()
             }
@@ -147,7 +147,7 @@ case class NodeViewApiEndpoint(
     * @return
     */
   private def mempool(params: Json, id: String): Future[Json] =
-    viewAsync { _.pool.take(100)(-_.dateAdded).map(_.tx).asJson }
+    asyncMempool { _.take(100)(-_.dateAdded).map(_.tx).asJson }
 
   /** #### Summary
     * Lookup a transaction by its id
@@ -162,10 +162,10 @@ case class NodeViewApiEndpoint(
     * @return
     */
   private def transactionById(params: Json, id: String): Future[Json] =
-    viewAsync { view =>
+    asyncHistory { hr =>
       (for {
         transactionId <- params.hcursor.get[ModifierId]("transactionId")
-      } yield view.history.transactionById(transactionId)) match {
+      } yield hr.transactionById(transactionId)) match {
         case Right(Some((tx, blockId, height))) =>
           tx.asJson.deepMerge {
             Map(
@@ -192,10 +192,10 @@ case class NodeViewApiEndpoint(
     * @return
     */
   private def transactionFromMempool(params: Json, id: String): Future[Json] =
-    viewAsync { view =>
+    asyncMempool { mr =>
       (for {
         transactionId <- params.hcursor.get[ModifierId]("transactionId")
-      } yield view.pool.modifierById(transactionId)) match {
+      } yield mr.modifierById(transactionId)) match {
         case Right(Some(tx)) => tx.asJson
         case Right(None)     => throw new Exception("Unable to retrieve transaction")
         case Left(ex)        => throw ex
@@ -215,10 +215,10 @@ case class NodeViewApiEndpoint(
     * @return
     */
   private def blockById(params: Json, id: String): Future[Json] =
-    viewAsync { view =>
+    asyncHistory { hr =>
       (for {
         blockId <- params.hcursor.get[ModifierId]("blockId")
-      } yield view.history.modifierById(blockId)) match {
+      } yield hr.modifierById(blockId)) match {
         case Right(Some(block)) => block.asJson
         case Right(None)        => throw new Exception("The requested block could not be found")
         case Left(ex)           => throw ex
@@ -238,10 +238,10 @@ case class NodeViewApiEndpoint(
     * @return
     */
   private def blockByHeight(params: Json, id: String): Future[Json] =
-    viewAsync { view =>
+    asyncHistory { hr =>
       (for {
         height <- params.hcursor.get[Long]("height")
-      } yield view.history.modifierByHeight(height)) match {
+      } yield hr.modifierByHeight(height)) match {
         case Right(Some(block)) => block.asJson
         case Right(None)        => throw new Exception("The requested block could not be found")
         case Left(ex)           => throw ex

--- a/src/main/scala/co/topl/http/api/endpoints/TransactionApiEndpoint.scala
+++ b/src/main/scala/co/topl/http/api/endpoints/TransactionApiEndpoint.scala
@@ -93,7 +93,7 @@ case class TransactionApiEndpoint(
     * @return
     */
   private def rawAssetTransfer(implicit params: Json, id: String): Future[Json] =
-    viewAsync { view =>
+    asyncState { stateReader =>
       val p = params.hcursor
       // parse arguments from the request
       (for {
@@ -108,14 +108,14 @@ case class TransactionApiEndpoint(
       } yield {
 
         // check that the state is available
-        checkAddress(sender, view)
+        checkAddress(sender, stateReader)
 
         // construct the transaction
         propType match {
           case PublicKeyPropositionCurve25519.`typeString` =>
             AssetTransfer
               .createRaw[PublicKeyPropositionCurve25519](
-                view.state,
+                stateReader,
                 recipients,
                 sender,
                 changeAddr,
@@ -128,7 +128,7 @@ case class TransactionApiEndpoint(
           case ThresholdPropositionCurve25519.`typeString` =>
             AssetTransfer
               .createRaw[ThresholdPropositionCurve25519](
-                view.state,
+                stateReader,
                 recipients,
                 sender,
                 changeAddr,
@@ -186,7 +186,7 @@ case class TransactionApiEndpoint(
     * @return
     */
   private def rawPolyTransfer(implicit params: Json, id: String): Future[Json] =
-    viewAsync { view =>
+    asyncState { stateReader =>
       val p = params.hcursor
 
       // parse arguments from the request
@@ -200,7 +200,7 @@ case class TransactionApiEndpoint(
       } yield {
 
         // check that the state is available
-        checkAddress(sender, view)
+        checkAddress(sender, stateReader)
 
         // convert to simple value type
         val to = recipients.map(r => r._1 -> SimpleValue(r._2))
@@ -209,11 +209,11 @@ case class TransactionApiEndpoint(
         propType match {
           case PublicKeyPropositionCurve25519.`typeString` =>
             PolyTransfer
-              .createRaw[PublicKeyPropositionCurve25519](view.state, to, sender, changeAddr, None, fee, data)
+              .createRaw[PublicKeyPropositionCurve25519](stateReader, to, sender, changeAddr, None, fee, data)
 
           case ThresholdPropositionCurve25519.`typeString` =>
             PolyTransfer
-              .createRaw[ThresholdPropositionCurve25519](view.state, to, sender, changeAddr, None, fee, data)
+              .createRaw[ThresholdPropositionCurve25519](stateReader, to, sender, changeAddr, None, fee, data)
         }
       }) match {
         case Right(Success(tx)) =>
@@ -264,7 +264,7 @@ case class TransactionApiEndpoint(
     * @return
     */
   private def rawArbitTransfer(implicit params: Json, id: String): Future[Json] =
-    viewAsync { view =>
+    asyncState { stateReader =>
       val p = params.hcursor
 
       // parse arguments from the request
@@ -279,7 +279,7 @@ case class TransactionApiEndpoint(
       } yield {
 
         // check that the state is available
-        checkAddress(sender, view)
+        checkAddress(sender, stateReader)
 
         // convert to simple value type
         val to = recipients.map(r => r._1 -> SimpleValue(r._2))
@@ -289,7 +289,7 @@ case class TransactionApiEndpoint(
           case PublicKeyPropositionCurve25519.`typeString` =>
             ArbitTransfer
               .createRaw[PublicKeyPropositionCurve25519](
-                view.state,
+                stateReader,
                 to,
                 sender,
                 changeAddr,
@@ -301,7 +301,7 @@ case class TransactionApiEndpoint(
           case ThresholdPropositionCurve25519.`typeString` =>
             ArbitTransfer
               .createRaw[ThresholdPropositionCurve25519](
-                view.state,
+                stateReader,
                 to,
                 sender,
                 changeAddr,

--- a/src/main/scala/co/topl/nodeView/CurrentView.scala
+++ b/src/main/scala/co/topl/nodeView/CurrentView.scala
@@ -1,3 +1,0 @@
-package co.topl.nodeView
-
-case class CurrentView[HIS, MS, MP](history: HIS, state: MS, pool: MP)

--- a/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
+++ b/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
@@ -127,7 +127,7 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
   }
 
   protected def getNodeViewChanges: Receive = {
-    case GetNodeViewChanges(history, state, mempool) =>
+    case t @ GetNodeViewChanges(history, state, mempool) =>
       if (history) sender() ! ChangedHistory(nodeView._1.getReader)
       if (state) sender() ! ChangedState(nodeView._2.getReader)
       if (mempool) sender() ! ChangedMempool(nodeView._3.getReader)

--- a/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
+++ b/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
@@ -95,7 +95,6 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
   override def receive: Receive =
     processModifiers orElse
       transactionsProcessing orElse
-      getCurrentInfo orElse
       getNodeViewChanges orElse
       nonsense
 
@@ -121,13 +120,8 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
       }
   }
 
-  protected def getCurrentInfo: Receive = {
-    case GetDataFromCurrentView =>
-      sender() ! CurrentView(history().getReader, minimalState().getReader, memoryPool().getReader)
-  }
-
   protected def getNodeViewChanges: Receive = {
-    case t @ GetNodeViewChanges(history, state, mempool) =>
+    case GetNodeViewChanges(history, state, mempool) =>
       if (history) sender() ! ChangedHistory(nodeView._1.getReader)
       if (state) sender() ! ChangedState(nodeView._2.getReader)
       if (mempool) sender() ! ChangedMempool(nodeView._3.getReader)
@@ -483,7 +477,7 @@ class NodeViewHolder ( settings: AppSettings, appContext: AppContext )
 ////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// COMPANION SINGLETON ////////////////////////////////
 
-object NodeViewHolder {
+object     NodeViewHolder {
   val actorName = "nodeViewHolder"
 
   case class UpdateInformation[HIS, MS, PMOD <: PersistentNodeViewModifier](history: HIS,

--- a/src/main/scala/co/topl/nodeView/history/HistoryReader.scala
+++ b/src/main/scala/co/topl/nodeView/history/HistoryReader.scala
@@ -1,6 +1,7 @@
 package co.topl.nodeView.history
 
 import co.topl.modifier.block.{Block, PersistentNodeViewModifier}
+import co.topl.modifier.transaction.Transaction
 import co.topl.modifier.{ContainsModifiers, ModifierId}
 import co.topl.network.message.SyncInfo
 import co.topl.nodeView.NodeViewComponent
@@ -14,13 +15,24 @@ trait HistoryReader[PM <: PersistentNodeViewModifier, SI <: SyncInfo] extends No
   with ContainsModifiers[PM] {
 
   val height: Long
-  val bestBlock: Block
+  val bestBlock: PM
   val difficulty: Long
+  val bestBlockId: ModifierId
+  val score: Long
 
   /**
     * Is there's no history, even genesis block
     */
   def isEmpty: Boolean
+
+  /** Retrieve a series of PersistentNodeViewModifiers until the filter is satisfied */
+  def filter(f: PM => Boolean): Seq[PM]
+
+  /** get block id at a certain height */
+  def modifierByHeight(height: Long): Option[PM]
+
+  /** get parent block of a given block */
+  def parentBlock(m: PM): Option[PM]
 
   /** Gets the timestamps for 'count' number of blocks prior to (and including) the startBlock
     *
@@ -28,7 +40,10 @@ trait HistoryReader[PM <: PersistentNodeViewModifier, SI <: SyncInfo] extends No
     * @param count number of blocks to go back
     * @return timestamps of number of blocks including the given starting block
     */
-  def getTimestampsFrom(startBlock: Block, count: Long): Vector[TimeProvider.Time]
+  def getTimestampsFrom(startBlock: PM, count: Long): Vector[TimeProvider.Time]
+
+
+  def transactionById(id: ModifierId): Option[(Transaction.TX, ModifierId, Long)]
 
   /**
     * Whether a modifier could be applied to the history

--- a/src/main/scala/co/topl/nodeView/state/StateReader.scala
+++ b/src/main/scala/co/topl/nodeView/state/StateReader.scala
@@ -1,5 +1,6 @@
 package co.topl.nodeView.state
 
+import co.topl.attestation.Address
 import co.topl.modifier.BoxReader
 import co.topl.nodeView.NodeViewComponent
 import co.topl.nodeView.state.MinimalState.VersionTag
@@ -11,6 +12,10 @@ trait StateReader[KP, KT] extends BoxReader[KP, KT] with NodeViewComponent {
 
   type ProgramKey = KP
   type TokenKey = KT
+
+  val hasTBR: Boolean
+  val hasPBR: Boolean
+  val nodeKeys: Option[Set[KT]]
 
   //must be ID of last applied modifier
   def version: VersionTag

--- a/src/test/scala/co/topl/api/DebugRPCSpec.scala
+++ b/src/test/scala/co/topl/api/DebugRPCSpec.scala
@@ -18,7 +18,7 @@ class DebugRPCSpec extends AnyWordSpec
            |   "id": "1",
            |   "method": "debug_delay",
            |   "params": [{
-           |      "blockId": "${view().history.bestBlockId}",
+           |      "blockId": "${view()._1.bestBlockId}",
            |      "numBlocks": 1
            |   }]
            |}

--- a/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
+++ b/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
@@ -16,8 +16,8 @@ class NodeViewRPCSpec extends AnyWordSpec
   val txId: String = txs.head.id.toString
   val block: Block = blockGen.sample.get.copy(transactions = txs)
 
-  view().history.storage.update(block, isBest = false)
-  view().pool.putWithoutCheck(txs, block.timestamp)
+  view()._1.storage.update(block, isBest = false)
+  view()._3.putWithoutCheck(txs, block.timestamp)
 
   "NodeView RPC" should {
     "Get first 100 transactions in mempool" in {

--- a/src/test/scala/co/topl/api/RPCMockState.scala
+++ b/src/test/scala/co/topl/api/RPCMockState.scala
@@ -1,11 +1,13 @@
 package co.topl.api
 
+import java.io.File
+
 import akka.actor.{ActorRef, ActorSystem}
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{HttpEntity, HttpMethods, HttpRequest, MediaTypes}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.pattern.ask
+import akka.testkit.TestActorRef
 import akka.util.{ByteString, Timeout}
 import co.topl.consensus.{Forger, ForgerRef, KeyManager, KeyManagerRef}
 import co.topl.http.HttpService
@@ -13,22 +15,18 @@ import co.topl.http.api.ApiEndpoint
 import co.topl.http.api.endpoints._
 import co.topl.modifier.block.Block
 import co.topl.network.message.BifrostSyncInfo
-import co.topl.nodeView.NodeViewHolder.ReceivableMessages.GetDataFromCurrentView
 import co.topl.nodeView.history.History
 import co.topl.nodeView.mempool.MemPool
+import co.topl.nodeView.nodeViewHolder.TestableNodeViewHolder
 import co.topl.nodeView.state.State
-import co.topl.nodeView.{CurrentView, NodeViewHolder, NodeViewHolderRef}
 import co.topl.settings.{AppContext, AppSettings, StartupOpts}
 import co.topl.utils.GenesisGenerators
+import co.topl.utils.NetworkType.NetworkPrefix
 import org.scalatest.wordspec.AnyWordSpec
 
-import java.io.File
-import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
-trait RPCMockState extends AnyWordSpec
-  with GenesisGenerators
-  with ScalatestRouteTest {
+trait RPCMockState extends AnyWordSpec with GenesisGenerators with ScalatestRouteTest {
 
   type BSI = BifrostSyncInfo
   type PMOD = Block
@@ -40,23 +38,34 @@ trait RPCMockState extends AnyWordSpec
 
   val rpcSettings: AppSettings = settings.copy(
     application = settings.application.copy(
-    dataDir = Some(tempFile.getPath + "data")
-  ))
+      dataDir = Some(tempFile.getPath + "data")
+    )
+  )
 
   val genesisState: State = genesisState(rpcSettings)
 
   //TODO Fails when using rpcSettings
   override def createActorSystem(): ActorSystem = ActorSystem(settings.network.agentName)
 
-  /* ----------------- *//* ----------------- *//* ----------------- *//* ----------------- *//* ----------------- */
+  /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
   // save environment into a variable for reference throughout the application
   protected val appContext = new AppContext(rpcSettings, StartupOpts.empty, None)
 
+  // place network prefix into implicit scope
+  override implicit val networkPrefix: NetworkPrefix = appContext.networkType.netPrefix
+
   // Create Bifrost singleton actors
   protected val keyManagerRef: ActorRef = KeyManagerRef(KeyManager.actorName, rpcSettings, appContext)
-  protected val forgerRef: ActorRef = ForgerRef[BSI, PMOD, HIS, ST, MP](Forger.actorName, rpcSettings, appContext, keyManagerRef)
-  protected val nodeViewHolderRef: ActorRef = NodeViewHolderRef(NodeViewHolder.actorName, rpcSettings, appContext)
-  /* ----------------- *//* ----------------- *//* ----------------- *//* ----------------- *//* ----------------- */
+  protected val forgerRef: ActorRef = ForgerRef[HIS, ST, MP](Forger.actorName, rpcSettings, appContext, keyManagerRef)
+
+  // create actor manually so that we have access to the underlying instance of the class in order
+  // to directly manipulate the nodeview
+  protected val nodeViewHolderRef: TestActorRef[TestableNodeViewHolder] = TestActorRef(
+    new TestableNodeViewHolder(settings, appContext)
+  )
+  private val nvh = nodeViewHolderRef.underlyingActor
+
+  /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */
 
   implicit val timeout: Timeout = Timeout(10.seconds)
 
@@ -71,14 +80,13 @@ trait RPCMockState extends AnyWordSpec
   private val httpService = HttpService(apiRoutes, rpcSettings.rpcApi)
   val route: Route = httpService.compositeRoute
 
-  def httpPOST(jsonRequest: ByteString): HttpRequest = {
+  def httpPOST(jsonRequest: ByteString): HttpRequest =
     HttpRequest(
       HttpMethods.POST,
       entity = HttpEntity(MediaTypes.`application/json`, jsonRequest)
     ).withHeaders(RawHeader("x-api-key", "test_key"))
-  }
 
-  protected def view(): CurrentView[History, State, MemPool] = Await.result(
-    (nodeViewHolderRef ? GetDataFromCurrentView).mapTo[CurrentView[History, State, MemPool]],
-    10.seconds)
+  // this method returns modifiable instances of the node view components
+  protected def view(): (History, State, MemPool) = nvh.nodeViewPublicAccessor
+
 }

--- a/src/test/scala/co/topl/api/program/ProgramRPCMockState.scala
+++ b/src/test/scala/co/topl/api/program/ProgramRPCMockState.scala
@@ -14,7 +14,7 @@ trait ProgramRPCMockState extends RPCMockState
 
   def directlyAddPBRStorage(version: ModifierId, boxes: Seq[ProgramBox]): Unit = {
     // Manually manipulate state
-    state.directlyAddPBRStorage(version, boxes, view().state)
+    state.directlyAddPBRStorage(version, boxes, view()._2)
   }
 
   lazy val (signSk, signPk) = sampleUntilNonEmpty(keyPairSetGen).head

--- a/src/test/scala/co/topl/mempool/MempoolSpec.scala
+++ b/src/test/scala/co/topl/mempool/MempoolSpec.scala
@@ -5,6 +5,7 @@ import akka.pattern.ask
 import akka.util.Timeout
 import co.topl.modifier.block.Block
 import co.topl.modifier.transaction.Transaction
+import co.topl.network.NodeViewSynchronizer.ReceivableMessages.{ChangedHistory, ChangedMempool}
 import co.topl.network.message.BifrostSyncInfo
 import co.topl.nodeView.NodeViewHolder.ReceivableMessages.{GetDataFromCurrentView, GetNodeViewChanges, LocallyGeneratedTransaction}
 import co.topl.nodeView.history.{History, HistoryReader}
@@ -35,13 +36,13 @@ class MempoolSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matcher
 
   private def getHistory: HistoryReader[Block, BifrostSyncInfo] = Await.result(
     (nodeViewHolderRef ? GetNodeViewChanges(history = true, state = false, mempool = false))
-      .mapTo[HistoryReader[Block, BifrostSyncInfo]],
+      .mapTo[ChangedHistory[HistoryReader[Block, BifrostSyncInfo]]].map(_.reader),
     10.seconds
   )
 
   private def getMempool: MemPoolReader[Transaction.TX] = Await.result(
     (nodeViewHolderRef ? GetNodeViewChanges(history = false, state = false, mempool = true))
-      .mapTo[MemPoolReader[Transaction.TX]],
+      .mapTo[ChangedMempool[MemPoolReader[Transaction.TX]]].map(_.reader),
     10.seconds
   )
 

--- a/src/test/scala/co/topl/mempool/MempoolSpec.scala
+++ b/src/test/scala/co/topl/mempool/MempoolSpec.scala
@@ -10,7 +10,7 @@ import co.topl.nodeView.NodeViewHolder.ReceivableMessages.{GetDataFromCurrentVie
 import co.topl.nodeView.history.{History, HistoryReader}
 import co.topl.nodeView.mempool.{MemPool, MemPoolReader}
 import co.topl.nodeView.state.State
-import co.topl.nodeView.{CurrentView, NodeViewHolderRef}
+import co.topl.nodeView.NodeViewHolderRef
 import co.topl.settings.{AppContext, StartupOpts}
 import co.topl.utils.CoreGenerators
 import org.scalatest.DoNotDiscover

--- a/src/test/scala/co/topl/mempool/MempoolSpec.scala
+++ b/src/test/scala/co/topl/mempool/MempoolSpec.scala
@@ -3,9 +3,12 @@ package co.topl.mempool
 import akka.actor.{ActorRef, ActorSystem}
 import akka.pattern.ask
 import akka.util.Timeout
-import co.topl.nodeView.NodeViewHolder.ReceivableMessages.{GetDataFromCurrentView, LocallyGeneratedTransaction}
-import co.topl.nodeView.history.History
-import co.topl.nodeView.mempool.MemPool
+import co.topl.modifier.block.Block
+import co.topl.modifier.transaction.Transaction
+import co.topl.network.message.BifrostSyncInfo
+import co.topl.nodeView.NodeViewHolder.ReceivableMessages.{GetDataFromCurrentView, GetNodeViewChanges, LocallyGeneratedTransaction}
+import co.topl.nodeView.history.{History, HistoryReader}
+import co.topl.nodeView.mempool.{MemPool, MemPoolReader}
 import co.topl.nodeView.state.State
 import co.topl.nodeView.{CurrentView, NodeViewHolderRef}
 import co.topl.settings.{AppContext, StartupOpts}
@@ -20,10 +23,7 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, ExecutionContext}
 
 @DoNotDiscover
-class MempoolSpec extends AnyPropSpec
-  with ScalaCheckPropertyChecks
-  with Matchers
-  with CoreGenerators {
+class MempoolSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with CoreGenerators {
 
   private implicit val actorSystem: ActorSystem = ActorSystem(settings.network.agentName)
   private implicit val executionContext: ExecutionContext = actorSystem.dispatcher
@@ -33,14 +33,24 @@ class MempoolSpec extends AnyPropSpec
 
   implicit val timeout: Timeout = Timeout(10.seconds)
 
-  private def view() = Await.result(
-    (nodeViewHolderRef ? GetDataFromCurrentView).mapTo[CurrentView[History, State, MemPool]],
-    10.seconds)
+  private def getHistory: HistoryReader[Block, BifrostSyncInfo] = Await.result(
+    (nodeViewHolderRef ? GetNodeViewChanges(history = true, state = false, mempool = false))
+      .mapTo[HistoryReader[Block, BifrostSyncInfo]],
+    10.seconds
+  )
 
-  property("Repeated transactions already in history should be discarded " +
-    "when received by the node view") {
-    val txs = view().history.bestBlock.transactions
+  private def getMempool: MemPoolReader[Transaction.TX] = Await.result(
+    (nodeViewHolderRef ? GetNodeViewChanges(history = false, state = false, mempool = true))
+      .mapTo[MemPoolReader[Transaction.TX]],
+    10.seconds
+  )
+
+  property(
+    "Repeated transactions already in history should be discarded " +
+    "when received by the node view"
+  ) {
+    val txs = getHistory.bestBlock.transactions
     txs.foreach(tx ⇒ nodeViewHolderRef ! LocallyGeneratedTransaction(tx))
-    txs.foreach(tx ⇒ view().pool.contains(tx) shouldBe false)
+    txs.foreach(tx ⇒ getMempool.contains(tx) shouldBe false)
   }
 }

--- a/src/test/scala/co/topl/nodeView/nodeViewHolder/TestableNodeViewHolder.scala
+++ b/src/test/scala/co/topl/nodeView/nodeViewHolder/TestableNodeViewHolder.scala
@@ -6,11 +6,21 @@ import co.topl.utils.NetworkType.NetworkPrefix
 
 import scala.concurrent.ExecutionContext
 
-class TestableNodeViewHolder(settings: AppSettings, appContext: AppContext)(implicit
-  ec:                                  ExecutionContext,
-  np:                                  NetworkPrefix
+class TestableNodeViewHolder(
+  settings:   AppSettings,
+  appContext: AppContext
+)(implicit
+  ec: ExecutionContext,
+  np: NetworkPrefix
 ) extends NodeViewHolder(settings, appContext) {
 
   def nodeViewPublicAccessor: NodeView = (history(), minimalState(), memoryPool())
+
+  def updateNodeViewPublicAccessor(
+    updatedHistory: Option[HIS] = None,
+    updatedState:   Option[MS] = None,
+    updatedMempool: Option[MP] = None
+  ): Unit =
+    updateNodeView(updatedHistory, updatedState, updatedMempool)
 
 }

--- a/src/test/scala/co/topl/nodeView/nodeViewHolder/TestableNodeViewHolder.scala
+++ b/src/test/scala/co/topl/nodeView/nodeViewHolder/TestableNodeViewHolder.scala
@@ -1,0 +1,16 @@
+package co.topl.nodeView.nodeViewHolder
+
+import co.topl.nodeView.NodeViewHolder
+import co.topl.settings.{AppContext, AppSettings}
+import co.topl.utils.NetworkType.NetworkPrefix
+
+import scala.concurrent.ExecutionContext
+
+class TestableNodeViewHolder(settings: AppSettings, appContext: AppContext)(implicit
+  ec:                                  ExecutionContext,
+  np:                                  NetworkPrefix
+) extends NodeViewHolder(settings, appContext) {
+
+  def nodeViewPublicAccessor: NodeView = (history(), minimalState(), memoryPool())
+
+}


### PR DESCRIPTION
## Summary
When Bifrost was first written, the method for retrieving data from various node view components (history, state, mempool) was to ask the NodeViewHolder to return it's current nodeView wrapped in a case class. Two problems became apparent using this approach.
1. The components returned in the `CurrentView` class exposed the complete API for each of the components. Meaning that it was possible to manipulate (write to) a node view component directly and therefore bypass the validation and event sourcing that accompanies node view updates when done through the NodeViewHolder.
2. In every use case so far, we have only ever needed a single component to complete the functions that require a `CurrentView` from the NodeViewHolder.

To solve these problems an alternative pattern was partially adopted during the Scorex upgrade last summer. This process introduced `Reader` traits for each component that only expose getter type methods. We've also deprecated the `CurrentView` case class in favor of individual `Changed<COMP>` classes. 

## Changes
- Refactored forging process to use a context bound receive statement
- Removed `forgeTime` global var in the Forger (reduced it's scope to the forging attempt)
- Reduced the number of generic types in the forger signature
- Updated API to target individual node view components
- Removed `CurrentView` case class and controller for the message in NodeViewHolder
- Refactored component readers to include additional read methods
  - NOTE: I'd like us to take a harder look at these readers at some point. Their functionality has organically evolved and they should be scrutinized
- Modified tests to remove `CurrentView` usage
- Added a `TestableNodeViewHolder` in the tests package to expose protected methods in the NodeViewHolder 
  - this is needed to directly manipulate the NVH during unit testing

## Testing
- All tests available from `sbt:test` run and pass successfully
- Basic runtime behavior was verified (forging starts from genesis and RPC requests are fulfilled)

## Affected issues
- closes #615 