### PR TITLE
Ignore block validation for blocks impacted by target overflow bug

### DIFF
--- a/node/src/main/scala/co/topl/consensus/Hiccups.scala
+++ b/node/src/main/scala/co/topl/consensus/Hiccups.scala
@@ -1,0 +1,55 @@
+package co.topl.consensus
+
+import co.topl.utils.NetworkType.{NetworkPrefix, ValhallaTestnet}
+
+/**
+ * Represents the sets of blocks that should have failed to be added to networks, but were anyways.
+ */
+object Hiccups {
+
+  /**
+   * Represents a block that passed validation at some point in a chain when it should not have.
+   * @param id the ID of the block
+   * @param height the height of the block
+   */
+  case class HiccupBlock(id: String, height: Long, networkPrefix: NetworkPrefix)
+
+  /**
+   * Represent hiccups with semantic validation that should be ignored in node view holder checks.
+   */
+  val semanticValidation: Seq[HiccupBlock] = Seq(
+    HiccupBlock(
+      "29QHPjqyLB1QN6DhArf125Nu3qfgKLcPRnZGvaCX8qDNf",
+      255181,
+      ValhallaTestnet.netPrefix
+    ),
+    HiccupBlock(
+      "2AsEgm1548vbwos8qqfe1qwwBF6Ef1mzKnRhPvZpALM2A",
+      262558,
+      ValhallaTestnet.netPrefix
+    ),
+    HiccupBlock(
+      "293EqLkRWEEjV8aW99w4xXeyescvriYXytHdSn7LudSd1",
+      262875,
+      ValhallaTestnet.netPrefix
+    )
+  )
+
+  /**
+   * Represents hiccups with block validation that should be ignored in history appends.
+   */
+  val blockValidation: Seq[HiccupBlock] = Seq(
+    // Valhalla
+    HiccupBlock(
+      "21oHt9kQaKRn5wnTvBPG1wUaeUGAVBKPQMbh1ZjFqviu4",
+      928865,
+      ValhallaTestnet.netPrefix
+    ),
+    // Valhalla
+    HiccupBlock(
+      "xNtkkMJd3oHd9W8iHdrNoJR8KZ6KdZYDUTh7rWeBkgtE",
+      929061,
+      ValhallaTestnet.netPrefix
+    ),
+  )
+}

--- a/node/src/main/scala/co/topl/consensus/Hiccups.scala
+++ b/node/src/main/scala/co/topl/consensus/Hiccups.scala
@@ -39,17 +39,25 @@ object Hiccups {
    * Represents hiccups with block validation that should be ignored in history appends.
    */
   val blockValidation: Seq[HiccupBlock] = Seq(
-    // Valhalla
+    HiccupBlock(
+      "25A6uT3GrnEd8kVA8caZVedeGoCzy7Qojb2UvZtpDBtbc",
+      927870,
+      ValhallaTestnet.netPrefix
+    ),
+    HiccupBlock(
+      "xvVKLeN2k2KJgpcENgo6fTJtxou7wz58YutVXR9SRHkj",
+      928143,
+      ValhallaTestnet.netPrefix
+    ),
     HiccupBlock(
       "21oHt9kQaKRn5wnTvBPG1wUaeUGAVBKPQMbh1ZjFqviu4",
       928865,
       ValhallaTestnet.netPrefix
     ),
-    // Valhalla
     HiccupBlock(
       "xNtkkMJd3oHd9W8iHdrNoJR8KZ6KdZYDUTh7rWeBkgtE",
       929061,
       ValhallaTestnet.netPrefix
-    ),
+    )
   )
 }

