### PR TITLE
blockIdsInRange rpc

### DIFF
--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -81,6 +81,9 @@ bifrost {
     # Max number of blocks to retrieve for methods like topl_blocksByIds and topl_blocksInRange
     blockRetrievalLimit = 100
 
+    # Max number of block ids to retrieve for methods like topl_blockIdsInRange
+    blockIdRetrievalLimit = 1000
+
     # Max number of transactions to retrieve for methods like topl_mempool
     txRetrievalLimit = 100
   }

--- a/node/src/main/scala/co/topl/rpc/ToplRpcServer.scala
+++ b/node/src/main/scala/co/topl/rpc/ToplRpcServer.scala
@@ -46,6 +46,7 @@ class ToplRpcServer(handlers: ToplRpcHandlers, appContext: AppContext)(implicit
         .append(ToplRpc.NodeView.BlocksByIds.rpc)(handlers.nodeView.blocksByIds)
         .append(ToplRpc.NodeView.BlockByHeight.rpc)(handlers.nodeView.blockByHeight)
         .append(ToplRpc.NodeView.BlocksInRange.rpc)(handlers.nodeView.blocksInRange)
+        .append(ToplRpc.NodeView.BlockIdsInRange.rpc)(handlers.nodeView.blockIdsInRange)
         .append(ToplRpc.NodeView.Mempool.rpc)(handlers.nodeView.mempool)
         .append(ToplRpc.NodeView.TransactionFromMempool.rpc)(handlers.nodeView.transactionFromMempool)
         .append(ToplRpc.NodeView.ConfirmationStatus.rpc)(handlers.nodeView.confirmationStatus)

--- a/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
@@ -4,7 +4,7 @@ import akka.actor.typed.ActorSystem
 import cats.implicits._
 import co.topl.akkahttprpc.{CustomError, InvalidParametersError, RpcError, ThrowableData}
 import co.topl.attestation.Address
-import co.topl.consensus.{ForgerInterface, blockVersion, getProtocolRules}
+import co.topl.consensus.{blockVersion, getProtocolRules, ForgerInterface}
 import co.topl.modifier.ModifierId
 import co.topl.modifier.block.Block
 import co.topl.modifier.box._

--- a/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
@@ -90,7 +90,7 @@ class NodeViewRpcHandlerImpls(
   override val blockIdsInRange: ToplRpc.NodeView.BlockIdsInRange.rpc.ServerHandler =
     params =>
       withNodeView(view =>
-        checkHeightRange(view.history.height, params.startHeight, params.endHeight, rpcSettings.blockRetrievalLimit)
+        checkHeightRange(view.history.height, params.startHeight, params.endHeight, rpcSettings.blockIdRetrievalLimit)
           .map(range => getBlockIdsInRange(view.history, range._1, range._2))
       ).subflatMap(identity)
 

--- a/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
@@ -80,7 +80,7 @@ class NodeViewRpcHandlerImpls(
   override val blocksByIds: ToplRpc.NodeView.BlocksByIds.rpc.ServerHandler =
     params =>
       withNodeView(view =>
-        blocksByIdsResponse(
+        checkBlocksFoundWithIds(
           params.blockIds,
           params.blockIds.map(view.history.modifierById),
           rpcSettings.blockRetrievalLimit

--- a/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
@@ -122,8 +122,7 @@ class NodeViewRpcHandlerImpls(
   override val confirmationStatus: ToplRpc.NodeView.ConfirmationStatus.rpc.ServerHandler =
     params =>
       withNodeView { view =>
-        getConfirmationStatus(params.transactionIds, view.history.height, view)
-        checkTxIds(getConfirmationStatus(params.transactionIds, view))
+        checkTxIds(getConfirmationStatus(params.transactionIds, view.history.height, view))
       }.subflatMap(identity)
 
   override val info: ToplRpc.NodeView.Info.rpc.ServerHandler =

--- a/node/src/main/scala/co/topl/rpc/handlers/ToplRpcHandlers.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/ToplRpcHandlers.scala
@@ -36,6 +36,7 @@ object ToplRpcHandlers {
     def blocksByIds: ToplRpc.NodeView.BlocksByIds.rpc.ServerHandler
     def blockByHeight: ToplRpc.NodeView.BlockByHeight.rpc.ServerHandler
     def blocksInRange: ToplRpc.NodeView.BlocksInRange.rpc.ServerHandler
+    def blockIdsInRange: ToplRpc.NodeView.BlockIdsInRange.rpc.ServerHandler
     def mempool: ToplRpc.NodeView.Mempool.rpc.ServerHandler
     def transactionFromMempool: ToplRpc.NodeView.TransactionFromMempool.rpc.ServerHandler
     def confirmationStatus: ToplRpc.NodeView.ConfirmationStatus.rpc.ServerHandler

--- a/node/src/main/scala/co/topl/rpc/handlers/package.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/package.scala
@@ -4,8 +4,6 @@ import co.topl.akkahttprpc.RpcError
 import co.topl.attestation.Address
 import co.topl.modifier.ModifierId
 import co.topl.modifier.block.Block
-import co.topl.network.message.BifrostSyncInfo
-import co.topl.nodeView.history.HistoryReader
 import co.topl.nodeView.state.StateReader
 import co.topl.rpc.ToplRpc.NodeView.ConfirmationStatus.TxStatus
 
@@ -24,12 +22,11 @@ package object handlers {
       )
     } yield keys
 
-  private[handlers] def blocksByIdsResponse(
-    ids:       List[ModifierId],
-    sizeLimit: Int,
-    history:   HistoryReader[Block, BifrostSyncInfo]
-  ): Either[RpcError, ToplRpc.NodeView.BlocksByIds.Response] = {
-    val blocksOption = ids.map(history.modifierById)
+  private[handlers] def checkBlocksFoundWithIds(
+    ids:          List[ModifierId],
+    blocksOption: List[Option[Block]],
+    sizeLimit:    Int
+  ): Either[RpcError, ToplRpc.NodeView.BlocksByIds.Response] =
     for {
       _ <- Either.cond(
         ids.size <= sizeLimit,
@@ -42,7 +39,6 @@ package object handlers {
         ToplRpcErrors.NoBlockWithId
       )
     } yield blocks
-  }
 
   private[handlers] def checkHeightRange(
     bestBlockHeight: Long,

--- a/node/src/main/scala/co/topl/settings/AppSettings.scala
+++ b/node/src/main/scala/co/topl/settings/AppSettings.scala
@@ -24,14 +24,15 @@ case class ApplicationSettings(
 )
 
 case class RPCApiSettings(
-  bindAddress:         InetSocketAddress,
-  disableAuth:         Boolean,
-  apiKeyHash:          String,
-  timeout:             FiniteDuration,
-  verboseAPI:          Boolean,
-  namespaceSelector:   NamespaceSelector,
-  blockRetrievalLimit: Int,
-  txRetrievalLimit:    Int
+  bindAddress:           InetSocketAddress,
+  disableAuth:           Boolean,
+  apiKeyHash:            String,
+  timeout:               FiniteDuration,
+  verboseAPI:            Boolean,
+  namespaceSelector:     NamespaceSelector,
+  blockRetrievalLimit:   Int,
+  blockIdRetrievalLimit: Int,
+  txRetrievalLimit:      Int
 )
 
 case class NetworkSettings(

--- a/node/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
+++ b/node/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
@@ -288,6 +288,26 @@ class NodeViewRPCSpec extends AnyWordSpec with Matchers with RPCMockState with E
       }
     }
 
+    "Get block at the height given" in {
+      val requestBody = ByteString(s"""
+        |{
+        |   "jsonrpc": "2.0",
+        |   "id": "1",
+        |   "method": "topl_blockByHeight",
+        |   "params": [{
+        |      "height": 1
+        |    }]
+        |}
+        """.stripMargin)
+
+      httpPOST(requestBody) ~> route ~> check {
+        val res: Json = parse(responseAs[String]).value
+        val blockId = res.hcursor.downField("result").downField("header").get[String]("id").value
+        blockId shouldEqual block.id.toString
+        res.hcursor.downField("error").values shouldBe None
+      }
+    }
+
     "Get a segment of the chain by height range" in {
       val requestBody = ByteString(s"""
         |{

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
@@ -251,6 +251,21 @@ object ToplRpc {
       type Response = List[Block]
     }
 
+    object BlockIdsInRange {
+
+      /**
+       * Retrieve the ids of a segment of the chain in a height range
+       */
+      val rpc: Rpc[Params, Response] = Rpc(List("topl_blockIdsInRange"))
+
+      /**
+       * @param startHeight starting height for the segment of chain
+       * @param endHeight end heigh for the segment of chain
+       */
+      case class Params(startHeight: Long, endHeight: Long)
+      type Response = List[ModifierId]
+    }
+
     object BlockByHeight {
 
       /**

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
@@ -160,7 +160,7 @@ object ToplRpc {
       /**
        * Retrieve the best block's id and other info
        *
-       * Find information about the current state of the chain including height, score, bestBlockId, etc
+       * Find information about the current state of the chain including height and bestBlockId
        */
       val rpc: Rpc[Params, Response] = Rpc(List("topl_headInfo"))
 

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
@@ -86,6 +86,9 @@ trait NodeViewRpcParamsEncoders {
   implicit val nodeViewBlocksInRangeParamsEncoder: Encoder[ToplRpc.NodeView.BlocksInRange.Params] =
     deriveEncoder
 
+  implicit val nodeViewBlockIdsInRangeParamsEncoder: Encoder[ToplRpc.NodeView.BlockIdsInRange.Params] =
+    deriveEncoder
+
   implicit val nodeViewMempoolParamsEncoder: Encoder[ToplRpc.NodeView.Mempool.Params] =
     deriveEncoder
 
@@ -372,6 +375,9 @@ trait NodeViewRpcParamsDecoders {
     deriveDecoder
 
   implicit val nodeViewBlocksInRangeParamsDecoder: Decoder[ToplRpc.NodeView.BlocksInRange.Params] =
+    deriveDecoder
+
+  implicit val nodeViewBlockIdsInRangeParamsDecoder: Decoder[ToplRpc.NodeView.BlockIdsInRange.Params] =
     deriveDecoder
 
   implicit val nodeViewMempoolParamsDecoder: Decoder[ToplRpc.NodeView.Mempool.Params] =


### PR DESCRIPTION
## Purpose
Add an RPC method that just gets the block ids in a height range, instead of entire blocks

## Approach
Added an RPC method `topl_blockIdsInRange` in the topl name space

## Testing
Tested getting ids in a height range

## Tickets
#1822 