### PR TITLE
Disable gjallarhorn

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -170,16 +170,9 @@ lazy val bifrost = project
     common,
     akkaHttpRpc,
     toplRpc,
-    gjallarhorn,
     benchmarking,
     crypto,
     brambl
-  )
-  .dependsOn(
-    node,
-    common,
-    gjallarhorn,
-    benchmarking
   )
 
 lazy val node = project
@@ -269,20 +262,21 @@ lazy val toplRpc = project
   )
   .dependsOn(akkaHttpRpc, common)
 
-lazy val gjallarhorn = project
-  .in(file("gjallarhorn"))
-  .settings(
-    name := "gjallarhorn",
-    commonSettings,
-    crossScalaVersions := Seq(scala213), // don't care about cross-compiling applications
-    publish / skip := true,
-    Defaults.itSettings,
-    libraryDependencies ++= Dependencies.gjallarhorn
-  )
-  .dependsOn(crypto, common)
-  .configs(IntegrationTest)
-  .disablePlugins(sbtassembly.AssemblyPlugin)
-  .settings(scalamacrosParadiseSettings)
+// This module has fallen out of sync with the rest of the codebase and is not currently needed
+//lazy val gjallarhorn = project
+//  .in(file("gjallarhorn"))
+//  .settings(
+//    name := "gjallarhorn",
+//    commonSettings,
+//    crossScalaVersions := Seq(scala213), // don't care about cross-compiling applications
+//    publish / skip := true,
+//    Defaults.itSettings,
+//    libraryDependencies ++= Dependencies.gjallarhorn
+//  )
+//  .dependsOn(crypto, common)
+//  .configs(IntegrationTest)
+//  .disablePlugins(sbtassembly.AssemblyPlugin)
+//  .settings(scalamacrosParadiseSettings)
 
 lazy val benchmarking = project
   .in(file("benchmark"))


### PR DESCRIPTION
# Purpose
- gjallarhorn is not currently in use and its code is not up-to-date with the rest of the project
- Unused modules lead to erroneous autocompletion results
- Unused modules increase test+compile time

# Approach
- Comment out `lazy val gjallarhorn` in build.sbt

# Testing
- Ran unit tests locally
- Checked IntelliJ's "intelligent search" and results no longer include gjallarhorn classes

# Tickets
- closes #1481 