### PR TITLE
Finished demonstration of HD KES scheme with MMM SymmetricKeys

### DIFF
--- a/common/src/main/scala/co/topl/attestation/keyManagement/derivedKeys/ExtendedPrivateKeyEd25519.scala
+++ b/common/src/main/scala/co/topl/attestation/keyManagement/derivedKeys/ExtendedPrivateKeyEd25519.scala
@@ -126,12 +126,11 @@ class ExtendedPrivateKeyEd25519(
    * @param message the message to sign serialized as a `MessageToSign`
    * @return the signature
    */
-  def sign(message: Array[Byte]): SignatureEd25519 = {
+  def sign(message: Array[Byte]): Signature = {
     // signing is a mutable process
     val mutableKey: ExtendedPrivateKeyEd25519 = ExtendedPrivateKeyEd25519.copy(this)
-    val ec = new Ed25519
 
-    val resultSig = new Array[Byte](ec.SIGNATURE_SIZE)
+    val resultSig = new Array[Byte](ed25519.SIGNATURE_SIZE)
     val ctx: Array[Byte] = Array.empty
     val phflag: Byte = 0x00
 
@@ -140,9 +139,9 @@ class ExtendedPrivateKeyEd25519(
     val pk: Array[Byte] = mutableKey.public.bytes.toArray
     val m: Array[Byte] = message
 
-    ec.implSign(ec.sha512Digest, h, s, pk, 0, ctx, phflag, m, 0, m.length, resultSig, 0)
+    ed25519.implSign(ed25519.sha512Digest, h, s, pk, 0, ctx, phflag, m, 0, m.length, resultSig, 0)
 
-    SignatureEd25519(Signature(resultSig))
+    Signature(resultSig)
   }
 
   lazy val serializer: BifrostSerializer[ExtendedPrivateKeyEd25519] = ExtendedPrivateKeyEd25519Serializer

--- a/common/src/main/scala/co/topl/attestation/keyManagement/stakingKeys/HdKesKeyFile.scala
+++ b/common/src/main/scala/co/topl/attestation/keyManagement/stakingKeys/HdKesKeyFile.scala
@@ -1,7 +1,6 @@
 package co.topl.attestation.keyManagement.stakingKeys
 
 import co.topl.crypto.hash.blake2b256
-import co.topl.crypto.kes.keys._
 import co.topl.utils.encode.Base58
 import com.google.common.primitives.Ints
 import io.circe.{Decoder, HCursor, Json}
@@ -71,43 +70,11 @@ case class HdKesKeyFile(kes_info: CipherInfo, fileName: String, oldFileName: Str
 
 object HdKesKeyFile {
 
-  /**
-   * Create a new HdKesScheme and save it to the specified directory
-   * @param password pass phrase used in AES encryption scheme
-   * @param defaultKeyDir file folder location for storage
-   * @param offset offset of the key
-   * @return new key file with randomly generated public private key pairs
-   */
-  def newRandomKeyFile(
-                        password:      String,
-                        defaultKeyDir: String,
-                        maxTimeSteps: Int
-                      ): HdKesKeyFile = {
-    val newKey = HdKesScheme(maxTimeSteps)
-    val kes_info = {
-      val salt = blake2b256.hash(uuid).value
-      val ivData = blake2b256.hash(uuid).value.slice(0, 16)
-      val derivedKey = getDerivedKey(password, salt)
-      val keyBytes: Array[Byte] = newKey.getBytes
-      val (cipherText, mac) = encryptAES(derivedKey, ivData, keyBytes)
-      CipherInfo(newKey.rootVerificationKey.bytes.value.toArray, cipherText, mac, salt, ivData)
-    }
-    val dateString = Instant.now().truncatedTo(ChronoUnit.MILLIS).toString.replace(":", "-")
-    val fileName = s"$defaultKeyDir/$dateString-${Base58.encode(newKey.rootVerificationKey.bytes.value.toArray)}.json"
-    val newKeyFile = new HdKesKeyFile(kes_info, fileName, "NEWKEY")
-    val file = new File(fileName)
-    file.getParentFile.mkdirs
-    val w = new BufferedWriter(new FileWriter(file))
-    w.write(newKeyFile.json.toString())
-    w.close()
-    newKeyFile
-  }
-
   def newKeyFile(
-                  password:      String,
-                  defaultKeyDir: String,
-                  hdKesScheme: HdKesScheme
-                ): HdKesKeyFile = {
+    password:      String,
+    defaultKeyDir: String,
+    hdKesScheme:   HdKesScheme
+  ): HdKesKeyFile = {
     val kes_info = {
       val salt = blake2b256.hash(uuid).value
       val ivData = blake2b256.hash(uuid).value.slice(0, 16)
@@ -140,13 +107,13 @@ object HdKesKeyFile {
    */
 
   def updateKeyFile(
-                     keyFile:       HdKesKeyFile,
-                     updatedKey:    HdKesScheme,
-                     password:      String,
-                     defaultKeyDir: String,
-                     salt:          Array[Byte] = blake2b256.hash(uuid).value,
-                     derivedKey:    Array[Byte] = Array()
-                   ): Option[HdKesKeyFile] = Try {
+    keyFile:       HdKesKeyFile,
+    updatedKey:    HdKesScheme,
+    password:      String,
+    defaultKeyDir: String,
+    salt:          Array[Byte] = blake2b256.hash(uuid).value,
+    derivedKey:    Array[Byte] = Array()
+  ): Option[HdKesKeyFile] = Try {
     val kes_info = {
       val ivData = blake2b256.hash(uuid).value.slice(0, 16)
       val (cipherText, mac) = if (derivedKey.isEmpty) {
@@ -226,11 +193,11 @@ object HdKesKeyFile {
     SCrypt.generate(password.getBytes(StandardCharsets.UTF_8), salt, scala.math.pow(2, 14).toInt, 8, 1, 32)
 
   private def getAESResult(
-                            derivedKey: Array[Byte],
-                            ivData:     Array[Byte],
-                            inputText:  Array[Byte],
-                            encrypt:    Boolean
-                          ): (Array[Byte], Array[Byte]) = {
+    derivedKey: Array[Byte],
+    ivData:     Array[Byte],
+    inputText:  Array[Byte],
+    encrypt:    Boolean
+  ): (Array[Byte], Array[Byte]) = {
     val cipherParams = new ParametersWithIV(new KeyParameter(derivedKey), ivData)
     val aesCtr = new BufferedBlockCipher(new SICBlockCipher(new AESEngine))
     aesCtr.init(encrypt, cipherParams)
@@ -241,10 +208,10 @@ object HdKesKeyFile {
   }
 
   private def encryptAES(
-                          derivedKey: Array[Byte],
-                          ivData:     Array[Byte],
-                          inputText:  Array[Byte]
-                        ): (Array[Byte], Array[Byte]) = {
+    derivedKey: Array[Byte],
+    ivData:     Array[Byte],
+    inputText:  Array[Byte]
+  ): (Array[Byte], Array[Byte]) = {
     val cipherParams = new ParametersWithIV(new KeyParameter(derivedKey), ivData)
     val aesCtr = new BufferedBlockCipher(new SICBlockCipher(new AESEngine))
     aesCtr.init(true, cipherParams)
@@ -256,10 +223,10 @@ object HdKesKeyFile {
   }
 
   private def decryptAES(
-                          derivedKey: Array[Byte],
-                          ivData:     Array[Byte],
-                          inputText:  Array[Byte]
-                        ): (Array[Byte], Array[Byte]) = {
+    derivedKey: Array[Byte],
+    ivData:     Array[Byte],
+    inputText:  Array[Byte]
+  ): (Array[Byte], Array[Byte]) = {
     val cipherParams = new ParametersWithIV(new KeyParameter(derivedKey), ivData)
     val aesCtr = new BufferedBlockCipher(new SICBlockCipher(new AESEngine))
     aesCtr.init(false, cipherParams)

--- a/common/src/main/scala/co/topl/attestation/keyManagement/stakingKeys/HdKesScheme.scala
+++ b/common/src/main/scala/co/topl/attestation/keyManagement/stakingKeys/HdKesScheme.scala
@@ -1,13 +1,17 @@
 package co.topl.attestation.keyManagement.stakingKeys
 
-import co.topl.attestation.SignatureEd25519
 import co.topl.crypto.kes
-import co.topl.attestation.keyManagement.derivedKeys.{DerivedKeyIndex, ExtendedPrivateKeyEd25519, ExtendedPublicKeyEd25519, SoftIndex}
+import co.topl.attestation.keyManagement.derivedKeys.{
+  DerivedKeyIndex,
+  ExtendedPrivateKeyEd25519,
+  ExtendedPublicKeyEd25519,
+  SoftIndex
+}
 import co.topl.attestation.keyManagement.mnemonic
-import co.topl.attestation.keyManagement.stakingKeys.HdKesScheme.serializer
 import co.topl.crypto.kes.keys.SymmetricKey
+import co.topl.crypto.hash.blake2b256
 import com.google.common.primitives.{Bytes, Ints, Longs}
-import scodec.bits.{ByteOrdering, ByteVector}
+import scodec.bits.ByteOrdering
 import co.topl.utils.SizedBytes
 import co.topl.utils.SizedBytes.Types.ByteVector32
 import co.topl.utils.SizedBytes.implicits._
@@ -15,25 +19,34 @@ import co.topl.utils.SizedBytes.implicits._
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
-case class HdKesScheme(rootVerificationKey: ExtendedPublicKeyEd25519, privateKeySet: mutable.Map[SoftIndex, ExtendedPrivateKeyEd25519]) {
+case class HdKesScheme(
+  registrationSlot:    Long,
+  rootVerificationKey: ExtendedPublicKeyEd25519,
+  privateKeySet:       mutable.Map[SoftIndex, ExtendedPrivateKeyEd25519]
+) {
 
-  def deriveVerificationKey(index: SoftIndex): ExtendedPublicKeyEd25519 =
-    rootVerificationKey.derive(index)
+  import HdKesScheme.serializer
 
-  def generateKESKey(index: SoftIndex, previousOffset: Long): (SignatureEd25519, SymmetricKey) = Try{
-    require(privateKeySet.keySet.contains(index),s"Key set does not contain index ${index.value}")
-    require(!privateKeySet.keySet.exists(_.value < index.value),s"Key set contains indices below ${index.value}")
-    val sk_KES = kes.keys.SymmetricKey.newFromSeed(
-      privateKeySet(index).leftKey.value.toArray,
-      previousOffset + index.value * SymmetricKey.maxKeyTimeSteps
+  def deriveVerificationKey(index: Int): ExtendedPublicKeyEd25519 =
+    rootVerificationKey.derive(SoftIndex(index))
+
+  def generateKESKey(index: Int): SymmetricKey = Try {
+    val softIndex = SoftIndex(index)
+    require(privateKeySet.keySet.contains(softIndex), s"Key set does not contain index ${softIndex.value}")
+    require(
+      !privateKeySet.keySet.exists(_.value < softIndex.value),
+      s"Key set contains indices below ${softIndex.value}"
     )
-    val vk_KES = sk_KES.getVerificationKey
-    val sign_vk_KES = privateKeySet(index).sign(vk_KES.bytes)
-    privateKeySet.remove(index)
-    (sign_vk_KES, sk_KES)
+    val sk_KES = kes.keys.SymmetricKey.newFromSeed(
+      blake2b256.hash(privateKeySet(softIndex).leftKey.value.toArray).value,
+      registrationSlot + softIndex.value * SymmetricKey.maxKeyTimeSteps,
+      privateKeySet(softIndex).sign
+    )
+    privateKeySet.remove(softIndex)
+    sk_KES
   } match {
     case Success(value) => value
-    case Failure(e) => throw new Exception(s"HD KES Key Derivation Failed: $e")
+    case Failure(e)     => throw new Exception(s"HD KES Key Derivation Failed: $e")
   }
 
   def getBytes: Array[Byte] = serializer.getBytes(this)
@@ -42,13 +55,14 @@ case class HdKesScheme(rootVerificationKey: ExtendedPublicKeyEd25519, privateKey
 
 object HdKesScheme {
 
-  def apply(totalNumberOfKeys: Int): HdKesScheme = {
+  def apply(totalNumberOfKeys: Int, registrationSlot: Long): HdKesScheme = {
     val skm = ExtendedPrivateKeyEd25519(mnemonic.Entropy.fromUuid(java.util.UUID.randomUUID()), "")
     val skIndex = Array.range(0, totalNumberOfKeys).map(DerivedKeyIndex.soft)
     val pkm = skm.public
     val newScheme = new HdKesScheme(
-        pkm,
-        mutable.Map(skIndex.zip(skIndex.map(skm.derive(_).toOption.get)).toSeq: _*)
+      registrationSlot,
+      pkm,
+      mutable.Map(skIndex.zip(skIndex.map(skm.derive(_).toOption.get)).toSeq: _*)
     )
     newScheme
   }
@@ -63,37 +77,40 @@ object HdKesScheme {
 
     private def sHdKesScheme(key: HdKesScheme): Array[Byte] =
       Bytes.concat(
+        Longs.toByteArray(key.registrationSlot),
         key.rootVerificationKey.bytes.value.toArray,
         key.rootVerificationKey.chainCode.value.toArray,
         Ints.toByteArray(key.privateKeySet.keySet.size),
         Bytes.concat(
-          key.privateKeySet.map(
-            entry =>
+          key.privateKeySet
+            .map(entry =>
               Longs.toByteArray(entry._1.value)
-                ++ entry._2.leftKey.value.toArray
-                ++ entry._2.rightKey.value.toArray
-                ++ entry._2.chainCode.value.toArray
-          ).toIndexedSeq:_*
+              ++ entry._2.leftKey.value.toArray
+              ++ entry._2.rightKey.value.toArray
+              ++ entry._2.chainCode.value.toArray
+            )
+            .toIndexedSeq: _*
         )
       )
 
     private def dHdKesScheme(stream: ByteStream): HdKesScheme = {
-      val out1 = SizedBytes[ByteVector32].fit(stream.get(ByteVector32.size), ByteOrdering.LittleEndian)
+      val out1 = stream.getLong
       val out2 = SizedBytes[ByteVector32].fit(stream.get(ByteVector32.size), ByteOrdering.LittleEndian)
-      val out3len = stream.getInt
+      val out3 = SizedBytes[ByteVector32].fit(stream.get(ByteVector32.size), ByteOrdering.LittleEndian)
+      val out4len = stream.getInt
       var i = 0
-      val out3:mutable.Map[SoftIndex,ExtendedPrivateKeyEd25519] = mutable.Map.empty
-      while (i < out3len) {
+      val out4: mutable.Map[SoftIndex, ExtendedPrivateKeyEd25519] = mutable.Map.empty
+      while (i < out4len) {
         val index = SoftIndex(stream.getLong)
         val leftKey = SizedBytes[ByteVector32].fit(stream.get(ByteVector32.size), ByteOrdering.LittleEndian)
         val rightKey = SizedBytes[ByteVector32].fit(stream.get(ByteVector32.size), ByteOrdering.LittleEndian)
         val chainCode = SizedBytes[ByteVector32].fit(stream.get(ByteVector32.size), ByteOrdering.LittleEndian)
-        val sk = new ExtendedPrivateKeyEd25519(leftKey,rightKey,chainCode)
-        out3 += (index -> sk)
+        val sk = new ExtendedPrivateKeyEd25519(leftKey, rightKey, chainCode)
+        out4 += (index -> sk)
         i += 1
       }
       assert(stream.empty)
-      HdKesScheme(ExtendedPublicKeyEd25519(out1,out2),out3)
+      HdKesScheme(out1, ExtendedPublicKeyEd25519(out2, out3), out4)
     }
   }
 

--- a/common/src/test/scala/co/topl/attestation/keyManagement/stakingKeys/HdKesKeySpec.scala
+++ b/common/src/test/scala/co/topl/attestation/keyManagement/stakingKeys/HdKesKeySpec.scala
@@ -1,0 +1,91 @@
+package co.topl.attestation.keyManagement.stakingKeys
+
+import co.topl.crypto.kes.KesVerifier
+import co.topl.crypto.kes.keys.SymmetricKey
+import co.topl.utils.encode.Base58
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+import java.nio.file.{Files, Path}
+import java.security.SecureRandom
+import java.util.Comparator
+import scala.util.{Failure, Success, Try}
+
+class HdKesKeySpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+
+  protected var keyFileDir: Path = _
+
+  def beforeAll(): Unit =
+    keyFileDir = Files.createTempDirectory("bifrost-test-keyring")
+
+  def afterAll(): Unit = {
+    import scala.jdk.CollectionConverters._
+    Files
+      .walk(keyFileDir)
+      .sorted(Comparator.reverseOrder[Path]())
+      .iterator()
+      .asScala
+      .foreach(Files.delete)
+  }
+
+  property("HD KES Test") {
+    beforeAll()
+    val passed = Try {
+      val password = "password"
+      val rnd: SecureRandom = new SecureRandom()
+      val totalNumberOfKeys = 12
+      val registrationSlot = 3000000L
+      var hdKesScheme = HdKesScheme(totalNumberOfKeys, registrationSlot)
+      var hdKesKeyFile = HdKesKeyFile.newKeyFile(password, keyFileDir.toString, hdKesScheme)
+      for (i <- 0 until totalNumberOfKeys) {
+        var t = registrationSlot + i * SymmetricKey.maxKeyTimeSteps
+        val newKey = hdKesScheme.generateKESKey(i)
+        hdKesKeyFile = HdKesKeyFile.updateKeyFile(hdKesKeyFile, hdKesScheme, password, keyFileDir.toString).get
+        var productKeyFile = SymmetricKeyFile.newKeyFile(password, keyFileDir.toString, newKey)
+        val message = rnd.generateSeed(2048)
+        var prodKey = productKeyFile.getKey(password).get
+        t += 1
+        prodKey = prodKey.update(t)
+        productKeyFile = SymmetricKeyFile.updateKeyFile(productKeyFile, prodKey, password, keyFileDir.toString).get
+        t += 10
+        prodKey = prodKey.update(t)
+        var sigProd = prodKey.sign(message)
+        assert(KesVerifier.verify(message, sigProd, t))
+        t += 100
+        prodKey = prodKey.update(t)
+        productKeyFile = SymmetricKeyFile.updateKeyFile(productKeyFile, prodKey, password, keyFileDir.toString).get
+        sigProd = prodKey.sign(message)
+        assert(KesVerifier.verify(message, sigProd, t))
+        t += 1000
+        prodKey = prodKey.update(t)
+        productKeyFile = SymmetricKeyFile.updateKeyFile(productKeyFile, prodKey, password, keyFileDir.toString).get
+        t += 10000
+        prodKey = prodKey.update(t)
+        productKeyFile = SymmetricKeyFile.updateKeyFile(productKeyFile, prodKey, password, keyFileDir.toString).get
+        t += 100000
+        prodKey = prodKey.update(t)
+        productKeyFile = SymmetricKeyFile.updateKeyFile(productKeyFile, prodKey, password, keyFileDir.toString).get
+        prodKey = productKeyFile.getKey(password).get
+        sigProd = prodKey.sign(message)
+        assert(KesVerifier.verify(message, sigProd, t))
+        //validation step for index signature
+        hdKesScheme = hdKesKeyFile.getKey(password).get
+        val vk_i = hdKesScheme.deriveVerificationKey(i).toPublicKey
+        require(
+          KesVerifier.verify(vk_i, prodKey.getVerificationKey, prodKey.data.offset, prodKey.signature),
+          "verification failed"
+        )
+      }
+
+    } match {
+      case Success(_) =>
+        true
+      case Failure(e) =>
+        e.printStackTrace()
+        false
+    }
+    afterAll()
+    passed shouldBe true
+  }
+}

--- a/crypto/src/main/scala/co/topl/crypto/kes/KesVerifier.scala
+++ b/crypto/src/main/scala/co/topl/crypto/kes/KesVerifier.scala
@@ -1,15 +1,29 @@
 package co.topl.crypto.kes
 
-import co.topl.crypto.kes.signatures.{ProductSignature, SumSignature}
+import co.topl.crypto.hash.blake2b256
+import co.topl.crypto.kes.signatures.{AsymmetricSignature, ProductSignature, SumSignature, SymmetricSignature}
+import co.topl.crypto.signatures.Ed25519
+import com.google.common.primitives.Longs
+import co.topl.crypto.signatures.Signature
+import co.topl.crypto.PublicKey
 
 object KesVerifier {
 
   val kes: KeyEvolvingSignatureScheme = new KeyEvolvingSignatureScheme
+  val ec: Ed25519 = new Ed25519
 
-  def verify(message: Array[Byte], sig: ProductSignature, timeStep: Int): Boolean =
-    kes.verifyProductSignature(message, sig: ProductSignature, timeStep)
+  def verify(message: Array[Byte], sig: AsymmetricSignature, slot: Long): Boolean =
+    kes.verifyProductSignature(message, sig: ProductSignature, (slot - sig.offset).toInt)
 
-  def verify(message: Array[Byte], sig: SumSignature, timeStep: Int): Boolean =
-    kes.sumCompositionVerify(sig.pkl.bytes, message, sig.bytes, timeStep)
+  def verify(message: Array[Byte], sig: SymmetricSignature, slot: Long): Boolean =
+    kes.verifyProductSignature(message, sig: ProductSignature, (slot - sig.offset).toInt)
+
+  def verify(message: Array[Byte], sig: SumSignature, slot: Long): Boolean =
+    kes.sumCompositionVerify(sig.pkl.value, message, sig.bytes, (slot - sig.offset).toInt)
+
+  def verify(vk_i: PublicKey, vk_kes: PublicKey, offset: Long, sig: Signature): Boolean = {
+    val m = blake2b256.hash(vk_kes.value ++ Longs.toByteArray(offset)).value.array
+    ec.verify(sig, m, vk_i)
+  }
 
 }

--- a/crypto/src/main/scala/co/topl/crypto/kes/keys/AsymmetricKey.scala
+++ b/crypto/src/main/scala/co/topl/crypto/kes/keys/AsymmetricKey.scala
@@ -1,8 +1,9 @@
 package co.topl.crypto.kes.keys
 
-import co.topl.crypto.kes.signatures.ProductSignature
+import co.topl.crypto.kes.signatures.AsymmetricSignature
 import co.topl.crypto.kes.KeyEvolvingSignatureScheme
 import co.topl.crypto.kes.construction.KeyData
+import co.topl.crypto.PublicKey
 
 /**
  * AMS 2021:
@@ -18,7 +19,7 @@ case class AsymmetricKey(override val data: KeyData) extends ProductPrivateKey {
   def update(globalTimeStep: Long): AsymmetricKey =
     kes.updateAsymmetricProductKey(this, (globalTimeStep - data.offset).toInt)
 
-  def sign(message: Array[Byte]): ProductSignature =
+  def sign(message: Array[Byte]): AsymmetricSignature =
     kes.signAsymmetricProduct(this, message)
 
   def getVerificationKey: PublicKey =

--- a/crypto/src/main/scala/co/topl/crypto/kes/keys/SumPrivateKey.scala
+++ b/crypto/src/main/scala/co/topl/crypto/kes/keys/SumPrivateKey.scala
@@ -3,6 +3,7 @@ package co.topl.crypto.kes.keys
 import co.topl.crypto.kes.construction.Tree
 import co.topl.crypto.kes.KeyEvolvingSignatureScheme
 import co.topl.crypto.kes.signatures.SumSignature
+import co.topl.crypto.PublicKey
 
 case class SumPrivateKey(L: Tree[Array[Byte]], offset: Long) {
 

--- a/crypto/src/main/scala/co/topl/crypto/kes/keys/SymmetricKey.scala
+++ b/crypto/src/main/scala/co/topl/crypto/kes/keys/SymmetricKey.scala
@@ -2,7 +2,11 @@ package co.topl.crypto.kes.keys
 
 import co.topl.crypto.kes.KeyEvolvingSignatureScheme
 import co.topl.crypto.kes.construction.KeyData
-import co.topl.crypto.kes.signatures.ProductSignature
+import co.topl.crypto.kes.signatures.SymmetricSignature
+import co.topl.crypto.PublicKey
+import co.topl.crypto.hash.blake2b256
+import co.topl.crypto.signatures.{Ed25519, Signature}
+import com.google.common.primitives.Longs
 
 /**
  * AMS 2021:
@@ -12,14 +16,14 @@ import co.topl.crypto.kes.signatures.ProductSignature
  * to the time step of the signature since signatures include the offset
  */
 
-case class SymmetricKey(override val data: KeyData) extends ProductPrivateKey {
+case class SymmetricKey(override val data: KeyData, signature: Signature) extends ProductPrivateKey {
 
   import SymmetricKey._
 
   def update(globalTimeStep: Long): SymmetricKey =
     kes.updateSymmetricProductKey(this, (globalTimeStep - data.offset).toInt)
 
-  def sign(message: Array[Byte]): ProductSignature =
+  def sign(message: Array[Byte]): SymmetricSignature =
     kes.signSymmetricProduct(this, message)
 
   def getVerificationKey: PublicKey =
@@ -31,15 +35,38 @@ case class SymmetricKey(override val data: KeyData) extends ProductPrivateKey {
   def timeStep: Long =
     kes.getSymmetricProductKeyTimeStep(this)
 
+  override def getBytes: Array[Byte] = signature.value ++ ProductPrivateKey.serializer.getBytes(data)
+
 }
 
 object SymmetricKey {
 
   val kes: KeyEvolvingSignatureScheme = new KeyEvolvingSignatureScheme
 
-  val maxKeyTimeSteps:Int = kes.maxSymmetricKeyTimeSteps
+  val maxKeyTimeSteps: Int = kes.maxSymmetricKeyTimeSteps
 
-  def newFromSeed(seed: Array[Byte], offset: Long): SymmetricKey =
-    kes.generateSymmetricProductKey(seed, offset)
+  def newFromSeed(seed: Array[Byte], offset: Long, signer: Array[Byte] => Signature): SymmetricKey = {
+    val kd = kes.generateProductKeyData(seed, offset)
+    val m = blake2b256.hash(kes.publicKey(kd) ++ Longs.toByteArray(offset)).value
+    val signature = signer(m)
+    SymmetricKey(kd, signature)
+  }
+
+  import ProductPrivateKey.serializer
+
+  def deserializeSymmetricKey(bytes: Array[Byte]): SymmetricKey = {
+    val byteStream = new ProductPrivateKey.ByteStream(bytes, None)
+    val numBytes = byteStream.getInt
+    val sigBytes = byteStream.get(Ed25519.SignatureLength)
+    serializer.fromBytes(
+      new ProductPrivateKey.ByteStream(
+        byteStream.get(numBytes - Ed25519.SignatureLength),
+        ProductPrivateKey.DeserializeKey
+      )
+    ) match {
+      case kd: KeyData =>
+        SymmetricKey(kd, Signature(sigBytes))
+    }
+  }
 
 }

--- a/crypto/src/main/scala/co/topl/crypto/kes/signatures/ProductSignature.scala
+++ b/crypto/src/main/scala/co/topl/crypto/kes/signatures/ProductSignature.scala
@@ -1,6 +1,6 @@
 package co.topl.crypto.kes.signatures
 
-import co.topl.crypto.kes.keys.PublicKey
+import co.topl.crypto.PublicKey
 
 trait ProductSignature
 

--- a/crypto/src/main/scala/co/topl/crypto/kes/signatures/SumSignature.scala
+++ b/crypto/src/main/scala/co/topl/crypto/kes/signatures/SumSignature.scala
@@ -1,5 +1,5 @@
 package co.topl.crypto.kes.signatures
 
-import co.topl.crypto.kes.keys.PublicKey
+import co.topl.crypto.PublicKey
 
 case class SumSignature(bytes: Array[Byte], offset: Long, pkl: PublicKey)

--- a/crypto/src/main/scala/co/topl/crypto/signatures/Ed25519.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signatures/Ed25519.scala
@@ -38,10 +38,23 @@ class Ed25519 extends eddsa.Ed25519 with EllipticCurveSignatureScheme {
     Signature(sig)
   }
 
+  def sign(privateKey: Array[Byte], message: Array[Byte]): Signature = {
+    require(privateKey.length == SECRET_KEY_SIZE)
+    val sig = new Array[Byte](SIGNATURE_SIZE)
+    sign(privateKey, 0, message, 0, message.length, sig, 0)
+    Signature(sig)
+  }
+
   override def verify(signature: Signature, message: MessageToSign, publicKey: PublicKey): Boolean =
     signature.value.length == SIGNATURE_SIZE &&
     publicKey.value.length == PUBLIC_KEY_SIZE &&
     verify(signature.value, 0, publicKey.value, 0, message, 0, message.length)
+
+  def verify(signature: Array[Byte], message: Array[Byte], publicKey: Array[Byte]): Boolean =
+    signature.length == SIGNATURE_SIZE &&
+    publicKey.length == PUBLIC_KEY_SIZE &&
+    verify(signature, 0, publicKey, 0, message, 0, message.length)
+
 }
 
 object Ed25519 {

--- a/crypto/src/test/scala/co/topl/crypto/kes/KeyEvolvingSignatureSchemeSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/kes/KeyEvolvingSignatureSchemeSpec.scala
@@ -3,8 +3,10 @@ package co.topl.crypto.kes
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
 import scala.util.{Failure, Success, Try}
 import java.security.SecureRandom
+import co.topl.crypto.signatures.Signature
 
 class KeyEvolvingSignatureSchemeSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
 
@@ -56,7 +58,7 @@ class KeyEvolvingSignatureSchemeSpec extends AnyPropSpec with ScalaCheckDrivenPr
         val productSignature2 = kes.signAsymmetricProduct(prodKey2, Array())
         productSignature2 match {
           case signatures.AsymmetricSignature(sigi, sigm, pki, offset, pkl) =>
-            val sigSize = sigi.length + sigm.length + pki.bytes.length
+            val sigSize = sigi.length + sigm.length + pki.value.length
             if (sigSize > oldSigSize) {
               oldSigSize = sigSize
               //println("Product Sig Length t "+i.toString+": "+sigSize.toString)
@@ -174,7 +176,7 @@ class KeyEvolvingSignatureSchemeSpec extends AnyPropSpec with ScalaCheckDrivenPr
     val passed = Try {
       //println("Testing MMM asymmetric product keys")
       val rnd: SecureRandom = new SecureRandom()
-      var t = 0
+      var t = 0L
       val message = rnd.generateSeed(2048)
       val seed1 = rnd.generateSeed(32)
       var prodKey = keys.AsymmetricKey.newFromSeed(seed1, 0)
@@ -245,10 +247,13 @@ class KeyEvolvingSignatureSchemeSpec extends AnyPropSpec with ScalaCheckDrivenPr
     val passed = Try {
       //Console.println("Testing MMM asymmetric product keys")
       val rnd: SecureRandom = new SecureRandom()
+      //dummy sign operation
+      def sign(m: Array[Byte]): Signature =
+        Signature(m)
       var t = 0
       val message = rnd.generateSeed(2048)
       val seed1 = rnd.generateSeed(32)
-      var prodKey = keys.SymmetricKey.newFromSeed(seed1, 0)
+      var prodKey = keys.SymmetricKey.newFromSeed(seed1, 0, sign)
       //println("Product key time step:")
       //println(prodKey.timeStepPlusOffset)
       //println("Updating MMM product key")


### PR DESCRIPTION
The HD KES scheme works as expected and provides the same degree of forward security as the MMM construction with linear performance in key derivation over time.  Years worth of keys may be cached and used in this setup, with a child MMM scheme that signs individual slots.  The key time step of the MMM construction remains one-to-one with the global slot, with an offset that is derived from the index of the parent HD scheme.  The HD private key cache is encrypted and updated with secure erasure each time a child MMM key and signature is generated.  The derivation of child public keys requires the root master public key to be included in the registration.  This supplants the definition of operational signature verification with a signature that verifies with the child public keys that commits to the verification key and offset of MMM symmetric keys.  More detailed documentation is forthcoming.