### PR TITLE
2.12 Compile Fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
       - image: toplprotocol/graalvm-jdk11-21.1.0-test
-
+    resource_class: medium
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           key: sbt-cache
-      - run: cat /dev/null | sbt test:compile
+      - run: cat /dev/null | sbt + test:compile
 
       - save_cache:
           paths:
@@ -40,7 +40,7 @@ jobs:
           key: v1-dependencies--{{ checksum "build.sbt" }}
 
       # run tests!
-      - run: cat /dev/null | sbt -mem 2048 test:test
+      - run: cat /dev/null | sbt -mem 2048 + test:test
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           key: sbt-cache
-      - run: cat /dev/null | sbt + test:compile
+      - run: cat /dev/null | sbt + update
 
       - save_cache:
           paths:
@@ -40,7 +40,7 @@ jobs:
           key: v1-dependencies--{{ checksum "build.sbt" }}
 
       # run tests!
-      - run: cat /dev/null | sbt -mem 2048 + test:test
+      - run: cat /dev/null | sbt -mem 2048 checkPR
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,7 @@ jobs:
     working_directory: ~/repo
 
     environment:
-      SBT_VERSION: 1.5.0
-      # Customize the JVM maximum heap limit
-      JVM_OPTS: -Xmx3600m
-      #SBT_OPTS: -XX:MaxMetaspaceSize=512M -Xmx6G # <- Graal is saying this is was deprecated
+      SBT_VERSION: 1.5.5
       TERM: dumb
 
     steps:
@@ -30,7 +27,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           key: sbt-cache
-      - run: cat /dev/null | sbt + update
+      - run: sbt + update
 
       - save_cache:
           paths:
@@ -40,7 +37,7 @@ jobs:
           key: v1-dependencies--{{ checksum "build.sbt" }}
 
       # run tests!
-      - run: cat /dev/null | sbt -mem 2048 checkPR
+      - run: sbt checkPR
 
 workflows:
   version: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Check Scala 2.12 Compatibility
-        run: sbt ++2.12.14 test:compile && sbt clean
-
       - name: Check formatting
         run: sbt scalafmtCheckAll
 
@@ -49,7 +46,7 @@ jobs:
         run: sbt "scalafixAll --check"
 
       - name: Compile
-        run: sbt test:compile
+        run: sbt + test:compile
 
       - name: Test
-        run: sbt test:test
+        run: sbt + test:test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
+      - name: Check Scala 2.12 Compatibility
+        run: sbt ++2.12.14 test:compile && sbt clean
 
       - name: Check formatting
         run: sbt scalafmtCheckAll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,4 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check formatting
-        run: sbt scalafmtCheckAll
-
-      - name: Check Scalafix
-        run: sbt "scalafixAll --check"
-
-      - name: Compile
-        run: sbt + test:compile
-
-      - name: Test
-        run: sbt + test:test
+        run: sbt checkPR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,5 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Check formatting
+      - name: Compile and Test
         run: sbt checkPR

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,6 @@ val scala213 = "2.13.6"
 inThisBuild(List(
   organization := "co.topl",
   scalaVersion := scala213,
-  crossScalaVersions := Seq(scala212, scala213),
   versionScheme := Some("early-semver"),
   dynverSeparator := "-",
   version := dynverGitDescribeOutput.value.mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value)),
@@ -33,6 +32,7 @@ lazy val commonSettings = Seq(
       case _                       => sourceDir / "scala-2.12-"
     }
   },
+  crossScalaVersions := Seq(scala212, scala213),
   Test / testOptions ++= Seq(
     Tests.Argument("-oD", "-u", "target/test-reports"),
     Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "2"),
@@ -184,7 +184,7 @@ lazy val node = project
     commonSettings,
     assemblySettings,
     Defaults.itSettings,
-    crossScalaVersions := Seq(scala213), // don't care about cross-compiling applications
+    crossScalaVersions := Seq(scala213), // The `monocle` library does not support Scala 2.12
     Compile / run / mainClass := Some("co.topl.BifrostApp"),
     publish / skip := true,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
@@ -211,7 +211,6 @@ lazy val common = project
     name := "common",
     commonSettings,
     publishSettings,
