### PR TITLE
Fix None.get from .sample.get

### DIFF
--- a/common/src/test/scala/co/topl/modifier/transaction/proposition/MultiSignatureCurve25519Spec.scala
+++ b/common/src/test/scala/co/topl/modifier/transaction/proposition/MultiSignatureCurve25519Spec.scala
@@ -7,6 +7,7 @@ import co.topl.attestation.{
   ThresholdSignatureCurve25519
 }
 import co.topl.utils.CommonGenerators
+import co.topl.utils.GeneratorOps.GeneratorOps
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
@@ -25,7 +26,7 @@ class MultiSignatureCurve25519Spec
   ) {
 
     forAll(keyPairSetCurve25519Gen) { s: Set[(PrivateKeyCurve25519, PublicKeyPropositionCurve25519)] =>
-      val message = nonEmptyBytesGen.sample.get
+      val message = nonEmptyBytesGen.sampleFirst()
       val signatures = s.map(_._1.sign(message))
       val pubKeyProps = SortedSet[PublicKeyPropositionCurve25519]() ++ s.map(_._2)
       val oneOfNProposition = ThresholdPropositionCurve25519(1, pubKeyProps)
@@ -42,7 +43,7 @@ class MultiSignatureCurve25519Spec
   ) {
 
     forAll(keyPairSetCurve25519Gen) { s: Set[(PrivateKeyCurve25519, PublicKeyPropositionCurve25519)] =>
-      val message = nonEmptyBytesGen.sample.get
+      val message = nonEmptyBytesGen.sampleFirst()
       val signatures = s.map(_._1.sign(message))
       val pubKeyProps = SortedSet[PublicKeyPropositionCurve25519]() ++ s.map(_._2)
       val oneOfNProposition = ThresholdPropositionCurve25519(2, pubKeyProps)

--- a/common/src/test/scala/co/topl/modifier/transaction/proposition/ThresholdPropositionCurve25519Spec.scala
+++ b/common/src/test/scala/co/topl/modifier/transaction/proposition/ThresholdPropositionCurve25519Spec.scala
@@ -3,6 +3,7 @@ package co.topl.modifier.transaction.proposition
 import co.topl.attestation.keyManagement.PrivateKeyCurve25519
 import co.topl.attestation.{ThresholdPropositionCurve25519, ThresholdSignatureCurve25519}
 import co.topl.utils.CommonGenerators
+import co.topl.utils.GeneratorOps.GeneratorOps
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
@@ -16,7 +17,7 @@ class ThresholdPropositionCurve25519Spec
   property("Any signature from set validates") {
     forAll(oneOfNPropositionCurve25519Gen) {
       case (keySet: Set[PrivateKeyCurve25519], mn: ThresholdPropositionCurve25519) =>
-        val message = nonEmptyBytesGen.sample.getOrElse(Array.fill(positiveMediumIntGen.sample.get)(1: Byte))
+        val message = nonEmptyBytesGen.sampleFirst()
         val signatures = keySet.map(_.sign(message))
 
         signatures

--- a/common/src/test/scala/co/topl/utils/GeneratorOps.scala
+++ b/common/src/test/scala/co/topl/utils/GeneratorOps.scala
@@ -1,0 +1,17 @@
+package co.topl.utils
+
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+
+object GeneratorOps {
+
+  implicit class GeneratorOps[T](gen: Gen[T]) {
+
+    def sampleFirst(
+      parameters: Gen.Parameters = Gen.Parameters.default,
+      seed:       Seed = Seed.random(),
+      retries:    Int = 100
+    ): T =
+      gen.pureApply(parameters, seed, retries)
+  }
+}

--- a/node/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
+++ b/node/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
@@ -3,6 +3,7 @@ package co.topl.api
 import akka.util.ByteString
 import co.topl.modifier.block.Block
 import co.topl.modifier.transaction.Transaction.TX
+import co.topl.utils.GeneratorOps.GeneratorOps
 import io.circe.Json
 import io.circe.parser.parse
 import org.scalatest.matchers.should.Matchers
@@ -17,9 +18,9 @@ class NodeViewRPCSpec extends AnyWordSpec with Matchers with RPCMockState {
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    txs = bifrostTransactionSeqGen.sample.get
+    txs = bifrostTransactionSeqGen.sampleFirst()
     txId = txs.head.id.toString
-    block = blockCurve25519Gen.sample.get.copy(transactions = txs)
+    block = blockCurve25519Gen.sampleFirst().copy(transactions = txs)
 
     view()._1.storage.update(block, isBest = false)
     view()._3.putWithoutCheck(txs, block.timestamp)

--- a/node/src/test/scala/co/topl/api/program/ProgramCallSpec.scala
+++ b/node/src/test/scala/co/topl/api/program/ProgramCallSpec.scala
@@ -1,6 +1,7 @@
 package co.topl.api.program
 
 import akka.util.ByteString
+import co.topl.utils.GeneratorOps.GeneratorOps
 import io.circe.parser.parse
 import io.circe.syntax._
 import org.scalatest.DoNotDiscover
@@ -11,7 +12,7 @@ class ProgramCallSpec extends ProgramRPCMockState {
   "programCall" should {
 
     val boxState = Seq(stateBox, codeBox, executionBox)
-    val version = modifierIdGen.sample.get
+    val version = modifierIdGen.sampleFirst()
 
     directlyAddPBRStorage(version, boxState)
 

--- a/node/src/test/scala/co/topl/api/program/ProgramMethodExecutionSpec.scala
+++ b/node/src/test/scala/co/topl/api/program/ProgramMethodExecutionSpec.scala
@@ -1,6 +1,7 @@
 package co.topl.api.program
 
 import akka.util.ByteString
+import co.topl.utils.GeneratorOps.GeneratorOps
 import io.circe.parser.parse
 import org.scalatest.DoNotDiscover
 
@@ -10,7 +11,7 @@ class ProgramMethodExecutionSpec extends ProgramRPCMockState {
   "executeProgramMethod" should {
 
     val boxState = Seq(stateBox, codeBox, executionBox)
-    val version = modifierIdGen.sample.get
+    val version = modifierIdGen.sampleFirst()
 
     directlyAddPBRStorage(version, boxState)
 

--- a/node/src/test/scala/co/topl/api/program/ProgramRPCMockState.scala
+++ b/node/src/test/scala/co/topl/api/program/ProgramRPCMockState.scala
@@ -5,6 +5,7 @@ import co.topl.attestation.{Address, PublicKeyPropositionCurve25519}
 import co.topl.modifier.ModifierId
 import co.topl.modifier.box._
 import co.topl.nodeView.state
+import co.topl.utils.GeneratorOps.GeneratorOps
 import io.circe.syntax._
 import org.scalatest.matchers.should
 
@@ -16,7 +17,7 @@ trait ProgramRPCMockState extends RPCMockState with should.Matchers {
 
   lazy val (signSk, signPk) = sampleUntilNonEmpty(keyPairSetCurve25519Gen).head
 
-  val publicKey: PublicKeyPropositionCurve25519 = propositionCurve25519Gen.sample.get
+  val publicKey: PublicKeyPropositionCurve25519 = propositionCurve25519Gen.sampleFirst()
   val address: Address = publicKey.address
 
   val fees: Map[String, Int] = Map(publicKey.toString -> 500)
@@ -32,16 +33,16 @@ trait ProgramRPCMockState extends RPCMockState with should.Matchers {
        |}
        |""".stripMargin
 
-  val stateBox: StateBox = StateBox(address.evidence, 0L, programIdGen.sample.get, Map("a" -> 0, "b" -> 1).asJson)
+  val stateBox: StateBox = StateBox(address.evidence, 0L, programIdGen.sampleFirst(), Map("a" -> 0, "b" -> 1).asJson)
 
   val codeBox: CodeBox = CodeBox(
     address.evidence,
     1L,
-    programIdGen.sample.get,
+    programIdGen.sampleFirst(),
     Seq("add = function(x,y) { a = x + y; return a }"),
     Map("add" -> Seq("Number", "Number"))
   )
 
   val executionBox: ExecutionBox =
-    ExecutionBox(address.evidence, 2L, programIdGen.sample.get, Seq(stateBox.value), Seq(codeBox.value))
+    ExecutionBox(address.evidence, 2L, programIdGen.sampleFirst(), Seq(stateBox.value), Seq(codeBox.value))
 }

--- a/node/src/test/scala/co/topl/api/program/ProgramTransferSpec.scala
+++ b/node/src/test/scala/co/topl/api/program/ProgramTransferSpec.scala
@@ -1,6 +1,7 @@
 package co.topl.api.program
 
 import akka.util.ByteString
+import co.topl.utils.GeneratorOps.GeneratorOps
 import io.circe.Json
 import io.circe.parser.parse
 import org.scalatest.DoNotDiscover
@@ -12,7 +13,7 @@ class ProgramTransferSpec extends ProgramRPCMockState {
 
     val boxState = Seq(stateBox, codeBox, executionBox)
 
-    val version = modifierIdGen.sample.get
+    val version = modifierIdGen.sampleFirst()
 
     directlyAddPBRStorage(version, boxState)
 

--- a/node/src/test/scala/co/topl/api/transaction/AssetTransferRPCSpec.scala
+++ b/node/src/test/scala/co/topl/api/transaction/AssetTransferRPCSpec.scala
@@ -2,6 +2,7 @@ package co.topl.api.transaction
 
 import co.topl.attestation.Address
 import co.topl.modifier.box.AssetCode
+import co.topl.utils.GeneratorOps.GeneratorOps
 import co.topl.utils.StringDataTypes.Latin1Data
 import io.circe.syntax._
 
@@ -22,7 +23,7 @@ class AssetTransferRPCSpec extends TransferRPCTestMethods {
     addressCurve25519recv = keyRingCurve25519.addresses.tail.head
     addressEd25519send = keyRingEd25519.addresses.head
     addressEd25519recv = keyRingEd25519.addresses.tail.head
-    recipients = assetToSeqGen.sample.get.asJson.toString()
+    recipients = assetToSeqGen.sampleFirst().asJson.toString()
     assetCodeCurve25519 = AssetCode(1: Byte, addressCurve25519send, Latin1Data.unsafe("test"))
     assetCodeEd25519 = AssetCode(1: Byte, addressEd25519send, Latin1Data.unsafe("test"))
   }

--- a/node/src/test/scala/co/topl/attestation/KeySpec.scala
+++ b/node/src/test/scala/co/topl/attestation/KeySpec.scala
@@ -7,6 +7,7 @@ import co.topl.utils.codecs.implicits._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import co.topl.utils.GeneratorOps.GeneratorOps
 
 class KeySpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with NodeGenerators with Matchers {
 
@@ -75,11 +76,11 @@ class KeySpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with NodeG
   }
 
   property("Trying to sign a message with an address not on the keyRing will fail") {
-    val randAddrCurve25519: Address = addressCurve25519Gen.sample.get
+    val randAddrCurve25519: Address = addressCurve25519Gen.sampleFirst()
     val errorCurve25519 = intercept[Exception](keyRingCurve25519.signWithAddress(randAddrCurve25519)(messageByte))
     errorCurve25519.getMessage shouldEqual "Unable to find secret for the given address"
 
-    val randAddrEd25519: Address = addressEd25519Gen.sample.get
+    val randAddrEd25519: Address = addressEd25519Gen.sampleFirst()
     val errorEd25519 = intercept[Exception](keyRingEd25519.signWithAddress(randAddrEd25519)(messageByte))
     errorEd25519.getMessage shouldEqual "Unable to find secret for the given address"
   }
@@ -87,14 +88,14 @@ class KeySpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with NodeG
   property("The proof from signing with an address should only be valid for the corresponding proposition") {
     val propCurve25519 = keyRingCurve25519.lookupPublicKey(addressCurve25519).get
     val newAddrCurve25519: Address =
-      keyRingCurve25519.DiskOps.generateKeyFile(Latin1Data.unsafe(stringGen.sample.get)).get
+      keyRingCurve25519.DiskOps.generateKeyFile(Latin1Data.unsafe(stringGen.sampleFirst())).get
     val newPropCurve25519 = keyRingCurve25519.lookupPublicKey(newAddrCurve25519).get
     val newProofCurve25519 = keyRingCurve25519.signWithAddress(newAddrCurve25519)(messageByte).get
     newProofCurve25519.isValid(propCurve25519, messageByte) shouldBe false
     newProofCurve25519.isValid(newPropCurve25519, messageByte) shouldBe true
 
     val propEd25519 = keyRingEd25519.lookupPublicKey(addressEd25519).get
-    val newAddrEd25519: Address = keyRingEd25519.DiskOps.generateKeyFile(Latin1Data.unsafe(stringGen.sample.get)).get
+    val newAddrEd25519: Address = keyRingEd25519.DiskOps.generateKeyFile(Latin1Data.unsafe(stringGen.sampleFirst())).get
     val newPropEd25519 = keyRingEd25519.lookupPublicKey(newAddrEd25519).get
     val newProofEd25519 = keyRingEd25519.signWithAddress(newAddrEd25519)(messageByte).get
     newProofEd25519.isValid(propEd25519, messageByte) shouldBe false

--- a/node/src/test/scala/co/topl/consensus/BlockVersionTests.scala
+++ b/node/src/test/scala/co/topl/consensus/BlockVersionTests.scala
@@ -5,6 +5,7 @@ import co.topl.modifier.ModifierId
 import co.topl.modifier.block.Block
 import co.topl.nodeView.history.History
 import co.topl.nodeView.state.{MockState, State}
+import co.topl.utils.GeneratorOps.GeneratorOps
 import co.topl.utils.GenesisBlockGenerators
 
 class BlockVersionTests extends MockState with GenesisBlockGenerators {
@@ -22,7 +23,7 @@ class BlockVersionTests extends MockState with GenesisBlockGenerators {
     setProtocolMngr(settings)
 
     fstVersion = protocolMngr.applicable.map(_.blockVersion).min.get
-    genesisBlockOldestVersion = genesisBlockGen.sample.get.copy(version = fstVersion)
+    genesisBlockOldestVersion = genesisBlockGen.sampleFirst().copy(version = fstVersion)
     history = generateHistory(genesisBlockOldestVersion)
     state = createState(genesisBlockOldestVersion)
   }
@@ -40,11 +41,13 @@ class BlockVersionTests extends MockState with GenesisBlockGenerators {
     val blocksCount: Int = blocksToAppend + 1 // with genesis block
 
     for (_ <- 1 to blocksToAppend) {
-      val oneBlock: Block = blockCurve25519Gen.sample.get.copy(
-        parentId = history.bestBlockId,
-        transactions = Seq(),
-        version = blockVersion(history.height + 1)
-      )
+      val oneBlock: Block = blockCurve25519Gen
+        .sampleFirst()
+        .copy(
+          parentId = history.bestBlockId,
+          transactions = Seq(),
+          version = blockVersion(history.height + 1)
+        )
       history = history.append(oneBlock).get._1
       state = state.applyModifier(oneBlock).get
     }
@@ -65,7 +68,7 @@ class BlockVersionTests extends MockState with GenesisBlockGenerators {
 
   property("Applying genesis block to history/state with different available versions should be successful") {
     for (version <- protocolMngr.applicable.map(_.blockVersion.get)) {
-      val genesisBlockWithVersion: Block = genesisBlockGen.sample.get.copy(version = version)
+      val genesisBlockWithVersion: Block = genesisBlockGen.sampleFirst().copy(version = version)
       history = generateHistory(genesisBlockWithVersion)
       history.modifierById(genesisBlockWithVersion.id).isDefined shouldBe true
       state = createState(genesisBlockWithVersion)

--- a/node/src/test/scala/co/topl/modifier/transaction/validation/TransactionValidationSpec.scala
+++ b/node/src/test/scala/co/topl/modifier/transaction/validation/TransactionValidationSpec.scala
@@ -15,6 +15,7 @@ import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import scala.util.Random
+import co.topl.utils.GeneratorOps.GeneratorOps
 
 class TransactionValidationSpec
     extends AnyPropSpec
@@ -99,7 +100,7 @@ class TransactionValidationSpec
   property("Attempting to validate an AssetTransfer with data of invalid length should error") {
     forAll(stringGen) { data: String =>
       whenever(data.length >= 128) {
-        val tx = assetTransferEd25519Gen.sample.get
+        val tx = assetTransferEd25519Gen.sampleFirst()
         val invalidDataTx = tx.copy(data = Some(Latin1Data.unsafe(data)))
         invalidDataTx.syntacticValidation should haveInvalidC[SyntacticValidationFailure](DataTooLong)
       }
@@ -109,8 +110,8 @@ class TransactionValidationSpec
   property("Attempting to validate an AssetTransfer with metadata of invalid length should error") {
     forAll(stringGen) { metadata: String =>
       whenever(metadata.length >= 128) {
-        val tx = assetTransferEd25519Gen.sample.get
-        val assetValue = assetValueEd25519Gen.sample.get.copy(metadata = Some(Latin1Data.unsafe(metadata)))
+        val tx = assetTransferEd25519Gen.sampleFirst()
+        val assetValue = assetValueEd25519Gen.sampleFirst().copy(metadata = Some(Latin1Data.unsafe(metadata)))
         val invalidDataTx = tx.copy(to = IndexedSeq((assetValue.assetCode.issuer, assetValue)))
 
         invalidDataTx.syntacticValidation should haveInvalidC[SyntacticValidationFailure](MetadataTooLong)

--- a/node/src/test/scala/co/topl/nodeView/history/StorageCacheSpec.scala
+++ b/node/src/test/scala/co/topl/nodeView/history/StorageCacheSpec.scala
@@ -2,6 +2,7 @@ package co.topl.nodeView.history
 
 import co.topl.consensus.consensusHelper.setProtocolMngr
 import co.topl.modifier.block.Block
+import co.topl.utils.GeneratorOps.GeneratorOps
 import co.topl.utils.{CommonGenerators, NodeGenerators}
 import org.scalatest.DoNotDiscover
 import org.scalatest.matchers.should.Matchers
@@ -41,7 +42,7 @@ class StorageCacheSpec
     val bestBlockIdKey = genesisBlock.parentId
 
     /* Append a new block, make sure it is updated in cache, then drop it */
-    val fstBlock: Block = blockCurve25519Gen.sample.get.copy(parentId = history.bestBlockId)
+    val fstBlock: Block = blockCurve25519Gen.sampleFirst().copy(parentId = history.bestBlockId)
     history = history.append(fstBlock).get._1
 
     history.storage.blockCache.getIfPresent(bestBlockIdKey) should not be null
@@ -107,7 +108,7 @@ class StorageCacheSpec
    */
 
   property("blockLoader should correctly return a block from storage not found in cache") {
-    val block: Block = blockCurve25519Gen.sample.get.copy(parentId = history.bestBlockId)
+    val block: Block = blockCurve25519Gen.sampleFirst().copy(parentId = history.bestBlockId)
     val tempHistory = history.append(block).get._1
 
     tempHistory.storage.blockCache.invalidateAll()

--- a/node/src/test/scala/co/topl/nodeView/state/ProgramBoxRegistrySpec.scala
+++ b/node/src/test/scala/co/topl/nodeView/state/ProgramBoxRegistrySpec.scala
@@ -4,6 +4,7 @@ import co.topl.attestation.{Address, PublicKeyPropositionCurve25519}
 import co.topl.modifier.box.StateBox
 import io.circe.Json
 import io.circe.syntax._
+import co.topl.utils.GeneratorOps.GeneratorOps
 
 class ProgramBoxRegistrySpec extends MockState {
 
@@ -32,18 +33,18 @@ class ProgramBoxRegistrySpec extends MockState {
 
     state = createState()
 
-    pubKey = propositionCurve25519Gen.sample.get
+    pubKey = propositionCurve25519Gen.sampleFirst()
     address = pubKey.address
 
-    sboxOne = StateBox(address.evidence, 0L, programIdGen.sample.get, stateOne)
-    sboxTwo = StateBox(address.evidence, 1L, programIdGen.sample.get, stateTwo)
+    sboxOne = StateBox(address.evidence, 0L, programIdGen.sampleFirst(), stateOne)
+    sboxTwo = StateBox(address.evidence, 1L, programIdGen.sampleFirst(), stateTwo)
   }
 
   property("BifrostState should update programBoxRegistry with state box and rollback correctly") {
 
     val changes_1: StateChanges = StateChanges(Seq(), Seq(sboxOne))
     val pbr_changes_1 = Some(ProgramRegistryChanges(Map(), Map(sboxOne.value -> Seq(sboxOne.id))))
-    newState_1 = state.applyChanges(modifierIdGen.sample.get, changes_1, None, pbr_changes_1).get
+    newState_1 = state.applyChanges(modifierIdGen.sampleFirst(), changes_1, None, pbr_changes_1).get
 
     assert(newState_1.registryLookup(sboxOne.value).get.head == sboxOne.id)
     assert(newState_1.getProgramBox[StateBox](sboxOne.value).get.bytes sameElements sboxOne.bytes)
@@ -51,7 +52,7 @@ class ProgramBoxRegistrySpec extends MockState {
     val changes_2: StateChanges = StateChanges(Seq(sboxOne.id), Seq(sboxTwo))
     val pbr_changes_2 =
       Some(ProgramRegistryChanges(Map(sboxOne.value -> Seq(sboxOne.id)), Map(sboxTwo.value -> Seq(sboxTwo.id))))
-    val newState_2 = newState_1.applyChanges(modifierIdGen.sample.get, changes_2, None, pbr_changes_2).get
+    val newState_2 = newState_1.applyChanges(modifierIdGen.sampleFirst(), changes_2, None, pbr_changes_2).get
 
     assert(newState_2.registryLookup(sboxTwo.value).get.head == sboxTwo.id)
     assert(newState_2.getProgramBox[StateBox](sboxTwo.value).get.bytes sameElements sboxTwo.bytes)
@@ -65,7 +66,7 @@ class ProgramBoxRegistrySpec extends MockState {
 
     val changes_2: StateChanges = StateChanges(Seq(sboxOne.id), Seq())
     val pbr_changes_2 = Some(ProgramRegistryChanges(Map(sboxOne.value -> Seq(sboxOne.id)), Map()))
-    val newState_2 = newState_1.applyChanges(modifierIdGen.sample.get, changes_2, None, pbr_changes_2).get
+    val newState_2 = newState_1.applyChanges(modifierIdGen.sampleFirst(), changes_2, None, pbr_changes_2).get
 
     assert(newState_2.registryLookup(sboxOne.value).isEmpty)
   }

--- a/node/src/test/scala/co/topl/nodeView/state/TokenBoxRegistrySpec.scala
+++ b/node/src/test/scala/co/topl/nodeView/state/TokenBoxRegistrySpec.scala
@@ -1,6 +1,7 @@
 package co.topl.nodeView.state
 
 import co.topl.attestation.Address
+import co.topl.utils.GeneratorOps.GeneratorOps
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.OptionValues.convertOptionToValuable
 import org.scalatest.matchers.should.Matchers
@@ -19,7 +20,7 @@ class TokenBoxRegistrySpec extends MockState with ScalaCheckDrivenPropertyChecks
   property("Token boxes should be inserted into the registry") {
     forAll(tokenBoxesGen) { tokens =>
       val keys = tokens.groupBy(_.evidence)
-      directlyAddTBRStorage(modifierIdGen.sample.get, tokens, state)
+      directlyAddTBRStorage(modifierIdGen.sampleFirst(), tokens, state)
       keys.foreach { key =>
         val ids = key._2.map(_.id)
         state.registryLookup(Address(key._1)).value shouldEqual ids
@@ -30,7 +31,7 @@ class TokenBoxRegistrySpec extends MockState with ScalaCheckDrivenPropertyChecks
   property("Rolling back should remove tokens from registry") {
     forAll(tokenBoxesGen) { tokens =>
       val tbr = state.tbrOpt.get
-      val version = modifierIdGen.sample.get
+      val version = modifierIdGen.sampleFirst()
       val keys = tokens.groupBy(_.evidence).map(k => Address(k._1) -> k._2)
       val update = keys.map(k => k._1 -> k._2.map(_.nonce))
 


### PR DESCRIPTION
# Purpose
- scalacheck generators generate new data most of the time, but sometimes a sample attempt may not yield a result.  In these cases, it should be tried again
- In many places in our unit tests, we only attempt a single generator sample which may result in a None.get which will fail the test

# Approach
- Implemented a GeneratorOps implicit class which adds a `.sampleFirst()` method to a `Gen`
- Updated references to `.sample.get` with `.sampleFirst()`

# Testing
- Unit tests pass locally.  Hopefully they continue to pass everywhere else!

# Tickets
- closes #1473 