### PR TITLE
Unsafe Resources

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/UnsafeResource.scala
+++ b/algebras/src/main/scala/co/topl/algebras/UnsafeResource.scala
@@ -1,0 +1,12 @@
+package co.topl.algebras
+
+/**
+ * Wraps some entity of type T that is deemed to not be thread-safe.
+ */
+trait UnsafeResource[F[_], T] {
+
+  /**
+   * Use the thread-unsafe resource in a thread-safe manner
+   */
+  def use[Res](f: T => Res): F[Res]
+}

--- a/algebras/src/main/scala/co/topl/algebras/UnsafeResource.scala
+++ b/algebras/src/main/scala/co/topl/algebras/UnsafeResource.scala
@@ -8,5 +8,5 @@ trait UnsafeResource[F[_], T] {
   /**
    * Use the thread-unsafe resource in a thread-safe manner
    */
-  def use[Res](f: T => Res): F[Res]
+  def use[Res](f: T => F[Res]): F[Res]
 }

--- a/algebras/src/test/scala/co/topl/algebras/testInterpreters/NoOpLogger.scala
+++ b/algebras/src/test/scala/co/topl/algebras/testInterpreters/NoOpLogger.scala
@@ -1,0 +1,26 @@
+package co.topl.algebras.testInterpreters
+
+import cats.Applicative
+import org.typelevel.log4cats.Logger
+
+class NoOpLogger[F[_]: Applicative] extends Logger[F] {
+  def error(t: Throwable)(message: => String): F[Unit] = Applicative[F].unit
+
+  def warn(t: Throwable)(message: => String): F[Unit] = Applicative[F].unit
+
+  def info(t: Throwable)(message: => String): F[Unit] = Applicative[F].unit
+
+  def debug(t: Throwable)(message: => String): F[Unit] = Applicative[F].unit
+
+  def trace(t: Throwable)(message: => String): F[Unit] = Applicative[F].unit
+
+  def error(message: => String): F[Unit] = Applicative[F].unit
+
+  def warn(message: => String): F[Unit] = Applicative[F].unit
+
+  def info(message: => String): F[Unit] = Applicative[F].unit
+
+  def debug(message: => String): F[Unit] = Applicative[F].unit
+
+  def trace(message: => String): F[Unit] = Applicative[F].unit
+}

--- a/build.sbt
+++ b/build.sbt
@@ -53,8 +53,8 @@ lazy val commonSettings = Seq(
     "Sonatype Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots/",
     "Bintray" at "https://jcenter.bintray.com/"
   ),
-  addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full),
-  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
+  addCompilerPlugin("org.typelevel" % "kind-projector"     % "0.13.2" cross CrossVersion.full),
+  addCompilerPlugin("com.olegpy"   %% "better-monadic-for" % "0.3.1")
 )
 
 lazy val publishSettings = Seq(
@@ -321,7 +321,7 @@ lazy val algebras = project
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "co.topl.buildinfo.algebras"
   )
-  .settings(libraryDependencies ++= Dependencies.test)
+  .settings(libraryDependencies ++= Dependencies.test ++ Seq(Dependencies.catsSlf4j % "test"))
   .settings(scalamacrosParadiseSettings)
   .dependsOn(models, crypto, byteCodecs)
 
@@ -340,7 +340,13 @@ lazy val consensus = project
     libraryDependencies ++= Dependencies.consensus
   )
   .settings(scalamacrosParadiseSettings)
-  .dependsOn(models % "compile->compile;test->test", typeclasses, crypto, byteCodecs, algebras)
+  .dependsOn(
+    models % "compile->compile;test->test",
+    typeclasses,
+    crypto,
+    byteCodecs,
+    algebras % "compile->compile;test->test"
+  )
 
 lazy val minting = project
   .in(file("minting"))
@@ -354,7 +360,14 @@ lazy val minting = project
   )
   .settings(libraryDependencies ++= Dependencies.test ++ Dependencies.catsEffect)
   .settings(scalamacrosParadiseSettings)
-  .dependsOn(models % "compile->compile;test->test", typeclasses, crypto, byteCodecs, algebras, consensus)
+  .dependsOn(
+    models % "compile->compile;test->test",
+    typeclasses,
+    crypto,
+    byteCodecs,
+    algebras % "compile->compile;test->test",
+    consensus
+  )
 
 lazy val demo = project
   .in(file("demo"))

--- a/consensus/src/main/scala/co/topl/consensus/BlockHeaderValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/BlockHeaderValidation.scala
@@ -2,10 +2,9 @@ package co.topl.consensus
 
 import cats._
 import cats.data._
-import cats.effect.Ref
 import cats.effect.kernel.Sync
 import cats.implicits._
-import co.topl.algebras.Store
+import co.topl.algebras.{Store, UnsafeResource}
 import co.topl.consensus.algebras._
 import co.topl.crypto.hash.blake2b256
 import co.topl.crypto.signing.{Ed25519, Ed25519VRF, KesProduct}
@@ -32,33 +31,31 @@ object BlockHeaderValidation {
       etaInterpreter:           EtaCalculationAlgebra[F],
       relativeStakeInterpreter: VrfRelativeStakeValidationLookupAlgebra[F],
       leaderElection:           LeaderElectionValidationAlgebra[F],
-      registrationInterpreter:  RegistrationLookupAlgebra[F]
+      registrationInterpreter:  RegistrationLookupAlgebra[F],
+      ed25519VRFResource:       UnsafeResource[F, Ed25519VRF],
+      kesProductResource:       UnsafeResource[F, KesProduct],
+      ed25519Resource:          UnsafeResource[F, Ed25519]
     ): F[BlockHeaderValidationAlgebra[F]] =
