### PR TITLE
Added latestBlocks, latestBlockIds methods and tests

### DIFF
--- a/akka-http-rpc/src/main/scala/co/topl/akkahttprpc/Rpc.scala
+++ b/akka-http-rpc/src/main/scala/co/topl/akkahttprpc/Rpc.scala
@@ -4,7 +4,7 @@ import cats.data.EitherT
 
 import scala.concurrent.Future
 
-case class Rpc[P, SR](method: List[String]) {
+case class Rpc[P, SR](methods: List[String]) {
   type Params = P
   type SuccessResponse = SR
   type ClientHandler = Rpc.ClientHandler[Params, SuccessResponse]

--- a/akka-http-rpc/src/main/scala/co/topl/akkahttprpc/RpcClient.scala
+++ b/akka-http-rpc/src/main/scala/co/topl/akkahttprpc/RpcClient.scala
@@ -45,7 +45,7 @@ class RpcClient[Params, SuccessResponse](val rpc: Rpc[Params, SuccessResponse]) 
           RpcContext(
             id = UUID.randomUUID().toString,
             jsonrpc = "2.0",
-            method = rpc.method.head,
+            method = rpc.methods.head,
             params = List(params).asJson
           ).asJson.toString()
         )

--- a/akka-http-rpc/src/main/scala/co/topl/akkahttprpc/RpcServer.scala
+++ b/akka-http-rpc/src/main/scala/co/topl/akkahttprpc/RpcServer.scala
@@ -15,7 +15,7 @@ class RpcServer[Params, SuccessResponse](val rpc: Rpc[Params, SuccessResponse]) 
     successResponseEncoder: Encoder[SuccessResponse],
     throwableEncoder:       Encoder[ThrowableData]
   ): Route =
-    rpcRoute[Params, SuccessResponse](rpc.method.head, handler)
+    rpcRoute[Params, SuccessResponse](rpc.methods.head, handler)
 
 }
 
