### PR TITLE
Balances RPC Response Boxes Type

### DIFF
--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
@@ -152,8 +152,9 @@ object ToplRpc {
         */
       case class Params(addresses: List[Address])
       type Response = Map[Address, Entry]
-      case class Entry(Balances: EntryBalances, Boxes: Map[String, List[TokenBox[_]]])
+      case class Entry(Balances: EntryBalances, Boxes: EntryBoxes)
       case class EntryBalances(Polys: Int128, Arbits: Int128)
+      case class EntryBoxes(PolyBox: List[PolyBox], ArbitBox: List[ArbitBox], AssetBox: List[AssetBox])
     }
 
     object TransactionById {

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
@@ -1,6 +1,5 @@
 package co.topl.rpc
 
-import cats.implicits._
 import co.topl.attestation.{Address, Proposition}
 import co.topl.modifier.ModifierId
 import co.topl.modifier.block.Block
@@ -188,14 +187,18 @@ trait NodeViewRpcResponseDecoders extends SharedCodecs {
   implicit val nodeViewInfoResponseDecoder: Decoder[ToplRpc.NodeView.Info.Response] =
     deriveDecoder
 
-  implicit def nodeViewBalancesResponseEntryBalancesDecoder(implicit
-    networkPrefix: NetworkPrefix
-  ): Decoder[ToplRpc.NodeView.Balances.EntryBalances] =
+  implicit val nodeViewBalancesResponseEntryBalancesDecoder: Decoder[ToplRpc.NodeView.Balances.EntryBalances] =
     deriveDecoder
 
-  implicit def nodeViewBalancesResponseEntryDecoder(implicit
-    networkPrefix: NetworkPrefix
-  ): Decoder[ToplRpc.NodeView.Balances.Entry] =
+  implicit val nodeViewBalancesResponseEntryBoxesDecoder: Decoder[ToplRpc.NodeView.Balances.EntryBoxes] =
+    c =>
+      for {
+        polyBox  <- c.getOrElse[List[PolyBox]]("PolyBox")(Nil)
+        arbitBox <- c.getOrElse[List[ArbitBox]]("ArbitBox")(Nil)
+        assetBox <- c.getOrElse[List[AssetBox]]("AssetBox")(Nil)
+      } yield ToplRpc.NodeView.Balances.EntryBoxes(polyBox, arbitBox, assetBox)
+
+  implicit val nodeViewBalancesResponseEntryDecoder: Decoder[ToplRpc.NodeView.Balances.Entry] =
     deriveDecoder
 
   implicit def nodeViewBalancesResponseDecoder(implicit
@@ -446,6 +449,9 @@ trait NodeViewRpcResponseEncoders extends SharedCodecs {
   implicit val nodeViewBalancesResponseEntryBalancesEncoder: Encoder[ToplRpc.NodeView.Balances.EntryBalances] =
     deriveEncoder
 
+  implicit val nodeViewBalancesResponseEntryBoxesEncoder: Encoder[ToplRpc.NodeView.Balances.EntryBoxes] =
+    deriveEncoder
+
   implicit val nodeViewBalancesResponseEncoder: Encoder[ToplRpc.NodeView.Balances.Response] =
     _.map { case (address, entry) =>
       Address.jsonKeyEncoder(address) -> entry
@@ -542,11 +548,14 @@ trait SharedCodecs {
       .map { case a: PolyTransfer[Proposition @unchecked] =>
         a
       }
-  implicit val tokenBoxEncoder: Encoder[TokenBox[_]] = b => Box.jsonEncoder(b)
 
-  implicit val tokenBoxDecoder: Decoder[TokenBox[_]] =
-    List[Decoder[TokenBox[_]]](ArbitBox.jsonDecoder.widen, PolyBox.jsonDecoder.widen, AssetBox.jsonDecoder.widen)
-      .reduceLeft(_ or _)
+  implicit def polyBoxEncoder: Encoder[PolyBox] = PolyBox.jsonEncoder
+  implicit def arbitBoxEncoder: Encoder[ArbitBox] = ArbitBox.jsonEncoder
+  implicit def assetBoxEncoder: Encoder[AssetBox] = AssetBox.jsonEncoder
+  implicit def polyBoxDecoder: Decoder[PolyBox] = PolyBox.jsonDecoder
+  implicit def arbitBoxDecoder: Decoder[ArbitBox] = ArbitBox.jsonDecoder
+  implicit def assetBoxDecoder: Decoder[AssetBox] = AssetBox.jsonDecoder
+
   implicit def int128Encoder: Encoder[Int128] = Int128Codec.jsonEncoder
   implicit def int128Decoder: Decoder[Int128] = Int128Codec.jsonDecoder
   implicit def simpleValueEncoder: Encoder[SimpleValue] = SimpleValue.jsonEncoder

--- a/topl-rpc/src/test/scala/co/topl/rpc/ToplRpcCodecsSpec.scala
+++ b/topl-rpc/src/test/scala/co/topl/rpc/ToplRpcCodecsSpec.scala
@@ -1,0 +1,42 @@
+package co.topl.rpc
+
+import co.topl.attestation.keyManagement.PrivateKeyCurve25519
+import co.topl.modifier.box._
+import co.topl.utils.NetworkType
+import co.topl.utils.NetworkType.NetworkPrefix
+import io.circe.syntax._
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ToplRpcCodecsSpec extends AnyFlatSpec with ToplRpcCodecs with Matchers with EitherValues {
+
+  private implicit val networkPrefix: NetworkPrefix = NetworkType.PrivateTestnet.netPrefix
+
+  private val address = PrivateKeyCurve25519.secretGenerator.generateSecret("test".getBytes)._2.address
+  private val assetCode = AssetCode(1: Byte, address, "test")
+
+  behavior of "ToplRpcCodecs"
+
+  it should "encode and decode EntryBoxes with values for each box type" in {
+    val boxes = ToplRpc.NodeView.Balances.EntryBoxes(
+      List(PolyBox(address.evidence, 0L, SimpleValue(50))),
+      List(ArbitBox(address.evidence, 0L, SimpleValue(50))),
+      List(AssetBox(address.evidence, 0L, AssetValue(50, assetCode)))
+    )
+
+    val encoded = boxes.asJson
+
+    val decoded = encoded.as[ToplRpc.NodeView.Balances.EntryBoxes].value
+
+    boxes shouldBe decoded
+  }
+
+  it should "decode EntryBoxes with a missing box type" in {
+    val polyBox = PolyBox(address.evidence, 0L, SimpleValue(50))
+    val raw = raw"""{"PolyBox": [${polyBox.asJson}]}"""
+    val parsedPolyBox = io.circe.parser.parse(raw).flatMap(_.as[ToplRpc.NodeView.Balances.EntryBoxes]).value
+    parsedPolyBox shouldBe ToplRpc.NodeView.Balances.EntryBoxes(List(polyBox), Nil, Nil)
+  }
+
+}


### PR DESCRIPTION
## Purpose
- A bug in the topl-rpc Box decoder causes all returned boxes in Balances.Response.{}.Boxes to be an `ArbitBox`
- Balances.Response.{}.Boxes was a generic Map but could be made into a type-specific case class instead

## Approach
- Added `Balances.EntryBoxes` case class
- Implemented corresponding codecs

## Testing
- Implemented unit tests for EntryBoxes codecs

## Tickets
- closes #1271 