-    crossScalaVersions := Seq(scala212, scala213),
     libraryDependencies ++= Dependencies.common
   )
   .dependsOn(crypto)
@@ -235,7 +234,6 @@ lazy val brambl = project
     name := "brambl",
     commonSettings,
     publishSettings,
-    crossScalaVersions := Seq(scala212, scala213),
     libraryDependencies ++= Dependencies.brambl,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "co.topl.buildinfo.brambl"
@@ -249,7 +247,6 @@ lazy val akkaHttpRpc = project
     name := "akka-http-rpc",
     commonSettings,
     publishSettings,
-    crossScalaVersions := Seq(scala212, scala213),
     libraryDependencies ++= Dependencies.akkaHttpRpc,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "co.topl.buildinfo.akkahttprpc"
@@ -262,7 +259,6 @@ lazy val toplRpc = project
     name := "topl-rpc",
     commonSettings,
     publishSettings,
-    crossScalaVersions := Seq(scala212, scala213),
     libraryDependencies ++= Dependencies.toplRpc,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "co.topl.buildinfo.toplrpc"
@@ -275,7 +271,6 @@ lazy val toplRpc = project
 //  .settings(
 //    name := "gjallarhorn",
 //    commonSettings,
-//    crossScalaVersions := Seq(scala213), // don't care about cross-compiling applications
 //    publish / skip := true,
 //    Defaults.itSettings,
 //    libraryDependencies ++= Dependencies.gjallarhorn
@@ -304,7 +299,6 @@ lazy val crypto = project
     commonSettings,
     publishSettings,
     scalamacrosParadiseSettings,
-    crossScalaVersions := Seq(scala212, scala213),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "co.topl.buildinfo.crypto",
     libraryDependencies ++= Dependencies.crypto,
@@ -317,7 +311,6 @@ lazy val tools = project
     name := "tools",
     commonSettings,
     publishSettings,
-    crossScalaVersions := Seq(scala212, scala213),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "co.topl.buildinfo.tools",
     libraryDependencies ++= Dependencies.tools

--- a/build.sbt
+++ b/build.sbt
@@ -289,7 +289,6 @@ lazy val benchmarking = project
     publish / skip := true,
     libraryDependencies ++= Dependencies.benchmarking
   )
-  .dependsOn(node % "compile->compile;test->test")
   .enablePlugins(JmhPlugin)
   .disablePlugins(sbtassembly.AssemblyPlugin)
 
@@ -328,5 +327,5 @@ lazy val loadTesting = project
   )
   .dependsOn(common, brambl)
 
-addCommandAlias("checkPR", "; scalafixAll --check; scalafmtCheckAll; test")
-addCommandAlias("preparePR", "; scalafixAll; scalafmtAll; test")
+addCommandAlias("checkPR", s"; scalafixAll --check; scalafmtCheckAll; test; clean; ++${scala212} compile")
+addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; test; clean; ++${scala212} compile")

--- a/build.sbt
+++ b/build.sbt
@@ -211,6 +211,7 @@ lazy val common = project
     name := "common",
     commonSettings,
     publishSettings,
+    crossScalaVersions := Seq(scala212, scala213),
     libraryDependencies ++= Dependencies.common
   )
   .dependsOn(crypto)
@@ -234,6 +235,7 @@ lazy val brambl = project
     name := "brambl",
     commonSettings,
     publishSettings,
+    crossScalaVersions := Seq(scala212, scala213),
     libraryDependencies ++= Dependencies.brambl,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "co.topl.buildinfo.brambl"
@@ -247,6 +249,7 @@ lazy val akkaHttpRpc = project
     name := "akka-http-rpc",
     commonSettings,
     publishSettings,
+    crossScalaVersions := Seq(scala212, scala213),
     libraryDependencies ++= Dependencies.akkaHttpRpc,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "co.topl.buildinfo.akkahttprpc"
@@ -259,6 +262,7 @@ lazy val toplRpc = project
     name := "topl-rpc",
     commonSettings,
     publishSettings,
+    crossScalaVersions := Seq(scala212, scala213),
     libraryDependencies ++= Dependencies.toplRpc,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "co.topl.buildinfo.toplrpc"