-      (
-        Ref.of[F, Ed25519VRF](Ed25519VRF.precomputed()),
-        Ref.of[F, KesProduct](new KesProduct),
-        Ref.of[F, Ed25519](new Ed25519)
-      )
-        .mapN((vrfRef, kesRef, ed25519Ref) =>
-          new Impl[F](
-            etaInterpreter,
-            relativeStakeInterpreter,
-            leaderElection,
-            registrationInterpreter,
-            vrfRef,
-            kesRef,
-            ed25519Ref
-          )
+      Sync[F].delay(
+        new Impl[F](
+          etaInterpreter,
+          relativeStakeInterpreter,
+          leaderElection,
+          registrationInterpreter,
+          ed25519VRFResource,
+          kesProductResource,
+          ed25519Resource
         )
+      )
 
     private class Impl[F[_]: Monad: Sync](
       etaInterpreter:           EtaCalculationAlgebra[F],
       relativeStakeInterpreter: VrfRelativeStakeValidationLookupAlgebra[F],
       leaderElection:           LeaderElectionValidationAlgebra[F],
       registrationInterpreter:  RegistrationLookupAlgebra[F],
-      vrfRef:                   Ref[F, Ed25519VRF],
-      kesRef:                   Ref[F, KesProduct],
-      ed25519Ref:               Ref[F, Ed25519]
+      ed25519VRFResource:       UnsafeResource[F, Ed25519VRF],
+      kesProductResource:       UnsafeResource[F, KesProduct],
+      ed25519Resource:          UnsafeResource[F, Ed25519]
     ) extends BlockHeaderValidationAlgebra[F] {
 
       def validate(
@@ -101,9 +98,9 @@ object BlockHeaderValidation {
         EitherT
           .liftF(etaInterpreter.etaToBe(header.parentSlotId, header.slot))
           .flatMapF(expectedEta =>
-            vrfRef.modify { implicit ed25519vrf =>
+            ed25519VRFResource.use { implicit ed25519vrf =>
               val certificate = header.eligibilityCertificate
-              ed25519vrf -> header
+              header
                 .asRight[BlockHeaderValidationFailure]
                 .ensure(
                   BlockHeaderValidationFailures
@@ -129,9 +126,9 @@ object BlockHeaderValidation {
         header: BlockHeaderV2
       ): EitherT[F, BlockHeaderValidationFailure, BlockHeaderV2] =
         EitherT(
-          kesRef
-            .modify(kesProduct =>
-              kesProduct -> kesProduct.verify(
+          kesProductResource
+            .use(kesProduct =>
+              kesProduct.verify(
                 header.operationalCertificate.parentSignature,
                 header.operationalCertificate.childVK.bytes.data ++ Bytes(Longs.toByteArray(header.slot)),
                 header.operationalCertificate.parentVK
@@ -147,10 +144,10 @@ object BlockHeaderValidation {
         )
           .flatMap(_ =>
             EitherT(
-              ed25519Ref
-                .modify(ed25519 =>
+              ed25519Resource
+                .use(ed25519 =>
                   // Use the ed25519 instance to verify the childSignature against the header's bytes
-                  ed25519 -> ed25519.verify(
+                  ed25519.verify(
                     header.operationalCertificate.childSignature,
                     header.signableBytes,
                     header.operationalCertificate.childVK
@@ -206,9 +203,9 @@ object BlockHeaderValidation {
       ): EitherT[F, BlockHeaderValidationFailure, BlockHeaderV2] =
         EitherT
           .liftF(
-            vrfRef
-              .modify { implicit ed25519Vrf =>
-                ed25519Vrf -> ed25519Vrf.proofToHash(header.eligibilityCertificate.vrfSig)
+            ed25519VRFResource
+              .use { implicit ed25519Vrf =>
+                ed25519Vrf.proofToHash(header.eligibilityCertificate.vrfSig)
               }
               .flatMap(leaderElection.isSlotLeaderForThreshold(threshold))
           )
@@ -242,8 +239,8 @@ object BlockHeaderValidation {
                 )
                 .value
             )
-            kesRef
-              .modify(p => (p, p.verify(commitment, message, header.operationalCertificate.parentVK.copy(step = 0))))
+            kesProductResource
+              .use(p => p.verify(commitment, message, header.operationalCertificate.parentVK.copy(step = 0)))
               .map(isValid =>
                 Either.cond(
                   isValid,

--- a/consensus/src/main/scala/co/topl/consensus/EtaCalculation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/EtaCalculation.scala
@@ -61,7 +61,7 @@ object EtaCalculation {
                 parentSlotData.eta.pure[F]
               // TODO: If childEpoch - parentEpoch > 1, destroy the node
               // OR: childSlot - parentSlot > slotsPerEpoch
-              case (_, childEpoch, parentSlotData) =>
+              case (_, _, parentSlotData) =>
                 cachingF(parentSlotId.blockId)(ttl = Some(1.day))(
                   locateTwoThirdsBest(parentSlotData)
                     .flatMap(calculate)
@@ -117,7 +117,7 @@ object EtaCalculation {
           show"Calculating new eta.  previousEta=$previousEta epoch=$epoch rhoValues=[${rhoValues.length}]{${rhoValues.head}..${rhoValues.last}}"
         ) >>
           blake2b512Resource
-            .use(implicit blake2b512 => rhoValues.map(Ed25519VRF.rhoToRhoNonceHash))
+            .use(implicit blake2b512 => rhoValues.map(Ed25519VRF.rhoToRhoNonceHash).pure[F])
             .flatMap(calculateFromNonceHashValues(previousEta, epoch, _)))
           .flatTap(nextEta =>
             Logger[F].info(
@@ -137,7 +137,7 @@ object EtaCalculation {
           _.hash(
             Bytes
               .concat(EtaCalculationArgs(previousEta, epoch, rhoNonceHashValues.toIterable).digestMessages)
-          )
+          ).pure[F]
         )
     }
 

--- a/consensus/src/main/scala/co/topl/consensus/SlotDataCache.scala
+++ b/consensus/src/main/scala/co/topl/consensus/SlotDataCache.scala
@@ -4,7 +4,7 @@ import cats.MonadError
 import cats.data.OptionT
 import cats.effect._
 import cats.implicits._
-import co.topl.algebras.Store
+import co.topl.algebras.{Store, UnsafeResource}
 import co.topl.crypto.signing.Ed25519VRF
 import co.topl.models.{BlockHeaderV2, TypedIdentifier}
 import co.topl.typeclasses.implicits._
@@ -25,19 +25,16 @@ object SlotDataCache {
 
     // TODO: Use Epoch thirds for storage
     def make[F[_]: MonadError[*[_], Throwable]: Clock: Sync](
-      blockHeaderLookup: Store[F, BlockHeaderV2]
+      blockHeaderLookup:  Store[F, BlockHeaderV2],
+      ed25519VRFResource: UnsafeResource[F, Ed25519VRF]
     ): F[SlotDataCache[F]] =
-      Ref
-        .of[F, Ed25519VRF](Ed25519VRF.precomputed())
-        .flatMap(ref =>
-          CaffeineCache[F, SlotData].map(implicit cache =>
-            (blockId: TypedIdentifier) =>
-              cachingF(blockId)(ttl = Some(1.day))(
-                OptionT(blockHeaderLookup.get(blockId))
-                  .getOrElseF(new IllegalStateException(blockId.show).raiseError[F, BlockHeaderV2])
-                  .flatMap(header => ref.modify(implicit ed25519Vrf => ed25519Vrf -> SlotData(header)))
-              )
+      CaffeineCache[F, SlotData].map(implicit cache =>
+        (blockId: TypedIdentifier) =>
+          cachingF(blockId)(ttl = Some(1.day))(
+            OptionT(blockHeaderLookup.get(blockId))
+              .getOrElseF(new IllegalStateException(blockId.show).raiseError[F, BlockHeaderV2])
+              .flatMap(header => ed25519VRFResource.use(implicit ed25519Vrf => SlotData(header)))
           )
-        )
+      )
   }
 }

--- a/consensus/src/main/scala/co/topl/consensus/SlotDataCache.scala
+++ b/consensus/src/main/scala/co/topl/consensus/SlotDataCache.scala
@@ -33,7 +33,7 @@ object SlotDataCache {
           cachingF(blockId)(ttl = Some(1.day))(
             OptionT(blockHeaderLookup.get(blockId))
               .getOrElseF(new IllegalStateException(blockId.show).raiseError[F, BlockHeaderV2])
-              .flatMap(header => ed25519VRFResource.use(implicit ed25519Vrf => SlotData(header)))
+              .flatMap(header => ed25519VRFResource.use(implicit ed25519Vrf => SlotData(header).pure[F]))
           )
       )
   }

--- a/consensus/src/test/scala/co/topl/consensus/BlockHeaderValidationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/BlockHeaderValidationSpec.scala
@@ -189,16 +189,16 @@ class BlockHeaderValidationSpec
         .returning(eta.pure[F])
 
       (ed25519VRFResource
-        .use[Boolean](_: Function1[Ed25519VRF, Boolean]))
+        .use[Boolean](_: Function1[Ed25519VRF, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519VRF, Boolean] => f(ed25519Vrf).pure[F] }
+        .onCall { f: Function1[Ed25519VRF, F[Boolean]] => f(ed25519Vrf) }
 
       (ed25519VRFResource
-        .use[Rho](_: Function1[Ed25519VRF, Rho]))
+        .use[Rho](_: Function1[Ed25519VRF, F[Rho]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519VRF, Rho] => f(ed25519Vrf).pure[F] }
+        .onCall { f: Function1[Ed25519VRF, F[Rho]] => f(ed25519Vrf) }
 
       underTest
         .validate(child, parent)
@@ -241,28 +241,28 @@ class BlockHeaderValidationSpec
         .returning(eta.pure[F])
 
       (ed25519VRFResource
-        .use[Boolean](_: Function1[Ed25519VRF, Boolean]))
+        .use[Boolean](_: Function1[Ed25519VRF, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519VRF, Boolean] => f(ed25519Vrf).pure[F] }
+        .onCall { f: Function1[Ed25519VRF, F[Boolean]] => f(ed25519Vrf) }
 
       (ed25519VRFResource
-        .use[Rho](_: Function1[Ed25519VRF, Rho]))
+        .use[Rho](_: Function1[Ed25519VRF, F[Rho]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519VRF, Rho] => f(ed25519Vrf).pure[F] }
+        .onCall { f: Function1[Ed25519VRF, F[Rho]] => f(ed25519Vrf) }
 
       (kesProductResource
-        .use[Boolean](_: Function1[KesProduct, Boolean]))
+        .use[Boolean](_: Function1[KesProduct, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[KesProduct, Boolean] => f(kesProduct).pure[F] }
+        .onCall { f: Function1[KesProduct, F[Boolean]] => f(kesProduct) }
 
       (ed25519Resource
-        .use[Boolean](_: Function1[Ed25519, Boolean]))
+        .use[Boolean](_: Function1[Ed25519, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519, Boolean] => f(ed25519).pure[F] }
+        .onCall { f: Function1[Ed25519, F[Boolean]] => f(ed25519) }
 
       underTest
         .validate(badBlock, parent)
@@ -312,34 +312,34 @@ class BlockHeaderValidationSpec
         .returning(eta.pure[F])
 
       (ed25519VRFResource
-        .use[Boolean](_: Function1[Ed25519VRF, Boolean]))
+        .use[Boolean](_: Function1[Ed25519VRF, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519VRF, Boolean] => f(ed25519Vrf).pure[F] }
+        .onCall { f: Function1[Ed25519VRF, F[Boolean]] => f(ed25519Vrf) }
 
       (ed25519VRFResource
-        .use[Rho](_: Function1[Ed25519VRF, Rho]))
+        .use[Rho](_: Function1[Ed25519VRF, F[Rho]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519VRF, Rho] => f(ed25519Vrf).pure[F] }
+        .onCall { f: Function1[Ed25519VRF, F[Rho]] => f(ed25519Vrf) }
 
       (kesProductResource
-        .use[Boolean](_: Function1[KesProduct, Boolean]))
+        .use[Boolean](_: Function1[KesProduct, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[KesProduct, Boolean] => f(kesProduct).pure[F] }
+        .onCall { f: Function1[KesProduct, F[Boolean]] => f(kesProduct) }
 
       (ed25519Resource
-        .use[Boolean](_: Function1[Ed25519, Boolean]))
+        .use[Boolean](_: Function1[Ed25519, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519, Boolean] => f(ed25519).pure[F] }
+        .onCall { f: Function1[Ed25519, F[Boolean]] => f(ed25519) }
 
       (blake2b256Resource
-        .use[Evidence](_: Function1[Blake2b256, Evidence]))
+        .use[Evidence](_: Function1[Blake2b256, F[Evidence]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Blake2b256, Evidence] => f(blake2b256).pure[F] }
+        .onCall { f: Function1[Blake2b256, F[Evidence]] => f(blake2b256) }
 
       underTest
         .validate(child, parent)
@@ -391,34 +391,34 @@ class BlockHeaderValidationSpec
         .returning(Ratio(0).some.pure[F])
 
       (ed25519VRFResource
-        .use[Boolean](_: Function1[Ed25519VRF, Boolean]))
+        .use[Boolean](_: Function1[Ed25519VRF, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519VRF, Boolean] => f(ed25519Vrf).pure[F] }
+        .onCall { f: Function1[Ed25519VRF, F[Boolean]] => f(ed25519Vrf) }
 
       (ed25519VRFResource
-        .use[Rho](_: Function1[Ed25519VRF, Rho]))
+        .use[Rho](_: Function1[Ed25519VRF, F[Rho]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519VRF, Rho] => f(ed25519Vrf).pure[F] }
+        .onCall { f: Function1[Ed25519VRF, F[Rho]] => f(ed25519Vrf) }
 
       (kesProductResource
-        .use[Boolean](_: Function1[KesProduct, Boolean]))
+        .use[Boolean](_: Function1[KesProduct, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[KesProduct, Boolean] => f(kesProduct).pure[F] }
+        .onCall { f: Function1[KesProduct, F[Boolean]] => f(kesProduct) }
 
       (ed25519Resource
-        .use[Boolean](_: Function1[Ed25519, Boolean]))
+        .use[Boolean](_: Function1[Ed25519, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519, Boolean] => f(ed25519).pure[F] }
+        .onCall { f: Function1[Ed25519, F[Boolean]] => f(ed25519) }
 
       (blake2b256Resource
-        .use[Evidence](_: Function1[Blake2b256, Evidence]))
+        .use[Evidence](_: Function1[Blake2b256, F[Evidence]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Blake2b256, Evidence] => f(blake2b256).pure[F] }
+        .onCall { f: Function1[Blake2b256, F[Evidence]] => f(blake2b256) }
 
       underTest
         .validate(child, parent)
@@ -470,34 +470,34 @@ class BlockHeaderValidationSpec
         .returning(relativeStake.some.pure[F])
 
       (ed25519VRFResource
-        .use[Boolean](_: Function1[Ed25519VRF, Boolean]))
+        .use[Boolean](_: Function1[Ed25519VRF, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519VRF, Boolean] => f(ed25519Vrf).pure[F] }
+        .onCall { f: Function1[Ed25519VRF, F[Boolean]] => f(ed25519Vrf) }
 
       (ed25519VRFResource
-        .use[Rho](_: Function1[Ed25519VRF, Rho]))
+        .use[Rho](_: Function1[Ed25519VRF, F[Rho]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519VRF, Rho] => f(ed25519Vrf).pure[F] }
+        .onCall { f: Function1[Ed25519VRF, F[Rho]] => f(ed25519Vrf) }
 
       (kesProductResource
-        .use[Boolean](_: Function1[KesProduct, Boolean]))
+        .use[Boolean](_: Function1[KesProduct, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[KesProduct, Boolean] => f(kesProduct).pure[F] }
+        .onCall { f: Function1[KesProduct, F[Boolean]] => f(kesProduct) }
 
       (ed25519Resource
-        .use[Boolean](_: Function1[Ed25519, Boolean]))
+        .use[Boolean](_: Function1[Ed25519, F[Boolean]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519, Boolean] => f(ed25519).pure[F] }
+        .onCall { f: Function1[Ed25519, F[Boolean]] => f(ed25519) }
 
       (blake2b256Resource
-        .use[Evidence](_: Function1[Blake2b256, Evidence]))
+        .use[Evidence](_: Function1[Blake2b256, F[Evidence]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Blake2b256, Evidence] => f(blake2b256).pure[F] }
+        .onCall { f: Function1[Blake2b256, F[Evidence]] => f(blake2b256) }
 
       underTest.validate(child, parent).unsafeRunSync().value shouldBe child
     }

--- a/consensus/src/test/scala/co/topl/consensus/EtaCalculationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/EtaCalculationSpec.scala
@@ -95,16 +95,16 @@ class EtaCalculationSpec
       .anyNumberOfTimes()
 
     (blake2b256Resource
-      .use[NonEmptyChain[RhoNonceHash]](_: Function1[Blake2b256, NonEmptyChain[RhoNonceHash]]))
+      .use[NonEmptyChain[RhoNonceHash]](_: Function1[Blake2b256, F[NonEmptyChain[RhoNonceHash]]]))
       .expects(*)
       .anyNumberOfTimes()
-      .onCall { f: Function1[Blake2b256, NonEmptyChain[RhoNonceHash]] => f(blake2b256).pure[F] }
+      .onCall { f: Function1[Blake2b256, F[NonEmptyChain[RhoNonceHash]]] => f(blake2b256) }
 
     (blake2b512Resource
-      .use[NonEmptyChain[RhoNonceHash]](_: Function1[Blake2b512, NonEmptyChain[RhoNonceHash]]))
+      .use[NonEmptyChain[RhoNonceHash]](_: Function1[Blake2b512, F[NonEmptyChain[RhoNonceHash]]]))
       .expects(*)
       .anyNumberOfTimes()
-      .onCall { f: Function1[Blake2b512, NonEmptyChain[RhoNonceHash]] => f(blake2b512).pure[F] }
+      .onCall { f: Function1[Blake2b512, F[NonEmptyChain[RhoNonceHash]]] => f(blake2b512) }
 
     val actual =
       underTest.etaToBe(blocks.last.slotId, 16L).unsafeRunSync()
@@ -144,16 +144,16 @@ class EtaCalculationSpec
       .returning(SlotData(genesis.headerV2).pure[F])
 
     (blake2b256Resource
-      .use[NonEmptyChain[RhoNonceHash]](_: Function1[Blake2b256, NonEmptyChain[RhoNonceHash]]))
+      .use[NonEmptyChain[RhoNonceHash]](_: Function1[Blake2b256, F[NonEmptyChain[RhoNonceHash]]]))
       .expects(*)
       .anyNumberOfTimes()
-      .onCall { f: Function1[Blake2b256, NonEmptyChain[RhoNonceHash]] => f(blake2b256).pure[F] }
+      .onCall { f: Function1[Blake2b256, F[NonEmptyChain[RhoNonceHash]]] => f(blake2b256) }
 
     (blake2b512Resource
-      .use[NonEmptyChain[RhoNonceHash]](_: Function1[Blake2b512, NonEmptyChain[RhoNonceHash]]))
+      .use[NonEmptyChain[RhoNonceHash]](_: Function1[Blake2b512, F[NonEmptyChain[RhoNonceHash]]]))
       .expects(*)
       .anyNumberOfTimes()
-      .onCall { f: Function1[Blake2b512, NonEmptyChain[RhoNonceHash]] => f(blake2b512).pure[F] }
+      .onCall { f: Function1[Blake2b512, F[NonEmptyChain[RhoNonceHash]]] => f(blake2b512) }
 
     val actual =
       underTest.etaToBe(genesis.headerV2.slotId, 16L).unsafeRunSync()

--- a/consensus/src/test/scala/co/topl/consensus/EtaCalculationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/EtaCalculationSpec.scala
@@ -1,17 +1,16 @@
 package co.topl.consensus
 
+import cats.data.NonEmptyChain
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
-import co.topl.algebras.ClockAlgebra
-import co.topl.crypto.hash.blake2b256
+import co.topl.algebras.testInterpreters.NoOpLogger
+import co.topl.algebras.{ClockAlgebra, UnsafeResource}
+import co.topl.crypto.hash.{Blake2b256, Blake2b512}
 import co.topl.crypto.signing.Ed25519VRF
 import co.topl.models.ModelGenerators._
 import co.topl.models.Proofs.Knowledge
 import co.topl.models._
-import co.topl.models.utility.HasLength.instances._
-import co.topl.models.utility.Lengths._
-import co.topl.models.utility.Sized
 import co.topl.typeclasses._
 import co.topl.typeclasses.implicits._
 import org.scalacheck.Gen
@@ -32,15 +31,30 @@ class EtaCalculationSpec
 
   type F[A] = IO[A]
 
+  implicit private val logger: NoOpLogger[F] = new NoOpLogger[F]
+
   implicit private val ed25519Vrf: Ed25519VRF =
     Ed25519VRF.precomputed()
+
+  private val blake2b256 = new Blake2b256
+  private val blake2b512 = new Blake2b512
 
   it should "compute the eta for an epoch" in {
     val state = mock[SlotDataCache[F]]
     val clock = mock[ClockAlgebra[F]]
+    val blake2b256Resource = mock[UnsafeResource[F, Blake2b256]]
+    val blake2b512Resource = mock[UnsafeResource[F, Blake2b512]]
     val genesis = BlockGenesis(Nil).value
+
+    (() => clock.slotsPerEpoch)
+      .expects()
+      .anyNumberOfTimes()
+      .returning(15L.pure[F])
+
     val underTest =
-      EtaCalculation.Eval.make[F](state, clock, genesis.headerV2.eligibilityCertificate.eta).unsafeRunSync()
+      EtaCalculation.Eval
+        .make[F](state, clock, genesis.headerV2.eligibilityCertificate.eta, blake2b256Resource, blake2b512Resource)
+        .unsafeRunSync()
     val epoch = 0L
     val skVrf = KeyInitializer[SecretKeys.VrfEd25519].random()
     val args: List[(Slot, Knowledge.VrfEd25519)] = List.tabulate(8) { offset =>
@@ -74,16 +88,23 @@ class EtaCalculationSpec
         }
         .toList
 
-    (() => clock.slotsPerEpoch)
-      .expects()
-      .anyNumberOfTimes()
-      .returning(15L.pure[F])
-
     (state
       .get(_: TypedIdentifier))
       .expects(*)
       .onCall((id: TypedIdentifier) => SlotData(blocks.find(_.id eqv id).get).pure[F])
       .anyNumberOfTimes()
+
+    (blake2b256Resource
+      .use[NonEmptyChain[RhoNonceHash]](_: Function1[Blake2b256, NonEmptyChain[RhoNonceHash]]))
+      .expects(*)
+      .anyNumberOfTimes()
+      .onCall { f: Function1[Blake2b256, NonEmptyChain[RhoNonceHash]] => f(blake2b256).pure[F] }
+
+    (blake2b512Resource
+      .use[NonEmptyChain[RhoNonceHash]](_: Function1[Blake2b512, NonEmptyChain[RhoNonceHash]]))
+      .expects(*)
+      .anyNumberOfTimes()
+      .onCall { f: Function1[Blake2b512, NonEmptyChain[RhoNonceHash]] => f(blake2b512).pure[F] }
 
     val actual =
       underTest.etaToBe(blocks.last.slotId, 16L).unsafeRunSync()
@@ -91,7 +112,7 @@ class EtaCalculationSpec
     val expected =
       EtaCalculationSpec.expectedEta(
         genesis.headerV2.eligibilityCertificate.eta,
-        epoch,
+        epoch + 1,
         blocks.map(_.eligibilityCertificate.vrfSig).map(ed25519Vrf.proofToHash)
       )
 
@@ -101,15 +122,20 @@ class EtaCalculationSpec
   it should "compute the eta for an epoch with only a genesis block" in {
     val state = mock[SlotDataCache[F]]
     val clock = mock[ClockAlgebra[F]]
+    val blake2b256Resource = mock[UnsafeResource[F, Blake2b256]]
+    val blake2b512Resource = mock[UnsafeResource[F, Blake2b512]]
     val genesis = BlockGenesis(Nil).value
-    val underTest =
-      EtaCalculation.Eval.make[F](state, clock, genesis.headerV2.eligibilityCertificate.eta).unsafeRunSync()
-    val epoch = 0L
 
     (() => clock.slotsPerEpoch)
       .expects()
       .anyNumberOfTimes()
       .returning(15L.pure[F])
+
+    val underTest =
+      EtaCalculation.Eval
+        .make[F](state, clock, genesis.headerV2.eligibilityCertificate.eta, blake2b256Resource, blake2b512Resource)
+        .unsafeRunSync()
+    val epoch = 0L
 
     (state
       .get(_: TypedIdentifier))
@@ -117,13 +143,25 @@ class EtaCalculationSpec
       .once()
       .returning(SlotData(genesis.headerV2).pure[F])
 
+    (blake2b256Resource
+      .use[NonEmptyChain[RhoNonceHash]](_: Function1[Blake2b256, NonEmptyChain[RhoNonceHash]]))
+      .expects(*)
+      .anyNumberOfTimes()
+      .onCall { f: Function1[Blake2b256, NonEmptyChain[RhoNonceHash]] => f(blake2b256).pure[F] }
+
+    (blake2b512Resource
+      .use[NonEmptyChain[RhoNonceHash]](_: Function1[Blake2b512, NonEmptyChain[RhoNonceHash]]))
+      .expects(*)
+      .anyNumberOfTimes()
+      .onCall { f: Function1[Blake2b512, NonEmptyChain[RhoNonceHash]] => f(blake2b512).pure[F] }
+
     val actual =
       underTest.etaToBe(genesis.headerV2.slotId, 16L).unsafeRunSync()
 
     val expected =
       EtaCalculationSpec.expectedEta(
         genesis.headerV2.eligibilityCertificate.eta,
-        epoch,
+        epoch + 1,
         List(ed25519Vrf.proofToHash(genesis.headerV2.eligibilityCertificate.vrfSig))
       )
 
@@ -133,19 +171,14 @@ class EtaCalculationSpec
 
 object EtaCalculationSpec {
 
+  implicit private val blake2b256: Blake2b256 = new Blake2b256
+  implicit private val blake2b512: Blake2b512 = new Blake2b512
+
   private[consensus] def expectedEta(previousEta: Eta, epoch: Epoch, rhoValues: List[Rho]): Eta = {
     val messages: List[Bytes] =
       List(previousEta.data) ++ List(Bytes(BigInt(epoch).toByteArray)) ++ rhoValues
         .map(Ed25519VRF.rhoToRhoNonceHash)
         .map(_.sizedBytes.data)
-    Sized.strictUnsafe(
-      Bytes(
-        blake2b256
-          .hash(
-            Bytes.concat(messages).toArray
-          )
-          .value
-      )
-    )
+    blake2b256.hash(Bytes.concat(messages))
   }
 }

--- a/crypto/src/main/scala/co/topl/crypto/hash/Blake2b.scala
+++ b/crypto/src/main/scala/co/topl/crypto/hash/Blake2b.scala
@@ -13,7 +13,7 @@ abstract class Blake2bHash[D: Digest] extends Hash[Blake2b, D] {
 
   override def hash(prefix: Option[Byte], messages: Message*): D =
     // must be synchronized on the digest function so that everyone shares an instance
-    {
+    synchronized {
       // update digest with prefix and messages
       prefix.foreach(p => digestFunc.update(p))
       messages.iterator.foreach { m =>

--- a/crypto/src/main/scala/co/topl/crypto/hash/Blake2b.scala
+++ b/crypto/src/main/scala/co/topl/crypto/hash/Blake2b.scala
@@ -31,6 +31,9 @@ abstract class Blake2bHash[D: Digest] extends Hash[Blake2b, D] {
     }
 }
 
+/**
+ * A thread-unsafe version of the blake2b interface defined above
+ */
 class Blake2b256 {
   private val digest = new Blake2bDigest(256)
 
@@ -42,6 +45,9 @@ class Blake2b256 {
   }
 }
 
+/**
+ * A thread-unsafe version of the blake2b interface defined above
+ */
 class Blake2b512 {
   private val digest = new Blake2bDigest(512)
 

--- a/crypto/src/main/scala/co/topl/crypto/hash/Blake2b.scala
+++ b/crypto/src/main/scala/co/topl/crypto/hash/Blake2b.scala
@@ -13,7 +13,7 @@ abstract class Blake2bHash[D: Digest] extends Hash[Blake2b, D] {
 
   override def hash(prefix: Option[Byte], messages: Message*): D =
     // must be synchronized on the digest function so that everyone shares an instance
-    synchronized {
+    {
       // update digest with prefix and messages
       prefix.foreach(p => digestFunc.update(p))
       messages.iterator.foreach { m =>

--- a/crypto/src/main/scala/co/topl/crypto/hash/Blake2b.scala
+++ b/crypto/src/main/scala/co/topl/crypto/hash/Blake2b.scala
@@ -1,6 +1,9 @@
 package co.topl.crypto.hash
 
 import co.topl.crypto.hash.digest.Digest
+import co.topl.models.Bytes
+import co.topl.models.utility.HasLength.instances.bytesLength
+import co.topl.models.utility.{Lengths, Sized}
 import org.bouncycastle.crypto.digests.Blake2bDigest
 
 abstract class Blake2bHash[D: Digest] extends Hash[Blake2b, D] {
@@ -26,4 +29,26 @@ abstract class Blake2bHash[D: Digest] extends Hash[Blake2b, D] {
         .from(res)
         .valueOr(err => throw new Error(s"Blake2b hash with digest size $digestSize was invalid! $err"))
     }
+}
+
+class Blake2b256 {
+  private val digest = new Blake2bDigest(256)
+
+  def hash(bytes: Bytes*): Sized.Strict[Bytes, Lengths.`32`.type] = {
+    val out = new Array[Byte](32)
+    bytes.foreach(b => digest.update(b.toArray, 0, b.length.toInt))
+    digest.doFinal(out, 0)
+    Sized.strictUnsafe(Bytes(out))
+  }
+}
+
+class Blake2b512 {
+  private val digest = new Blake2bDigest(512)
+
+  def hash(bytes: Bytes*): Sized.Strict[Bytes, Lengths.`64`.type] = {
+    val out = new Array[Byte](64)
+    bytes.foreach(b => digest.update(b.toArray, 0, b.length.toInt))
+    digest.doFinal(out, 0)
+    Sized.strictUnsafe(Bytes(out))
+  }
 }

--- a/crypto/src/main/scala/co/topl/crypto/hash/hash.scala
+++ b/crypto/src/main/scala/co/topl/crypto/hash/hash.scala
@@ -54,16 +54,16 @@ package object hash {
 
   import digest.implicits._
 
-  def blake2b256: Hash[Blake2b, Digest32] = new Blake2bHash[Digest32] {}
-  def blake2b512: Hash[Blake2b, Digest64] = new Blake2bHash[Digest64] {}
+  val blake2b256: Hash[Blake2b, Digest32] = new Blake2bHash[Digest32] {}
+  val blake2b512: Hash[Blake2b, Digest64] = new Blake2bHash[Digest64] {}
   val sha256: Hash[Sha, Digest32] = new ShaHash[Digest32]("Sha-256") {}
   val sha512: Hash[Sha, Digest64] = new ShaHash[Digest64]("Sha-512") {}
 
   trait Instances {
     implicit val sha256Hash: Hash[Sha, Digest32] = sha256
     implicit val sha512Hash: Hash[Sha, Digest64] = sha512
-    implicit def blake2b256Hash: Hash[Blake2b, Digest32] = blake2b256
-    implicit def blake2b512Hash: Hash[Blake2b, Digest64] = blake2b512
+    implicit val blake2b256Hash: Hash[Blake2b, Digest32] = blake2b256
+    implicit val blake2b512Hash: Hash[Blake2b, Digest64] = blake2b512
   }
 
   object implicits extends Instances with DigestImplicits

--- a/crypto/src/main/scala/co/topl/crypto/hash/hash.scala
+++ b/crypto/src/main/scala/co/topl/crypto/hash/hash.scala
@@ -54,16 +54,16 @@ package object hash {
 
   import digest.implicits._
 
-  val blake2b256: Hash[Blake2b, Digest32] = new Blake2bHash[Digest32] {}
-  val blake2b512: Hash[Blake2b, Digest64] = new Blake2bHash[Digest64] {}
+  def blake2b256: Hash[Blake2b, Digest32] = new Blake2bHash[Digest32] {}
+  def blake2b512: Hash[Blake2b, Digest64] = new Blake2bHash[Digest64] {}
   val sha256: Hash[Sha, Digest32] = new ShaHash[Digest32]("Sha-256") {}
   val sha512: Hash[Sha, Digest64] = new ShaHash[Digest64]("Sha-512") {}
 
   trait Instances {
     implicit val sha256Hash: Hash[Sha, Digest32] = sha256
     implicit val sha512Hash: Hash[Sha, Digest64] = sha512
-    implicit val blake2b256Hash: Hash[Blake2b, Digest32] = blake2b256
-    implicit val blake2b512Hash: Hash[Blake2b, Digest64] = blake2b512
+    implicit def blake2b256Hash: Hash[Blake2b, Digest32] = blake2b256
+    implicit def blake2b512Hash: Hash[Blake2b, Digest64] = blake2b512
   }
 
   object implicits extends Instances with DigestImplicits

--- a/crypto/src/main/scala/co/topl/crypto/signing/Ed25519VRF.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signing/Ed25519VRF.scala
@@ -1,6 +1,6 @@
 package co.topl.crypto.signing
 
-import co.topl.crypto.hash.{blake2b512, Blake2b512}
+import co.topl.crypto.hash.Blake2b512
 import co.topl.crypto.signing.eddsa.ECVRF25519
 import co.topl.models.utility.HasLength.instances.bytesLength
 import co.topl.models.utility.Sized
@@ -68,22 +68,18 @@ object Ed25519VRF {
     new Ed25519VRF
 
   private val TestStringBytes =
-    "TEST".getBytes(StandardCharsets.UTF_8)
+    Bytes("TEST".getBytes(StandardCharsets.UTF_8))
 
   private val NonceStringBytes =
-    "NONCE".getBytes(StandardCharsets.UTF_8)
+    Bytes("NONCE".getBytes(StandardCharsets.UTF_8))
 
-  def rhoToRhoTestHash(rho: Rho): RhoTestHash =
+  def rhoToRhoTestHash(rho: Rho)(implicit blake2b512: Blake2b512): RhoTestHash =
     RhoTestHash(
-      Sized.strictUnsafe(
-        Bytes(
-          blake2b512.hash(rho.sizedBytes.data.toArray ++ TestStringBytes).value
-        )
-      )
+      blake2b512.hash(rho.sizedBytes.data ++ TestStringBytes)
     )
 
   def rhoToRhoNonceHash(rho: Rho)(implicit blake2b512: Blake2b512): RhoNonceHash =
     RhoNonceHash(
-      blake2b512.hash(rho.sizedBytes.data ++ Bytes(NonceStringBytes))
+      blake2b512.hash(rho.sizedBytes.data ++ NonceStringBytes)
     )
 }

--- a/crypto/src/main/scala/co/topl/crypto/signing/Ed25519VRF.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signing/Ed25519VRF.scala
@@ -1,6 +1,6 @@
 package co.topl.crypto.signing
 
-import co.topl.crypto.hash.blake2b512
+import co.topl.crypto.hash.{blake2b512, Blake2b512}
 import co.topl.crypto.signing.eddsa.ECVRF25519
 import co.topl.models.utility.HasLength.instances.bytesLength
 import co.topl.models.utility.Sized
@@ -82,12 +82,8 @@ object Ed25519VRF {
       )
     )
 
-  def rhoToRhoNonceHash(rho: Rho): RhoNonceHash =
+  def rhoToRhoNonceHash(rho: Rho)(implicit blake2b512: Blake2b512): RhoNonceHash =
     RhoNonceHash(
-      Sized.strictUnsafe(
-        Bytes(
-          blake2b512.hash(rho.sizedBytes.data.toArray ++ NonceStringBytes).value
-        )
-      )
+      blake2b512.hash(rho.sizedBytes.data ++ Bytes(NonceStringBytes))
     )
 }

--- a/demo/src/main/scala/co/topl/demo/ActorPoolUnsafeResource.scala
+++ b/demo/src/main/scala/co/topl/demo/ActorPoolUnsafeResource.scala
@@ -1,0 +1,92 @@
+package co.topl.demo
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, ActorSystem, Behavior, PostStop}
+import akka.util.Timeout
+import cats.data.Chain
+import cats.effect.{Async, Sync}
+import co.topl.algebras.UnsafeResource
+
+import java.util.UUID
+
+object ActorPoolUnsafeResource {
+
+  object Eval {
+
+    def make[F[_]: Async, T](init: => T, cleanup: T => Unit)(implicit
+      system:                      ActorSystem[_],
+      askTimeout:                  Timeout
+    ): F[UnsafeResource[F, T]] =
+      Sync[F].delay {
+        val parent = system.systemActorOf(
+          ParentActor[T](init, cleanup, Chain.empty),
+          "ActorPoolUnsharedResource" + UUID.randomUUID().toString
+        )
+
+        new UnsafeResource[F, T] {
+          import akka.actor.typed.scaladsl.AskPattern._
+          def use[Res](f: T => Res): F[Res] =
+            Async[F].fromFuture(
+              Sync[F].delay(
+                parent.ask(
+                  ParentActor.Use(f, _)
+                )
+              )
+            )
+        }
+      }
+  }
+
+  private object ParentActor {
+    sealed abstract class ReceivableMessage[T]
+
+    case class Use[T, Res](f: T => Res, replyTo: ActorRef[Res]) extends ReceivableMessage[T] {
+
+      def run(child: ActorRef[ChildActor.ReceivableMessage[T]]): Unit =
+        child.tell(ChildActor.Use(f, replyTo))
+    }
+    case class Ready[T](child: ActorRef[ChildActor.ReceivableMessage[T]]) extends ReceivableMessage[T]
+
+    def apply[T](
+      init:             => T,
+      cleanup:          T => Unit,
+      inactiveChildren: Chain[ActorRef[ChildActor.ReceivableMessage[T]]]
+    ): Behavior[ReceivableMessage[T]] =
+      Behaviors.receive {
+        case (ctx, u @ Use(_, _)) =>
+          val (remaining, child) =
+            inactiveChildren.initLast.getOrElse(
+              (Chain.empty, ctx.spawnAnonymous(ChildActor(init, cleanup, ctx.self)))
+            )
+          u.run(child)
+          apply(init, cleanup, remaining)
+
+        case (_, Ready(child)) =>
+          apply(init, cleanup, inactiveChildren :+ child)
+      }
+  }
+
+  private object ChildActor {
+    sealed abstract class ReceivableMessage[T]
+
+    case class Use[T, Res](f: T => Res, replyTo: ActorRef[Res]) extends ReceivableMessage[T] {
+      def run(t: T): Unit = replyTo.tell(f(t))
+    }
+
+    def apply[T](
+      value:   T,
+      cleanup: T => Unit,
+      parent:  ActorRef[ParentActor.ReceivableMessage[T]]
+    ): Behavior[ReceivableMessage[T]] =
+      Behaviors
+        .receive[ReceivableMessage[T]] { case (ctx, u @ Use(_, _)) =>
+          u.run(value)
+          parent.tell(ParentActor.Ready(ctx.self))
+          Behaviors.same
+        }
+        .receiveSignal { case (_, PostStop) =>
+          cleanup(value)
+          Behaviors.same
+        }
+  }
+}

--- a/demo/src/main/scala/co/topl/demo/ActorPoolUnsafeResource.scala
+++ b/demo/src/main/scala/co/topl/demo/ActorPoolUnsafeResource.scala
@@ -1,62 +1,70 @@
 package co.topl.demo
 
-import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.{ActorRef, ActorSystem, Behavior, PostStop}
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+import akka.actor.typed.{ActorRef, ActorSystem, Behavior, PostStop, Scheduler}
+import akka.pattern.StatusReply
 import akka.util.Timeout
 import cats.data.Chain
-import cats.effect.{Async, Sync}
+import cats.effect.{Async, IO, Sync}
+import cats.~>
 import co.topl.algebras.UnsafeResource
 
 import java.util.UUID
 
+/**
+ * Interprets the `UnsafeResource` algebra using a pool of actors.  When a Resource is needed, an actor is created to
+ * own the Resource and handle commands to use it.  If another request arrives before the first actor completes, a second
+ * actor is created.  When the first actor finishes, it is into the pool of available workers.  Actors can then
+ * be re-used.
+ */
 object ActorPoolUnsafeResource {
 
   object Eval {
 
-    def make[F[_]: Async, T](init: => T, cleanup: T => Unit)(implicit
-      system:                      ActorSystem[_],
-      askTimeout:                  Timeout
+    def make[F[_]: Async: ~>[*[_], IO], T](init: => T, cleanup: T => Unit)(implicit
+      system:                                    ActorSystem[_],
+      askTimeout:                                Timeout
     ): F[UnsafeResource[F, T]] =
       Sync[F].delay {
+        implicit val scheduler: Scheduler = system.scheduler
         val parent = system.systemActorOf(
-          ParentActor[T](init, cleanup, Chain.empty),
+          PoolManagerActor[T](init, cleanup, Chain.empty),
           "ActorPoolUnsharedResource" + UUID.randomUUID().toString
         )
 
+        // TODO: Release resources after inactivity period
         new UnsafeResource[F, T] {
-          import akka.actor.typed.scaladsl.AskPattern._
-          def use[Res](f: T => Res): F[Res] =
-            Async[F].fromFuture(
-              Sync[F].delay(
-                parent.ask(
-                  ParentActor.Use(f, _)
-                )
-              )
-            )
+          import CatsActor._
+          def use[Res](f: T => F[Res]): F[Res] =
+            parent.askMWithStatus[F, Res](PoolManagerActor.Use(f, _))
         }
       }
   }
 
-  private object ParentActor {
+  /**
+   * Maintains a set of available worker actors.  Forwards incoming requests to the first available worker.
+   */
+  private object PoolManagerActor {
     sealed abstract class ReceivableMessage[T]
 
-    case class Use[T, Res](f: T => Res, replyTo: ActorRef[Res]) extends ReceivableMessage[T] {
+    case class Use[F[_]: ~>[*[_], IO], T, Res](f: T => F[Res], replyTo: ActorRef[StatusReply[Res]])
+        extends ReceivableMessage[T] {
 
-      def run(child: ActorRef[ChildActor.ReceivableMessage[T]]): Unit =
-        child.tell(ChildActor.Use(f, replyTo))
+      def run(child: ActorRef[SingleResourceOwner.ReceivableMessage[T]]): Unit =
+        child.tell(SingleResourceOwner.Use(f, replyTo))
     }
-    case class Ready[T](child: ActorRef[ChildActor.ReceivableMessage[T]]) extends ReceivableMessage[T]
+    case class Ready[T](child: ActorRef[SingleResourceOwner.ReceivableMessage[T]]) extends ReceivableMessage[T]
 
     def apply[T](
       init:             => T,
       cleanup:          T => Unit,
-      inactiveChildren: Chain[ActorRef[ChildActor.ReceivableMessage[T]]]
+      inactiveChildren: Chain[ActorRef[SingleResourceOwner.ReceivableMessage[T]]]
     ): Behavior[ReceivableMessage[T]] =
       Behaviors.receive {
         case (ctx, u @ Use(_, _)) =>
           val (remaining, child) =
             inactiveChildren.initLast.getOrElse(
-              (Chain.empty, ctx.spawnAnonymous(ChildActor(init, cleanup, ctx.self)))
+              (Chain.empty, ctx.spawnAnonymous(SingleResourceOwner(init, cleanup, ctx.self)))
             )
           u.run(child)
           apply(init, cleanup, remaining)
@@ -66,27 +74,68 @@ object ActorPoolUnsafeResource {
       }
   }
 
-  private object ChildActor {
+  /**
+   * Owns an individual resource.  Handles commands to use the resource.  Notifies the pool upon completion.
+   */
+  private object SingleResourceOwner {
     sealed abstract class ReceivableMessage[T]
 
-    case class Use[T, Res](f: T => Res, replyTo: ActorRef[Res]) extends ReceivableMessage[T] {
-      def run(t: T): Unit = replyTo.tell(f(t))
+    case class Use[F[_]: ~>[*[_], IO], T, Res](f: T => F[Res], replyTo: ActorRef[StatusReply[Res]])
+        extends ReceivableMessage[T] {
+
+      def run(t: T, ctx: ActorContext[ReceivableMessage[T]]): Unit =
+        implicitly[~>[F, IO]]
+          .apply(f(t))
+          .unsafeRunAsync(e =>
+            ctx.self.tell(
+              Complete(
+                e.fold(StatusReply.error(_), StatusReply.success),
+                replyTo
+              )
+            )
+          )(AkkaCatsRuntime(ctx.system).runtime)
+    }
+
+    case class Complete[T, Res](result: StatusReply[Res], replyTo: ActorRef[StatusReply[Res]])
+        extends ReceivableMessage[T] {
+
+      def run(): Unit =
+        replyTo.tell(result)
     }
 
     def apply[T](
       value:   T,
       cleanup: T => Unit,
-      parent:  ActorRef[ParentActor.ReceivableMessage[T]]
+      parent:  ActorRef[PoolManagerActor.ReceivableMessage[T]]
     ): Behavior[ReceivableMessage[T]] =
       Behaviors
-        .receive[ReceivableMessage[T]] { case (ctx, u @ Use(_, _)) =>
-          u.run(value)
-          parent.tell(ParentActor.Ready(ctx.self))
-          Behaviors.same
+        .receive[ReceivableMessage[T]] {
+          case (ctx, u @ Use(_, _)) =>
+            u.run(value, ctx)
+            Behaviors.same
+          case (ctx, u @ Complete(_, _)) =>
+            u.run()
+            parent.tell(PoolManagerActor.Ready(ctx.self))
+            Behaviors.same
         }
         .receiveSignal { case (_, PostStop) =>
           cleanup(value)
           Behaviors.same
         }
+  }
+}
+
+object CatsActor {
+
+  implicit class ActorRefOps[T](ref: ActorRef[T]) {
+    import akka.actor.typed.scaladsl.AskPattern._
+
+    def askM[F[_]: Async, Res](messageF: ActorRef[Res] => T)(implicit timeout: Timeout, scheduler: Scheduler): F[Res] =
+      Async[F].fromFuture(Async[F].delay(ref.ask(messageF)))
+
+    def askMWithStatus[F[_]: Async, Res](
+      messageF:         ActorRef[StatusReply[Res]] => T
+    )(implicit timeout: Timeout, scheduler: Scheduler): F[Res] =
+      Async[F].fromFuture(Async[F].delay(ref.askWithStatus(messageF)))
   }
 }

--- a/demo/src/main/scala/co/topl/demo/AkkaCatsRuntime.scala
+++ b/demo/src/main/scala/co/topl/demo/AkkaCatsRuntime.scala
@@ -1,0 +1,35 @@
+package co.topl.demo
+
+import akka.actor.typed.{ActorSystem, DispatcherSelector, Extension, ExtensionId}
+import cats.effect.unsafe.{IORuntime, IORuntimeConfig, Scheduler}
+
+import scala.concurrent.duration.FiniteDuration
+
+class AkkaCatsRuntime(system: ActorSystem[_]) extends Extension {
+
+  val scheduler = new Scheduler {
+
+    def sleep(delay: FiniteDuration, task: Runnable): Runnable = {
+      val c =
+        system.scheduler.scheduleOnce(delay, task)(system.executionContext)
+      () => c.cancel()
+    }
+
+    def nowMillis(): Long = cats.effect.unsafe.implicits.global.scheduler.nowMillis()
+
+    def monotonicNanos(): Long = cats.effect.unsafe.implicits.global.scheduler.monotonicNanos()
+  }
+
+  val runtime: IORuntime =
+    IORuntime(
+      system.executionContext,
+      system.dispatchers.lookup(DispatcherSelector.blocking()),
+      scheduler = scheduler,
+      shutdown = () => system.terminate(),
+      config = IORuntimeConfig.apply()
+    )
+}
+
+object AkkaCatsRuntime extends ExtensionId[AkkaCatsRuntime] {
+  def createExtension(system: ActorSystem[_]): AkkaCatsRuntime = new AkkaCatsRuntime(system)
+}

--- a/demo/src/main/scala/co/topl/demo/AkkaCatsRuntime.scala
+++ b/demo/src/main/scala/co/topl/demo/AkkaCatsRuntime.scala
@@ -7,7 +7,9 @@ import scala.concurrent.duration.FiniteDuration
 
 class AkkaCatsRuntime(system: ActorSystem[_]) extends Extension {
 
-  val scheduler = new Scheduler {
+  val ioRuntimeConfig = IORuntimeConfig.apply()
+
+  val scheduler: Scheduler = new Scheduler {
 
     def sleep(delay: FiniteDuration, task: Runnable): Runnable = {
       val c =
@@ -15,9 +17,9 @@ class AkkaCatsRuntime(system: ActorSystem[_]) extends Extension {
       () => c.cancel()
     }
 
-    def nowMillis(): Long = cats.effect.unsafe.implicits.global.scheduler.nowMillis()
+    def nowMillis(): Long = System.currentTimeMillis()
 
-    def monotonicNanos(): Long = cats.effect.unsafe.implicits.global.scheduler.monotonicNanos()
+    def monotonicNanos(): Long = System.nanoTime()
   }
 
   val runtime: IORuntime =
@@ -26,7 +28,7 @@ class AkkaCatsRuntime(system: ActorSystem[_]) extends Extension {
       system.dispatchers.lookup(DispatcherSelector.blocking()),
       scheduler = scheduler,
       shutdown = () => system.terminate(),
-      config = IORuntimeConfig.apply()
+      config = ioRuntimeConfig
     )
 }
 

--- a/demo/src/main/scala/co/topl/demo/DemoProgram.scala
+++ b/demo/src/main/scala/co/topl/demo/DemoProgram.scala
@@ -9,7 +9,7 @@ import co.topl.algebras.{ClockAlgebra, ConsensusState, Store, UnsafeResource}
 import co.topl.consensus.algebras.{BlockHeaderValidationAlgebra, EtaCalculationAlgebra, LocalChainAlgebra}
 import co.topl.consensus.{BlockHeaderValidationFailure, SlotData}
 import co.topl.crypto.signing.Ed25519VRF
-import co.topl.minting.algebras.{BlockMintAlgebra, VrfProofAlgebra}
+import co.topl.minting.algebras.BlockMintAlgebra
 import co.topl.models._
 import co.topl.models.utility.Ratio
 import co.topl.typeclasses.implicits._
@@ -171,7 +171,7 @@ object DemoProgram {
     for {
       _                     <- Logger[F].info(show"Minted block ${nextBlock.headerV2}")
       _                     <- blockStore.put(nextBlock)
-      slotData              <- ed25519VrfResource.use(implicit ed25519Vrf => SlotData(nextBlock.headerV2))
+      slotData              <- ed25519VrfResource.use(implicit ed25519Vrf => SlotData(nextBlock.headerV2).pure[F])
       localChainIsWorseThan <- localChain.isWorseThan(slotData)
       _ <-
         if (localChainIsWorseThan)

--- a/demo/src/main/scala/co/topl/demo/TetraDemo.scala
+++ b/demo/src/main/scala/co/topl/demo/TetraDemo.scala
@@ -237,7 +237,8 @@ object TetraDemo extends IOApp.Simple {
         RegistrationLookup.Eval.make(state, clock),
         ed25519VRFResource,
         kesProductResource,
-        ed25519Resource
+        ed25519Resource,
+        blake2b256Resource
       )
       cachedHeaderValidation <- BlockHeaderValidation.WithCache.make[F](underlyingHeaderValidation, blockHeaderStore)
       localChain <- LocalChain.Eval.make(

--- a/demo/src/main/scala/co/topl/demo/TetraDemo.scala
+++ b/demo/src/main/scala/co/topl/demo/TetraDemo.scala
@@ -6,6 +6,7 @@ import cats.arrow.FunctionK
 import cats.data.OptionT
 import cats.effect.implicits._
 import cats.effect.kernel.Sync
+import cats.effect.unsafe.{IORuntime, IORuntimeConfig}
 import cats.effect.{Async, IO, IOApp}
 import cats.implicits._
 import cats.~>
@@ -110,6 +111,9 @@ object TetraDemo extends IOApp.Simple {
       NodeViewHolder(initialNodeView),
       "TetraDemo"
     )
+
+  override val runtime: IORuntime = AkkaCatsRuntime(system).runtime
+  override val runtimeConfig: IORuntimeConfig = AkkaCatsRuntime(system).ioRuntimeConfig
 
   // Interpreter initialization
 

--- a/demo/src/test/scala/co/topl/demo/ActorPoolUnsafeResourceSpec.scala
+++ b/demo/src/test/scala/co/topl/demo/ActorPoolUnsafeResourceSpec.scala
@@ -1,0 +1,70 @@
+package co.topl.demo
+
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import cats.arrow.FunctionK
+import cats.effect.{IO, Sync}
+import cats.effect.unsafe.implicits.global
+import cats.~>
+import co.topl.models.Bytes
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{BeforeAndAfterAll, EitherValues, Inspectors, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.{ExecutionContextExecutor, Future}
+
+class ActorPoolUnsafeResourceSpec
+    extends ScalaTestWithActorTestKit
+    with Inspectors
+    with Matchers
+    with MockFactory
+    with EitherValues
+    with OptionValues
+    with BeforeAndAfterAll
+    with AnyFlatSpecLike {
+
+  type F[A] = IO[A]
+  implicit val ioToIo: F ~> IO = FunctionK.id
+
+  implicit val ec: ExecutionContextExecutor = testKit.system.executionContext
+
+  // This test is just to demonstrate the thread safety issue
+  "Mutable data that is thread-unsafe" should "result in inconsistent result data" in {
+    val badMutableData = new MutableResource(16)
+    val a1 = Array.fill(16)(0: Byte)
+    val a2 = Array.fill(16)(1: Byte)
+    val f1 = Future { badMutableData.setBytesSlowly(a1); badMutableData.getArrayCopy }
+    val f2 = Future { badMutableData.setBytesSlowly(a2); badMutableData.getArrayCopy }
+    val (r1, r2) = f1.zip(f2).futureValue
+    (Bytes(r1) == Bytes(a1)) shouldBe false
+    (Bytes(r2) == Bytes(a2)) shouldBe false
+  }
+
+  behavior of "ActorPoolUnsafeResource"
+
+  it should "give thread safety to mutable data" in {
+    val underTest =
+      ActorPoolUnsafeResource.Eval.make[F, MutableResource](new MutableResource(16), _ => ()).unsafeRunSync()
+
+    val a1 = Array.fill(16)(0: Byte)
+    val a2 = Array.fill(16)(1: Byte)
+    val f1 = underTest.use(d => Sync[F].delay { d.setBytesSlowly(a1); d.getArrayCopy }).unsafeToFuture()
+    val f2 = underTest.use(d => Sync[F].delay { d.setBytesSlowly(a2); d.getArrayCopy }).unsafeToFuture()
+    val (r1, r2) = f1.zip(f2).futureValue
+    (Bytes(r1) == Bytes(a1)) shouldBe true
+    (Bytes(r2) == Bytes(a2)) shouldBe true
+  }
+
+}
+
+private class MutableResource(length: Int) {
+  private var array = new Array[Byte](length)
+  def set(index: Int, byte: Byte): Unit = array(index) = byte
+
+  def setBytesSlowly(newBytes: Array[Byte]): Unit =
+    newBytes.zipWithIndex.foreach { case (byte, idx) =>
+      set(idx, byte)
+      Thread.sleep(100)
+    }
+  def getArrayCopy: Array[Byte] = array.clone()
+}

--- a/minting/src/main/scala/co/topl/minting/OperationalKeys.scala
+++ b/minting/src/main/scala/co/topl/minting/OperationalKeys.scala
@@ -6,16 +6,16 @@ import cats.effect.Ref
 import cats.effect.kernel.Concurrent
 import cats.implicits._
 import co.topl.algebras.ClockAlgebra.implicits._
-import co.topl.algebras.{ClockAlgebra, ConsensusState}
+import co.topl.algebras.{ClockAlgebra, ConsensusState, UnsafeResource}
 import co.topl.codecs.bytes.implicits._
 import co.topl.consensus.algebras.EtaCalculationAlgebra
 import co.topl.crypto.keyfile.SecureStore
+import co.topl.crypto.mnemonic.Entropy
 import co.topl.crypto.signing._
 import co.topl.minting.algebras._
 import co.topl.models._
-import co.topl.models.utility.Ratio
-import co.topl.typeclasses.KeyInitializer
 import co.topl.typeclasses.implicits._
+import co.topl.models.utility.Ratio
 import com.google.common.primitives.Longs
 import org.typelevel.log4cats.Logger
 
@@ -41,13 +41,12 @@ object OperationalKeys {
       vrfProof:                    VrfProofAlgebra[F],
       etaCalculation:              EtaCalculationAlgebra[F],
       consensusState:              ConsensusState[F],
+      kesProductResource:          UnsafeResource[F, KesProduct],
+      ed25519Resource:             UnsafeResource[F, Ed25519],
       parentSlotId:                SlotId,
       operationalPeriodLength:     Long,
       activationOperationalPeriod: Long,
       address:                     TaktikosAddress
-    )(implicit
-      kesProductScheme: KesProduct,
-      ed25519Scheme:    Ed25519
     ): F[OperationalKeysAlgebra[F]] =
       for {
         initialSlot <- clock.globalSlot
@@ -66,8 +65,11 @@ object OperationalKeys {
                   relativeStake,
                   clock,
                   vrfProof,
-                  etaCalculation
-                )
+                  etaCalculation,
+                  kesProductResource,
+                  ed25519Resource
+                ),
+                kesProductResource
               )
             )
             .value
@@ -78,6 +80,8 @@ object OperationalKeys {
         vrfProof,
         etaCalculation,
         consensusState,
+        kesProductResource,
+        ed25519Resource,
         operationalPeriodLength,
         activationOperationalPeriod,
         address,
@@ -90,13 +94,12 @@ object OperationalKeys {
       vrfProof:                    VrfProofAlgebra[F],
       etaCalculation:              EtaCalculationAlgebra[F],
       consensusState:              ConsensusState[F],
+      kesProductResource:          UnsafeResource[F, KesProduct],
+      ed25519Resource:             UnsafeResource[F, Ed25519],
       operationalPeriodLength:     Long,
       activationOperationalPeriod: Long,
       address:                     TaktikosAddress,
       ref:                         Ref[F, (Long, Option[LongMap[OperationalKeyOut]])]
-    )(implicit
-      kesProductScheme: KesProduct,
-      ed25519Scheme:    Ed25519
     ): OperationalKeysAlgebra[F] = { (slot: Slot, parentSlotId: SlotId) =>
       val operationalPeriod = slot / operationalPeriodLength
       ref.get.flatMap {
@@ -116,8 +119,11 @@ object OperationalKeys {
                   relativeStake,
                   clock,
                   vrfProof,
-                  etaCalculation
-                )
+                  etaCalculation,
+                  kesProductResource,
+                  ed25519Resource
+                ),
+                kesProductResource
               )
             )
             .semiflatTap(newKeys => ref.set(operationalPeriod -> newKeys.some))
@@ -133,10 +139,11 @@ object OperationalKeys {
      * key for `timeStep + 1` is constructed and saved to disk.
      */
     private def consumeEvolvePersist[F[_]: MonadError[*[_], Throwable]: Logger, T](
-      timeStep:                  Int,
-      secureStore:               SecureStore[F],
-      use:                       SecretKeys.KesProduct => F[T]
-    )(implicit kesProductScheme: KesProduct): F[Option[T]] = {
+      timeStep:           Int,
+      secureStore:        SecureStore[F],
+      use:                SecretKeys.KesProduct => F[T],
+      kesProductResource: UnsafeResource[F, KesProduct]
+    ): F[Option[T]] = {
       for {
         fileName <- OptionT.liftF(secureStore.list.flatMap {
           case Chain(fileName) => fileName.pure[F]
@@ -147,20 +154,18 @@ object OperationalKeys {
         })
         _       <- OptionT.liftF(Logger[F].info(show"Consuming key id=$fileName"))
         diskKey <- OptionT(secureStore.consume[SecretKeys.KesProduct](fileName))
-        latest = kesProductScheme.getCurrentStep(diskKey)
-        currentPeriodKey =
-          if (latest === timeStep) diskKey
-          else kesProductScheme.update(diskKey, timeStep.toInt)
+        latest  <- OptionT.liftF(kesProductResource.use(_.getCurrentStep(diskKey)))
+        currentPeriodKey <-
+          if (latest === timeStep) OptionT.pure[F](diskKey)
+          else OptionT.liftF(kesProductResource.use(_.update(diskKey, timeStep.toInt)))
         res <- OptionT.liftF(use(currentPeriodKey))
         nextTimeStep = timeStep + 1
-        _ <- OptionT.liftF(Logger[F].info(show"Saving next key idx=$nextTimeStep"))
+        _       <- OptionT.liftF(Logger[F].info(show"Saving next key idx=$nextTimeStep"))
+        updated <- OptionT.liftF(kesProductResource.use(_.update(currentPeriodKey, nextTimeStep)))
         _ <- OptionT.liftF(
           secureStore.write(
             UUID.randomUUID().toString,
-            kesProductScheme.update(
-              currentPeriodKey,
-              nextTimeStep
-            )
+            updated
           )
         )
       } yield res
@@ -180,10 +185,9 @@ object OperationalKeys {
       relativeStake:           Ratio,
       clock:                   ClockAlgebra[F],
       vrfProof:                VrfProofAlgebra[F],
-      etaCalculation:          EtaCalculationAlgebra[F]
-    )(implicit
-      kesProductScheme: KesProduct,
-      ed25519Scheme:    Ed25519
+      etaCalculation:          EtaCalculationAlgebra[F],
+      kesProductResource:      UnsafeResource[F, KesProduct],
+      ed25519Resource:         UnsafeResource[F, Ed25519]
     ): F[LongMap[OperationalKeyOut]] =
       for {
         epoch <- clock.epochOf(fromSlot)
@@ -194,30 +198,44 @@ object OperationalKeys {
           (operationalPeriod + 1) * operationalPeriodLength,
           1L
         )
+        _ <- Logger[F].info(
+          show"Computing ineligible slots for" +
+          show" epoch=$epoch" +
+          show" eta=$eta" +
+          show" range=${operationalPeriodSlots.start}..${operationalPeriodSlots.last}"
+        )
         ineligibleSlots <- vrfProof.ineligibleSlots(epoch, eta, operationalPeriodSlots.some, relativeStake).map(_.toSet)
         slots = Vector
           .tabulate((operationalPeriodLength - (fromSlot % operationalPeriodLength)).toInt)(_ + fromSlot)
           .filterNot(ineligibleSlots)
-        _ <- Logger[F].info(s"Preparing linear keys.  count=${slots.size}")
-        outs = prepareOperationalPeriodKeys(kesParent, slots)
+        _    <- Logger[F].info(s"Preparing linear keys.  count=${slots.size}")
+        outs <- prepareOperationalPeriodKeys(kesParent, slots, kesProductResource, ed25519Resource)
         mappedKeys = LongMap.from(outs.map(o => o.slot -> o))
       } yield mappedKeys
 
     /**
      * From some "parent" KES key, create several SKs for each slot in the given list of slots
      */
-    private def prepareOperationalPeriodKeys(kesParent: SecretKeys.KesProduct, slots: Vector[Slot])(implicit
-      kesProductScheme:                                 KesProduct,
-      ed25519Scheme:                                    Ed25519
-    ): Vector[OperationalKeyOut] =
-      slots.map { slot =>
-        val childSK = KeyInitializer[SecretKeys.Ed25519].random()
-        val signedVK =
-          kesProductScheme.sign(
-            kesParent,
-            (ed25519Scheme.getVerificationKey(childSK).bytes.data ++ Bytes(Longs.toByteArray(slot)))
-          )
-        OperationalKeyOut(slot, childSK, signedVK, kesProductScheme.getVerificationKey(kesParent))
-      }
+    private def prepareOperationalPeriodKeys[F[_]: Monad](
+      kesParent:          SecretKeys.KesProduct,
+      slots:              Vector[Slot],
+      kesProductResource: UnsafeResource[F, KesProduct],
+      ed25519Resource:    UnsafeResource[F, Ed25519]
+    ): F[Vector[OperationalKeyOut]] =
+      ed25519Resource
+        .use(ed => List.fill(slots.size)(ed.createKeyPair(Entropy.fromUuid(UUID.randomUUID()), None)))
+        .flatMap(children =>
+          kesProductResource.use { kesProductScheme =>
+            val parentVK = kesProductScheme.getVerificationKey(kesParent)
+            slots.zip(children).map { case (slot, (childSK, childVK)) =>
+              val parentSignature =
+                kesProductScheme.sign(
+                  kesParent,
+                  (childVK.bytes.data ++ Bytes(Longs.toByteArray(slot)))
+                )
+              OperationalKeyOut(slot, childSK, parentSignature, parentVK)
+            }
+          }
+        )
   }
 }

--- a/minting/src/main/scala/co/topl/minting/Staking.scala
+++ b/minting/src/main/scala/co/topl/minting/Staking.scala
@@ -76,7 +76,7 @@ object Staking {
             BlockV2(
               header,
               BlockBodyV2(header.id, unsignedBlock.transactions)
-            )
+            ).pure[F]
           }
         }.value
     }

--- a/minting/src/main/scala/co/topl/minting/Staking.scala
+++ b/minting/src/main/scala/co/topl/minting/Staking.scala
@@ -1,72 +1,83 @@
 package co.topl.minting
 
-import cats.Monad
+import cats.{Applicative, Monad}
 import cats.data.OptionT
 import cats.implicits._
+import co.topl.algebras.{ClockAlgebra, UnsafeResource}
 import co.topl.consensus.algebras.EtaCalculationAlgebra
 import co.topl.crypto.signing.Ed25519
 import co.topl.minting.algebras.LeaderElectionMintingAlgebra.VrfHit
 import co.topl.minting.algebras._
 import co.topl.models._
 import co.topl.typeclasses.implicits._
+import org.typelevel.log4cats.Logger
 
 object Staking {
 
   object Eval {
 
-    def make[F[_]: Monad](
+    def make[F[_]: Monad: Logger](
       a:                      TaktikosAddress,
       leaderElection:         LeaderElectionMintingAlgebra[F],
       evolver:                OperationalKeysAlgebra[F],
       vrfRelativeStakeLookup: VrfRelativeStakeMintingLookupAlgebra[F],
-      etaCalculation:         EtaCalculationAlgebra[F]
-    )(implicit ed25519:       Ed25519): StakingAlgebra[F] = new StakingAlgebra[F] {
+      etaCalculation:         EtaCalculationAlgebra[F],
+      ed25519Resource:        UnsafeResource[F, Ed25519],
+      vrfProof:               VrfProofAlgebra[F],
+      clock:                  ClockAlgebra[F]
+    ): StakingAlgebra[F] = new StakingAlgebra[F] {
       val address: F[TaktikosAddress] = a.pure[F]
 
       def elect(parent: BlockHeaderV2, slot: Slot): F[Option[VrfHit]] =
-        etaCalculation
-          .etaToBe(parent.slotId, slot)
-          .flatMap(eta =>
-            OptionT(vrfRelativeStakeLookup.lookupAt(slot, a))
-              .flatMapF(relativeStake => leaderElection.getHit(relativeStake, slot, slot - parent.slot, eta))
-              .value
+        for {
+          _             <- Logger[F].debug(show"Attempting mint at slot=$slot with parent=${parent.id}")
+          slotsPerEpoch <- clock.slotsPerEpoch
+          eta           <- etaCalculation.etaToBe(parent.slotId, slot)
+          _ <- Applicative[F].whenA(slot % slotsPerEpoch === 0L)(
+            vrfProof.precomputeForEpoch(slot / slotsPerEpoch, eta)
           )
+          maybeHit <- OptionT(vrfRelativeStakeLookup.lookupAt(slot, a))
+            .flatMapF(relativeStake => leaderElection.getHit(relativeStake, slot, slot - parent.slot, eta))
+            .value
+        } yield maybeHit
 
       def certifyBlock(
         parentSlotId:         SlotId,
         slot:                 Slot,
         unsignedBlockBuilder: BlockHeaderV2.Unsigned.PartialOperationalCertificate => BlockV2.Unsigned
       ): F[Option[BlockV2]] =
-        OptionT(evolver.operationalKeyForSlot(slot, parentSlotId)).map { operationalKeyOut =>
-          val partialCertificate = BlockHeaderV2.Unsigned.PartialOperationalCertificate(
-            operationalKeyOut.parentVK,
-            operationalKeyOut.parentSignature,
-            ed25519.getVerificationKey(operationalKeyOut.childSK)
-          )
-          val unsignedBlock = unsignedBlockBuilder(partialCertificate)
-          val operationalCertificate = OperationalCertificate(
-            operationalKeyOut.parentVK,
-            operationalKeyOut.parentSignature,
-            ed25519.getVerificationKey(operationalKeyOut.childSK),
-            ed25519.sign(operationalKeyOut.childSK, unsignedBlock.unsignedHeader.signableBytes)
-          )
-          val header = BlockHeaderV2(
-            unsignedBlock.unsignedHeader.parentHeaderId,
-            unsignedBlock.unsignedHeader.parentSlot,
-            unsignedBlock.unsignedHeader.txRoot,
-            unsignedBlock.unsignedHeader.bloomFilter,
-            unsignedBlock.unsignedHeader.timestamp,
-            unsignedBlock.unsignedHeader.height,
-            unsignedBlock.unsignedHeader.slot,
-            unsignedBlock.unsignedHeader.eligibilityCertificate,
-            operationalCertificate,
-            unsignedBlock.unsignedHeader.metadata,
-            unsignedBlock.unsignedHeader.address
-          )
-          BlockV2(
-            header,
-            BlockBodyV2(header.id, unsignedBlock.transactions)
-          )
+        OptionT(evolver.operationalKeyForSlot(slot, parentSlotId)).semiflatMap { operationalKeyOut =>
+          ed25519Resource.use { ed25519 =>
+            val partialCertificate = BlockHeaderV2.Unsigned.PartialOperationalCertificate(
+              operationalKeyOut.parentVK,
+              operationalKeyOut.parentSignature,
+              ed25519.getVerificationKey(operationalKeyOut.childSK)
+            )
+            val unsignedBlock = unsignedBlockBuilder(partialCertificate)
+            val operationalCertificate = OperationalCertificate(
+              operationalKeyOut.parentVK,
+              operationalKeyOut.parentSignature,
+              ed25519.getVerificationKey(operationalKeyOut.childSK),
+              ed25519.sign(operationalKeyOut.childSK, unsignedBlock.unsignedHeader.signableBytes)
+            )
+            val header = BlockHeaderV2(
+              unsignedBlock.unsignedHeader.parentHeaderId,
+              unsignedBlock.unsignedHeader.parentSlot,
+              unsignedBlock.unsignedHeader.txRoot,
+              unsignedBlock.unsignedHeader.bloomFilter,
+              unsignedBlock.unsignedHeader.timestamp,
+              unsignedBlock.unsignedHeader.height,
+              unsignedBlock.unsignedHeader.slot,
+              unsignedBlock.unsignedHeader.eligibilityCertificate,
+              operationalCertificate,
+              unsignedBlock.unsignedHeader.metadata,
+              unsignedBlock.unsignedHeader.address
+            )
+            BlockV2(
+              header,
+              BlockBodyV2(header.id, unsignedBlock.transactions)
+            )
+          }
         }.value
     }
   }

--- a/minting/src/main/scala/co/topl/minting/VrfProof.scala
+++ b/minting/src/main/scala/co/topl/minting/VrfProof.scala
@@ -79,7 +79,7 @@ object VrfProof {
               }
             )
             val rhoValues = LongMap.from(vrfProofs.view.mapValues(ed.proofToHash))
-            vrfProofs -> rhoValues
+            (vrfProofs -> rhoValues).pure[F]
           }
           _ <- (vrfProofsCache.put(eta)(vrfProofs), rhosCache.put(eta)(rhoValues)).tupled
         } yield ()

--- a/minting/src/main/scala/co/topl/minting/VrfProof.scala
+++ b/minting/src/main/scala/co/topl/minting/VrfProof.scala
@@ -1,11 +1,11 @@
 package co.topl.minting
 
-import cats.MonadError
+import cats.{MonadError, Parallel}
 import cats.data.OptionT
-import cats.effect.{Ref, Sync}
+import cats.effect.Sync
 import cats.implicits._
-import co.topl.algebras.ClockAlgebra
 import co.topl.algebras.ClockAlgebra.implicits._
+import co.topl.algebras.{ClockAlgebra, UnsafeResource}
 import co.topl.consensus.LeaderElectionValidation
 import co.topl.consensus.LeaderElectionValidation.VrfConfig
 import co.topl.consensus.algebras.LeaderElectionValidationAlgebra
@@ -14,6 +14,7 @@ import co.topl.minting.algebras.VrfProofAlgebra
 import co.topl.models._
 import co.topl.models.utility.Ratio
 import co.topl.typeclasses.implicits._
+import org.typelevel.log4cats.Logger
 import scalacache.caffeine.CaffeineCache
 import scalacache.{CacheConfig, CacheKeyBuilder}
 
@@ -23,104 +24,114 @@ object VrfProof {
 
   object Eval {
 
-    def make[F[_]: MonadError[*[_], Throwable]: Sync](
+    implicit private val cacheConfig: CacheConfig = CacheConfig(cacheKeyBuilder = new CacheKeyBuilder {
+
+      def toCacheKey(parts: Seq[Any]): String =
+        parts.map {
+          case eta: Eta @unchecked => eta.data.show
+          case t                   => throw new MatchError(t)
+        }.mkString
+
+      def stringToCacheKey(key: String): String = key
+    })
+
+    def make[F[_]: MonadError[*[_], Throwable]: Sync: Logger: Parallel](
       skVrf:                    SecretKeys.VrfEd25519,
       clock:                    ClockAlgebra[F],
       leaderElectionValidation: LeaderElectionValidationAlgebra[F],
+      ed25519VRFResource:       UnsafeResource[F, Ed25519VRF],
       vrfConfig:                VrfConfig
-    ): F[VrfProofAlgebra[F]] = {
-      implicit val cacheConfig: CacheConfig = CacheConfig(cacheKeyBuilder = new CacheKeyBuilder {
-        def toCacheKey(parts: Seq[Any]): String =
-          parts.map {
-            case eta: Eta @unchecked => eta.data.show
-            case t                   => throw new MatchError(t)
-          }.mkString
+    ): F[VrfProofAlgebra[F]] =
+      (CaffeineCache[F, LongMap[Proofs.Knowledge.VrfEd25519]], CaffeineCache[F, LongMap[Rho]]).mapN(
+        (vrfProofsCache, rhosCache) =>
+          new Impl[F](
+            skVrf,
+            clock,
+            leaderElectionValidation,
+            ed25519VRFResource,
+            vrfConfig,
+            vrfProofsCache,
+            rhosCache
+          )
+      )
 
-        def stringToCacheKey(key: String): String = key
-      })
+    private class Impl[F[_]: MonadError[*[_], Throwable]: Sync: Logger: Parallel](
+      skVrf:                    SecretKeys.VrfEd25519,
+      clock:                    ClockAlgebra[F],
+      leaderElectionValidation: LeaderElectionValidationAlgebra[F],
+      ed25519VRFResource:       UnsafeResource[F, Ed25519VRF],
+      vrfConfig:                VrfConfig,
+      vrfProofsCache:           CaffeineCache[F, LongMap[Proofs.Knowledge.VrfEd25519]],
+      rhosCache:                CaffeineCache[F, LongMap[Rho]]
+    ) extends VrfProofAlgebra[F] {
 
-      CaffeineCache[F, LongMap[Proofs.Knowledge.VrfEd25519]].flatMap { implicit vrfProofsCache =>
-        CaffeineCache[F, LongMap[Rho]].flatMap { implicit rhosCache =>
-          Ref
-            .of[F, Ed25519VRF](Ed25519VRF.precomputed())
-            .map(ed25519VRFRef =>
-              new VrfProofAlgebra[F] {
-
-                def precomputeForEpoch(epoch: Epoch, eta: Eta): F[Unit] =
-                  clock
-                    .epochRange(epoch)
-                    .flatMap(boundary =>
-                      ed25519VRFRef.modify { implicit ed =>
-                        val vrfProofs = LongMap.from(
-                          boundary.map { slot =>
-                            slot -> compute(
-                              LeaderElectionValidation.VrfArgument(eta, slot),
-                              ed
-                            )
-                          }
-                        )
-                        val rhoValues = LongMap.from(vrfProofs.view.mapValues(ed.proofToHash))
-                        ed -> (vrfProofs -> rhoValues)
-                      }
-                    )
-                    .flatTap { case (vrfProofs, rhoValues) =>
-                      (vrfProofsCache.put(eta)(vrfProofs), rhosCache.put(eta)(rhoValues)).tupled
-                    }
-                    .void
-
-                def proofForSlot(slot: Slot, eta: Eta): F[Proofs.Knowledge.VrfEd25519] =
-                  OptionT(vrfProofsCache.get(eta))
-                    .subflatMap(_.get(slot))
-                    .getOrElseF(
-                      new IllegalStateException(show"testProof was not precomputed for slot=$slot eta=$eta")
-                        .raiseError[F, Proofs.Knowledge.VrfEd25519]
-                    )
-
-                def rhoForSlot(slot: Slot, eta: Eta): F[Rho] =
-                  OptionT(rhosCache.get(eta))
-                    .subflatMap(_.get(slot))
-                    .getOrElseF(
-                      new IllegalStateException(show"rho was not precomputed for slot=$slot eta=$eta")
-                        .raiseError[F, Rho]
-                    )
-
-                private def compute(
-                  arg:        LeaderElectionValidation.VrfArgument,
-                  ed25519VRF: Ed25519VRF
-                ): Proofs.Knowledge.VrfEd25519 =
-                  ed25519VRF.sign(
-                    skVrf,
-                    arg.signableBytes
-                  )
-
-                def ineligibleSlots(
-                  epoch:         Epoch,
-                  eta:           Eta,
-                  inRange:       Option[NumericRange.Exclusive[Long]],
-                  relativeStake: Ratio
-                ): F[Vector[Slot]] =
-                  for {
-                    rhosMap <-
-                      OptionT(rhosCache.get(eta))
-                        .getOrElseF(
-                          new IllegalStateException(show"rhos were not precomputed for epoch=$epoch eta=$eta")
-                            .raiseError[F, LongMap[Rho]]
-                        )
-                    rhosList = rhosMap.toList
-                    rhos = inRange.fold(rhosList)(r => rhosList.filter(l1 => r.contains(l1._1)))
-                    threshold <- leaderElectionValidation
-                      .getThreshold(relativeStake, vrfConfig.lddCutoff)
-                    leaderCalculations <- rhos.traverse { case (slot, rho) =>
-                      leaderElectionValidation
-                        .isSlotLeaderForThreshold(threshold)(rho)
-                        .map(isLeader => slot -> isLeader)
-                    }
-                    slots = leaderCalculations.collect { case (slot, false) => slot }.toVector
-                  } yield slots
+      def precomputeForEpoch(epoch: Epoch, eta: Eta): F[Unit] =
+        for {
+          _        <- Logger[F].info(show"Precomputing VRF Proofs and Rho values for epoch=$epoch eta=$eta")
+          boundary <- clock.epochRange(epoch)
+          (vrfProofs, rhoValues) <- ed25519VRFResource.use { implicit ed =>
+            val vrfProofs = LongMap.from(
+              boundary.map { slot =>
+                slot -> compute(
+                  LeaderElectionValidation.VrfArgument(eta, slot),
+                  ed
+                )
               }
             )
-        }
-      }
+            val rhoValues = LongMap.from(vrfProofs.view.mapValues(ed.proofToHash))
+            vrfProofs -> rhoValues
+          }
+          _ <- (vrfProofsCache.put(eta)(vrfProofs), rhosCache.put(eta)(rhoValues)).tupled
+        } yield ()
+
+      def proofForSlot(slot: Slot, eta: Eta): F[Proofs.Knowledge.VrfEd25519] =
+        OptionT(vrfProofsCache.get(eta))
+          .subflatMap(_.get(slot))
+          .getOrElseF(
+            new IllegalStateException(show"proof was not precomputed for slot=$slot eta=$eta")
+              .raiseError[F, Proofs.Knowledge.VrfEd25519]
+          )
+
+      def rhoForSlot(slot: Slot, eta: Eta): F[Rho] =
+        OptionT(rhosCache.get(eta))
+          .subflatMap(_.get(slot))
+          .getOrElseF(
+            new IllegalStateException(show"rho was not precomputed for slot=$slot eta=$eta")
+              .raiseError[F, Rho]
+          )
+
+      private def compute(
+        arg:        LeaderElectionValidation.VrfArgument,
+        ed25519VRF: Ed25519VRF
+      ): Proofs.Knowledge.VrfEd25519 =
+        ed25519VRF.sign(
+          skVrf,
+          arg.signableBytes
+        )
+
+      def ineligibleSlots(
+        epoch:         Epoch,
+        eta:           Eta,
+        inRange:       Option[NumericRange.Exclusive[Long]],
+        relativeStake: Ratio
+      ): F[Vector[Slot]] =
+        for {
+          rhosMap <-
+            OptionT(rhosCache.get(eta))
+              .getOrElseF(
+                new IllegalStateException(show"rhos were not precomputed for epoch=$epoch eta=$eta")
+                  .raiseError[F, LongMap[Rho]]
+              )
+          rhosList = rhosMap.toList
+          rhos = inRange.fold(rhosList)(r => rhosList.filter(l1 => r.contains(l1._1)))
+          threshold <- leaderElectionValidation.getThreshold(relativeStake, vrfConfig.lddCutoff)
+          leaderCalculations <- rhos.parTraverse { case (slot, rho) =>
+            leaderElectionValidation
+              .isSlotLeaderForThreshold(threshold)(rho)
+              .map(isLeader => slot -> isLeader)
+          }
+          slots = leaderCalculations.collect { case (slot, false) => slot }.toVector
+        } yield slots
     }
   }
 }

--- a/minting/src/main/scala/co/topl/minting/algebras/VrfProofAlgebra.scala
+++ b/minting/src/main/scala/co/topl/minting/algebras/VrfProofAlgebra.scala
@@ -6,7 +6,7 @@ import co.topl.models.utility.Ratio
 import scala.collection.immutable.NumericRange
 
 trait VrfProofAlgebra[F[_]] {
-  def precomputeForEpoch(epoch: Epoch, previousEta: Eta): F[Unit]
+  def precomputeForEpoch(epoch: Epoch, eta: Eta): F[Unit]
 
   def rhoForSlot(slot: Slot, eta: Eta): F[Rho]
 

--- a/minting/src/test/scala/co/topl/minting/OperationalKeysSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/OperationalKeysSpec.scala
@@ -1,7 +1,7 @@
 package co.topl.minting
 
 import cats.Applicative
-import cats.data.{Chain, NonEmptyChain}
+import cats.data.Chain
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import co.topl.algebras.testInterpreters.NoOpLogger
@@ -104,30 +104,30 @@ class OperationalKeysSpec
         .returning(Ratio(1).some.pure[F])
 
       (kesProductResource
-        .use[Int](_: Function1[KesProduct, Int]))
+        .use[Int](_: Function1[KesProduct, F[Int]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[KesProduct, Int] => f(kesProduct).pure[F] }
+        .onCall { f: Function1[KesProduct, F[Int]] => f(kesProduct) }
 
       (kesProductResource
-        .use[SecretKeys.KesProduct](_: Function1[KesProduct, SecretKeys.KesProduct]))
+        .use[SecretKeys.KesProduct](_: Function1[KesProduct, F[SecretKeys.KesProduct]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[KesProduct, SecretKeys.KesProduct] => f(kesProduct).pure[F] }
+        .onCall { f: Function1[KesProduct, F[SecretKeys.KesProduct]] => f(kesProduct) }
 
       (kesProductResource
-        .use[Vector[OperationalKeyOut]](_: Function1[KesProduct, Vector[OperationalKeyOut]]))
+        .use[Vector[OperationalKeyOut]](_: Function1[KesProduct, F[Vector[OperationalKeyOut]]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[KesProduct, Vector[OperationalKeyOut]] => f(kesProduct).pure[F] }
+        .onCall { f: Function1[KesProduct, F[Vector[OperationalKeyOut]]] => f(kesProduct) }
 
       (ed25519Resource
         .use[List[(SecretKeys.Ed25519, VerificationKeys.Ed25519)]](
-          _: Function1[Ed25519, List[(SecretKeys.Ed25519, VerificationKeys.Ed25519)]]
+          _: Function1[Ed25519, F[List[(SecretKeys.Ed25519, VerificationKeys.Ed25519)]]]
         ))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519, List[(SecretKeys.Ed25519, VerificationKeys.Ed25519)]] => f(ed25519).pure[F] }
+        .onCall { f: Function1[Ed25519, F[List[(SecretKeys.Ed25519, VerificationKeys.Ed25519)]]] => f(ed25519) }
 
       val underTest = OperationalKeys.FromSecureStore
         .make[F](
@@ -224,30 +224,30 @@ class OperationalKeysSpec
         .returning(Ratio(1).some.pure[F])
 
       (kesProductResource
-        .use[Int](_: Function1[KesProduct, Int]))
+        .use[Int](_: Function1[KesProduct, F[Int]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[KesProduct, Int] => f(kesProduct).pure[F] }
+        .onCall { f: Function1[KesProduct, F[Int]] => f(kesProduct) }
 
       (kesProductResource
-        .use[SecretKeys.KesProduct](_: Function1[KesProduct, SecretKeys.KesProduct]))
+        .use[SecretKeys.KesProduct](_: Function1[KesProduct, F[SecretKeys.KesProduct]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[KesProduct, SecretKeys.KesProduct] => f(kesProduct).pure[F] }
+        .onCall { f: Function1[KesProduct, F[SecretKeys.KesProduct]] => f(kesProduct) }
 
       (kesProductResource
-        .use[Vector[OperationalKeyOut]](_: Function1[KesProduct, Vector[OperationalKeyOut]]))
+        .use[Vector[OperationalKeyOut]](_: Function1[KesProduct, F[Vector[OperationalKeyOut]]]))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[KesProduct, Vector[OperationalKeyOut]] => f(kesProduct).pure[F] }
+        .onCall { f: Function1[KesProduct, F[Vector[OperationalKeyOut]]] => f(kesProduct) }
 
       (ed25519Resource
         .use[List[(SecretKeys.Ed25519, VerificationKeys.Ed25519)]](
-          _: Function1[Ed25519, List[(SecretKeys.Ed25519, VerificationKeys.Ed25519)]]
+          _: Function1[Ed25519, F[List[(SecretKeys.Ed25519, VerificationKeys.Ed25519)]]]
         ))
         .expects(*)
         .anyNumberOfTimes()
-        .onCall { f: Function1[Ed25519, List[(SecretKeys.Ed25519, VerificationKeys.Ed25519)]] => f(ed25519).pure[F] }
+        .onCall { f: Function1[Ed25519, F[List[(SecretKeys.Ed25519, VerificationKeys.Ed25519)]]] => f(ed25519) }
 
       val underTest = OperationalKeys.FromSecureStore
         .make[F](

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,12 +8,15 @@ object Dependencies {
   val kamonVersion = "2.1.21"
   val graalVersion = "21.1.0"
 
+  val catsSlf4j =
+    "org.typelevel" %% "log4cats-slf4j" % "2.1.1"
+
   val logging = Seq(
     "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.4",
     "ch.qos.logback"              % "logback-classic" % "1.2.5",
     "ch.qos.logback"              % "logback-core"    % "1.2.5",
     "org.slf4j"                   % "slf4j-api"       % "1.7.32",
-    "org.typelevel"              %% "log4cats-slf4j"  % "2.1.1"
+    catsSlf4j
   )
 
   val test = Seq(

--- a/typeclasses/src/main/scala/co/topl/typeclasses/ShowInstances.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ShowInstances.scala
@@ -25,6 +25,9 @@ trait ShowInstances {
   implicit val showSlotId: Show[SlotId] =
     slotID => show"{${slotID.slot},${slotID.blockId}}"
 
+  implicit val showRho: Show[Rho] =
+    _.sizedBytes.show
+
   implicit val showTaktikosAddress: Show[TaktikosAddress] =
     showBytes.contramap[TaktikosAddress](_.bytes)
 


### PR DESCRIPTION
## Purpose
- Functional programming prefers immutable data structures to avoid concurrency issues
- Certain cryptographic routines perform much better with mutable internal state
- Mixing these routines into a functional/immutable system leads to concurrency issues
- These routines need thread-safe protection
- Cats Effect `Ref` does not provide the thread-safe protection I had initially expected
  - It repeats an action if there's a parallel collision; it doesn't prevent parallel usage of the resource though

## Approach
- Added an `UnsafeResource[F[_]]` algebra
- Implemented `ActorPoolUnsafeResource` interpreter
  - Implemented as a pool of child actors, each of which owns a single instance of the resource
  - If the entire pool is busy, the pool grows if needed

## Testing
- Added unit tests for `ActorPoolUnsafeResource`
- Updated existing unit tests

## Tickets
_* closes #1885_
