### PR TITLE
crossbuild-patch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -183,6 +183,7 @@ lazy val node = project.in(file("node"))
     commonSettings,
     assemblySettings,
     Defaults.itSettings,
+    crossScalaVersions := Seq(scala213), // don't care about cross-compiling applications
     publish / skip := true,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "co.topl.buildinfo.bifrost",
@@ -260,6 +261,7 @@ lazy val gjallarhorn = project.in(file("gjallarhorn"))
   .settings(
     name := "gjallarhorn",
     commonSettings,
+    crossScalaVersions := Seq(scala213), // don't care about cross-compiling applications
     publish / skip := true,
     Defaults.itSettings,
     libraryDependencies ++= Dependencies.gjallarhorn

--- a/common/src/main/scala/co/topl/modifier/transaction/validation/SemanticallyValidatable.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/validation/SemanticallyValidatable.scala
@@ -10,6 +10,7 @@ import co.topl.utils.Int128
 import co.topl.utils.NetworkType.NetworkPrefix
 import simulacrum._
 
+import scala.collection.compat.immutable.LazyList
 import scala.language.implicitConversions
 
 @typeclass trait SemanticallyValidatable[T] {

--- a/common/src/main/scala/co/topl/utils/Extensions.scala
+++ b/common/src/main/scala/co/topl/utils/Extensions.scala
@@ -1,8 +1,8 @@
 package co.topl.utils
 
 import java.nio.charset.{Charset, StandardCharsets}
-import scala.collection.BuildFrom
 import scala.reflect.ClassTag
+import scala.collection.compat.BuildFrom
 
 object Extensions {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -104,8 +104,9 @@ object Dependencies {
 
   lazy val common: Seq[ModuleID] = {
     Seq(
-      "com.typesafe.akka" %% "akka-actor" % akkaVersion,
-      "org.typelevel"     %% "simulacrum" % "1.0.0"
+      "com.typesafe.akka"      %% "akka-actor"              % akkaVersion,
+      "org.typelevel"          %% "simulacrum"              % "1.0.0",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.4"
     ) ++
     logging ++
     circe ++
@@ -115,8 +116,9 @@ object Dependencies {
 
   lazy val chainProgram: Seq[ModuleID] =
     Seq(
-      "io.circe" %% "circe-core"   % circeVersion,
-      "io.circe" %% "circe-parser" % circeVersion
+      "io.circe"               %% "circe-core"              % circeVersion,
+      "io.circe"               %% "circe-parser"            % circeVersion,
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.4"
     ) ++
     test ++
     graal
@@ -126,9 +128,10 @@ object Dependencies {
 
   lazy val akkaHttpRpc: Seq[ModuleID] =
     Seq(
-      "de.heikoseeberger" %% "akka-http-circe" % "1.36.0",
-      "io.circe"          %% "circe-optics"    % circeVersion,
-      "io.circe"          %% "circe-generic"   % circeVersion
+      "de.heikoseeberger"      %% "akka-http-circe"         % "1.36.0",
+      "io.circe"               %% "circe-optics"            % circeVersion,
+      "io.circe"               %% "circe-generic"           % circeVersion,
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.4"
     ) ++
     circe ++
     akka ++
@@ -136,7 +139,8 @@ object Dependencies {
 
   lazy val toplRpc: Seq[ModuleID] =
     Seq(
-      "io.circe" %% "circe-generic" % circeVersion
+      "io.circe"               %% "circe-generic"           % circeVersion,
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.4"
     ) ++
     circe ++
     test


### PR DESCRIPTION
This is a patch to fix some Scala version incompatibilities that use `LazyList` or `BuildFrom`, which are only in Scala 2.13.