### PR TITLE
Confirmation Status RPC

### DIFF
--- a/node/src/main/scala/co/topl/rpc/ToplRpcServer.scala
+++ b/node/src/main/scala/co/topl/rpc/ToplRpcServer.scala
@@ -48,6 +48,7 @@ class ToplRpcServer(handlers: ToplRpcHandlers, appContext: AppContext)(implicit
         .append(ToplRpc.NodeView.BlocksInRange.rpc)(handlers.nodeView.blocksInRange)
         .append(ToplRpc.NodeView.Mempool.rpc)(handlers.nodeView.mempool)
         .append(ToplRpc.NodeView.TransactionFromMempool.rpc)(handlers.nodeView.transactionFromMempool)
+        .append(ToplRpc.NodeView.ConfirmationStatus.rpc)(handlers.nodeView.confirmationStatus)
         .append(ToplRpc.NodeView.Info.rpc)(handlers.nodeView.info)
         .append(ToplRpc.NodeView.NodeStatus.rpc)(handlers.nodeView.nodeStatus)
     } else RpcServer.Builder.empty

--- a/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
@@ -6,12 +6,14 @@ import cats.implicits._
 import co.topl.akkahttprpc.{CustomError, InvalidParametersError, RpcError, ThrowableData}
 import co.topl.attestation.Address
 import co.topl.consensus.ForgerInterface
+import co.topl.modifier.ModifierId
 import co.topl.modifier.block.Block
 import co.topl.modifier.box._
 import co.topl.network.message.BifrostSyncInfo
 import co.topl.nodeView.history.HistoryReader
 import co.topl.nodeView.state.StateReader
 import co.topl.nodeView.{NodeViewHolderInterface, ReadableNodeView}
+import co.topl.rpc.ToplRpc.NodeView.ConfirmationStatus.TxStatus
 import co.topl.rpc.{ToplRpc, ToplRpcErrors}
 import co.topl.settings.{AppContext, RPCApiSettings}
 import co.topl.utils.Int128
@@ -105,7 +107,11 @@ class NodeViewRpcHandlerImpls(
         )
 
   override val confirmationStatus: ToplRpc.NodeView.ConfirmationStatus.rpc.ServerHandler =
-    params => withNodeView(view => checkTxIds(params.transactionIds, view)).subflatMap(identity)
+    params =>
+      withNodeView { view =>
+        getConfirmationStatus(params.transactionIds, view)
+        checkTxIds(getConfirmationStatus(params.transactionIds, view))
+      }.subflatMap(identity)
 
   override val info: ToplRpc.NodeView.Info.rpc.ServerHandler =
     _ =>
