### PR TITLE
Tetra Registration Box Remove activationSlot

### DIFF
--- a/consensus/src/test/scala/co/topl/consensus/BlockHeaderValidationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/BlockHeaderValidationSpec.scala
@@ -410,11 +410,7 @@ object BlockHeaderValidationSpec {
     skKes:               SecretKeys.KesProduct
   )(implicit kesProduct: KesProduct): Box.Values.TaktikosRegistration = {
     val commitmentMessage = Bytes(blake2b256.hash((vkVrf.bytes.data ++ poolVK.bytes.data).toArray).value)
-    Box.Values
-      .TaktikosRegistration(
-        kesProduct.sign(skKes, commitmentMessage),
-        0L
-      )
+    Box.Values.TaktikosRegistration(kesProduct.sign(skKes, commitmentMessage))
   }
 
   def validAddress(paymentSK: SecretKeys.Ed25519, poolVK: VerificationKeys.Ed25519)(implicit

--- a/demo/src/main/scala/co/topl/demo/TetraDemo.scala
+++ b/demo/src/main/scala/co/topl/demo/TetraDemo.scala
@@ -80,8 +80,7 @@ object TetraDemo extends IOApp.Simple {
         commitment = kesProduct.sign(
           kesKey,
           new Blake2b256().hash(ed25519Vrf.getVerificationKey(stakerVrfKey).signableBytes, poolVK.bytes.data).data
-        ),
-        activationSlot = 0
+        )
       )
 
     val stakerAddress: TaktikosAddress = {

--- a/demo/src/main/scala/co/topl/demo/TetraDemo.scala
+++ b/demo/src/main/scala/co/topl/demo/TetraDemo.scala
@@ -77,8 +77,7 @@ object TetraDemo extends IOApp.Simple {
               .hash((ed25519Vrf.getVerificationKey(stakerVrfKey).signableBytes ++ poolVK.bytes.data).toArray)
               .value
           )
-        ),
-        activationSlot = 0
+        )
       )
 
     val stakerAddress: TaktikosAddress = {

--- a/models/src/main/scala/co/topl/models/Box.scala
+++ b/models/src/main/scala/co/topl/models/Box.scala
@@ -25,11 +25,7 @@ object Box {
 
     /**
      * @param commitment message: Hash(vrfVK | poolVK), SK: 0th timestep of the KES
-     * @param activationSlot Slot in which this staker can start staking
      */
-    case class TaktikosRegistration(
-      commitment:     Proofs.Knowledge.KesProduct,
-      activationSlot: Slot
-    ) extends Value
+    case class TaktikosRegistration(commitment: Proofs.Knowledge.KesProduct) extends Value
   }
 }


### PR DESCRIPTION
## Purpose
- Registrations only become valid 2 epochs after the initial registration
- This restriction will now be implicitly checked by the book-keeping of "Consensus State" which tracks registrations through the epochs.  (Consensus State book-keeping will be fully implemented later)
 
## Approach
- Remove `activationSlot` from Registration Box value

## Testing
- `preparePR` still passes

## Tickets
>_* closes #1667_
