### PR TITLE
ExtendedEd25519 Fix.  Incorporate ByteVector.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,8 @@ inThisBuild(
   )
 )
 
+Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
+
 enablePlugins(ReproducibleBuildsPlugin, ReproducibleBuildsAssemblyPlugin)
 
 lazy val commonSettings = Seq(
@@ -422,7 +424,7 @@ lazy val crypto = project
     libraryDependencies ++= Dependencies.crypto
   )
   .settings(scalamacrosParadiseSettings)
-  .dependsOn(models, byteCodecs)
+  .dependsOn(models % "compile->compile;test->test", byteCodecs)
 
 lazy val tools = project
   .in(file("tools"))

--- a/chain-program/src/test/scala/co/topl/program/ProgramSpec.scala
+++ b/chain-program/src/test/scala/co/topl/program/ProgramSpec.scala
@@ -11,11 +11,7 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import java.time.Instant
 import scala.util.{Failure, Success, Try}
 
-class ProgramSpec
-    extends AnyPropSpec
-    with ScalaCheckDrivenPropertyChecks
-    with Matchers
-    with ProgramGenerators {
+class ProgramSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers with ProgramGenerators {
 
   property("Json works properly for ExecutionBuilderTerms") {
     forAll(validExecutionBuilderTermsGen) { t: ExecutionBuilderTerms =>
@@ -35,7 +31,7 @@ class ProgramSpec
     ).json
 
   def getMockPublicKeyProposition(fillByte: Byte): PublicKeyPropositionCurve25519 =
-    PublicKeyPropositionCurve25519(PublicKey(Array.fill(Curve25519.vkLength)(fillByte)))
+    PublicKeyPropositionCurve25519(PublicKey(Array.fill(Curve25519.instance.KeyLength)(fillByte)))
 
   property("Can create program") {
     Try {

--- a/consensus/src/main/scala/co/topl/consensus/tine/Tine.scala
+++ b/consensus/src/main/scala/co/topl/consensus/tine/Tine.scala
@@ -1,13 +1,12 @@
 package co.topl.consensus.tine
 
+import co.topl.consensus.TetraParameters
+import co.topl.consensus.vrf.ProofToHash
+import co.topl.models._
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 
-import co.topl.models._
-import co.topl.consensus.vrf.ProofToHash
-import co.topl.consensus.TetraParameters
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
-import scala.collection.immutable.ArraySeq
 
 case class Tine(
   var best:        mutable.SortedMap[BigInt, SlotId] = mutable.SortedMap(),
@@ -280,7 +279,7 @@ case class Tine(
             case Left(cache) =>
               val filtered = cache.filter(data => data._1 < t.minSlot.get && data._1 >= min).toSeq
               Bytes.concat(
-                Bytes.concat(filtered.map(entry => entry._3.data): _*),
+                filtered.map(entry => entry._3.data) :+
                 t.orderedNonceData(t.minSlot.get, max, None)
               )
             case Right(cache) =>
@@ -288,21 +287,21 @@ case class Tine(
               for (index <- min / databaseInterval to (t.minSlot.get - 1) / databaseInterval) {
                 val cacheKey = BigInt(index)
                 val newCache = cache.get(cacheKey).filter(data => data._1 < t.minSlot.get && data._1 >= min)
-                out = Bytes.concat(out, Bytes.concat(newCache.map(entry => entry._3.data).toIndexedSeq: _*))
+                out = Bytes.concat(out :: newCache.map(entry => entry._3.data).toList)
               }
-              Bytes.concat(out, t.orderedNonceData(t.minSlot.get, max, tine))
+              Bytes.concat(List(out, t.orderedNonceData(t.minSlot.get, max, tine)))
           }
         case _ =>
           tineDB match {
             case Left(cache) =>
               val newCache = cache.filter(data => data._1 <= max && data._1 >= min)
-              Bytes.concat(newCache.map(entry => entry._3.data).toIndexedSeq: _*)
+              Bytes.concat(newCache.map(entry => entry._3.data).toList)
             case Right(cache) =>
               var out: Bytes = Bytes.empty
               for (index <- min / databaseInterval to max / databaseInterval) {
                 val cacheKey = BigInt(index)
                 val newCache = cache.get(cacheKey).filter(data => data._1 <= max && data._1 >= min)
-                out = Bytes.concat(out, Bytes.concat(newCache.map(entry => entry._3.data).toIndexedSeq: _*))
+                out = Bytes.concat(out :: newCache.map(entry => entry._3.data).toList)
               }
               out
           }

--- a/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala
@@ -8,20 +8,23 @@ import co.topl.models.utility.Sized
 import org.bouncycastle.crypto.digests.SHA512Digest
 import org.bouncycastle.crypto.macs.HMac
 import org.bouncycastle.crypto.params.KeyParameter
+import scodec.bits.ByteVector
 
 import java.nio.charset.StandardCharsets
 import java.nio.{ByteBuffer, ByteOrder}
 
 class ExtendedEd25519
-    extends eddsa.Ed25519
-    with EllipticCurveSignatureScheme[
+    extends EllipticCurveSignatureScheme[
       SecretKeys.ExtendedEd25519,
       VerificationKeys.ExtendedEd25519,
       Proofs.Signature.Ed25519
     ] {
-  override val SignatureLength: Int = SIGNATURE_SIZE
-  override val KeyLength: Int = SECRET_KEY_SIZE
-  val PublicKeyLength: Int = PUBLIC_KEY_SIZE
+
+  private val impl = new eddsa.Ed25519
+
+  override val SignatureLength: Int = impl.SIGNATURE_SIZE
+  override val KeyLength: Int = impl.SECRET_KEY_SIZE
+  val PublicKeyLength: Int = impl.PUBLIC_KEY_SIZE
 
   override def createKeyPair(seed: Bytes): (SecretKeys.ExtendedEd25519, VerificationKeys.ExtendedEd25519) = {
     val sk = ExtendedEd25519.fromEntropy(Entropy(seed.toArray))("")
@@ -30,24 +33,24 @@ class ExtendedEd25519
   }
 
   override def sign(privateKey: SecretKeys.ExtendedEd25519, message: Bytes): Proofs.Signature.Ed25519 = {
-    val resultSig = new Array[Byte](SIGNATURE_SIZE)
-    val pk: Array[Byte] = new Array[Byte](PUBLIC_KEY_SIZE)
+    val resultSig = new Array[Byte](SignatureLength)
+    val pk: Array[Byte] = new Array[Byte](PublicKeyLength)
     val ctx: Array[Byte] = Array.empty
     val phflag: Byte = 0x00
     val h: Array[Byte] = privateKey.leftKey.data.toArray ++ privateKey.rightKey.data.toArray
     val s: Array[Byte] = privateKey.leftKey.data.toArray
     val m: Array[Byte] = message.toArray
 
-    scalarMultBaseEncoded(privateKey.leftKey.data.toArray, pk, 0)
-    implSign(sha512Digest, h, s, pk, 0, ctx, phflag, m, 0, m.length, resultSig, 0)
+    impl.scalarMultBaseEncoded(privateKey.leftKey.data.toArray, pk, 0)
+    impl.implSign(impl.sha512Digest, h, s, pk, 0, ctx, phflag, m, 0, m.length, resultSig, 0)
 
     Proofs.Signature.Ed25519(Sized.strictUnsafe(Bytes(resultSig)))
   }
 
   def verify(signature: Proofs.Signature.Ed25519, message: Bytes, verifyKey: VerificationKeys.Ed25519): Boolean =
-    verifyKey.bytes.data.length == PUBLIC_KEY_SIZE &&
-    signature.bytes.data.length == SIGNATURE_SIZE &&
-    verify(
+    verifyKey.bytes.data.length == PublicKeyLength &&
+    signature.bytes.data.length == SignatureLength &&
+    impl.verify(
       signature.bytes.data.toArray,
       0,
       verifyKey.bytes.data.toArray,
@@ -62,9 +65,9 @@ class ExtendedEd25519
     message:   Bytes,
     verifyKey: VerificationKeys.ExtendedEd25519
   ): Boolean =
-    signature.bytes.data.length == SIGNATURE_SIZE &&
-    verifyKey.vk.bytes.data.length == PUBLIC_KEY_SIZE &&
-    verify(
+    signature.bytes.data.length == SignatureLength &&
+    verifyKey.vk.bytes.data.length == PublicKeyLength &&
+    impl.verify(
       signature.bytes.data.toArray,
       0,
       verifyKey.vk.bytes.data.toArray,
@@ -152,7 +155,7 @@ class ExtendedEd25519
 
     val z = ExtendedEd25519.hmac512WithKey(
       verificationKey.chainCode.data.toArray,
-      Array(0x02.toByte) ++ verificationKey.vk.bytes.data.toArray ++ index.bytes.data
+      (((0x02: Byte) +: verificationKey.vk.bytes.data) ++ index.bytes.data).toArray
     )
 
     val zL = z.slice(0, 28)
@@ -166,16 +169,16 @@ class ExtendedEd25519
       .array()
       .take(32)
 
-    val scaledZL = new PointAccum
-    scalarMultBase(zLMult8, scaledZL)
+    val scaledZL = new impl.PointAccum
+    impl.scalarMultBase(zLMult8, scaledZL)
 
-    val publicKeyPoint = new PointExt
-    decodePointVar(verificationKey.vk.bytes.data.toArray, 0, negate = false, publicKeyPoint)
+    val publicKeyPoint = new impl.PointExt
+    impl.decodePointVar(verificationKey.vk.bytes.data.toArray, 0, negate = false, publicKeyPoint)
 
-    pointAddVar(negate = false, publicKeyPoint, scaledZL)
+    impl.pointAddVar(negate = false, publicKeyPoint, scaledZL)
 
-    val nextPublicKeyBytes = new Array[Byte](PUBLIC_KEY_SIZE)
-    encodePoint(scaledZL, nextPublicKeyBytes, 0)
+    val nextPublicKeyBytes = new Array[Byte](PublicKeyLength)
+    impl.encodePoint(scaledZL, nextPublicKeyBytes, 0)
 
     val nextPk = Bytes(nextPublicKeyBytes)
 
@@ -183,7 +186,7 @@ class ExtendedEd25519
       ExtendedEd25519
         .hmac512WithKey(
           verificationKey.chainCode.data.toArray,
-          Array(0x03.toByte) ++ verificationKey.vk.bytes.data.toArray ++ index.bytes.data
+          Array(0x03.toByte) ++ verificationKey.vk.bytes.data.toArray ++ index.bytes.data.toArray
         )
         .slice(32, 64)
 
@@ -194,19 +197,25 @@ class ExtendedEd25519
   }
 
   def getVerificationKey(secretKey: SecretKeys.ExtendedEd25519): VerificationKeys.ExtendedEd25519 = {
-    val pk = new Array[Byte](PUBLIC_KEY_SIZE)
-    scalarMultBaseEncoded(secretKey.leftKey.data.toArray, pk, 0)
+    val pk = new Array[Byte](PublicKeyLength)
+    impl.scalarMultBaseEncoded(secretKey.leftKey.data.toArray, pk, 0)
 
     VerificationKeys.ExtendedEd25519(
       VerificationKeys.Ed25519(Sized.strictUnsafe(Bytes(pk))),
       secretKey.chainCode
     )
   }
+
+  def precompute(): Unit = impl.precompute()
 }
 
 object ExtendedEd25519 {
-  val instance = new ExtendedEd25519
-  instance.precompute()
+
+  def precomputed(): ExtendedEd25519 = {
+    val instance = new ExtendedEd25519
+    instance.precompute()
+    instance
+  }
 
   /**
    * The type of the password used alongside a mnemonic to generate an `ExtendedPrivateKeyEd25519`
@@ -242,13 +251,13 @@ object ExtendedEd25519 {
       val seed = sizedSeed.data.toArray
 
       // turn seed into a valid ExtendedPrivateKeyEd25519 per the SLIP-0023 Icarus spec
-      seed(0) = (seed(0) & 0xf8).toByte
-      seed(31) = ((seed(31) & 0x1f) | 0x40).toByte
+      seed(0) = (seed(0) & 0xf8.toByte).toByte
+      seed(31) = ((seed(31) & 0x1f.toByte) | 0x40.toByte).toByte
 
       SecretKeys.ExtendedEd25519(
-        Sized.strictUnsafe(Bytes(seed.slice(0, 32).reverse)),
-        Sized.strictUnsafe(Bytes(seed.slice(32, 64).reverse)),
-        Sized.strictUnsafe(Bytes(seed.slice(64, 96).reverse))
+        Sized.strictUnsafe(Bytes(seed.slice(0, 32))),
+        Sized.strictUnsafe(Bytes(seed.slice(32, 64))),
+        Sized.strictUnsafe(Bytes(seed.slice(64, 96)))
       )
     }
 

--- a/crypto/src/test/scala/co/topl/crypto/mnemonic/MnemonicToExtendedEd25519.scala
+++ b/crypto/src/test/scala/co/topl/crypto/mnemonic/MnemonicToExtendedEd25519.scala
@@ -9,6 +9,7 @@ import co.topl.crypto.utils.Hex.implicits._
 import co.topl.models.SecretKeys
 import co.topl.models.utility.HasLength.instances.bytesLength
 import co.topl.models.utility.{Lengths, Sized}
+import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}
@@ -17,7 +18,8 @@ class MnemonicToExtendedEd25519
     extends AnyFlatSpec
     with ScalaCheckPropertyChecks
     with ScalaCheckDrivenPropertyChecks
-    with Matchers {
+    with Matchers
+    with EitherValues {
 
   case class TestVector(name: String, specIn: SpecIn, specOut: SpecOut)
   case class SpecIn(phrase: String, size: MnemonicSize, language: Language, password: String)
@@ -43,10 +45,7 @@ class MnemonicToExtendedEd25519
         "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
         Mnemonic12,
         English
-      ) match {
-        case Left(value)  => throw new Error(s"Problem deriving SecretKeys.ExtendedEd25519 from mnemonic: $value")
-        case Right(value) => value
-      }
+      ).value
 
     forAll(stringGen) { password =>
       val firstAttempt = createKey(password)
@@ -63,10 +62,7 @@ class MnemonicToExtendedEd25519
         "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
         Mnemonic12,
         English
-      ) match {
-        case Left(value)  => throw new Error(s"Problem deriving SecretKeys.ExtendedEd25519 from mnemonic: $value")
-        case Right(value) => value
-      }
+      ).value
 
     forAll(stringGen, stringGen) { (password1, password2) =>
       val firstAttempt = createKey(password1)
@@ -95,10 +91,9 @@ class MnemonicToExtendedEd25519
     )
 
     val sk = FromEntropy
-      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language) match {
-      case Left(value)  => throw new Error(s"failed test: $value")
-      case Right(value) => value(tv.specIn.password)
-    }
+      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language)
+      .map(_.apply(tv.specIn.password))
+      .value
 
     sk shouldBe tv.specOut.sk
   }
@@ -118,10 +113,9 @@ class MnemonicToExtendedEd25519
     )
 
     val sk = FromEntropy
-      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language) match {
-      case Left(value)  => throw new Error(s"failed test: $value")
-      case Right(value) => value(tv.specIn.password)
-    }
+      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language)
+      .map(_.apply(tv.specIn.password))
+      .value
 
     sk shouldBe tv.specOut.sk
   }
@@ -142,11 +136,9 @@ class MnemonicToExtendedEd25519
     )
 
     val sk = FromEntropy
-      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language) match {
-      case Left(value)  => throw new Error(s"failed test: $value")
-      case Right(value) => value(tv.specIn.password)
-
-    }
+      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language)
+      .map(_.apply(tv.specIn.password))
+      .value
 
     sk shouldBe tv.specOut.sk
   }
@@ -167,11 +159,9 @@ class MnemonicToExtendedEd25519
     )
 
     val sk = FromEntropy
-      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language) match {
-      case Left(value)  => throw new Error(s"failed test: $value")
-      case Right(value) => value(tv.specIn.password)
-
-    }
+      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language)
+      .map(_.apply(tv.specIn.password))
+      .value
 
     sk shouldBe tv.specOut.sk
   }
@@ -192,11 +182,9 @@ class MnemonicToExtendedEd25519
     )
 
     val sk = FromEntropy
-      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language) match {
-      case Left(value)  => throw new Error(s"failed test: $value")
-      case Right(value) => value(tv.specIn.password)
-
-    }
+      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language)
+      .map(_.apply(tv.specIn.password))
+      .value
 
     sk shouldBe tv.specOut.sk
   }
@@ -217,11 +205,55 @@ class MnemonicToExtendedEd25519
     )
 
     val sk = FromEntropy
-      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language) match {
-      case Left(value)  => throw new Error(s"failed test: $value")
-      case Right(value) => value(tv.specIn.password)
+      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language)
+      .map(_.apply(tv.specIn.password))
+      .value
 
-    }
+    sk shouldBe tv.specOut.sk
+  }
+  // https://github.com/cardano-foundation/CIPs/blob/master/CIP-0003/Icarus.md#test-vectors
+  it should "satisfy test vector 1 from icarus" in {
+    val tv = TestVector(
+      "Icarus Test Vector #1",
+      SpecIn(
+        "eight country switch draw meat scout mystery blade tip drift useless good keep usage title",
+        Mnemonic15,
+        English,
+        ""
+      ),
+      SpecOut.fromHexString(
+        "c065afd2832cd8b087c4d9ab7011f481ee1e0721e78ea5dd609f3ab3f156d245d176bd8fd4ec60b4731c3918a2a72a0" +
+        "226c0cd119ec35b47e4d55884667f552a23f7fdcd4a10c6cd2c7393ac61d877873e248f417634aa3d812af327ffe9d620"
+      )
+    )
+
+    val sk = FromEntropy
+      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language)
+      .map(_.apply(tv.specIn.password))
+      .value
+
+    sk shouldBe tv.specOut.sk
+  }
+  // https://github.com/cardano-foundation/CIPs/blob/master/CIP-0003/Icarus.md#test-vectors
+  it should "satisfy test vector 2 from icarus" in {
+    val tv = TestVector(
+      "Icarus Test Vector #1",
+      SpecIn(
+        "eight country switch draw meat scout mystery blade tip drift useless good keep usage title",
+        Mnemonic15,
+        English,
+        "foo"
+      ),
+      SpecOut.fromHexString(
+        "70531039904019351e1afb361cd1b312a4d0565d4ff9f8062d38acf4b15cce41d7b5738d9c893feea55512a3004acb0" +
+        "d222c35d3e3d5cde943a15a9824cbac59443cf67e589614076ba01e354b1a432e0e6db3b59e37fc56b5fb0222970a010e"
+      )
+    )
+
+    val sk = FromEntropy
+      .derive[String => SecretKeys.ExtendedEd25519](tv.specIn.phrase, tv.specIn.size, tv.specIn.language)
+      .map(_.apply(tv.specIn.password))
+      .value
 
     sk shouldBe tv.specOut.sk
   }

--- a/crypto/src/test/scala/co/topl/crypto/mnemonic/MnemonicToExtendedEd25519.scala
+++ b/crypto/src/test/scala/co/topl/crypto/mnemonic/MnemonicToExtendedEd25519.scala
@@ -7,6 +7,8 @@ import co.topl.crypto.mnemonic.MnemonicSize._
 import co.topl.crypto.utils.Generators._
 import co.topl.crypto.utils.Hex.implicits._
 import co.topl.models.SecretKeys
+import co.topl.models.utility.HasLength.instances.bytesLength
+import co.topl.models.utility.{Lengths, Sized}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}
@@ -20,6 +22,20 @@ class MnemonicToExtendedEd25519
   case class TestVector(name: String, specIn: SpecIn, specOut: SpecOut)
   case class SpecIn(phrase: String, size: MnemonicSize, language: Language, password: String)
   case class SpecOut(sk: SecretKeys.ExtendedEd25519)
+
+  object SpecOut {
+
+    def fromHexString(hexString: String): SpecOut = {
+      val allBytes = hexString.unsafeStrictBytes[Lengths.`96`.type].data
+      SpecOut(
+        SecretKeys.ExtendedEd25519(
+          Sized.strictUnsafe(allBytes.slice(0, 32)),
+          Sized.strictUnsafe(allBytes.slice(32, 64)),
+          Sized.strictUnsafe(allBytes.slice(64, 96))
+        )
+      )
+    }
+  }
 
   "Key from mnemonic phrase" should "output same the key with the same password" in {
     val createKey: String => SecretKeys.ExtendedEd25519 =
@@ -72,12 +88,9 @@ class MnemonicToExtendedEd25519
         English,
         "dinner"
       ),
-      SpecOut(
-        SecretKeys.ExtendedEd25519(
-          "49275d5103766daaf068000326cfa0b8b18389967c1995eee2cc36fc66d2d610".unsafeStrictBytes,
-          "7e83aaa8f1afc49ffb6b5f7755b813134c98d60523d2b2f0eeea5145d50c03ff".unsafeStrictBytes,
-          "36bf96ba09651007f338c4dfc4355f79fa3f947a68037e8976b2d8eac63d7743".unsafeStrictBytes
-        )
+      SpecOut.fromHexString(
+        "10d6d266fc36cce2ee95197c968983b1b8a0cf26030068f0aa6d7603515d2749ff030cd54551eaeef0b2d22305d6984c1313b" +
+        "855775f6bfb9fc4aff1a8aa837e43773dc6ead8b276897e03687a943ffa795f35c4dfc438f307106509ba96bf36"
       )
     )
 
@@ -98,12 +111,9 @@ class MnemonicToExtendedEd25519
         English,
         "heart"
       ),
-      SpecOut(
-        SecretKeys.ExtendedEd25519(
-          "4702e7f65dbd2af89c3959cdb4e79f72552102a61d89ad9918eb89a259065c10".unsafeStrictBytes,
-          "9dc74fe3f9a498114f2656a8be4f93831dbc5d94b43fd4416602deefd8cfa414".unsafeStrictBytes,
-          "ed2f79a789e55ee34e8c186c56af710017b85a9497418f62ada9b26c2a98d5ad".unsafeStrictBytes
-        )
+      SpecOut.fromHexString(
+        "105c0659a289eb1899ad891da6022155729fe7b4cd59399cf82abd5df6e7024714a4cfd8efde026641d43fb4945dbc1d83934" +
+        "fbea856264f1198a4f9e34fc79dadd5982a6cb2a9ad628f4197945ab8170071af566c188c4ee35ee589a7792fed"
       )
     )
 
@@ -125,12 +135,9 @@ class MnemonicToExtendedEd25519
         English,
         "describe"
       ),
-      SpecOut(
-        SecretKeys.ExtendedEd25519(
-          "5ec220a0c63beccc8b273a60dd7968ed9b10c6667e435bab39514479718c01f8".unsafeStrictBytes,
-          "6a61b32fcdc5d799b327a62d968a7331f773a6ad64b1684b0a1f35b6149a0ad1".unsafeStrictBytes,
-          "4ecf48d6c5e2d7918c5405ebba037a931ae29dc7de59815a7c3af6aa5b4dd367".unsafeStrictBytes
-        )
+      SpecOut.fromHexString(
+        "f8018c7179445139ab5b437e66c6109bed6879dd603a278bccec3bc6a020c25ed10a9a14b6351f0a4b68b164ada673f731738a9" +
+        "62da627b399d7c5cd2fb3616a67d34d5baaf63a7c5a8159dec79de21a937a03baeb05548c91d7e2c5d648cf4e"
       )
     )
 
@@ -153,12 +160,9 @@ class MnemonicToExtendedEd25519
         English,
         "manager"
       ),
-      SpecOut(
-        SecretKeys.ExtendedEd25519(
-          "5555589c9bf2dfcfcf70c2199a6c59631ab04cd5898c3a2cb3e63ece6f71e790".unsafeStrictBytes,
-          "7a3c9e2d94881a051f75d729b41b5ffc15224b457c2611348a5513413d8dbabe".unsafeStrictBytes,
-          "052ce0b1aaed6d6429a3a5dcb3b364e0876d63ab2f3a87d36bf5065b3b50618c".unsafeStrictBytes
-        )
+      SpecOut.fromHexString(
+        "90e7716fce3ee6b32c3a8c89d54cb01a63596c9a19c270cfcfdff29b9c585555beba8d3d4113558a3411267c454b2215fc5f1bb" +
+        "429d7751f051a88942d9e3c7a8c61503b5b06f56bd3873a2fab636d87e064b3b3dca5a329646dedaab1e02c05"
       )
     )
 
@@ -181,12 +185,9 @@ class MnemonicToExtendedEd25519
         English,
         "exact"
       ),
-      SpecOut(
-        SecretKeys.ExtendedEd25519(
-          "5f65b9988a25ed64c1ab99a31dfb87864067bdb236262a6d3a735ae2072edf98".unsafeStrictBytes,
-          "9ffb42972d707a282b77fb270e7c9afea86e868a162f0c7ad7e225a17d509719".unsafeStrictBytes,
-          "6124807717e882b56ea96c8acb15d45b867a48b6c91ee05ddf96651393084be1".unsafeStrictBytes
-        )
+      SpecOut.fromHexString(
+        "98df2e07e25a733a6d2a2636b2bd67408687fb1da399abc164ed258a98b9655f1997507da125e2d77a0c2f168a866ea8fe9a7c0e27fb" +
+        "772b287a702d9742fb9fe14b0893136596df5de01ec9b6487a865bd415cb8a6ca96eb582e81777802461"
       )
     )
 
@@ -209,12 +210,9 @@ class MnemonicToExtendedEd25519
         English,
         ""
       ),
-      SpecOut(
-        SecretKeys.ExtendedEd25519(
-          "5385aad34e831743a6acd89017628a86bcbf93d693abc34bc1d2d393f8576668".unsafeStrictBytes,
-          "5716f1bff83f4e5b7380246d4ab859041c62abae17863bbb52b82c434a098d7d".unsafeStrictBytes,
-          "5bc52f2580c9c7728426d8edd5e58c72412212e41d87b5af3e63b7c8d3aa4a94".unsafeStrictBytes
-        )
+      SpecOut.fromHexString(
+        "686657f893d3d2c14bc3ab93d693bfbc868a621790d8aca64317834ed3aa85537d8d094a432cb852bb3b8617aeab621c0459b84a6d24" +
+        "80735b4e3ff8bff11657944aaad3c8b7633eafb5871de4122241728ce5d5edd8268472c7c980252fc55b"
       )
     )
 

--- a/crypto/src/test/scala/co/topl/crypto/signing/Curve25519AxolotlSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/signing/Curve25519AxolotlSpec.scala
@@ -2,6 +2,7 @@ package co.topl.crypto.signing
 
 import co.topl.crypto.utils.Hex
 import co.topl.crypto.utils.Hex.implicits._
+import co.topl.models.ModelGenerators.arbitraryBytes
 import co.topl.models.utility.HasLength.instances._
 import co.topl.models.utility.Sized
 import co.topl.models.{Bytes, Proofs, SecretKeys, VerificationKeys}

--- a/crypto/src/test/scala/co/topl/crypto/signing/Ed25519Spec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/signing/Ed25519Spec.scala
@@ -2,6 +2,7 @@ package co.topl.crypto.signing
 
 import co.topl.crypto.utils.Hex
 import co.topl.crypto.utils.Hex.implicits._
+import co.topl.models.ModelGenerators.arbitraryBytes
 import co.topl.models.{Bytes, Proofs, SecretKeys, VerificationKeys}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec

--- a/crypto/src/test/scala/co/topl/crypto/signing/Ed25519VRFSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/signing/Ed25519VRFSpec.scala
@@ -2,8 +2,10 @@ package co.topl.crypto.signing
 
 import co.topl.crypto.utils.Hex
 import co.topl.crypto.utils.Hex.implicits._
+import co.topl.models.ModelGenerators.arbitraryBytes
 import co.topl.models.utility.{Lengths, Sized}
 import co.topl.models.{Bytes, Proofs, SecretKeys, VerificationKeys}
+import org.scalacheck.Arbitrary
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks

--- a/crypto/src/test/scala/co/topl/crypto/signing/ExtendedEd25519Spec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/signing/ExtendedEd25519Spec.scala
@@ -42,13 +42,8 @@ class ExtendedEd25519Spec
       }
     }
   }
-  it should "test vector - 1 - generate the correct master (sk,vk) from a seed with no password" in {
-    //todo: figure out if we can replicate https://github.com/cardano-foundation/CIPs/blob/master/CIP-0003/Icarus.md#test-vectors
-  }
-  it should "test vector - 2 - generate the correct master (sk,vk) from a seed including a password" in {
-    //todo: figure out if we can replicate https://github.com/cardano-foundation/CIPs/blob/master/CIP-0003/Icarus.md#test-vectors
-  }
-  it should "test vector - 3 - produce verifiable signatures with an empty message" in {
+
+  it should "test vector - 1 - produce verifiable signatures with an empty message" in {
     val extendedEd25519 = new ExtendedEd25519
     val specIn_xsk =
       SecretKeys.ExtendedEd25519(
@@ -75,7 +70,7 @@ class ExtendedEd25519Spec
     extendedEd25519.verify(specOut_sig, specIn_msg, xvk) shouldBe true
     extendedEd25519.verify(specOut_sig, specIn_msg, specOut_xvk) shouldBe true
   }
-  it should "test vector - 4 - produce verifiable signatures with a short message" in {
+  it should "test vector - 2 - produce verifiable signatures with a short message" in {
     val extendedEd25519 = new ExtendedEd25519
     val specIn_xsk =
       SecretKeys.ExtendedEd25519(
@@ -102,7 +97,7 @@ class ExtendedEd25519Spec
     extendedEd25519.verify(specOut_sig, specIn_msg, xvk) shouldBe true
     extendedEd25519.verify(specOut_sig, specIn_msg, specOut_xvk) shouldBe true
   }
-  it should "test vector - 5 - produce verifiable signatures with a long message" in {
+  it should "test vector - 3 - produce verifiable signatures with a long message" in {
     val extendedEd25519 = new ExtendedEd25519
     val specIn_xsk =
       SecretKeys.ExtendedEd25519(
@@ -151,7 +146,7 @@ class ExtendedEd25519Spec
     extendedEd25519.verify(specOut_sig, specIn_msg, xvk) shouldBe true
     extendedEd25519.verify(specOut_sig, specIn_msg, specOut_xvk) shouldBe true
   }
-  it should "test vector - 6 - derive the correct child (sk,vk) using path m/0" in {
+  it should "test vector - 4 - derive the correct child (sk,vk) using path m/0" in {
     val extendedEd25519 = new ExtendedEd25519()
     val specIn_derivationPath = Vector(Bip32Indexes.SoftIndex(0))
     val specIn_master_xsk =
@@ -188,7 +183,7 @@ class ExtendedEd25519Spec
     child_xvk shouldBe specOut_child_xvk
     child_xvk shouldBe child_xvk_fromSecret
   }
-  it should "test vector - 7 - derive the correct child (sk,vk) using path m/1" in {
+  it should "test vector - 5 - derive the correct child (sk,vk) using path m/1" in {
     val extendedEd25519 = new ExtendedEd25519()
     val specIn_derivationPath = Vector(Bip32Indexes.SoftIndex(1))
     val specIn_master_xsk =
@@ -225,7 +220,7 @@ class ExtendedEd25519Spec
     child_xvk shouldBe specOut_child_xvk
     child_xvk shouldBe child_xvk_fromSecret
   }
-  it should "test vector - 8 - derive the correct child (sk,vk) using path m/2" in {
+  it should "test vector - 6 - derive the correct child (sk,vk) using path m/2" in {
     val extendedEd25519 = new ExtendedEd25519()
     val specIn_derivationPath = Vector(Bip32Indexes.SoftIndex(2))
     val specIn_master_xsk =
@@ -262,7 +257,7 @@ class ExtendedEd25519Spec
     child_xvk shouldBe specOut_child_xvk
     child_xvk shouldBe child_xvk_fromSecret
   }
-  it should "test vector - 9 - derive the correct child (sk,vk) using path m/0`" in {
+  it should "test vector - 7 - derive the correct child (sk,vk) using path m/0`" in {
     val extendedEd25519 = new ExtendedEd25519()
     val specIn_derivationPath = Vector(Bip32Indexes.HardenedIndex(0))
     val specIn_master_xsk =
@@ -291,7 +286,7 @@ class ExtendedEd25519Spec
     child_xsk shouldBe specOut_child_xsk
     child_xvk_fromSecret shouldBe specOut_child_xvk
   }
-  it should "test vector - 10 - derive the correct child (sk,vk) using path m/0`/100`" in {
+  it should "test vector - 8 - derive the correct child (sk,vk) using path m/0`/100`" in {
     val extendedEd25519 = new ExtendedEd25519()
     val specIn_derivationPath =
       Vector(Bip32Indexes.HardenedIndex(0), Bip32Indexes.HardenedIndex(100))
@@ -321,7 +316,7 @@ class ExtendedEd25519Spec
     child_xsk shouldBe specOut_child_xsk
     child_xvk_fromSecret shouldBe specOut_child_xvk
   }
-  it should "test vector - 11 - derive the correct child (sk,vk) using path m/0`/100`/55" in {
+  it should "test vector - 9 - derive the correct child (sk,vk) using path m/0`/100`/55" in {
     val extendedEd25519 = new ExtendedEd25519()
     val specIn_derivationPath =
       Vector(Bip32Indexes.HardenedIndex(0), Bip32Indexes.HardenedIndex(100), Bip32Indexes.SoftIndex(55))
@@ -351,7 +346,7 @@ class ExtendedEd25519Spec
     child_xsk shouldBe specOut_child_xsk
     child_xvk_fromSecret shouldBe specOut_child_xvk
   }
-  it should "test vector - 12 - derive the correct child (sk,vk) using path m/1852`/7091`/0`/0`" in {
+  it should "test vector - 10 - derive the correct child (sk,vk) using path m/1852`/7091`/0`/0`" in {
     val extendedEd25519 = new ExtendedEd25519()
     val specIn_derivationPath =
       Vector(
@@ -386,7 +381,7 @@ class ExtendedEd25519Spec
     child_xsk shouldBe specOut_child_xsk
     child_xvk_fromSecret shouldBe specOut_child_xvk
   }
-  it should "test vector - 13 - derive the correct child (sk,vk) using path m/1852`/7091`/0`/0`/0" in {
+  it should "test vector - 11 - derive the correct child (sk,vk) using path m/1852`/7091`/0`/0`/0" in {
     val extendedEd25519 = new ExtendedEd25519()
     val specIn_derivationPath =
       Vector(

--- a/crypto/src/test/scala/co/topl/crypto/signing/ExtendedEd25519Spec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/signing/ExtendedEd25519Spec.scala
@@ -3,7 +3,9 @@ package co.topl.crypto.signing
 import co.topl.crypto.mnemonic.Bip32Indexes
 import co.topl.crypto.utils.Hex
 import co.topl.crypto.utils.Hex.implicits._
+import co.topl.models.ModelGenerators.arbitraryBytes
 import co.topl.models.{Bytes, Proofs, SecretKeys, VerificationKeys}
+import org.scalacheck.Arbitrary
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}

--- a/models/src/main/scala/co/topl/models/package.scala
+++ b/models/src/main/scala/co/topl/models/package.scala
@@ -3,12 +3,13 @@ package co.topl
 import co.topl.models.utility.{Lengths, Sized}
 import io.estatico.newtype.macros.newtype
 import io.estatico.newtype.ops._
+import scodec.bits.ByteVector
 
-import scala.collection.immutable.{ArraySeq, ListMap}
+import scala.collection.immutable.ListMap
 import scala.language.implicitConversions
 
 package object models {
-  type Bytes = ArraySeq[Byte]
+  type Bytes = ByteVector
   type BoxNonce = Long
   type Eta = Sized.Strict[Bytes, Lengths.`32`.type]
   type Evidence = Sized.Strict[TypedBytes, Lengths.`33`.type]
@@ -36,24 +37,7 @@ package object models {
   type StakeAddress = Propositions.PublicKeyEd25519
   type Digest32 = Sized.Strict[Bytes, Lengths.`32`.type]
 
-  object Bytes {
-    def apply(array:       Array[Byte]): Bytes = new ArraySeq.ofByte(array)
-    def toByteArray(bytes: Bytes): Array[Byte] = bytes.toArray
-
-    def concat(arrays: Bytes*): Bytes = {
-      var length = 0
-      for (array <- arrays)
-        length += array.length
-      val result = new Array[Byte](length)
-      var pos = 0
-      for (array <- arrays) {
-        System.arraycopy(array, 0, result, pos, array.length)
-        pos += array.length
-      }
-      Bytes(result)
-    }
-    def empty: Bytes = Bytes(Array())
-  }
+  val Bytes = ByteVector
 
   @newtype case class TypedBytes(allBytes: Bytes) {
     def typePrefix: TypePrefix = allBytes.head
@@ -63,6 +47,6 @@ package object models {
   object TypedBytes {
 
     def apply(prefix: TypePrefix, dataBytes: Bytes): TypedBytes =
-      dataBytes.prepended(prefix).coerce
+      (prefix +: dataBytes).coerce
   }
 }

--- a/models/src/main/scala/co/topl/models/utility/Sized.scala
+++ b/models/src/main/scala/co/topl/models/utility/Sized.scala
@@ -81,7 +81,7 @@ object HasLength {
   trait Instances {
 
     implicit def bytesLength: HasLength[Bytes] =
-      _.length
+      _.length.toInt
 
     implicit def arrayLength[T]: HasLength[Array[T]] =
       _.length
@@ -96,7 +96,7 @@ object HasLength {
       _.value.length
 
     implicit val typedDataLength: HasLength[TypedBytes] =
-      _.allBytes.length
+      _.allBytes.length.toInt
   }
 
   object instances extends Instances

--- a/models/src/test/scala/co/topl/models/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/ModelGenerators.scala
@@ -5,7 +5,7 @@ import co.topl.models.utility.HasLength.instances._
 import co.topl.models.utility.Lengths._
 import co.topl.models.utility.StringDataTypes.Latin1Data
 import co.topl.models.utility.{Length, Lengths, Ratio, Sized}
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.rng.Seed
 
 trait ModelGenerators {
@@ -118,6 +118,9 @@ trait ModelGenerators {
       .containerOfN[Array, Byte](l.value, byteGen)
       .map(Bytes(_))
       .map(Sized.strict[Bytes, L](_).toOption.get)
+
+  implicit val arbitraryBytes: Arbitrary[Bytes] =
+    Arbitrary(implicitly[Arbitrary[Array[Byte]]].arbitrary.map(Bytes(_)))
 
   implicit class GenHelper[T](gen: Gen[T]) {
     def first: T = gen.pureApply(Gen.Parameters.default, Seed.random())

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -105,6 +105,10 @@ object Dependencies {
     "org.iq80.leveldb" % "leveldb"        % "0.12"
   )
 
+  val scodecBits = Seq(
+    "org.scodec" %% "scodec-bits" % "1.1.27"
+  )
+
   val node: Seq[ModuleID] = {
     Seq(
       "com.typesafe.akka"          %% "akka-cluster"  % akkaVersion,
@@ -129,10 +133,10 @@ object Dependencies {
   lazy val common: Seq[ModuleID] =
     Seq(
       "com.typesafe.akka"      %% "akka-actor"              % akkaVersion,
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0",
-      "org.scodec"             %% "scodec-bits"             % "1.1.27"
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0"
     ) ++
     logging ++
+    scodecBits ++
     circe ++
     simulacrum ++
     test
@@ -187,6 +191,7 @@ object Dependencies {
     Seq(
       "org.whispersystems" % "curve25519-java" % "0.5.0"
     ) ++
+    scodecBits ++
     misc ++
     circe ++
     bouncyCastle ++
@@ -195,7 +200,7 @@ object Dependencies {
     test
 
   lazy val models: Seq[ModuleID] =
-    cats ++ simulacrum ++ newType
+    cats ++ simulacrum ++ newType ++ scodecBits
 
   lazy val demo: Seq[ModuleID] =
     Seq(akka("actor"), akka("actor-typed"), akka("stream")) ++ logging

--- a/typeclasses/src/main/scala/co/topl/typeclasses/EqInstances.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/EqInstances.scala
@@ -10,8 +10,8 @@ trait EqInstances {
   implicit def arrayEq[T: Eq]: Eq[Array[T]] =
     (a, b) => a.length == b.length && a.zip(b).forall { case (a1, b1) => a1 === b1 }
 
-//  implicit val bytesEq: Eq[Bytes] =
-//    (a, b) => a.toArray === b.toArray
+  implicit val bytesEq: Eq[Bytes] =
+    (a, b) => a === b
 
   implicit val typedBytesEq: Eq[TypedBytes] =
     (a, b) => a.allBytes === b.allBytes

--- a/typeclasses/src/main/scala/co/topl/typeclasses/KeyInitializer.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/KeyInitializer.scala
@@ -64,7 +64,7 @@ object KeyInitializer {
           fromSeed(Bytes(defaultRandom))
 
         def fromSeed(seed: Bytes): SecretKeys.ExtendedEd25519 =
-          ExtendedEd25519.instance.createKeyPair(seed)._1
+          ExtendedEd25519.precomputed().createKeyPair(seed)._1
       }
 
     implicit def extendedEd25519PasswordInitializer: KeyInitializer[String => SecretKeys.ExtendedEd25519] =

--- a/typeclasses/src/test/scala/co/topl/typeclasses/BlockGenesisSpec.scala
+++ b/typeclasses/src/test/scala/co/topl/typeclasses/BlockGenesisSpec.scala
@@ -26,18 +26,18 @@ class BlockGenesisSpec extends AnyFlatSpec with Matchers with EitherValues with 
     val address =
       block.headerV2.address
 
-    forAll(address.stakingVerificationKey.data)(_ shouldBe (0: Byte))
-    forAll(address.signature.data)(_ shouldBe (0: Byte))
-    forAll(address.paymentVerificationKeyHash.data)(_ shouldBe (0: Byte))
+    forAll(address.stakingVerificationKey.data.toArray)(_ shouldBe (0: Byte))
+    forAll(address.signature.data.toArray)(_ shouldBe (0: Byte))
+    forAll(address.paymentVerificationKeyHash.data.toArray)(_ shouldBe (0: Byte))
   }
 
   it should "have all zeros for the Eligibility Certificate" in {
     val cert = block.headerV2.eligibilityCertificate
-    forAll(cert.vkVRF.bytes.data)(_ shouldBe (0: Byte))
-    forAll(cert.vrfNonceSig.bytes.data)(_ shouldBe (0: Byte))
-    forAll(cert.vrfTestSig.bytes.data)(_ shouldBe (0: Byte))
-    forAll(cert.thresholdEvidence.data.dataBytes)(_ shouldBe (0: Byte))
-    forAll(cert.eta.data)(_ shouldBe (0: Byte))
+    forAll(cert.vkVRF.bytes.data.toArray)(_ shouldBe (0: Byte))
+    forAll(cert.vrfNonceSig.bytes.data.toArray)(_ shouldBe (0: Byte))
+    forAll(cert.vrfTestSig.bytes.data.toArray)(_ shouldBe (0: Byte))
+    forAll(cert.thresholdEvidence.data.dataBytes.toArray)(_ shouldBe (0: Byte))
+    forAll(cert.eta.data.toArray)(_ shouldBe (0: Byte))
   }
 
   // TODO


### PR DESCRIPTION
# Purpose
- ExtendedEd25519 unit tests occasionally fail
  - This seems to be the result of an issue in the byte implementation in `ExtendedEd25519.fromEntropy`
- Switched the `Bytes`  type to use scodec's ByteVector

# Approach
- Remove the `.reverse` calls in the byte construction of ExtendedEd25519.fromEntropy
- Update the `MnemonicToExtendedEd25519` tests to use the raw vector test strings
- Include scodec dependency.  Change `type Bytes` to `type Bytes = ByteVector`.  Update any broken references.

# Testing
- Unit tests pass locally with updated test vector strings from the [spec](https://topl.atlassian.net/wiki/spaces/CORE/pages/304023492/HD+Wallet+Protocols+and+Test+Vectors)