### PR TITLE
Add apply method to HiccupBlock

### DIFF
--- a/brambl/src/main/scala/co/topl/client/Brambl.scala
+++ b/brambl/src/main/scala/co/topl/client/Brambl.scala
@@ -4,6 +4,7 @@ import co.topl.akkahttprpc.{CustomError, RpcClientFailure, RpcErrorFailure}
 import co.topl.attestation.keyManagement.{KeyRing, KeyfileCurve25519, KeyfileCurve25519Companion, PrivateKeyCurve25519}
 import co.topl.attestation.{Address, EvidenceProducer, Proof, Proposition}
 import co.topl.modifier.transaction._
+import co.topl.utils.Extensions.IterableOps
 import co.topl.utils.Identifiable
 import co.topl.utils.NetworkType.NetworkPrefix
 import io.circe.Json
@@ -64,7 +65,7 @@ object Brambl {
 
     val msg2Sign = transaction.messageToSign
     val signFunc = (addr: Address) => f(addr)(msg2Sign)
-    val signatures = ListMap.from(addresses.map(signFunc).reduce(_ ++ _))
+    val signatures = addresses.map(signFunc).reduce(_ ++ _).toListMap
 
     // I know this is eliminated by erasure but unsure how to fix at the moment and I've already restrited
     // Brambl to only work with PublicKey props at the moment so this shouldn't fail.

--- a/brambl/src/main/scala/co/topl/client/Brambl.scala
+++ b/brambl/src/main/scala/co/topl/client/Brambl.scala
@@ -4,7 +4,6 @@ import co.topl.akkahttprpc.{CustomError, RpcClientFailure, RpcErrorFailure}
 import co.topl.attestation.keyManagement.{KeyRing, KeyfileCurve25519, KeyfileCurve25519Companion, PrivateKeyCurve25519}
 import co.topl.attestation.{Address, EvidenceProducer, Proof, Proposition}
 import co.topl.modifier.transaction._
-import co.topl.utils.Extensions.IterableOps
 import co.topl.utils.Identifiable
 import co.topl.utils.NetworkType.NetworkPrefix
 import io.circe.Json
@@ -61,11 +60,11 @@ object Brambl {
   def signTransaction[P <: Proposition: EvidenceProducer: Identifiable, TX <: Transaction[_, P]](
     addresses:   Set[Address],
     transaction: TX
-  )(f:           Address => Array[Byte] => Map[P, Proof[P]]): Either[RpcClientFailure, Transaction.TX] = {
+  )(f:           Address => Array[Byte] => ListMap[P, Proof[P]]): Either[RpcClientFailure, Transaction.TX] = {
 
     val msg2Sign = transaction.messageToSign
     val signFunc = (addr: Address) => f(addr)(msg2Sign)
-    val signatures = addresses.map(signFunc).reduce(_ ++ _).toListMap
+    val signatures = addresses.map(signFunc).reduce(_ ++ _)
 
     // I know this is eliminated by erasure but unsure how to fix at the moment and I've already restrited
     // Brambl to only work with PublicKey props at the moment so this shouldn't fail.

--- a/brambl/src/test/scala/co/topl/client/rpcExample.scala
+++ b/brambl/src/test/scala/co/topl/client/rpcExample.scala
@@ -14,6 +14,7 @@ import co.topl.rpc.ToplRpc
 import co.topl.rpc.ToplRpc.NodeView._
 import co.topl.rpc.ToplRpc.Transaction.{BroadcastTx, RawArbitTransfer, RawAssetTransfer, RawPolyTransfer}
 import co.topl.rpc.implicits.client._
+import co.topl.utils.Extensions.IterableOps
 import co.topl.utils.IdiomaticScalaTransition.implicits.toValidatedOps
 import co.topl.utils.StringDataTypes.{Base58Data, Latin1Data}
 import io.circe.syntax.EncoderOps
@@ -156,7 +157,7 @@ object CreateAnDSendRawPolyTransfer {
       genKeys()
       val msg2Sign = rawTx.messageToSign
       val signFunc = (addr: Address) => keyRing.generateAttestation(addr)(msg2Sign)
-      val signatures = ListMap.from(keyRing.addresses.map(signFunc).reduce(_ ++ _))
+      val signatures = keyRing.addresses.map(signFunc).reduce(_ ++ _).toListMap
       Future(rawTx.copy(attestation = signatures))
     }
     broadcastTx <- ToplRpc.Transaction.BroadcastTx.rpc(ToplRpc.Transaction.BroadcastTx.Params(signTx))
@@ -192,7 +193,7 @@ object CreateAnDSendRawArbitTransfer {
       genKeys()
       val msg2Sign = rawTx.messageToSign
       val signFunc = (addr: Address) => keyRing.generateAttestation(addr)(msg2Sign)
-      val signatures = ListMap.from(keyRing.addresses.map(signFunc).reduce(_ ++ _))
+      val signatures = keyRing.addresses.map(signFunc).reduce(_ ++ _).toListMap
       Future(rawTx.copy(attestation = signatures))
     }
     broadcastTx <- ToplRpc.Transaction.BroadcastTx.rpc(ToplRpc.Transaction.BroadcastTx.Params(signTx))
@@ -229,7 +230,7 @@ object CreateAnDSendRawAssetMintingTransfer {
       genKeys()
       val msg2Sign = rawTx.messageToSign
       val signFunc = (addr: Address) => keyRing.generateAttestation(addr)(msg2Sign)
-      val signatures = ListMap.from(keyRing.addresses.map(signFunc).reduce(_ ++ _))
+      val signatures = keyRing.addresses.map(signFunc).reduce(_ ++ _).toListMap
       Future(rawTx.copy(attestation = signatures))
     }
     broadcastTx <- ToplRpc.Transaction.BroadcastTx.rpc(ToplRpc.Transaction.BroadcastTx.Params(signTx))
@@ -265,7 +266,7 @@ object CreateAnDSendRawAssetTransfer {
       genKeys()
       val msg2Sign = rawTx.messageToSign
       val signFunc = (addr: Address) => keyRing.generateAttestation(addr)(msg2Sign)
-      val signatures = ListMap.from(keyRing.addresses.map(signFunc).reduce(_ ++ _))
+      val signatures = keyRing.addresses.map(signFunc).reduce(_ ++ _).toListMap
       Future(rawTx.copy(attestation = signatures))
     }
     broadcastTx <- ToplRpc.Transaction.BroadcastTx.rpc(ToplRpc.Transaction.BroadcastTx.Params(signTx))

--- a/brambl/src/test/scala/co/topl/client/rpcExample.scala
+++ b/brambl/src/test/scala/co/topl/client/rpcExample.scala
@@ -14,12 +14,10 @@ import co.topl.rpc.ToplRpc
 import co.topl.rpc.ToplRpc.NodeView._
 import co.topl.rpc.ToplRpc.Transaction.{BroadcastTx, RawArbitTransfer, RawAssetTransfer, RawPolyTransfer}
 import co.topl.rpc.implicits.client._
-import co.topl.utils.Extensions.IterableOps
 import co.topl.utils.IdiomaticScalaTransition.implicits.toValidatedOps
 import co.topl.utils.StringDataTypes.{Base58Data, Latin1Data}
 import io.circe.syntax.EncoderOps
 
-import scala.collection.immutable.ListMap
 import scala.concurrent.{ExecutionContext, Future}
 
 object exampleState {
@@ -157,7 +155,7 @@ object CreateAnDSendRawPolyTransfer {
       genKeys()
       val msg2Sign = rawTx.messageToSign
       val signFunc = (addr: Address) => keyRing.generateAttestation(addr)(msg2Sign)
-      val signatures = keyRing.addresses.map(signFunc).reduce(_ ++ _).toListMap
+      val signatures = keyRing.addresses.map(signFunc).reduce(_ ++ _)
       Future(rawTx.copy(attestation = signatures))
     }
     broadcastTx <- ToplRpc.Transaction.BroadcastTx.rpc(ToplRpc.Transaction.BroadcastTx.Params(signTx))
@@ -193,7 +191,7 @@ object CreateAnDSendRawArbitTransfer {
       genKeys()
       val msg2Sign = rawTx.messageToSign
       val signFunc = (addr: Address) => keyRing.generateAttestation(addr)(msg2Sign)
-      val signatures = keyRing.addresses.map(signFunc).reduce(_ ++ _).toListMap
+      val signatures = keyRing.addresses.map(signFunc).reduce(_ ++ _)
       Future(rawTx.copy(attestation = signatures))
     }
     broadcastTx <- ToplRpc.Transaction.BroadcastTx.rpc(ToplRpc.Transaction.BroadcastTx.Params(signTx))
@@ -230,7 +228,7 @@ object CreateAnDSendRawAssetMintingTransfer {
       genKeys()
       val msg2Sign = rawTx.messageToSign
       val signFunc = (addr: Address) => keyRing.generateAttestation(addr)(msg2Sign)
-      val signatures = keyRing.addresses.map(signFunc).reduce(_ ++ _).toListMap
+      val signatures = keyRing.addresses.map(signFunc).reduce(_ ++ _)
       Future(rawTx.copy(attestation = signatures))
     }
     broadcastTx <- ToplRpc.Transaction.BroadcastTx.rpc(ToplRpc.Transaction.BroadcastTx.Params(signTx))
@@ -266,7 +264,7 @@ object CreateAnDSendRawAssetTransfer {
       genKeys()
       val msg2Sign = rawTx.messageToSign
       val signFunc = (addr: Address) => keyRing.generateAttestation(addr)(msg2Sign)
-      val signatures = keyRing.addresses.map(signFunc).reduce(_ ++ _).toListMap
+      val signatures = keyRing.addresses.map(signFunc).reduce(_ ++ _)
       Future(rawTx.copy(attestation = signatures))
     }
     broadcastTx <- ToplRpc.Transaction.BroadcastTx.rpc(ToplRpc.Transaction.BroadcastTx.Params(signTx))

--- a/common/src/main/scala/co/topl/utils/Extensions.scala
+++ b/common/src/main/scala/co/topl/utils/Extensions.scala
@@ -3,6 +3,7 @@ package co.topl.utils
 import java.nio.charset.{Charset, StandardCharsets}
 import scala.reflect.ClassTag
 import scala.collection.compat.BuildFrom
+import scala.collection.immutable.{Iterable, ListMap}
 
 object Extensions {
 
@@ -124,5 +125,9 @@ object Extensions {
     // returns the byte array of a string after ensuring utf-8 encoding
     def getValidUTF8Bytes: Option[Array[Byte]] = getValidBytes(s, StandardCharsets.UTF_8)
 
+  }
+
+  implicit class IterableOps[K, V](val iterable: Iterable[(K, V)]) {
+    def toListMap: ListMap[K, V] = iterable.foldLeft(ListMap[K, V]())(_ ++ ListMap(_))
   }
 }

--- a/common/src/main/scala/co/topl/utils/Extensions.scala
+++ b/common/src/main/scala/co/topl/utils/Extensions.scala
@@ -127,7 +127,4 @@ object Extensions {
 
   }
 
-  implicit class IterableOps[K, V](val iterable: Iterable[(K, V)]) {
-    def toListMap: ListMap[K, V] = iterable.foldLeft(ListMap[K, V]())(_ ++ ListMap(_))
-  }
 }

--- a/node/src/main/scala/co/topl/consensus/Hiccups.scala
+++ b/node/src/main/scala/co/topl/consensus/Hiccups.scala
@@ -1,5 +1,6 @@
 package co.topl.consensus
 
+import co.topl.modifier.block.Block
 import co.topl.utils.NetworkType.{NetworkPrefix, ValhallaTestnet}
 
 /**
@@ -13,6 +14,11 @@ object Hiccups {
    * @param height the height of the block
    */
   case class HiccupBlock(id: String, height: Long, networkPrefix: NetworkPrefix)
+
+  object HiccupBlock {
+    def apply(block: Block)(implicit networkPrefix: NetworkPrefix): HiccupBlock =
+      HiccupBlock(block.id.toString, block.height, networkPrefix)
+  }
 
   /**
    * Represent hiccups with semantic validation that should be ignored in node view holder checks.

--- a/node/src/main/scala/co/topl/consensus/Hiccups.scala
+++ b/node/src/main/scala/co/topl/consensus/Hiccups.scala
@@ -16,6 +16,7 @@ object Hiccups {
   case class HiccupBlock(id: String, height: Long, networkPrefix: NetworkPrefix)
 
   object HiccupBlock {
+
     def apply(block: Block)(implicit networkPrefix: NetworkPrefix): HiccupBlock =
       HiccupBlock(block.id.toString, block.height, networkPrefix)
   }

--- a/node/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
+++ b/node/src/main/scala/co/topl/nodeView/NodeViewHolder.scala
@@ -256,12 +256,12 @@ class NodeViewHolder(settings: AppSettings, appContext: AppContext)(implicit ec:
     if (!history().contains(pmod.id)) {
       context.system.eventStream.publish(StartingPersistentModifierApplication(pmod))
 
-      def isBlockTxsValidated: Boolean =
-        Hiccups.semanticValidation.contains(HiccupBlock(pmod.id.toString, pmod.height, np)) ||
+      val blockTxsValid: Boolean =
+        Hiccups.semanticValidation.contains(HiccupBlock(pmod)) ||
         pmod.transactions.forall(_.semanticValidation(minimalState()).isValid)
 
       // check that the transactions are semantically valid
-      if (isBlockTxsValidated) {
+      if (blockTxsValid) {
         log.info(s"Apply modifier ${pmod.id} of type ${pmod.modifierTypeId} to nodeViewHolder")
 
         // append the block to history

--- a/node/src/main/scala/co/topl/nodeView/history/History.scala
+++ b/node/src/main/scala/co/topl/nodeView/history/History.scala
@@ -82,7 +82,7 @@ class History(
 
     // test new block against all validators
     val validationResults =
-      if (!isGenesis(block) && !Hiccups.blockValidation.contains(HiccupBlock(block.id.toString, block.height, np))) {
+      if (!isGenesis(block) && !Hiccups.blockValidation.contains(HiccupBlock(block))) {
         validators.map(_.validate(block)).map {
           case Failure(e) =>
             log.warn(s"Block validation failed", e)


### PR DESCRIPTION
## Purpose

Creating a `HiccupBlock` to check against the existing list of hiccup blocks for semantic and block validation can be simplified by creating an `apply` method which converts a block into a `HiccupBlock`.

## Approach

Added an `apply` method inside of a new `HiccupBlock` companion object.
