### PR TITLE
Handle Block Cache Evictions

### DIFF
--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -2,7 +2,7 @@ bifrost {
 
   application {
     # application version of this software
-    version { value = 1.10.0 }
+    version { value = 1.10.1 }
 
     # directory where all network data is stored
     dataDir = ".bifrost/private-testnet/data"

--- a/node/src/main/scala/co/topl/network/NodeViewSynchronizer.scala
+++ b/node/src/main/scala/co/topl/network/NodeViewSynchronizer.scala
@@ -77,6 +77,7 @@ class NodeViewSynchronizer(
     context.system.eventStream.subscribe(self, classOf[NodeViewHolder.OutcomeEvent])
     context.system.eventStream.subscribe(self, classOf[NodeViewHolder.Events.DownloadRequest])
     context.system.eventStream.subscribe(self, classOf[ModifiersProcessingResult[Block]])
+    context.system.eventStream.subscribe(self, classOf[NodeViewHolder.Events.BlockCacheOverflow])
 
     log.info(s"${Console.YELLOW}NodeViewSynchronizer transitioning to the operational state${Console.RESET}")
 
@@ -165,6 +166,8 @@ class NodeViewSynchronizer(
       /** applied modifiers state was already changed at `SyntacticallySuccessfulModifier` */
       cleared.foreach(m => deliveryTracker.setUnknown(m.id))
       requestMoreModifiers(applied)
+
+    case NodeViewHolder.Events.BlockCacheOverflow(block) => deliveryTracker.setUnknown(block.id)
   }
 
   protected def peerManagerEvents: Receive = {


### PR DESCRIPTION
## Purpose
The `NodeViewSynchronizer` needs to be notified if a block is evicted from the NodeViewHolder's block cache. If it is not notified, the delivery tracking mechanism will always ignore requests for that block in the future because it thinks its been successfully handled.

## Approach
- adds an `onEvict` function to the `SortedCache#apply` method which can be used as a callback for when a block is evicted
- `NodeViewHolder` publishes a message when a block is evicted from the cache
- `NodeViewSynchronizer` subscribes to cache overflows so that the delivery tracker can be updated to reflect lost blocks

## Testing
- no new tests added

## Tickets
- closes #1914