### PR TITLE
Minor update to release candidate 1.10

### DIFF
--- a/akka-http-rpc/src/main/scala/co/topl/akkahttprpc/RpcServer.scala
+++ b/akka-http-rpc/src/main/scala/co/topl/akkahttprpc/RpcServer.scala
@@ -5,19 +5,7 @@ import cats.kernel.Semigroup
 import co.topl.akkahttprpc.RpcDirectives.{rpcRoute, rpcRoutes}
 import io.circe.{Decoder, Encoder}
 
-class RpcServer[Params, SuccessResponse](val rpc: Rpc[Params, SuccessResponse]) extends AnyVal {
-
-  /**
-   * Constructs a Route which serves a single RPC handler for the first rpc method name
-   */
-  def serve(handler:        rpc.ServerHandler)(implicit
-    paramsDecoder:          Decoder[Params],
-    successResponseEncoder: Encoder[SuccessResponse],
-    throwableEncoder:       Encoder[ThrowableData]
-  ): Route =
-    rpcRoute[Params, SuccessResponse](rpc.method, handler)
-
-}
+class RpcServer[Params, SuccessResponse](val rpc: Rpc[Params, SuccessResponse]) extends AnyVal
 
 object RpcServer {
 

--- a/akka-http-rpc/src/test/scala/co/topl/akkahttprpc/RpcSpec.scala
+++ b/akka-http-rpc/src/test/scala/co/topl/akkahttprpc/RpcSpec.scala
@@ -250,8 +250,8 @@ class RpcSpec
   private def normalRpc: Rpc[TestMethodParams, TestMethodSuccess] =
     Rpc[TestMethodParams, TestMethodSuccess]("test_method1")
 
-  private def normalRpcHandler: TestMethodParams => EitherT[Future, RpcError, TestMethodSuccess] = (params: TestMethodParams) =>
-    TestMethodSuccess(params.userId.length).asRight[RpcError].toEitherT[Future]
+  private def normalRpcHandler: TestMethodParams => EitherT[Future, RpcError, TestMethodSuccess] =
+    (params: TestMethodParams) => TestMethodSuccess(params.userId.length).asRight[RpcError].toEitherT[Future]
 
 }
 

--- a/akka-http-rpc/src/test/scala/co/topl/akkahttprpc/RpcSpec.scala
+++ b/akka-http-rpc/src/test/scala/co/topl/akkahttprpc/RpcSpec.scala
@@ -243,7 +243,9 @@ class RpcSpec
   }
 
   private def normalRoute: Route =
-    normalRpc.serve(normalRpcHandler)
+    RpcServer.Builder.empty
+      .append(normalRpc)(normalRpcHandler)
+      .route
 
   private def normalRpc: Rpc[TestMethodParams, TestMethodSuccess] =
     Rpc[TestMethodParams, TestMethodSuccess]("test_method1")