@@ -300,6 +304,7 @@ lazy val crypto = project
     commonSettings,
     publishSettings,
     scalamacrosParadiseSettings,
+    crossScalaVersions := Seq(scala212, scala213),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "co.topl.buildinfo.crypto",
     libraryDependencies ++= Dependencies.crypto,
@@ -312,6 +317,7 @@ lazy val tools = project
     name := "tools",
     commonSettings,
     publishSettings,
+    crossScalaVersions := Seq(scala212, scala213),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "co.topl.buildinfo.tools",
     libraryDependencies ++= Dependencies.tools
@@ -327,5 +333,5 @@ lazy val loadTesting = project
   )
   .dependsOn(common, brambl)
 
-addCommandAlias("checkPR", s"; scalafixAll --check; scalafmtCheckAll; test; clean; ++${scala212} compile")
-addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; test; clean; ++${scala212} compile")
+addCommandAlias("checkPR", s"; scalafixAll --check; scalafmtCheckAll; + test")
+addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; + test")

--- a/common/src/main/scala/co/topl/modifier/transaction/Transaction.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/Transaction.scala
@@ -68,7 +68,7 @@ object Transaction {
     case _: AssetTransfer[_] => AssetTransfer.identifier.getId
   }
 
-  implicit def jsonTypedEncoder[T, P <: Proposition]: Encoder[Transaction[T, P]] = { case tx: Transaction[_, _] =>
+  implicit def jsonTypedEncoder[T, P <: Proposition]: Encoder[Transaction[T, P]] = { tx =>
     jsonEncoder(tx)
   }
 

--- a/common/src/main/scala/co/topl/utils/actors/SortedCache.scala
+++ b/common/src/main/scala/co/topl/utils/actors/SortedCache.scala
@@ -106,7 +106,7 @@ object SortedCache {
      * Inserts the given items T into the items cache.  If the cache overflows, items are evicted and the `onEvict`
      * function is called.
      */
-    def append(others: IterableOnce[T]): Impl[T] = {
+    def append(others: Iterable[T]): Impl[T] = {
       // For future optimization: `.distinct.sorted` is expensive.  Is it cheaper to use a SortedSet instead?
       val (finalItems, sizeEvicted) =
         (items ++ others.iterator.map(PoppableItem(_, 0))).distinct.sorted.splitAt(itemLimit)

--- a/common/src/test/scala/co/topl/serialization/JsonTests.scala
+++ b/common/src/test/scala/co/topl/serialization/JsonTests.scala
@@ -120,7 +120,7 @@ class JsonTests extends AnyPropSpec with Matchers with ScalaCheckDrivenPropertyC
   }
 
   property("Transaction json") {
-    forAll(transferGen) { tx: Transaction.TX =>
+    forAll(transferGen) { tx =>
       tx.asJson.as[Transaction.TX] shouldEqual Right(tx)
     }
   }

--- a/common/src/test/scala/co/topl/utils/CommonGenerators.scala
+++ b/common/src/test/scala/co/topl/utils/CommonGenerators.scala
@@ -481,8 +481,12 @@ trait CommonGenerators extends Logging with NetworkPrefixTestHelper {
   lazy val assetTransferGen: Gen[AssetTransfer[_ <: Proposition]] =
     Gen.oneOf(assetTransferCurve25519Gen, assetTransferThresholdCurve25519Gen, assetTransferEd25519Gen)
 
-  lazy val transferGen: Gen[TransferTransaction[_ <: TokenValueHolder, _ <: Proposition]] =
-    Gen.oneOf(polyTransferGen, arbitTransferGen, assetTransferGen)
+  lazy val transferGen: Gen[Transaction.TX] =
+    Gen.oneOf(
+      polyTransferGen.map { t: Transaction.TX => t },
+      arbitTransferGen.map { t: Transaction.TX => t },
+      assetTransferGen.map { t: Transaction.TX => t }
+    )
 
   lazy val propTypes: Gen[String] = sampleUntilNonEmpty(
     Gen.oneOf(
@@ -531,10 +535,14 @@ trait CommonGenerators extends Logging with NetworkPrefixTestHelper {
   lazy val attestationGen: Gen[Map[_ <: Proposition, Proof[_ <: Proposition]]] =
     Gen.oneOf(attestationCurve25519Gen, attestationThresholdCurve25519Gen, attestationEd25519Gen)
 
-  val transactionTypes: Seq[Gen[Transaction.TX]] =
-    Seq(polyTransferGen, arbitTransferGen, assetTransferGen)
+  lazy val transactionTypes: Seq[Gen[TransferTransaction[_ <: TokenValueHolder, _ <: Proposition]]] =
+    Seq(
+      polyTransferGen.map { t: TransferTransaction[_ <: TokenValueHolder, _ <: Proposition] => t },
+      arbitTransferGen.map { t: TransferTransaction[_ <: TokenValueHolder, _ <: Proposition] => t },
+      assetTransferGen.map { t: TransferTransaction[_ <: TokenValueHolder, _ <: Proposition] => t }
+    )
 
-  lazy val bifrostTransactionSeqGen: Gen[Seq[Transaction.TX]] = for {
+  lazy val bifrostTransactionSeqGen: Gen[Seq[Transaction[_ <: TokenValueHolder, _ <: Proposition]]] = for {
     seqLen <- positiveMediumIntGen
   } yield 0 until seqLen map { _ =>
     sampleUntilNonEmpty(sampleUntilNonEmpty(Gen.oneOf(transactionTypes)))

--- a/crypto/src/main/scala/co/topl/crypto/accumulators/merkle/MerkleTree.scala
+++ b/crypto/src/main/scala/co/topl/crypto/accumulators/merkle/MerkleTree.scala
@@ -10,9 +10,10 @@ import scala.collection.mutable
 
 /* Forked from https://github.com/input-output-hk/scrypto */
 
+/* NOTE: Use of mutable.WrappedArray.ofByte for Scala 2.12 compatibility */
 class MerkleTree[H, D: Digest](
   topNode:           Option[Node[D]],
-  elementsHashIndex: Map[mutable.ArraySeq[Byte], Int]
+  elementsHashIndex: Map[mutable.WrappedArray.ofByte, Int]
 )(implicit h:        Hash[H, D]) {
 
   private lazy val emptyRootHash: D = Digest[D].empty
@@ -27,7 +28,7 @@ class MerkleTree[H, D: Digest](
   def proofByElement(element: Leaf[H, D]): Option[MerkleProof[H, D]] = proofByElementHash(element.hash)
 
   def proofByElementHash(hash: D): Option[MerkleProof[H, D]] =
-    elementsHashIndex.get(new mutable.ArraySeq.ofByte(hash.bytes)).flatMap(i => proofByIndex(i))
+    elementsHashIndex.get(new mutable.WrappedArray.ofByte(hash.bytes)).flatMap(i => proofByIndex(i))
 
   def proofByIndex(index: Int): Option[MerkleProof[H, D]] = if (index >= 0 && index < length) {
 
@@ -81,8 +82,8 @@ object MerkleTree {
 
     val elementsToIndex =
       leafs.zipWithIndex
-        .foldLeft(Map[mutable.ArraySeq[Byte], Int]()) { case (elements, (leaf, leafIndex)) =>
-          elements + (new mutable.ArraySeq.ofByte(leaf.hash.bytes) -> leafIndex)
+        .foldLeft(Map[mutable.WrappedArray.ofByte, Int]()) { case (elements, (leaf, leafIndex)) =>
+          elements + (new mutable.WrappedArray.ofByte(leaf.hash.bytes) -> leafIndex)
         }
 
     val topNode = calcTopNode[H, D](leafs)


### PR DESCRIPTION
# Purpose
- ArraySeq exists in Scala 2.13 but not in 2.12
- WrappedArray exists in 2.12 but is deprecated in 2.13
- Compile issues in Test
- CircleCI issues when running checkPR

# Approach
- Re-integrate 2.12 types
- Add checkPR step to verify 2.12 compiles
- Specify CircleCI resource_class.  Remove SBT settings.

# Testing
- `checkPR` passes locally and in CI