@@ -30,7 +30,7 @@ object RpcServer {
       throwableEncoder:                      Encoder[ThrowableData]
     ): Builder =
       copy(handlers =
-        handlers ++ rpc.method.map(
+        handlers ++ rpc.methods.map(
           (_, Builder.BuilderHandler(handler, paramsDecoder, successResponseEncoder, throwableEncoder))
         )
       )

--- a/common/src/main/scala/co/topl/modifier/box/SecurityRoot.scala
+++ b/common/src/main/scala/co/topl/modifier/box/SecurityRoot.scala
@@ -12,7 +12,7 @@ import io.circe.{Decoder, Encoder}
 
 class SecurityRoot private (private val root: Array[Byte]) extends BytesSerializable {
 
-  require(root.length == SecurityRoot.size, "Invalid securityRoot")
+  require(root.length == SecurityRoot.size, "Invalid securityRoot length")
 
   type M = SecurityRoot
   lazy val serializer: BifrostSerializer[SecurityRoot] = SecurityRoot

--- a/node/src/main/scala/co/topl/rpc/ToplRpcServer.scala
+++ b/node/src/main/scala/co/topl/rpc/ToplRpcServer.scala
@@ -47,6 +47,8 @@ class ToplRpcServer(handlers: ToplRpcHandlers, appContext: AppContext)(implicit
         .append(ToplRpc.NodeView.BlockByHeight.rpc)(handlers.nodeView.blockByHeight)
         .append(ToplRpc.NodeView.BlocksInRange.rpc)(handlers.nodeView.blocksInRange)
         .append(ToplRpc.NodeView.BlockIdsInRange.rpc)(handlers.nodeView.blockIdsInRange)
+        .append(ToplRpc.NodeView.LatestBlocks.rpc)(handlers.nodeView.latestBlocks)
+        .append(ToplRpc.NodeView.LatestBlockIds.rpc)(handlers.nodeView.latestBlockIds)
         .append(ToplRpc.NodeView.Mempool.rpc)(handlers.nodeView.mempool)
         .append(ToplRpc.NodeView.TransactionFromMempool.rpc)(handlers.nodeView.transactionFromMempool)
         .append(ToplRpc.NodeView.ConfirmationStatus.rpc)(handlers.nodeView.confirmationStatus)

--- a/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
@@ -111,6 +111,7 @@ class NodeViewRpcHandlerImpls(
     params =>
       for {
         headHeight <- withNodeView(_.history.height)
+        // Since the block at headHeight is included, we will get more than numberOfBlocks blocks without adding 1 here
         startHeight = headHeight - params.numberOfBlocks + 1
         range <- EitherT.fromEither[Future](
           checkHeightRange(headHeight, startHeight, headHeight, rpcSettings.blockRetrievalLimit)

--- a/node/src/main/scala/co/topl/rpc/handlers/ToplRpcHandlers.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/ToplRpcHandlers.scala
@@ -37,6 +37,8 @@ object ToplRpcHandlers {
     def blockByHeight: ToplRpc.NodeView.BlockByHeight.rpc.ServerHandler
     def blocksInRange: ToplRpc.NodeView.BlocksInRange.rpc.ServerHandler
     def blockIdsInRange: ToplRpc.NodeView.BlockIdsInRange.rpc.ServerHandler
+    def latestBlocks: ToplRpc.NodeView.LatestBlocks.rpc.ServerHandler
+    def latestBlockIds: ToplRpc.NodeView.LatestBlockIds.rpc.ServerHandler
     def mempool: ToplRpc.NodeView.Mempool.rpc.ServerHandler
     def transactionFromMempool: ToplRpc.NodeView.TransactionFromMempool.rpc.ServerHandler
     def confirmationStatus: ToplRpc.NodeView.ConfirmationStatus.rpc.ServerHandler

--- a/node/src/main/scala/co/topl/rpc/handlers/package.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/package.scala
@@ -59,6 +59,26 @@ package object handlers {
       )
     } yield (startHeight, endHeight)
 
+  private[handlers] def checkLatestBlockNumber(
+    headHeight:     Long,
+    numberOfBlocks: Int,
+    sizeLimit:      Int
+  ): Either[RpcError, Long] =
+    for {
+      _ <- Either.cond(
+        numberOfBlocks <= headHeight,
+        {},
+        ToplRpcErrors.unsupportedOperation("Requested number of blocks is greater than existing number of blocks")
+      )
+      _ <- Either.cond(
+        numberOfBlocks <= sizeLimit,
+        {},
+        ToplRpcErrors.unsupportedOperation(
+          "Requested number of blocks is greater than the max retrievable block number configured"
+        )
+      )
+    } yield headHeight - numberOfBlocks + 1
+
   private[handlers] def checkTxIds(
     txStatusOption: List[Option[(ModifierId, TxStatus)]]
   ): Either[RpcError, ToplRpc.NodeView.ConfirmationStatus.Response] =

--- a/node/src/main/scala/co/topl/rpc/handlers/package.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/package.scala
@@ -48,36 +48,21 @@ package object handlers {
   ): Either[RpcError, (Long, Long)] =
     for {
       _ <- Either.cond(
-        startHeight >= 1 && endHeight >= startHeight && bestBlockHeight >= startHeight && bestBlockHeight >= endHeight,
+        startHeight >= 1 && endHeight >= startHeight && bestBlockHeight >= startHeight,
         {},
         ToplRpcErrors.InvalidHeightRange
       )
       _ <- Either.cond(
+        bestBlockHeight >= endHeight,
+        {},
+        ToplRpcErrors.unsupportedOperation("End height exceeded head height")
+      )
+      _ <- Either.cond(
         (endHeight - startHeight + 1) <= sizeLimit,
         {},
-        ToplRpcErrors.unsupportedOperation("Height range exceeded blockRetrievalLimit")
+        ToplRpcErrors.unsupportedOperation("Height range exceeded block/block id retrieval limit")
       )
     } yield (startHeight, endHeight)
-
-  private[handlers] def checkLatestBlockNumber(
-    headHeight:     Long,
-    numberOfBlocks: Int,
-    sizeLimit:      Int
-  ): Either[RpcError, Long] =
-    for {
-      _ <- Either.cond(
-        numberOfBlocks <= headHeight,
-        {},
-        ToplRpcErrors.unsupportedOperation("Requested number of blocks is greater than existing number of blocks")
-      )
-      _ <- Either.cond(
-        numberOfBlocks <= sizeLimit,
-        {},
-        ToplRpcErrors.unsupportedOperation(
-          "Requested number of blocks is greater than the max retrievable block number configured"
-        )
-      )
-    } yield headHeight - numberOfBlocks + 1
 
   private[handlers] def checkTxIds(
     txStatusOption: List[Option[(ModifierId, TxStatus)]]

--- a/node/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
+++ b/node/src/test/scala/co/topl/api/NodeViewRPCSpec.scala
@@ -371,6 +371,46 @@ class NodeViewRPCSpec extends AnyWordSpec with Matchers with RPCMockState with E
       }
     }
 
+    "Get a number of latest blocks" in {
+      val requestBody = ByteString(s"""
+        |{
+        |   "jsonrpc": "2.0",
+        |   "id": "1",
+        |   "method": "topl_latestBlocks",
+        |   "params": [{
+        |      "numberOfBlocks": 1
+        |    }]
+        |}
+        """.stripMargin)
+
+      httpPOST(requestBody) ~> route ~> check {
+        val res: Json = parse(responseAs[String]).value
+        val blocks = res.hcursor.downField("result").as[Json].value.toString
+        blocks should include(block.id.toString)
+        res.hcursor.downField("error").values shouldBe None
+      }
+    }
+
+    "Get a number of latest block ids" in {
+      val requestBody = ByteString(s"""
+        |{
+        |   "jsonrpc": "2.0",
+        |   "id": "1",
+        |   "method": "topl_latestBlockIds",
+        |   "params": [{
+        |      "numberOfBlockIds": 1
+        |    }]
+        |}
+        """.stripMargin)
+
+      httpPOST(requestBody) ~> route ~> check {
+        val res: Json = parse(responseAs[String]).value
+        val blockIds = res.hcursor.downField("result").as[Seq[String]].value
+        blockIds.head shouldEqual block.id.toString
+        res.hcursor.downField("error").values shouldBe None
+      }
+    }
+
     "Return info about the node" in {
       val requestBody = ByteString(s"""
         |{

--- a/node/src/test/scala/co/topl/api/transaction/AssetTransferRPCSpec.scala
+++ b/node/src/test/scala/co/topl/api/transaction/AssetTransferRPCSpec.scala
@@ -7,8 +7,7 @@ import io.circe.Json
 import io.circe.parser.parse
 import io.circe.syntax._
 
-class
-AssetTransferRPCSpec extends TransferRPCTestMethods {
+class AssetTransferRPCSpec extends TransferRPCTestMethods {
 
   var addressCurve25519Fst: Address = _
   var addressCurve25519Sec: Address = _

--- a/node/src/test/scala/co/topl/api/transaction/AssetTransferRPCSpec.scala
+++ b/node/src/test/scala/co/topl/api/transaction/AssetTransferRPCSpec.scala
@@ -97,7 +97,7 @@ class AssetTransferRPCSpec extends TransferRPCTestMethods {
       testBroadcastTx(tx)
     }
 
-    "Threshold transaction with invalid attestation type should error" in {
+    "Return correct error response given a threshold transaction with invalid attestation type" in {
       val tx = testCreateSignAssetTransfer(
         addressThresholdCurve25519Fst,
         addressCurve25519Sec,
@@ -107,6 +107,27 @@ class AssetTransferRPCSpec extends TransferRPCTestMethods {
       )
       val attestation: Json = Map("signatures" -> attestationCurve25519Gen.sample.get.asJson).asJson
       testBroadcastTxInvalidProp(tx.hcursor.downField("signatures").delete.top.get.deepMerge(attestation))
+    }
+
+    "Return correct error responses if securityRoot is invalid" in {
+      testInvalidSecurityRoot(
+        addressCurve25519Fst,
+        addressCurve25519Sec,
+        assetCodeCurve25519Fst,
+        propTypeCurve25519,
+        3,
+        "111111111111111111111111111111=1"
+      )
+    }
+
+    "Return correct error responses if assetCode is invalid" in {
+      testInvalidAssetCode(
+        addressCurve25519Fst,
+        addressCurve25519Sec,
+        "65GtfBmwC9NHBayMzZfzCC69L2f2ZaxEe4BwQXRAABPynuNo4k2a8hqCsl",
+        propTypeCurve25519,
+        3
+      )
     }
   }
 }

--- a/node/src/test/scala/co/topl/api/transaction/TransferRPCTestMethods.scala
+++ b/node/src/test/scala/co/topl/api/transaction/TransferRPCTestMethods.scala
@@ -180,14 +180,15 @@ trait TransferRPCTestMethods extends AnyWordSpec with Matchers with RPCMockState
     }
   }
 
-  def testCreateSignAssetTransfer(
+  def assetTransferRequestBody(
     sender:         Address,
     recipient:      Address,
-    assetCode:      AssetCode,
+    assetCode:      String,
     senderPropType: String,
-    amount:         Int
-  ): Json = {
-    val requestBody = ByteString(s"""
+    amount:         Int,
+    securityRoot:   String = "11111111111111111111111111111111"
+  ): ByteString =
+    ByteString(s"""
       |{
       | "jsonrpc": "2.0",
       | "id": "2",
@@ -201,7 +202,7 @@ trait TransferRPCTestMethods extends AnyWordSpec with Matchers with RPCMockState
       |      "assetCode" : "${assetCode.toString}",
       |      "metadata" : "ApdGzs6uwKAhuKJQswBWoVAFjNA5B8enBKfxVbzlcQ8EnpxicpRcE9B9Bgn2LGv02kYUSA1h1181ZYeECvr",
       |      "type" : "Asset",
-      |      "securityRoot" : "11111111111111111111111111111111"
+      |      "securityRoot" : "$securityRoot"
       |    }
       |  ]],
       |   "sender": ["$sender"],
@@ -214,6 +215,15 @@ trait TransferRPCTestMethods extends AnyWordSpec with Matchers with RPCMockState
       | }]
       |}
       """.stripMargin)
+
+  def testCreateSignAssetTransfer(
+    sender:         Address,
+    recipient:      Address,
+    assetCode:      AssetCode,
+    senderPropType: String,
+    amount:         Int
+  ): Json = {
+    val requestBody = assetTransferRequestBody(sender, recipient, assetCode.toString, senderPropType, amount)
 
     httpPOST(requestBody) ~> route ~> check {
       val res = parse(responseAs[String]).value
@@ -247,4 +257,42 @@ trait TransferRPCTestMethods extends AnyWordSpec with Matchers with RPCMockState
       sigTx.value
     }
   }
+
+  def testInvalidSecurityRoot(
+    sender:         Address,
+    recipient:      Address,
+    assetCode:      AssetCode,
+    senderPropType: String,
+    amount:         Int,
+    securityRoot:   String
+  ): Unit = {
+    val requestBody =
+      assetTransferRequestBody(sender, recipient, assetCode.toString, senderPropType, amount, securityRoot)
+
+    httpPOST(requestBody) ~> route ~> check {
+      val res = parse(responseAs[String]).value
+      val error = res.hcursor.downField("error").as[Json].toString
+//      error should include("Invalid securityRoot")
+      println(error)
+    }
+  }
+
+  def testInvalidAssetCode(
+    sender:         Address,
+    recipient:      Address,
+    assetCode:      String,
+    senderPropType: String,
+    amount:         Int
+  ): Unit = {
+    val requestBody =
+      assetTransferRequestBody(sender, recipient, assetCode, senderPropType, amount)
+
+    httpPOST(requestBody) ~> route ~> check {
+      val res = parse(responseAs[String]).value
+      val error = res.hcursor.downField("error").as[Json].toString
+//      error should include("Invalid securityRoot")
+      println(error)
+    }
+  }
+
 }

--- a/node/src/test/scala/co/topl/api/transaction/TransferRPCTestMethods.scala
+++ b/node/src/test/scala/co/topl/api/transaction/TransferRPCTestMethods.scala
@@ -257,42 +257,4 @@ trait TransferRPCTestMethods extends AnyWordSpec with Matchers with RPCMockState
       sigTx.value
     }
   }
-
-  def testInvalidSecurityRoot(
-    sender:         Address,
-    recipient:      Address,
-    assetCode:      AssetCode,
-    senderPropType: String,
-    amount:         Int,
-    securityRoot:   String
-  ): Unit = {
-    val requestBody =
-      assetTransferRequestBody(sender, recipient, assetCode.toString, senderPropType, amount, securityRoot)
-
-    httpPOST(requestBody) ~> route ~> check {
-      val res = parse(responseAs[String]).value
-      val error = res.hcursor.downField("error").as[Json].toString
-//      error should include("Invalid securityRoot")
-      println(error)
-    }
-  }
-
-  def testInvalidAssetCode(
-    sender:         Address,
-    recipient:      Address,
-    assetCode:      String,
-    senderPropType: String,
-    amount:         Int
-  ): Unit = {
-    val requestBody =
-      assetTransferRequestBody(sender, recipient, assetCode, senderPropType, amount)
-
-    httpPOST(requestBody) ~> route ~> check {
-      val res = parse(responseAs[String]).value
-      val error = res.hcursor.downField("error").as[Json].toString
-//      error should include("Invalid securityRoot")
-      println(error)
-    }
-  }
-
 }

--- a/node/src/test/scala/co/topl/api/transaction/TransferRPCTestMethods.scala
+++ b/node/src/test/scala/co/topl/api/transaction/TransferRPCTestMethods.scala
@@ -199,7 +199,7 @@ trait TransferRPCTestMethods extends AnyWordSpec with Matchers with RPCMockState
       |   [["$recipient",
       |    {
       |      "quantity" : "$amount",
-      |      "assetCode" : "${assetCode.toString}",
+      |      "assetCode" : "$assetCode",
       |      "metadata" : "ApdGzs6uwKAhuKJQswBWoVAFjNA5B8enBKfxVbzlcQ8EnpxicpRcE9B9Bgn2LGv02kYUSA1h1181ZYeECvr",
       |      "type" : "Asset",
       |      "securityRoot" : "$securityRoot"

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
@@ -266,6 +266,32 @@ object ToplRpc {
       type Response = List[ModifierId]
     }
 
+    object LatestBlocks {
+      /**
+       * Retrieve a number of latest blocks, including the current best block
+       */
+      val rpc: Rpc[Params, Response] = Rpc(List("topl_latestBlocks"))
+
+      /**
+       * @param numberOfBlocks number of latest blocks to retrieve
+       */
+      case class Params(numberOfBlocks: Int)
+      type Response = List[Block]
+    }
+
+    object LatestBlockIds {
+      /**
+       * Retrieve a number of latest blocks' ids, including the current best block id
+       */
+      val rpc: Rpc[Params, Response] = Rpc(List("topl_latestBlockIds"))
+
+      /**
+       * @param numberOfBlockIds number of latest blocks to retrieve
+       */
+      case class Params(numberOfBlockIds: Int)
+      type Response = List[ModifierId]
+    }
+
     object BlockByHeight {
 
       /**

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
@@ -267,6 +267,7 @@ object ToplRpc {
     }
 
     object LatestBlocks {
+
       /**
        * Retrieve a number of latest blocks, including the current best block
        */
@@ -280,6 +281,7 @@ object ToplRpc {
     }
 
     object LatestBlockIds {
+
       /**
        * Retrieve a number of latest blocks' ids, including the current best block id
        */

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
@@ -89,6 +89,12 @@ trait NodeViewRpcParamsEncoders {
   implicit val nodeViewBlockIdsInRangeParamsEncoder: Encoder[ToplRpc.NodeView.BlockIdsInRange.Params] =
     deriveEncoder
 
+  implicit val nodeViewLatestBlocksParamsEncoder: Encoder[ToplRpc.NodeView.LatestBlocks.Params] =
+    deriveEncoder
+
+  implicit val nodeViewLatestBlockIdsParamsEncoder: Encoder[ToplRpc.NodeView.LatestBlockIds.Params] =
+    deriveEncoder
+
   implicit val nodeViewMempoolParamsEncoder: Encoder[ToplRpc.NodeView.Mempool.Params] =
     deriveEncoder
 
@@ -385,6 +391,12 @@ trait NodeViewRpcParamsDecoders {
     deriveDecoder
 
   implicit val nodeViewBlockIdsInRangeParamsDecoder: Decoder[ToplRpc.NodeView.BlockIdsInRange.Params] =
+    deriveDecoder
+
+  implicit val nodeViewLatestBlocksParamsDecoder: Decoder[ToplRpc.NodeView.LatestBlocks.Params] =
+    deriveDecoder
+
+  implicit val nodeViewLatestBlockIdsParamsDecoder: Decoder[ToplRpc.NodeView.LatestBlockIds.Params] =
     deriveDecoder
 
   implicit val nodeViewMempoolParamsDecoder: Decoder[ToplRpc.NodeView.Mempool.Params] =


### PR DESCRIPTION
## Purpose
We could benefit from RPC methods that retrieve a number of blocks and block ids at the head of the chain

## Approach
- Added RPC method `topl_latestBlocks`
- Added RPC method `topl_latestBlockIds`

## Testing
- Added test for both methods

## Tickets
#1843