@@ -168,6 +174,24 @@ class NodeViewRpcHandlerImpls(
       .flatMap(view.idAtHeightOf)
       .flatMap(view.modifierById)
       .toList
+
+  private def getConfirmationStatus(
+    txIds: List[ModifierId],
+    view:  ReadableNodeView
+  ): List[Option[(ModifierId, TxStatus)]] =
+    txIds.map { id =>
+      val mempoolStatus = view.memPool.modifierById(id)
+      val historyStatus = view.history.transactionById(id)
+      val bestBlockHeight = view.history.height
+      (mempoolStatus, historyStatus) match {
+        case (_, Some((tx, _, height))) =>
+          Some(tx.id -> TxStatus("Confirmed", bestBlockHeight - height))
+        case (Some(tx), None) =>
+          Some(tx.id -> TxStatus("Unconfirmed", -1))
+        case (None, None) =>
+          None
+      }
+    }
 
   private def withNodeView[T](f: ReadableNodeView => T) =
     nodeViewHolderInterface

--- a/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
@@ -104,6 +104,9 @@ class NodeViewRpcHandlerImpls(
           _.toRight[RpcError](InvalidParametersError.adhoc("Unable to retrieve transaction", "transactionId"))
         )
 
+  override val confirmationStatus: ToplRpc.NodeView.ConfirmationStatus.rpc.ServerHandler =
+    params => withNodeView(view => checkTxIds(params.transactionIds, view)).subflatMap(identity)
+
   override val info: ToplRpc.NodeView.Info.rpc.ServerHandler =
     _ =>
       EitherT.pure(

--- a/node/src/main/scala/co/topl/rpc/handlers/ToplRpcHandlers.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/ToplRpcHandlers.scala
@@ -38,6 +38,7 @@ object ToplRpcHandlers {
     def blocksInRange: ToplRpc.NodeView.BlocksInRange.rpc.ServerHandler
     def mempool: ToplRpc.NodeView.Mempool.rpc.ServerHandler
     def transactionFromMempool: ToplRpc.NodeView.TransactionFromMempool.rpc.ServerHandler
+    def confirmationStatus: ToplRpc.NodeView.ConfirmationStatus.rpc.ServerHandler
     def info: ToplRpc.NodeView.Info.rpc.ServerHandler
     def nodeStatus: ToplRpc.NodeView.NodeStatus.rpc.ServerHandler
   }

--- a/node/src/main/scala/co/topl/rpc/handlers/package.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/package.scala
@@ -5,8 +5,10 @@ import co.topl.attestation.Address
 import co.topl.modifier.ModifierId
 import co.topl.modifier.block.Block
 import co.topl.network.message.BifrostSyncInfo
+import co.topl.nodeView.ReadableNodeView
 import co.topl.nodeView.history.HistoryReader
 import co.topl.nodeView.state.StateReader
+import co.topl.rpc.ToplRpc.NodeView.ConfirmationStatus.TxStatus
 
 package object handlers {
 
@@ -38,7 +40,7 @@ package object handlers {
       blocks <- Either.cond(
         blocksOption.forall(_.nonEmpty),
         blocksOption.map(_.get),
-        ToplRpcErrors.NoBlockWithGivenId
+        ToplRpcErrors.NoBlockWithId
       )
     } yield blocks
   }
@@ -61,5 +63,32 @@ package object handlers {
         ToplRpcErrors.unsupportedOperation("Height range exceeded blockRetrievalLimit")
       )
     } yield (startHeight, endHeight)
+
+  private[handlers] def checkTxIds(
+    txIds: List[ModifierId],
+    view:  ReadableNodeView
+  ): Either[RpcError, ToplRpc.NodeView.ConfirmationStatus.Response] = {
+    val txStatusOption: List[Option[(ModifierId, TxStatus)]] = txIds.map { id =>
+      val mempoolStatus = view.memPool.modifierById(id)
+      val historyStatus = view.history.transactionById(id)
+      val bestBlockHeight = view.history.height
+      (mempoolStatus, historyStatus) match {
+        case (_, Some((tx, _, height))) =>
+          Some(tx.id -> TxStatus("Confirmed", bestBlockHeight - height))
+        case (Some(tx), None) =>
+          Some(tx.id -> TxStatus("Unconfirmed", -1))
+        case (None, None) =>
+          None
+      }
+    }
+
+    for {
+      txStatus <- Either.cond(
+        txStatusOption.forall(_.nonEmpty),
+        txStatusOption.map(_.get).toMap,
+        ToplRpcErrors.NoTransactionWithId
+      )
+    } yield txStatus
+  }
 
 }

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
@@ -291,6 +291,21 @@ object ToplRpc {
       type Response = TX
     }
 
