### PR TITLE
Specify an encoding type when getting bytes from serialized data #1472

### DIFF
--- a/common/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
+++ b/common/src/main/scala/co/topl/modifier/box/TokenValueHolder.scala
@@ -5,7 +5,7 @@ import co.topl.utils.Int128
 import co.topl.utils.StringDataTypes.{Base58Data, Latin1Data}
 import co.topl.utils.codecs.Int128Codec
 import co.topl.utils.codecs.implicits._
-import co.topl.utils.serialization.{BifrostSerializer, BytesSerializable, Reader, Writer}
+import co.topl.utils.serialization.{stringCharacterSet, BifrostSerializer, BytesSerializable, Reader, Writer}
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor}
 
@@ -130,7 +130,7 @@ object AssetValue extends BifrostSerializer[AssetValue] {
     AssetCode.serialize(obj.assetCode, w)
     SecurityRoot.serialize(obj.securityRoot, w)
     w.putOption(obj.metadata) { (writer, metadata) =>
-      writer.putByteString(new String(metadata.value))
+      writer.putByteString(new String(metadata.value, stringCharacterSet))
     }
   }
 

--- a/common/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/serialization/ArbitTransferSerializer.scala
@@ -9,7 +9,7 @@ import co.topl.utils.Extensions._
 import co.topl.utils.Int128
 import co.topl.utils.StringDataTypes.Latin1Data
 import co.topl.utils.StringDataTypes.implicits._
-import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
+import co.topl.utils.serialization.{stringCharacterSet, BifrostSerializer, Reader, Writer}
 
 import scala.collection.immutable.ListMap
 import scala.language.existentials