--- a/node/src/main/scala/co/topl/consensus/package.scala
+++ b/node/src/main/scala/co/topl/consensus/package.scala
@@ -65,7 +65,9 @@ package object consensus {
    */
   def calcTarget(stakeAmount: Int128, timeDelta: Long, difficulty: Long, parentHeight: Long): BigInt =
     (BigInt(stakeAmount.toByteArray) * BigInt(difficulty) * BigInt(timeDelta)) /
-    (BigInt(consensusStorage.totalStake.toByteArray) * targetBlockTime(parentHeight).toUnit(MILLISECONDS).toLong)
+    (BigInt(consensusStorage.totalStake.toByteArray) * BigInt(
+      targetBlockTime(parentHeight).toUnit(MILLISECONDS).toLong
+    ))
 
   /**
    * Calculate the block difficulty according to

--- a/node/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
+++ b/node/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
@@ -16,7 +16,7 @@ import co.topl.modifier.transaction.serialization.TransactionSerializer
 import co.topl.modifier.transaction.validation.implicits._
 import co.topl.modifier.{ModifierId, NodeViewModifier}
 import co.topl.network.NodeViewSynchronizer.ReceivableMessages._
-import co.topl.nodeView.NodeViewHolder.{consensusCheckpoints, UpdateInformation}
+import co.topl.nodeView.NodeViewHolder.{UpdateInformation, consensusCheckpoints}
 import co.topl.nodeView.history.GenericHistory.ProgressInfo
 import co.topl.nodeView.history.History
 import co.topl.nodeView.mempool.MemPool
@@ -524,7 +524,13 @@ object NodeViewHolder {
   val consensusCheckpoints: Seq[ModifierId] = Seq(
     ModifierId.fromBase58(
       Base58Data.unsafe("29QHPjqyLB1QN6DhArf125Nu3qfgKLcPRnZGvaCX8qDNf")
-    ) // block height 255181 Valhalla testnet
+    ), // block height 255181 Valhalla testnet
+    ModifierId.fromBase58(
+      Base58Data.unsafe("2AsEgm1548vbwos8qqfe1qwwBF6Ef1mzKnRhPvZpALM2A")
+    ), // block height 262558 Valhalla testnet
+    ModifierId.fromBase58(
+      Base58Data.unsafe("293EqLkRWEEjV8aW99w4xXeyescvriYXytHdSn7LudSd1")
+    ) // block height 262875 Valhalla testnet
   )
 }
 

--- a/node/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
+++ b/node/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
@@ -258,7 +258,7 @@ class NodeViewHolder(settings: AppSettings, appContext: AppContext)(implicit ec:
 
       def isBlockTxsValidated: Boolean =
         Hiccups.semanticValidation.contains(HiccupBlock(pmod.id.toString, pmod.height, np)) ||
-          pmod.transactions.forall(_.semanticValidation(minimalState()).isValid)
+        pmod.transactions.forall(_.semanticValidation(minimalState()).isValid)
 
       // check that the transactions are semantically valid
       if (isBlockTxsValidated) {

--- a/node/src/main/scala/co/topl/nodeView/history/History.scala
+++ b/node/src/main/scala/co/topl/nodeView/history/History.scala
@@ -1,7 +1,7 @@
 package co.topl.nodeView.history
 
 import co.topl.consensus.Hiccups.HiccupBlock
-import co.topl.consensus.{BlockValidator, DifficultyBlockValidator, Hiccups, SyntaxBlockValidator}
+import co.topl.consensus.{BlockValidator, DifficultyBlockValidator, Hiccups, SyntaxBlockValidator, TimestampValidator}
 import co.topl.modifier.ModifierId
 import co.topl.modifier.NodeViewModifier.ModifierTypeId
 import co.topl.modifier.block.Block
@@ -497,7 +497,8 @@ object History extends Logging {
 
     val validators = Seq(
       new DifficultyBlockValidator(storage, blockProcessor),
-      new SyntaxBlockValidator
+      new SyntaxBlockValidator,
+      new TimestampValidator(storage)
     )
 
     new History(storage, blockProcessor, validators)

--- a/node/src/main/scala/co/topl/nodeView/history/History.scala
+++ b/node/src/main/scala/co/topl/nodeView/history/History.scala
@@ -28,7 +28,8 @@ class History(
   val storage:        Storage, //todo: JAA - make this private[history]
   fullBlockProcessor: BlockProcessor,
   validators:         Seq[BlockValidator[Block]]
-)(implicit np: NetworkPrefix) extends GenericHistory[Block, BifrostSyncInfo, History]
+)(implicit np:        NetworkPrefix)
+    extends GenericHistory[Block, BifrostSyncInfo, History]
     with Logging {
 
   override type NVCT = History


### PR DESCRIPTION
## Purpose

There are two blocks impacted by issue #1439, which are currently valid in the Valhalla testnet despite having timestamps that are previous to their parent timestamp. Once the bug is fixed, these blocks will technically be invalid. These blocks must e added to a list of blocks to be ignored to allow future nodes to sync with the current valhalla chain.

## Approach

I've created a `Hiccups` object in consensus that keeps lists of blocks that should have automatic acceptance without validation in Valhalla. The list contains block id, height, and testnet info.

## Tests

I haven't added any unit tests for this behavior, though it might be good to test the hiccups code in the future.

## Tickets

- closes #1459 
- closes #1456 