+    object ConfirmationStatus {
+
+      /**
+       * Lookup the confirmation status of transactions
+       */
+      val rpc: Rpc[Params, Response] = Rpc("topl_confirmationStatus")
+
+      /**
+       * @param transactionIds Base58 encoded transaction hash
+       */
+      case class Params(transactionIds: List[ModifierId])
+      type Response = Map[ModifierId, TxStatus]
+      case class TxStatus(status: String, depthFromHead: Long)
+    }
+
     object Info {
 
       /**

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
@@ -92,6 +92,9 @@ trait NodeViewRpcParamsEncoders {
   implicit val nodeViewTransactionFromMempoolParamsEncoder: Encoder[ToplRpc.NodeView.TransactionFromMempool.Params] =
     deriveEncoder
 
+  implicit val nodeViewConfirmationStatusParamsEncoder: Encoder[ToplRpc.NodeView.ConfirmationStatus.Params] =
+    deriveEncoder
+
   implicit val nodeViewInfoParamsEncoder: Encoder[ToplRpc.NodeView.Info.Params] =
     deriveEncoder
 
@@ -225,6 +228,14 @@ trait NodeViewRpcResponseDecoders extends SharedCodecs {
     networkPrefix: NetworkPrefix
   ): Decoder[ToplRpc.NodeView.Balances.Response] =
     Decoder.decodeMap[Address, ToplRpc.NodeView.Balances.Entry]
+
+  implicit val nodeViewConfirmationStatusTxStatusDecoder: Decoder[ToplRpc.NodeView.ConfirmationStatus.TxStatus] =
+    deriveDecoder
+
+  implicit def nodeViewConfirmationStatusResponseDecoder(implicit
+    networkPrefix: NetworkPrefix
+  ): Decoder[ToplRpc.NodeView.ConfirmationStatus.Response] =
+    Decoder.decodeMap[ModifierId, ToplRpc.NodeView.ConfirmationStatus.TxStatus]
 }
 
 trait TransactionRpcResponseDecoders extends SharedCodecs {
@@ -367,6 +378,11 @@ trait NodeViewRpcParamsDecoders {
     deriveDecoder
 
   implicit val nodeViewTransactionFromMempoolParamsDecoder: Decoder[ToplRpc.NodeView.TransactionFromMempool.Params] =
+    deriveDecoder
+
+  implicit def nodeViewConfirmationStatusParamsDecoder(implicit
+    networkPrefix: NetworkPrefix
+  ): Decoder[ToplRpc.NodeView.ConfirmationStatus.Params] =
     deriveDecoder
 
   implicit val nodeViewInfoParamsDecoder: Decoder[ToplRpc.NodeView.Info.Params] =
@@ -569,6 +585,14 @@ trait NodeViewRpcResponseEncoders extends SharedCodecs {
 
   implicit val nodeViewNodeStatusResponseEncoder: Encoder[ToplRpc.NodeView.NodeStatus.Response] =
     deriveEncoder
+
+  implicit val nodeViewConfirmationStatusTxStatusEncoder: Encoder[ToplRpc.NodeView.ConfirmationStatus.TxStatus] =
+    deriveEncoder
+
+  implicit val nodeViewConfirmationStatusResponseEncoder: Encoder[ToplRpc.NodeView.ConfirmationStatus.Response] =
+    _.map { case (txId, txStatus) =>
+      ModifierId.jsonKeyEncoder(txId) -> txStatus
+    }.asJson
 }
 
 trait TransactionRpcResponseEncoders extends SharedCodecs {

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcErrors.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcErrors.scala
@@ -10,7 +10,9 @@ object ToplRpcErrors {
 
   val NoBlockIdsAtHeight: CustomError = CustomError(-32000, "No block ids found from that block height")
 
-  val NoBlockWithGivenId: CustomError = CustomError(-32008, "No corresponding block found for the given id")
+  val NoBlockWithId: CustomError = CustomError(-32008, "No corresponding block found for the given id")
+
+  val NoTransactionWithId: CustomError = CustomError(-32007, "No corresponding transaction with such id")
 
   val InvalidHeightRange: CustomError = CustomError(-32009, "Invalid height range")
 

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcErrors.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcErrors.scala
@@ -12,7 +12,7 @@ object ToplRpcErrors {
 
   val NoBlockWithId: CustomError = CustomError(-32008, "No corresponding block found for the given id")
 
-  val NoTransactionWithId: CustomError = CustomError(-32007, "No corresponding transaction with such id")
+  val NoTransactionWithId: CustomError = CustomError(-32007, "Could not find one or more of the specified transactions")
 
   val InvalidHeightRange: CustomError = CustomError(-32009, "Invalid height range")
 


### PR DESCRIPTION
## Purpose
Add a confirmation status check to see if transactions are still unconfirmed in the mempool or already included on chain

## Approach
- Added an RPC method `topl_confirmationStatus` that takes an array of transaction ids and returns the confirmation status
- If a transaction is in the mempool, return "Unconfirmed" with a depthFromHead of -1
- If a transaction is already on the chain, return "Confirmed" with the block height difference with the head of the chain as depthFromHead
- Return error if invalid ids are given or if no such ids are found in both mempool and history

## Tests
- Tested getting confirmation status for confirmed and unconfirmed transactions
- Tested getting error response for non existent transaction ids

## Closes
# 1166