@@ -49,7 +49,7 @@ object ArbitTransferSerializer extends BifrostSerializer[ArbitTransfer[_ <: Prop
 
     /* data: Option[String] */
     w.putOption(obj.data) { (writer, d) =>
-      writer.putByteString(new String(d.value))
+      writer.putByteString(new String(d.value, stringCharacterSet))
     }
 
     /* minting: Boolean */

--- a/common/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/serialization/AssetTransferSerializer.scala
@@ -9,7 +9,7 @@ import co.topl.utils.Extensions._
 import co.topl.utils.Int128
 import co.topl.utils.StringDataTypes.Latin1Data
 import co.topl.utils.StringDataTypes.implicits._
-import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
+import co.topl.utils.serialization.{stringCharacterSet, BifrostSerializer, Reader, Writer}
 
 import scala.collection.immutable.ListMap
 import scala.language.existentials
@@ -49,7 +49,7 @@ object AssetTransferSerializer extends BifrostSerializer[AssetTransfer[_ <: Prop
 
     /* data: Option[Latin1Data] */
     w.putOption(obj.data) { (writer, d) =>
-      writer.putByteString(new String(d.value))
+      writer.putByteString(new String(d.value, stringCharacterSet))
     }
 
     /* minting: Boolean */

--- a/common/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/serialization/PolyTransferSerializer.scala
@@ -8,7 +8,7 @@ import co.topl.modifier.transaction.PolyTransfer
 import co.topl.utils.Extensions._
 import co.topl.utils.Int128
 import co.topl.utils.StringDataTypes.implicits._
-import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
+import co.topl.utils.serialization.{stringCharacterSet, BifrostSerializer, Reader, Writer}
 import co.topl.utils.StringDataTypes.Latin1Data
 import co.topl.utils.StringDataTypes.implicits._
 
@@ -50,7 +50,7 @@ object PolyTransferSerializer extends BifrostSerializer[PolyTransfer[_ <: Propos
 
     /* data: Option[String] */
     w.putOption(obj.data) { (writer, d) =>
-      writer.putByteString(new String(d.value))
+      writer.putByteString(new String(d.value, stringCharacterSet))
     }
 
     /* minting: Boolean */

--- a/common/src/main/scala/co/topl/utils/serialization/VLQReader.scala
+++ b/common/src/main/scala/co/topl/utils/serialization/VLQReader.scala
@@ -118,7 +118,7 @@ trait VLQReader extends Reader {
    */
   @inline override def getByteString(): String = {
     val size = getUByte()
-    new String(getBytes(size))
+    new String(getBytes(size), stringCharacterSet)
   }
 
   /**
@@ -128,6 +128,6 @@ trait VLQReader extends Reader {
    */
   @inline override def getIntString(): String = {
     val size = getUInt().toIntExact
-    new String(getBytes(size))
+    new String(getBytes(size), stringCharacterSet)
   }
 }

--- a/common/src/main/scala/co/topl/utils/serialization/VLQWriter.scala
+++ b/common/src/main/scala/co/topl/utils/serialization/VLQWriter.scala
@@ -141,29 +141,27 @@ trait VLQWriter extends Writer {
   }
 
   /**
-   * Encode String is shorter than 256 bytes
+   * Encode a `String` that is shorter than 256 bytes.
    *
-   * @param s String
-   * @return
+   * @param s String the value to encode
    */
   override def putByteString(s: String): this.type = {
-    val bytes = s.getBytes
-    require(bytes.size < 256)
-    putUByte(bytes.size.toByte)
+    val bytes = s.getBytes(stringCharacterSet)
+    require(bytes.length < 256)
+    put(bytes.length.toByte)
     putBytes(bytes)
     this
   }
 
   /**
-   * Encode String that is longer than 256 bytes
+   * Encode a `String` that is smaller than 2147483647 bytes.
    *
-   * @param s String
-   * @return
+   * @param s String the value to encode
    */
   override def putIntString(s: String): this.type = {
-    val bytes = s.getBytes
-    require(bytes.size < Int.MaxValue)
-    putUInt(bytes.size)
+    val bytes = s.getBytes(stringCharacterSet)
+    require(bytes.length < Int.MaxValue)
+    putUInt(bytes.length)
     putBytes(bytes)
     this
   }

--- a/common/src/main/scala/co/topl/utils/serialization/package.scala
+++ b/common/src/main/scala/co/topl/utils/serialization/package.scala
@@ -1,0 +1,11 @@
+package co.topl.utils
+
+import java.nio.charset.StandardCharsets
+
+package object serialization {
+
+  /**
+   * Character set to use for encoding/decoding `String` types to/from bytes.
+   */
+  val stringCharacterSet = StandardCharsets.UTF_8
+}

--- a/common/src/test/scala/co/topl/serialization/VLQWriterSpec.scala
+++ b/common/src/test/scala/co/topl/serialization/VLQWriterSpec.scala
@@ -1,0 +1,35 @@
+package co.topl.serialization
+
+import co.topl.utils.CommonGenerators
+import co.topl.utils.serialization.{stringCharacterSet, VLQByteStringWriter}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+class VLQWriterSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks with CommonGenerators {
+
+  "VLQWriter putByteString" should "throw an illegal argument exception when input bytes is length 256" in {
+    val vlqWriter = new VLQByteStringWriter()
+    val inputString = new String(Array.fill(256)(0x02).map(_.toByte), stringCharacterSet)
+
+    an[IllegalArgumentException] should be thrownBy vlqWriter.putByteString(inputString)
+  }
+
+  it should "not throw an illegal argument exception when input bytes is length 255" in {
+    val vlqWriter = new VLQByteStringWriter()
+    val inputString = new String(Array.fill(255)(0x01).map(_.toByte), stringCharacterSet)
+
+    // should not throw
+    vlqWriter.putByteString(inputString)
+  }
+
+  "VLQWriter putIntString"
+    .should("not throw an illegal argument exception when input bytes size is 5000")
+    .in {
+      val vlqWriter = new VLQByteStringWriter()
+      val inputString = new String(Array.fill(5000)(0x04).map(_.toByte), stringCharacterSet)
+
+      // should not throw
+      vlqWriter.putIntString(inputString)
+    }
+}

--- a/node/src/main/scala/co/topl/network/peer/PeerSpecSerializer.scala
+++ b/node/src/main/scala/co/topl/network/peer/PeerSpecSerializer.scala
@@ -2,7 +2,7 @@ package co.topl.network.peer
 
 import co.topl.settings.{Version, VersionSerializer}
 import co.topl.utils.Extensions._
-import co.topl.utils.serialization.{BifrostSerializer, Reader, Writer}
+import co.topl.utils.serialization.{stringCharacterSet, BifrostSerializer, Reader, Writer}
 
 import java.net.{InetAddress, InetSocketAddress}
 


### PR DESCRIPTION
## Purpose

`VLQWriter` methods `putByteString` and `putIntString` call `.getBytes` on the input strings without specifying a character set. This will default to the default system character set, which could differ from system to system. To stop any potential bugs this could cause in the future, we should specify a character set (UTF-8).

## Approach

- Specify a string character set in the serialization package that should be used by any serializers and any functions creatng strings to pass to the serializers
- Pass the `stringCharacterSet` as an argument when calling `.getBytes` on `String` values in `VLQWriter` or `new String` in `VLQReader`

## Testing

- Added a few `VLQWriter` tests
- [] Add some `VLQReader` tests
- [] Add encoding targeted `VLQWriter` and `VLQReader` tests

## Closes

- closes #1472 