### PR TITLE
AppSettings lenses

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,11 +83,13 @@ object Dependencies {
 
   val node: Seq[ModuleID] = {
     Seq(
-      "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
-      "com.typesafe.akka" %% "akka-remote"  % akkaVersion,
-      "com.typesafe"       % "config"       % "1.4.1",
-      "com.lihaoyi"       %% "mainargs"     % "0.2.1",
-      "net.jpountz.lz4"    % "lz4"          % "1.3.0"
+      "com.typesafe.akka"          %% "akka-cluster"  % akkaVersion,
+      "com.typesafe.akka"          %% "akka-remote"   % akkaVersion,
+      "com.typesafe"                % "config"        % "1.4.1",
+      "com.lihaoyi"                %% "mainargs"      % "0.2.1",
+      "net.jpountz.lz4"             % "lz4"           % "1.3.0",
+      "com.github.julien-truffaut" %% "monocle-core"  % "3.0.0-M5",
+      "com.github.julien-truffaut" %% "monocle-macro" % "3.0.0-M5"
     ) ++
     logging ++
     test ++


### PR DESCRIPTION
## Purpose
Copying and replacing every field in a large, nested case class leads to verbose code. This PR removes the boilerplate by introducing lenses, that can be generated for every field in a case class. Now whenever many changes need to be made to a single instance of a case class, in particular `AppSettings`, these much more concise lenses can be used instead.


## Approach
* Implement `Focus` macro from the Monocle library to generate lenses for each value being modified from `AppSettings` in `StartupOpts`
* Replicate each copy operation as a `modify` or `replace`

## Testing
* Manually tested all startup flags to make sure behavior is preserved for every option

## Tickets
* closes #1125 