### PR TITLE
Fix target calculation overflow

### DIFF
--- a/node/src/main/scala/co/topl/consensus/BlockValidator.scala
+++ b/node/src/main/scala/co/topl/consensus/BlockValidator.scala
@@ -64,7 +64,7 @@ class DifficultyBlockValidator(storage: Storage, blockProcessor: BlockProcessor)
     )
 
     // did the forger create a block with a valid forger box and adjusted difficulty?
-    require(hit < target, s"Block difficulty failed since $hit >= $target")
+    require(BigInt(hit) < target, s"Block difficulty failed since $hit >= $target")
   }
 
   /** Helper function to find the source of the parent block (either storage or chain cache) */

--- a/node/src/main/scala/co/topl/consensus/LeaderElection.scala
+++ b/node/src/main/scala/co/topl/consensus/LeaderElection.scala
@@ -45,7 +45,7 @@ object LeaderElection extends Logging {
         boxes
           .map(box => (box, calcHit(parent)(box)))
           .filter { case (box, hit) =>
-            hit < calcTarget(box.value.quantity, timestamp - parent.timestamp, parent.difficulty, parent.height)
+            BigInt(hit) < calcTarget(box.value.quantity, timestamp - parent.timestamp, parent.difficulty, parent.height)
           }
           .map(_._1)
           .headOption

--- a/node/src/main/scala/co/topl/consensus/package.scala
+++ b/node/src/main/scala/co/topl/consensus/package.scala
@@ -63,9 +63,9 @@ package object consensus {
    * @param parentHeight parent block height
    * @return the target value
    */
-  def calcTarget(stakeAmount: Int128, timeDelta: Long, difficulty: Long, parentHeight: Long): Int128 =
-    (stakeAmount * difficulty * timeDelta) /
-    (consensusStorage.totalStake * targetBlockTime(parentHeight).toUnit(MILLISECONDS).toLong)
+  def calcTarget(stakeAmount: Int128, timeDelta: Long, difficulty: Long, parentHeight: Long): BigInt =
+    (BigInt(stakeAmount.toByteArray) * BigInt(difficulty) * BigInt(timeDelta)) /
+    (BigInt(consensusStorage.totalStake.toByteArray) * targetBlockTime(parentHeight).toUnit(MILLISECONDS).toLong)
 
   /**
    * Calculate the block difficulty according to


### PR DESCRIPTION
## Purpose

There is a bug on the Valhalla network where new nodes are unable to sync beyond the genesis block due to an error calculating the target threshold. This bug is due to an overflow in the numerator of the `calcTarget` function within the `consensus` package.

## Approach

I've converted all of the values from `Int128` types to `BigInt` types so that no overflow will occur on the numerator multiplication. BigInt values have an extremely large upper bound, so overflows will no longer be a problem.

## Closes

- #1439