### PR TITLE
blocksByIds rpc method

### DIFF
--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -77,6 +77,12 @@ bifrost {
         admin = true
         debug = false
     }
+
+    # Max number of blocks to retrieve for methods like topl_blocksByIds and topl_blocksInRange
+    blockRetrievalLimit = 100
+
+    # Max number of transactions to retrieve for methods like topl_mempool
+    txRetrievalLimit = 100
   }
 
   gjallarhorn {

--- a/node/src/main/scala/co/topl/Heimdall.scala
+++ b/node/src/main/scala/co/topl/Heimdall.scala
@@ -241,7 +241,7 @@ object Heimdall {
         ToplRpcHandlers(
           new DebugRpcHandlerImpls(nodeViewHolderInterface, keyManagerInterface),
           new UtilsRpcHandlerImpls,
-          new NodeViewRpcHandlerImpls(appContext, nodeViewHolderInterface, forgerInterface),
+          new NodeViewRpcHandlerImpls(settings.rpcApi, appContext, nodeViewHolderInterface, forgerInterface),
           new TransactionRpcHandlerImpls(nodeViewHolderInterface),
           new AdminRpcHandlerImpls(forgerInterface, keyManagerInterface)
         ),

--- a/node/src/main/scala/co/topl/rpc/ToplRpcServer.scala
+++ b/node/src/main/scala/co/topl/rpc/ToplRpcServer.scala
@@ -43,6 +43,7 @@ class ToplRpcServer(handlers: ToplRpcHandlers, appContext: AppContext)(implicit
         .append(ToplRpc.NodeView.Balances.rpc)(handlers.nodeView.balances)
         .append(ToplRpc.NodeView.TransactionById.rpc)(handlers.nodeView.transactionById)
         .append(ToplRpc.NodeView.BlockById.rpc)(handlers.nodeView.blockById)
+        .append(ToplRpc.NodeView.BlocksByIds.rpc)(handlers.nodeView.blocksByIds)
         .append(ToplRpc.NodeView.BlockByHeight.rpc)(handlers.nodeView.blockByHeight)
         .append(ToplRpc.NodeView.BlocksInRange.rpc)(handlers.nodeView.blocksInRange)
         .append(ToplRpc.NodeView.Mempool.rpc)(handlers.nodeView.mempool)

--- a/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
@@ -6,7 +6,6 @@ import cats.implicits._
 import co.topl.akkahttprpc.{CustomError, InvalidParametersError, RpcError, ThrowableData}
 import co.topl.attestation.Address
 import co.topl.consensus.ForgerInterface
-import co.topl.modifier.ModifierId
 import co.topl.modifier.block.Block
 import co.topl.modifier.box._
 import co.topl.network.message.BifrostSyncInfo
@@ -74,6 +73,10 @@ class NodeViewRpcHandlerImpls(
         .subflatMap(
           _.toRight[RpcError](InvalidParametersError.adhoc("The requested block could not be found", "blockId"))
         )
+
+  override val blocksByIds: ToplRpc.NodeView.BlocksByIds.rpc.ServerHandler = { params =>
+    withNodeView(view => blocksByIdsResponse(params.blockIds, view.history)).subflatMap(identity)
+  }
 
   override val blocksInRange: ToplRpc.NodeView.BlocksInRange.rpc.ServerHandler =
     params =>
@@ -155,7 +158,7 @@ class NodeViewRpcHandlerImpls(
     view:        HistoryReader[Block, BifrostSyncInfo],
     startHeight: Long,
     endHeight:   Long
-  ): List[Block] =
+  ): ToplRpc.NodeView.BlocksByIds.Response =
     (startHeight to endHeight)
       .flatMap(view.idAtHeightOf)
       .flatMap(view.modifierById)

--- a/node/src/main/scala/co/topl/rpc/handlers/ToplRpcHandlers.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/ToplRpcHandlers.scala
@@ -33,6 +33,7 @@ object ToplRpcHandlers {
     def balances: ToplRpc.NodeView.Balances.rpc.ServerHandler
     def transactionById: ToplRpc.NodeView.TransactionById.rpc.ServerHandler
     def blockById: ToplRpc.NodeView.BlockById.rpc.ServerHandler
+    def blocksByIds: ToplRpc.NodeView.BlocksByIds.rpc.ServerHandler
     def blockByHeight: ToplRpc.NodeView.BlockByHeight.rpc.ServerHandler
     def blocksInRange: ToplRpc.NodeView.BlocksInRange.rpc.ServerHandler
     def mempool: ToplRpc.NodeView.Mempool.rpc.ServerHandler

--- a/node/src/main/scala/co/topl/settings/AppSettings.scala
+++ b/node/src/main/scala/co/topl/settings/AppSettings.scala
@@ -24,12 +24,14 @@ case class ApplicationSettings(
 )
 
 case class RPCApiSettings(
-  bindAddress:       InetSocketAddress,
-  disableAuth:       Boolean,
-  apiKeyHash:        String,
-  timeout:           FiniteDuration,
-  verboseAPI:        Boolean,
-  namespaceSelector: NamespaceSelector
+  bindAddress:         InetSocketAddress,
+  disableAuth:         Boolean,
+  apiKeyHash:          String,
+  timeout:             FiniteDuration,
+  verboseAPI:          Boolean,
+  namespaceSelector:   NamespaceSelector,
+  blockRetrievalLimit: Int,
+  txRetrievalLimit:    Int
 )
 
 case class NetworkSettings(

--- a/node/src/test/scala/co/topl/api/NameSpaceSpec.scala
+++ b/node/src/test/scala/co/topl/api/NameSpaceSpec.scala
@@ -40,7 +40,7 @@ class NameSpaceSpec extends AnyWordSpec with Matchers with RPCMockState {
         ToplRpcHandlers(
           new DebugRpcHandlerImpls(nodeViewHolderInterface, keyManagerInterface),
           new UtilsRpcHandlerImpls,
-          new NodeViewRpcHandlerImpls(newAppContext, nodeViewHolderInterface, forgerInterface),
+          new NodeViewRpcHandlerImpls(newRpcSettings.rpcApi, newAppContext, nodeViewHolderInterface, forgerInterface),
           new TransactionRpcHandlerImpls(nodeViewHolderInterface),
           new AdminRpcHandlerImpls(forgerInterface, keyManagerInterface)
         ),

--- a/node/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
+++ b/node/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
@@ -247,7 +247,7 @@ class NodeViewRPCSpec extends AnyWordSpec with Matchers with RPCMockState with E
 
       httpPOST(requestBody) ~> route ~> check {
         val res: Json = parse(responseAs[String]).value
-        res.hcursor.downField("error").as[Json].toString should include("No corresponding block found for id")
+        res.hcursor.downField("error").as[Json].toString should include("No corresponding block found for the given id")
       }
     }
 

--- a/node/src/test/scala/co/topl/api/RPCMockState.scala
+++ b/node/src/test/scala/co/topl/api/RPCMockState.scala
@@ -128,7 +128,7 @@ trait RPCMockState
         ToplRpcHandlers(
           new DebugRpcHandlerImpls(nodeViewHolderInterface, keyManagerInterface),
           new UtilsRpcHandlerImpls,
-          new NodeViewRpcHandlerImpls(appContext, nodeViewHolderInterface, forgerInterface),
+          new NodeViewRpcHandlerImpls(settings.rpcApi, appContext, nodeViewHolderInterface, forgerInterface),
           new TransactionRpcHandlerImpls(nodeViewHolderInterface),
           new AdminRpcHandlerImpls(forgerInterface, keyManagerInterface)
         ),

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
@@ -222,6 +222,20 @@ object ToplRpc {
       type Response = Block
     }
 
+    object BlocksByIds {
+
+      /**
+       * Lookup a block by its id
+       */
+      val rpc: Rpc[Params, Response] = Rpc("topl_blocksByIds")
+
+      /**
+       * @param blockIds Base58 encoded transaction hash
+       */
+      case class Params(blockIds: List[ModifierId])
+      type Response = List[Block]
+    }
+
     object BlocksInRange {
 
       /**

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
@@ -7,7 +7,6 @@ import co.topl.modifier.block.Block
 import co.topl.modifier.box._
 import co.topl.modifier.transaction.builder.{BoxSelectionAlgorithm, BoxSelectionAlgorithms}
 import co.topl.modifier.transaction.{ArbitTransfer, AssetTransfer, PolyTransfer, Transaction}
-import co.topl.rpc.ToplRpc.Transaction.RawAssetTransfer
 import co.topl.utils.Int128
 import co.topl.utils.NetworkType.NetworkPrefix
 import co.topl.utils.StringDataTypes.Latin1Data
@@ -76,6 +75,9 @@ trait NodeViewRpcParamsEncoders {
     deriveEncoder
 
   implicit val nodeViewBlockByIdParamsEncoder: Encoder[ToplRpc.NodeView.BlockById.Params] =
+    deriveEncoder
+
+  implicit val nodeViewBlocksByIdsParamsEncoder: Encoder[ToplRpc.NodeView.BlocksByIds.Params] =
     deriveEncoder
 
   implicit val nodeViewBlockByHeightParamsEncoder: Encoder[ToplRpc.NodeView.BlockByHeight.Params] =
@@ -349,7 +351,10 @@ trait NodeViewRpcParamsDecoders {
   implicit val nodeViewTransactionsByIdParamsDecoder: Decoder[ToplRpc.NodeView.TransactionById.Params] =
     deriveDecoder
 
-  implicit val nodeViewBlocksByIdParamsDecoder: Decoder[ToplRpc.NodeView.BlockById.Params] =
+  implicit val nodeViewBlockByIdParamsDecoder: Decoder[ToplRpc.NodeView.BlockById.Params] =
+    deriveDecoder
+
+  implicit val nodeViewBlocksByIdsParamsDecoder: Decoder[ToplRpc.NodeView.BlocksByIds.Params] =
     deriveDecoder
 
   implicit val nodeViewBlocksByHeightParamsDecoder: Decoder[ToplRpc.NodeView.BlockByHeight.Params] =

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcErrors.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcErrors.scala
@@ -10,6 +10,8 @@ object ToplRpcErrors {
 
   val NoBlockIdsAtHeight: CustomError = CustomError(-32000, "No block ids found from that block height")
 
+  val NoBlockWithGivenId: CustomError = CustomError(-32008, "No corresponding block found for the given id")
+
   val InvalidHeightRange: CustomError = CustomError(-32009, "Invalid height range")
 
   def FailedToGenerateAssetCode(throwable: Throwable)(implicit


### PR DESCRIPTION
## Purpose
It would be useful if there is an RPC method that retrieves multiple blocks by their ids instead of just one

## Approach
- Added an RPC method `topl_blocksByIds` that takes an array of block ids and returns the corresponding blocks

## Tests
- Tested getting blocks with an array of ids
- Tested that the method should fail if there exists invalid ids

## Closes
# 1783