### PR TITLE
Unproven Arbit Transfer RPC Method

### DIFF
--- a/common/src/main/scala/co/topl/utils/catsinstances/ShowInstances.scala
+++ b/common/src/main/scala/co/topl/utils/catsinstances/ShowInstances.scala
@@ -1,5 +1,6 @@
 package co.topl.utils.catsinstances
 
+import cats.implicits._
 import cats.Show
 import co.topl.attestation.keyManagement.{PrivateKeyCurve25519, PrivateKeyEd25519}
 import co.topl.attestation._
@@ -9,8 +10,9 @@ import co.topl.crypto.hash.digest.Digest
 import co.topl.modifier.ModifierId
 import co.topl.modifier.block.{Block, BlockBody, BlockHeader, BloomFilter}
 import co.topl.modifier.box._
-import co.topl.modifier.transaction.builder.BuildTransferFailure
+import co.topl.modifier.transaction.builder.{BuildTransferFailure, BuildTransferFailures}
 import co.topl.modifier.transaction.{ArbitTransfer, AssetTransfer, PolyTransfer, Transaction}
+import co.topl.utils.Int128
 import co.topl.utils.StringDataTypes.{
   Base16Data,
   Base58Data,
@@ -120,5 +122,36 @@ trait ShowInstances {
 
   private def asJsonWithSpaces[T: Encoder]: Show[T] = value => Encoder[T].apply(value).spaces2
 
-  implicit val buildTransferFailureShow: Show[BuildTransferFailure] = Show.fromToString
+  implicit val int128Show: Show[Int128] = value => value.bigInt.toString
+
+  implicit val buildTransferFailureShow: Show[BuildTransferFailure] =
+    Show.show(failure =>
+      "Failed to build transfer: " +
+      (failure match {
+        case BuildTransferFailures.EmptyOutputs =>
+          "no outputs provided"
+        case BuildTransferFailures.DuplicateInputs =>
+          "duplicate input boxes provided"
+        case BuildTransferFailures.EmptyPolyInputs =>
+          "no poly inputs provided"
+        case BuildTransferFailures.MultipleAssetCodes(expected, actual) =>
+          show"expected asset code $expected to be provided as inputs and outputs, but received $actual"
+        case BuildTransferFailures.InsufficientArbitFunds(provided, needed) =>
+          show"insufficient arbit funds provided: needed $needed but received $provided"
+        case BuildTransferFailures.InsufficientPolyFunds(provided, needed) =>
+          show"insufficient poly funds provided: needed $needed but received $provided"
+        case BuildTransferFailures.InsufficientAssetFunds(code, provided, needed) =>
+          show"insufficient assets with code $code provided: needed $needed but received $provided"
+        case BuildTransferFailures.DuplicateOutputs =>
+          "duplicate addresses were provided as outputs"
+        case BuildTransferFailures.Int128Overflow(value) =>
+          show"numeric value was too large to fit into an Int-128 value: $value"
+        case BuildTransferFailures.InvalidAddress(address) =>
+          show"address is invalid: $address"
+        case BuildTransferFailures.InvalidShortName(shortName) =>
+          show"asset short name is invalid: $shortName"
+        case BuildTransferFailures.InvalidOutputValues(values) =>
+          show"output values are invalid: $values"
+      })
+    )
 }

--- a/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
+++ b/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
@@ -378,9 +378,9 @@ trait ModelsJsonCodecs {
       )
     case o: Transaction.ArbitOutput =>
       Json.obj(
-        "coinType"    -> "Arbit".asJson,
-        "dionAddress" -> o.dionAddress.asJson,
-        "value"       -> o.value.asJson
+        "coinType" -> "Arbit".asJson,
+        "address"  -> o.dionAddress.asJson,
+        "value"    -> o.value.asJson
       )
     case o: Transaction.AssetOutput =>
       Json.obj(
@@ -400,7 +400,7 @@ trait ModelsJsonCodecs {
           case "Poly" =>
             valueJson.as[Int128].map(value => Transaction.PolyOutput(address, value))
           case "Arbit" =>
-            valueJson.as[Int128].map(value => Transaction.PolyOutput(address, value))
+            valueJson.as[Int128].map(value => Transaction.ArbitOutput(address, value))
           case "Asset" =>
             valueJson.as[Box.Values.Asset].map(value => Transaction.AssetOutput(address, value))
           case _ =>

--- a/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
+++ b/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
@@ -378,9 +378,9 @@ trait ModelsJsonCodecs {
       )
     case o: Transaction.ArbitOutput =>
       Json.obj(
-        "coinType" -> "Arbit".asJson,
-        "address"  -> o.dionAddress.asJson,
-        "value"    -> o.value.asJson
+        "coinType"    -> "Arbit".asJson,
+        "dionAddress" -> o.dionAddress.asJson,
+        "value"       -> o.value.asJson
       )
     case o: Transaction.AssetOutput =>
       Json.obj(

--- a/node/src/main/scala/co/topl/rpc/ToplRpcServer.scala
+++ b/node/src/main/scala/co/topl/rpc/ToplRpcServer.scala
@@ -62,6 +62,7 @@ class ToplRpcServer(handlers: ToplRpcHandlers, appContext: AppContext)(implicit
         .append(ToplRpc.Transaction.RawArbitTransfer.rpc)(handlers.transaction.rawArbitTransfer)
         .append(ToplRpc.Transaction.RawPolyTransfer.rpc)(handlers.transaction.rawPolyTransfer)
         .append(ToplRpc.Transaction.UnprovenPolyTransfer.rpc)(handlers.transaction.unprovenPolyTransfer)
+        .append(ToplRpc.Transaction.UnprovenArbitTransfer.rpc)(handlers.transaction.unprovenArbitTransfer)
         .append(ToplRpc.Transaction.BroadcastTx.rpc)(handlers.transaction.broadcastTx)
         .append(ToplRpc.Transaction.BroadcastTetraTransfer.rpc)(handlers.transaction.broadcastTetraTransfer)
         .append(ToplRpc.Transaction.EncodeTransfer.rpc)(handlers.transaction.encodeTransfer)

--- a/node/src/main/scala/co/topl/rpc/handlers/TransactionRpcHandlerImpls.scala
+++ b/node/src/main/scala/co/topl/rpc/handlers/TransactionRpcHandlerImpls.scala
@@ -116,7 +116,7 @@ class TransactionRpcHandlerImpls(
               .buildUnprovenTransfer(
                 view.state,
                 TransferRequests.UnprovenTransferRequest(
-                  params.sender.toList,
+                  params.senders.toList,
                   params.recipients.toList,
                   params.changeAddress,
                   params.changeAddress,

--- a/node/src/test/scala/co/topl/api/transaction/UnprovenArbitTransferRPCHandlerSpec.scala
+++ b/node/src/test/scala/co/topl/api/transaction/UnprovenArbitTransferRPCHandlerSpec.scala
@@ -1,0 +1,201 @@
+package co.topl.api.transaction
+
+import akka.util.ByteString
+import cats.data.NonEmptyChain
+import co.topl.api.RPCMockState
+import co.topl.attestation.PublicKeyPropositionCurve25519
+import co.topl.attestation.implicits._
+import co.topl.codecs.json.tetra.instances._
+import co.topl.models.{BoxReference, Transaction}
+import io.circe.HCursor
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should.Matchers
+
+class UnprovenArbitTransferRPCHandlerSpec extends RPCMockState with Matchers with EitherValues {
+
+  import UnprovenArbitTransferRPCHandlerSpec._
+
+  val propositionType: String = PublicKeyPropositionCurve25519.typeString
+  val amount = 100
+  val fee = 1
+
+  var sender: String = ""
+  var recipient: String = ""
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    sender = keyRingCurve25519.addresses.head.toDionAddress.toOption.get.allBytes.toBase58
+    recipient = keyRingCurve25519.addresses.head.toDionAddress.toOption.get.allBytes.toBase58
+  }
+
+  "Unproven Arbit Transfer RPC Handler" should {
+
+    "successfully create a transfer with the provided sender in the 'inputs' field" in {
+      val requestBody = createRequestBody(List(sender), List(recipient -> amount), fee, sender, None)
+
+      val path = (cursor: HCursor) => cursor.downField("result").downField("unprovenTransfer").downField("inputs")
+
+      val result =
+        httpPOST(requestBody) ~> route ~> check(
+          traverseJsonPath[NonEmptyChain[BoxReference]](responseAs[String], path)
+        )
+
+      result.map(_.head._1.allBytes.toBase58).value shouldBe sender
+    }
+
+    "successfully create a transfer with 'minting' set to false" in {
+      val requestBody = createRequestBody(List(sender), List(recipient -> amount), fee, sender, None)
+
+      val path = (cursor: HCursor) => cursor.downField("result").downField("unprovenTransfer").downField("minting")
+
+      val result =
+        httpPOST(requestBody) ~> route ~> check(
+          traverseJsonPath[Boolean](responseAs[String], path)
+        )
+
+      result.value shouldBe false
+    }
+
+    "successfully create a transfer with recipient in 'coinOutputs' field" in {
+      val requestBody = createRequestBody(List(sender), List(recipient -> amount), fee, sender, None)
+
+      val path = (cursor: HCursor) => cursor.downField("result").downField("unprovenTransfer").downField("coinOutputs")
+
+      val result =
+        httpPOST(requestBody) ~> route ~> check(
+          traverseJsonPath[List[Transaction.CoinOutput]](responseAs[String], path)
+        )
+
+      val outputAddresses =
+        result.map(outputs =>
+          outputs.flatMap {
+            case Transaction.ArbitOutput(dionAddress, _) =>
+              List(dionAddress.allBytes.toBase58)
+            case _ =>
+              List.empty
+          }
+        )
+
+      outputAddresses.value should contain(recipient)
+    }
+
+    "successfully create a transfer with the expected change address" in {
+      val requestBody = createRequestBody(List(sender), List(recipient -> amount), fee, sender, None)
+
+      val path = (cursor: HCursor) =>
+        cursor.downField("result").downField("unprovenTransfer").downField("feeOutput").downField("dionAddress")
+
+      val result =
+        httpPOST(requestBody) ~> route ~> check(
+          traverseJsonPath[String](responseAs[String], path)
+        )
+
+      result.value shouldBe sender
+    }
+
+    "successfully create a transfer with the expected 'data'" in {
+      val data = "test-data"
+
+      val requestBody = createRequestBody(List(sender), List(recipient -> amount), fee, sender, Some(data))
+
+      val path = (cursor: HCursor) => cursor.downField("result").downField("unprovenTransfer").downField("data")
+
+      val result =
+        httpPOST(requestBody) ~> route ~> check(
+          traverseJsonPath[Option[String]](responseAs[String], path)
+        )
+
+      result.value.get shouldBe data
+    }
+
+    "fail to create a transfer when sender has no polys" in {
+      val emptySender = addressGen.sample.get.toDionAddress.toOption.get.allBytes.toBase58
+
+      val requestBody = createRequestBody(List(emptySender), List(recipient -> amount), fee, sender, None)
+
+      val path = (cursor: HCursor) => cursor.downField("error").downField("data").downField("message")
+
+      val result = httpPOST(requestBody) ~> route ~> check(traverseJsonPath[String](responseAs[String], path))
+
+      result.value shouldBe "Failed to build transfer: no poly inputs provided"
+    }
+
+    "fail to create a transfer when no sender is provided" in {
+      val requestBody = createRequestBody(List.empty, List(recipient -> amount), fee, sender, None)
+
+      val path = (cursor: HCursor) => cursor.downField("error").downField("message")
+
+      val result = httpPOST(requestBody) ~> route ~> check {
+        val json = responseAs[String]
+        traverseJsonPath[String](json, path)
+      }
+
+      result.value shouldBe "Invalid method parameter(s)"
+    }
+
+    "fail to create a transfer when send amount is negative" in {
+      val negativeAmount = -100
+
+      val requestBody = createRequestBody(List(sender), List(recipient -> negativeAmount), fee, sender, None)
+
+      val path = (cursor: HCursor) => cursor.downField("error").downField("message")
+
+      val result = httpPOST(requestBody) ~> route ~> check {
+        val json = responseAs[String]
+        traverseJsonPath[String](json, path)
+      }
+
+      result.value shouldBe "Could not validate transaction"
+    }
+  }
+}
+
+object UnprovenArbitTransferRPCHandlerSpec {
+
+  /**
+   * Creates an Unproven Arbit Transfer request HTTP body.
+   * @param propositionType the type of proposition used for signing the transfer
+   * @param sender the address that polys should be sent from
+   * @param recipient the recipient of the polys
+   * @param amount the amount of polys to send
+   * @param fee the fee provided for the transaction
+   * @return a [[ByteString]] representing the HTTP body
+   */
+  def createRequestBody(
+    senders:       List[String],
+    recipients:    List[(String, Int)],
+    fee:           Int,
+    changeAddress: String,
+    data:          Option[String]
+  ): ByteString = {
+    val sendersString =
+      senders
+        .map(value => s""""$value"""")
+        .mkString(", ")
+
+    val recipientsString =
+      recipients
+        .map(value => s"""{ "dionAddress": "${value._1}", "value": "${value._2}" }""")
+        .mkString(", ")
+
+    val dataString = data.fold("null")(value => s""""$value"""")
+
+    ByteString(s"""
+      |{
+      | "jsonrpc": "2.0",
+      | "id": "2",
+      | "method": "topl_unprovenArbitTransfer",
+      | "params": [ {
+      |   "senders": [$sendersString],
+      |   "recipients": [$recipientsString],
+      |   "fee": $fee,
+      |   "changeAddress": "$changeAddress",
+      |   "data": $dataString,
+      |   "boxSelectionAlgorithm": "All"
+      | } ]
+      |}
+    """.stripMargin)
+  }
+
+}

--- a/node/src/test/scala/co/topl/api/transaction/UnprovenAssetTransferRPCHandlerSpec.scala
+++ b/node/src/test/scala/co/topl/api/transaction/UnprovenAssetTransferRPCHandlerSpec.scala
@@ -139,7 +139,7 @@ class UnprovenAssetTransferRPCHandlerSpec extends RPCMockState with Matchers wit
 
       val result = httpPOST(requestBody) ~> route ~> check(traverseJsonPath[String](responseAs[String], path))
 
-      result.value.contains("InsufficientAssetFunds") shouldBe true
+      result.value.contains(s"insufficient assets") shouldBe true
     }
 
     "fail to create a transfer when no sender is provided" in {

--- a/node/src/test/scala/co/topl/api/transaction/UnprovenPolyTransferRPCHandlerSpec.scala
+++ b/node/src/test/scala/co/topl/api/transaction/UnprovenPolyTransferRPCHandlerSpec.scala
@@ -34,7 +34,7 @@ class UnprovenPolyTransferRPCHandlerSpec extends RPCMockState with Matchers with
     "successfully create a transfer with the provided sender in the 'inputs' field" in {
       val requestBody = createRequestBody(propositionType, sender, recipient, amount, fee)
 
-      val path = (cursor: HCursor) => cursor.downField("result").downField("inputs")
+      val path = (cursor: HCursor) => cursor.downField("result").downField("unprovenTransfer").downField("inputs")
 
       val result =
         httpPOST(requestBody) ~> route ~> check(
@@ -47,7 +47,7 @@ class UnprovenPolyTransferRPCHandlerSpec extends RPCMockState with Matchers with
     "successfully create a transfer with 'minting' set to false" in {
       val requestBody = createRequestBody(propositionType, sender, recipient, amount, fee)
 
-      val path = (cursor: HCursor) => cursor.downField("result").downField("minting")
+      val path = (cursor: HCursor) => cursor.downField("result").downField("unprovenTransfer").downField("minting")
 
       val result =
         httpPOST(requestBody) ~> route ~> check(
@@ -60,7 +60,7 @@ class UnprovenPolyTransferRPCHandlerSpec extends RPCMockState with Matchers with
     "successfully create a transfer with recipient in 'coinOutputs' field" in {
       val requestBody = createRequestBody(propositionType, sender, recipient, amount, fee)
 
-      val path = (cursor: HCursor) => cursor.downField("result").downField("coinOutputs")
+      val path = (cursor: HCursor) => cursor.downField("result").downField("unprovenTransfer").downField("coinOutputs")
 
       val result =
         httpPOST(requestBody) ~> route ~> check(
@@ -83,7 +83,8 @@ class UnprovenPolyTransferRPCHandlerSpec extends RPCMockState with Matchers with
     "successfully create a transfer with the expected change address" in {
       val requestBody = createRequestBody(propositionType, sender, recipient, amount, fee)
 
-      val path = (cursor: HCursor) => cursor.downField("result").downField("feeOutput").downField("dionAddress")
+      val path = (cursor: HCursor) =>
+        cursor.downField("result").downField("unprovenTransfer").downField("feeOutput").downField("dionAddress")
 
       val result =
         httpPOST(requestBody) ~> route ~> check(
@@ -116,7 +117,7 @@ class UnprovenPolyTransferRPCHandlerSpec extends RPCMockState with Matchers with
           |}
         """.stripMargin)
 
-      val path = (cursor: HCursor) => cursor.downField("result").downField("data")
+      val path = (cursor: HCursor) => cursor.downField("result").downField("unprovenTransfer").downField("data")
 
       val result =
         httpPOST(requestBody) ~> route ~> check(
@@ -135,7 +136,7 @@ class UnprovenPolyTransferRPCHandlerSpec extends RPCMockState with Matchers with
 
       val result = httpPOST(requestBody) ~> route ~> check(traverseJsonPath[String](responseAs[String], path))
 
-      result.value shouldBe "EmptyPolyInputs"
+      result.value shouldBe "Failed to build transfer: no poly inputs provided"
     }
 
     "fail to create a transfer when no sender is provided" in {

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
@@ -525,7 +525,7 @@ object ToplRpc {
       val rpc: Rpc[Params, Response] = Rpc("topl_unprovenArbitTransfer")
 
       case class Params(
-        sender:                NonEmptyChain[DionAddress],
+        senders:               NonEmptyChain[DionAddress],
         recipients:            NonEmptyChain[TetraTransaction.ArbitOutput],
         fee:                   TetraInt128,
         changeAddress:         DionAddress,

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
@@ -647,6 +647,9 @@ trait TransactionRpcResponseEncoders extends SharedCodecs {
   implicit val transactionUnprovenPolyTransferResponseEncoder
     : Encoder[ToplRpc.Transaction.UnprovenPolyTransfer.Response] = deriveEncoder
 
+  implicit val transactionUnprovenArbitTransferResponseEncoder
+    : Encoder[ToplRpc.Transaction.UnprovenArbitTransfer.Response] = deriveEncoder
+
   implicit val transactionEncodeTransferResponseEncoder: Encoder[ToplRpc.Transaction.EncodeTransfer.Response] =
     deriveEncoder
 }


### PR DESCRIPTION
## Purpose

Completes the implementation setup for the Unproven Arbit RPC Method function.

## Approach

- Adds an `Encoder` instance for `ToplRpc.Transaction.UnprovenArbitTransfer.Response`
- Adds a handler for `ToplRpc.Transaction.UnprovenArbitTransfer.rpc`
- Improves error messaging with an instance of `Show` for `BuildTransferFailure`

## Testing

The `UnprovenPolyTransferRPCHandlerSpec` has been updated with changes to the `Show` instance of `BuildTransferFailure`.

## Tickets

No tickets are closed.
