### PR TITLE
Refactor NodeViewSynchronizer initialization

### DIFF
--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -2,7 +2,7 @@ bifrost {
 
   application {
     # application version of this software
-    version { value = 1.4.3 }
+    version { value = 1.4.4 }
 
     # directory where all network data is stored
     dataDir = ".bifrost/private-testnet/data"

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -2,7 +2,7 @@ bifrost {
 
   application {
     # application version of this software
-    version { value = 1.4.2 }
+    version { value = 1.4.3 }
 
     # directory where all network data is stored
     dataDir = ".bifrost/private-testnet/data"

--- a/node/src/main/scala/co/topl/network/NodeViewSynchronizer.scala
+++ b/node/src/main/scala/co/topl/network/NodeViewSynchronizer.scala
@@ -94,12 +94,6 @@ class NodeViewSynchronizer[
     context.system.eventStream.subscribe(self, classOf[ModificationOutcome])
     context.system.eventStream.subscribe(self, classOf[DownloadRequest])
     context.system.eventStream.subscribe(self, classOf[ModifiersProcessingResult[PMOD]])
-
-    /** instantiate the internal NodeViewSynchronizer state for History and Mempool */
-    viewHolderRef ! GetNodeViewChanges(history = true, state = false, mempool = true)
-
-    /** schedules a SendLocalSyncInfo message to be sent at a fixed interval */
-    statusTracker.scheduleSendSyncInfo()
   }
 
   ////////////////////////////////////////////////////////////////////////////////////
@@ -120,7 +114,15 @@ class NodeViewSynchronizer[
   // ----------- MESSAGE PROCESSING FUNCTIONS ----------- //
   private def initialization(): Receive = { case NodeViewReady(_) =>
     log.info(s"${Console.YELLOW}NodeViewSynchronizer transitioning to the operational state${Console.RESET}")
-    context become operational
+
+    /** instantiate the internal NodeViewSynchronizer state for History and Mempool */
+    viewHolderRef ! GetNodeViewChanges(history = true, state = false, mempool = true)
+
+    /** schedules a SendLocalSyncInfo message to be sent at a fixed interval */
+    statusTracker.scheduleSendSyncInfo()
+
+    /** set the state of the actor */
+    context.become(operational)
   }
 
   protected def processSyncStatus: Receive = {

--- a/node/src/main/scala/co/topl/nodeView/history/History.scala
+++ b/node/src/main/scala/co/topl/nodeView/history/History.scala
@@ -129,9 +129,10 @@ class History(
           (new History(storage, fullBlockProcessor, validators), progInfo)
         }
       }
-      log.info(s"${Console.CYAN} block ${block.id} appended to parent ${block.parentId} with score ${storage
-        .scoreOf(block.id)}.${Console.RESET}")
-      // return result
+      log.info(
+        s"${Console.CYAN} Block ${block.id} appended to parent ${block.parentId} at height ${block.height} with score ${storage
+          .scoreOf(block.id)}.${Console.RESET}"
+      )
       res
 
     } else {

--- a/node/src/main/scala/co/topl/nodeView/history/History.scala
+++ b/node/src/main/scala/co/topl/nodeView/history/History.scala
@@ -129,7 +129,8 @@ class History(
           (new History(storage, fullBlockProcessor, validators), progInfo)
         }
       }
-      log.info(s"block ${block.id} appended to parent ${block.parentId} with score ${storage.scoreOf(block.id)}.")
+      log.info(s"${Console.CYAN} block ${block.id} appended to parent ${block.parentId} with score ${storage
+        .scoreOf(block.id)}.${Console.RESET}")
       // return result
       res
 


### PR DESCRIPTION
## Purpose
Currently, when restarting Valhalla, I observe the NetworkController receiving many unhandled messages from the NodeViewSynchronizer due to the setup of the NVS preStart function which schedules a peer connection attempt. This scheduling should be delayed until the NodeviewHolder is ready since the NetworkController can't process any messages until this point.

## Changes
- Moved the scheduling invocations to occur when the `NodeViewReady` message is received

## Testing
- Ran in local environment
- All tests passing