--- a/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
@@ -66,7 +66,7 @@ class NodeViewRpcHandlerImpls(
   override val transactionById: ToplRpc.NodeView.TransactionById.rpc.ServerHandler =
     params =>
       getTxsByIds(List(params.transactionId)).subflatMap {
-        case (tx, blockId, blockNumber) :: Nil =>
+        case (tx, blockId, blockNumber) :: _ =>
           Either.right(ToplRpc.NodeView.TransactionById.Response(tx, blockNumber, blockId))
         case _ => Either.left(ToplRpcErrors.NoTransactionWithId)
       }

--- a/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/NodeViewRpcHandlerImpls.scala
@@ -14,8 +14,8 @@ import co.topl.network.message.BifrostSyncInfo
 import co.topl.nodeView.history.HistoryReader
 import co.topl.nodeView.state.StateReader
 import co.topl.nodeView.{NodeViewHolderInterface, ReadableNodeView}
-import co.topl.rpc.ToplRpc
 import co.topl.rpc.ToplRpc.NodeView.ConfirmationStatus.TxStatus
+import co.topl.rpc.{ToplRpc, ToplRpcErrors}
 import co.topl.settings.{AppContext, RPCApiSettings}
 import co.topl.utils.Int128
 import co.topl.utils.NetworkType.NetworkPrefix
@@ -65,10 +65,10 @@ class NodeViewRpcHandlerImpls(
 
   override val transactionById: ToplRpc.NodeView.TransactionById.rpc.ServerHandler =
     params =>
-      getTxsByIds(List(params.transactionId)).map {
-        _.head match {
-          case (tx, blockId, blockNumber) => ToplRpc.NodeView.TransactionById.Response(tx, blockNumber, blockId)
-        }
+      getTxsByIds(List(params.transactionId)).subflatMap {
+        case (tx, blockId, blockNumber) :: Nil =>
+          Either.right(ToplRpc.NodeView.TransactionById.Response(tx, blockNumber, blockId))
+        case _ => Either.left(ToplRpcErrors.NoTransactionWithId)
       }
 
   override val blockById: ToplRpc.NodeView.BlockById.rpc.ServerHandler =
@@ -81,9 +81,8 @@ class NodeViewRpcHandlerImpls(
     params =>
       for {
         headHeight <- withNodeView(_.history.height)
-        range <- EitherT.fromEither[Future](
-          checkHeightRange(headHeight, params.startHeight, params.endHeight, rpcSettings.blockRetrievalLimit)
-        )
+        range <- checkHeightRange(headHeight, params.startHeight, params.endHeight, rpcSettings.blockRetrievalLimit)
+          .toEitherT[Future]
         blocks <- withNodeView(view => getBlocksInRange(view.history, range._1, range._2))
       } yield blocks
 
@@ -91,9 +90,8 @@ class NodeViewRpcHandlerImpls(
     params =>
       for {
         headHeight <- withNodeView(_.history.height)
-        range <- EitherT.fromEither[Future](
-          checkHeightRange(headHeight, params.startHeight, params.endHeight, rpcSettings.blockIdRetrievalLimit)
-        )
+        range <- checkHeightRange(headHeight, params.startHeight, params.endHeight, rpcSettings.blockIdRetrievalLimit)
+          .toEitherT[Future]
         ids <- withNodeView(view => getBlockIdsInRange(view.history, range._1, range._2))
       } yield ids
 
@@ -103,9 +101,8 @@ class NodeViewRpcHandlerImpls(
         headHeight <- withNodeView(_.history.height)
         // Since the block at headHeight is included, we will get more than numberOfBlocks blocks without adding 1 here
         startHeight = headHeight - params.numberOfBlocks + 1
-        range <- EitherT.fromEither[Future](
-          checkHeightRange(headHeight, startHeight, headHeight, rpcSettings.blockRetrievalLimit)
-        )
+        range <- checkHeightRange(headHeight, startHeight, headHeight, rpcSettings.blockRetrievalLimit)
+          .toEitherT[Future]
         blocks <- withNodeView(view => getBlocksInRange(view.history, range._1, range._2))
       } yield blocks
 
@@ -114,9 +111,9 @@ class NodeViewRpcHandlerImpls(
       for {
         headHeight <- withNodeView(_.history.height)
         startHeight = headHeight - params.numberOfBlockIds + 1
-        range <- EitherT.fromEither[Future](
-          checkHeightRange(headHeight, startHeight, headHeight, rpcSettings.blockIdRetrievalLimit)
-        )
+        range <-
+          checkHeightRange(headHeight, startHeight, headHeight, rpcSettings.blockIdRetrievalLimit).toEitherT[Future]
+
         ids <- withNodeView(view => getBlockIdsInRange(view.history, range._1, range._2))
       } yield ids
 
@@ -133,9 +130,9 @@ class NodeViewRpcHandlerImpls(
   override val transactionFromMempool: ToplRpc.NodeView.TransactionFromMempool.rpc.ServerHandler =
     params =>
       for {
-        txIds <- EitherT.fromEither[Future](checkModifierIdType(Transaction.modifierTypeId, List(params.transactionId)))
-        txsOption <- withNodeView(view => txIds.map(view.memPool.modifierById))
-        txs       <- EitherT.fromEither[Future](checkTxFoundWithIds(txIds, txsOption, rpcSettings.txRetrievalLimit))
+        txIds     <- checkModifierIdType(Transaction.modifierTypeId, List(params.transactionId)).toEitherT[Future]
+        txOptions <- withNodeView(view => txIds.map(view.memPool.modifierById))
+        txs       <- txOptions.sequence.toRight(ToplRpcErrors.NoTransactionWithId: RpcError).toEitherT[Future]
       } yield txs.head
 
   override val confirmationStatus: ToplRpc.NodeView.ConfirmationStatus.rpc.ServerHandler =
@@ -143,7 +140,7 @@ class NodeViewRpcHandlerImpls(
       for {
         txIds <- EitherT.fromEither[Future](checkModifierIdType(Transaction.modifierTypeId, params.transactionIds))
         txStatusOption <- withNodeView(view => getConfirmationStatus(txIds, view.history.height, view))
-        txStatus <- EitherT.fromEither[Future](checkTxFoundWithIds(txIds, txStatusOption, rpcSettings.txRetrievalLimit))
+        txStatus       <- txStatusOption.sequence.toRight(ToplRpcErrors.NoTransactionWithId: RpcError).toEitherT[Future]
       } yield txStatus.toMap
 
   override val info: ToplRpc.NodeView.Info.rpc.ServerHandler =
@@ -195,20 +192,21 @@ class NodeViewRpcHandlerImpls(
 
   private def getBlocksByIds(ids: List[ModifierId]): EitherT[Future, RpcError, List[Block]] =
     for {
-      blockIds     <- EitherT.fromEither[Future](checkModifierIdType(Block.modifierTypeId, ids))
-      blocksOption <- withNodeView(view => blockIds.map(view.history.modifierById))
-      blocks <- EitherT.fromEither[Future](
-        checkBlocksFoundWithIds(blockIds, blocksOption, rpcSettings.blockRetrievalLimit)
-      )
+      _            <- checkModifierRetrievalLimit(ids, rpcSettings.blockRetrievalLimit).toEitherT[Future]
+      _            <- checkModifierIdType(Block.modifierTypeId, ids).toEitherT[Future]
+      blockOptions <- withNodeView(view => ids.map(view.history.modifierById))
+      blocks       <- blockOptions.sequence.toRight(ToplRpcErrors.NoBlockWithId: RpcError).toEitherT[Future]
     } yield blocks
 
   private def getTxsByIds(ids: List[ModifierId]): EitherT[Future, RpcError, List[(Transaction.TX, ModifierId, Long)]] =
     for {
-      txIds     <- EitherT.fromEither[Future](checkModifierIdType(Transaction.modifierTypeId, ids))
-      txsOption <- withNodeView(view => txIds.map(view.history.transactionById))
-      txs       <- EitherT.fromEither[Future](checkTxFoundWithIds(txIds, txsOption, rpcSettings.txRetrievalLimit))
+      _         <- checkModifierRetrievalLimit(ids, rpcSettings.txRetrievalLimit).toEitherT[Future]
+      _         <- checkModifierIdType(Transaction.modifierTypeId, ids).toEitherT[Future]
+      txOptions <- withNodeView(view => ids.map(view.history.transactionById))
+      txs       <- txOptions.sequence.toRight(ToplRpcErrors.NoTransactionWithId: RpcError).toEitherT[Future]
     } yield txs
 
+  /** this function should be faster than getting the entire block out of storage and grabbing the id since the block id is stored separately */
   private def getBlockIdsInRange(
     view:        HistoryReader[Block, BifrostSyncInfo],
     startHeight: Long,

--- a/node/src/main/scala/co/topl/rpc/handlers/package.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/package.scala
@@ -1,6 +1,7 @@
 package co.topl.rpc
 
 import cats.data.EitherT
+import cats.implicits._
 import co.topl.akkahttprpc.{CustomError, RpcError, ThrowableData}
 import co.topl.attestation.Address
 import co.topl.modifier.ModifierId
@@ -37,50 +38,40 @@ package object handlers {
       case Transaction.modifierTypeId => "Transaction"
       case Block.modifierTypeId       => "Block"
     }
-    for {
-      _ <- Either.cond(
-        ids.forall(_.getModType == idType),
-        {},
-        ToplRpcErrors.unsupportedOperation(s"The requested id's type is not an id type for $modifierTypeName")
-      )
-    } yield ids
+    Either.cond(
+      ids.forall(_.getModType == idType),
+      ids,
+      ToplRpcErrors.unsupportedOperation(s"The requested id's type is not an id type for $modifierTypeName")
+    )
   }
 
-  private[handlers] def checkBlocksFoundWithIds(
-    ids:          List[ModifierId],
-    blocksOption: List[Option[Block]],
-    sizeLimit:    Int
-  ): Either[RpcError, List[Block]] =
-    for {
-      _ <- Either.cond(
-        ids.size <= sizeLimit,
-        {},
-        ToplRpcErrors.unsupportedOperation("Number of ids given exceeded blockRetrievalLimit")
-      )
-      blocks <- Either.cond(
-        blocksOption.forall(_.nonEmpty),
-        blocksOption.map(_.get),
-        ToplRpcErrors.NoBlockWithId
-      )
-    } yield blocks
-
-  private[handlers] def checkTxFoundWithIds[T](
+  private[handlers] def checkModifierRetrievalLimit(
     ids:       List[ModifierId],
-    txOption:  List[Option[T]],
     sizeLimit: Int
-  ): Either[RpcError, List[T]] =
-    for {
-      _ <- Either.cond(
-        ids.size <= sizeLimit,
-        {},
-        ToplRpcErrors.unsupportedOperation("Number of ids given exceeded txRetrievalLimit")
-      )
-      txs <- Either.cond(
-        txOption.forall(_.nonEmpty),
-        txOption.map(_.get),
-        ToplRpcErrors.NoTransactionWithId
-      )
-    } yield txs
+  ): Either[CustomError, List[ModifierId]] =
+    Either.cond(
+      ids.size <= sizeLimit,
+      ids,
+      ToplRpcErrors.unsupportedOperation(s"Number of ids given exceeded retrieval limit of $sizeLimit")
+    )
+
+//  private[handlers] def checkBlocksFoundWithIds(
+//    blockOptions: List[Option[Block]],
+//  ): Either[RpcError, List[Block]] = blockOptions.sequence.toRight(ToplRpcErrors.NoBlockWithId)
+//
+//  private[handlers] def checkTxFoundWithIds[T](
+//    ids:       List[ModifierId],
+//    txOptions:  List[Option[T]],
+//    sizeLimit: Int
+//  ): Either[RpcError, List[T]] =
+//    for {
+//      _ <- Either.cond(
+//        ids.size <= sizeLimit,
+//        {},
+//        ToplRpcErrors.unsupportedOperation("Number of ids given exceeded txRetrievalLimit")
+//      )
+//      txs <- txOptions.sequence.toRight(ToplRpcErrors.NoTransactionWithId)
+//    } yield txs
 
   private[handlers] def checkHeightRange(
     bestBlockHeight: Long,

--- a/node/src/main/scala/co/topl/rpc/handlers/package.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/package.scala
@@ -55,24 +55,6 @@ package object handlers {
       ToplRpcErrors.unsupportedOperation(s"Number of ids given exceeded retrieval limit of $sizeLimit")
     )
 
-//  private[handlers] def checkBlocksFoundWithIds(
-//    blockOptions: List[Option[Block]],
-//  ): Either[RpcError, List[Block]] = blockOptions.sequence.toRight(ToplRpcErrors.NoBlockWithId)
-//
-//  private[handlers] def checkTxFoundWithIds[T](
-//    ids:       List[ModifierId],
-//    txOptions:  List[Option[T]],
-//    sizeLimit: Int
-//  ): Either[RpcError, List[T]] =
-//    for {
-//      _ <- Either.cond(
-//        ids.size <= sizeLimit,
-//        {},
-//        ToplRpcErrors.unsupportedOperation("Number of ids given exceeded txRetrievalLimit")
-//      )
-//      txs <- txOptions.sequence.toRight(ToplRpcErrors.NoTransactionWithId)
-//    } yield txs
-
   private[handlers] def checkHeightRange(
     bestBlockHeight: Long,
     startHeight:     Long,


### PR DESCRIPTION
## Purpose
Minor refactoring of 1.10 release candidate. Separate PR to aid in review

## Approach
- Removed `.serve` method from `RpcServer` and transitioned tests to target the `RpcBuilder` instead
- Separated the retrieval limit check to happen before querying `view` in order to fail fast
- Handle potential edge case in `getTransatctionById` to avoid `.head` usage
- Removed `check___FoundWithIds` function defs and replaced with lambdas

## Testing
- Passes unit tests
- Passes integration tests

## Tickets
- closes #1873 