### PR TITLE
Core-1183: Tetra Transaction Codecs

### DIFF
--- a/brambl/src/main/scala/co/topl/credential/Credential.scala
+++ b/brambl/src/main/scala/co/topl/credential/Credential.scala
@@ -185,7 +185,7 @@ object Credential {
 //        Propositions.Contextual.RequiredDionOutput(index, address)
 //    }
 
-    case class RequiredBoxState(location: BoxLocation, boxes: List[(Int, Box[Box.Value])]) extends Credential {
+    case class RequiredBoxState(location: BoxLocation, boxes: List[(Int, Box)]) extends Credential {
       def prove(currentProof: Proof): Proof = Proofs.Contextual.RequiredBoxState()
 
       val proposition: Propositions.Contextual.RequiredBoxState =

--- a/brambl/src/main/scala/co/topl/credential/Credential.scala
+++ b/brambl/src/main/scala/co/topl/credential/Credential.scala
@@ -75,7 +75,7 @@ object Credential {
       override def prove(currentProof: Proof): Proof = Proofs.Knowledge.HashLock(salt, value)
 
       override def proposition: Proposition =
-        Propositions.Knowledge.HashLock(Sized.strictUnsafe(Bytes(blake2b256.hash(salt.data.toArray :+ value).value)))
+        Propositions.Knowledge.HashLock(Sized.strictUnsafe(Bytes(blake2b256.hash((salt.data :+ value).toArray).value)))
     }
   }
 

--- a/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundBV.scala
+++ b/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundBV.scala
@@ -131,7 +131,7 @@ object CredentialPlaygroundBV extends App {
       )
 
     override def currentHeight: Slot = 10
-    def inputBoxes: List[Box[Box.Value]] = List()
+    def inputBoxes: List[Box] = List()
     def currentSlot: Slot = 1
   }
 

--- a/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundJAA.scala
+++ b/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundJAA.scala
@@ -115,7 +115,7 @@ object CredentialPlaygroundJAA extends App {
     def currentTransaction: Transaction = transaction
     def currentHeight: Long = 1
 
-    def inputBoxes: List[Box[Box.Value]] = List(
+    def inputBoxes: List[Box] = List(
       Box(
         proposition.typedEvidence,
         unprovenTransaction.inputs.head._2,
@@ -164,7 +164,7 @@ object RequiredOutput extends App {
     def currentTransaction: Transaction = transaction
     def currentHeight: Long = 1
 
-    def inputBoxes: List[Box[Box.Value]] = List(
+    def inputBoxes: List[Box] = List(
       Box(
         proposition.typedEvidence,
         unprovenTransaction.inputs.head._2,
@@ -304,7 +304,7 @@ object XorGameCompletion extends App {
     def currentTransaction: Transaction = transaction
     def currentHeight: Long = 1
 
-    def inputBoxes: List[Box[Box.Value]] = List(
+    def inputBoxes: List[Box] = List(
       Box(
         halfGameProposition.typedEvidence,
         unprovenTransaction.inputs.head._2,
@@ -361,7 +361,7 @@ object RequiredBoxValue extends App {
   implicit val context: VerificationContext[F] = new VerificationContext[F] {
     def currentTransaction: Transaction = transaction
     def currentHeight: Long = 1
-    def inputBoxes: List[Box[Box.Value]] = List()
+    def inputBoxes: List[Box] = List()
     def currentSlot: Slot = 1
   }
 
@@ -396,7 +396,7 @@ object NotTest extends App {
     def currentTransaction: Transaction = transaction
     def currentHeight: Long = 3
 
-    def inputBoxes: List[Box[Box.Value]] = List(
+    def inputBoxes: List[Box] = List(
       Box(
         proposition.typedEvidence,
         unprovenTransaction.inputs.head._2,

--- a/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundNE.scala
+++ b/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundNE.scala
@@ -92,7 +92,7 @@ object CredentialPlaygroundNE extends App {
 
       def currentHeight: Long = 50L
 
-      def inputBoxes: List[Box[Box.Value]] = List(
+      def inputBoxes: List[Box] = List(
         Box(
           proposition.typedEvidence,
           unprovenTransaction.inputs.head._2,
@@ -221,7 +221,7 @@ object TruthTable extends App {
 
       def currentHeight: Long = 50L
 
-      def inputBoxes: List[Box[Box.Value]] = List(
+      def inputBoxes: List[Box] = List(
         Box(
           proposition.typedEvidence,
           unprovenTransaction.inputs.head._2,

--- a/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundOriginal.scala
+++ b/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundOriginal.scala
@@ -91,7 +91,7 @@ object CredentialPlaygroundOriginal extends App {
       def currentTransaction: Transaction = transaction
 
       def currentHeight: Long = 50L
-      def inputBoxes: List[Box[Box.Value]] = List()
+      def inputBoxes: List[Box] = List()
       def currentSlot: Slot = 1
     }
 

--- a/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundSean.scala
+++ b/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundSean.scala
@@ -107,7 +107,7 @@ object CredentialPlaygroundSean extends App {
 
       def currentSlot: Slot = 450L
 
-      def inputBoxes: List[Box[Box.Value]] = List()
+      def inputBoxes: List[Box] = List()
     }
 
   implicit val jsExecutor: Propositions.Script.JS.JSScript => F[(Json, Json) => F[Boolean]] =

--- a/brambl/src/test/scala/co/topl/credential/playground/CredentialTestJing.scala
+++ b/brambl/src/test/scala/co/topl/credential/playground/CredentialTestJing.scala
@@ -152,7 +152,7 @@ object CredentialTestJing extends App {
       new VerificationContext[F] {
         def currentTransaction: Transaction = transaction
         def currentHeight: Long = height
-        def inputBoxes: List[Box[Box.Value]] = List()
+        def inputBoxes: List[Box] = List()
         def currentSlot: Slot = 1
       }
     prop.isSatisfiedBy[F](proof).unsafeRunSync()

--- a/byte-codecs/src/main/scala/co/topl/codecs/bytes/scodecs/valuetypes/ValuetypesCodecs.scala
+++ b/byte-codecs/src/main/scala/co/topl/codecs/bytes/scodecs/valuetypes/ValuetypesCodecs.scala
@@ -1,5 +1,6 @@
 package co.topl.codecs.bytes.scodecs.valuetypes
 
+import cats.data.NonEmptyChain
 import cats.implicits._
 import co.topl.codecs.bytes.ZigZagEncoder._
 import co.topl.codecs.bytes.scodecs.valuetypes.Constants._
@@ -134,6 +135,12 @@ trait ValuetypesCodecs {
 
   implicit def seqCodec[T: Codec]: Codec[Seq[T]] =
     listCodec[T].xmap(list => list.toSeq, seq => seq.toList)
+
+  implicit def nonEmptyChainCodec[T: Codec]: Codec[NonEmptyChain[T]] =
+    listCodec[T].exmap(
+      list => Attempt.fromOption(NonEmptyChain.fromSeq(list), Err("Expected non-empty seq, but empty found")),
+      seq => Attempt.successful(seq.toList)
+    )
 
   implicit def arrayCodec[T: Codec: ClassTag]: Codec[Array[T]] =
     listCodec[T].xmap(list => list.toArray, array => array.toList)

--- a/byte-codecs/src/main/scala/co/topl/codecs/bytes/scodecs/valuetypes/ValuetypesCodecs.scala
+++ b/byte-codecs/src/main/scala/co/topl/codecs/bytes/scodecs/valuetypes/ValuetypesCodecs.scala
@@ -2,17 +2,38 @@ package co.topl.codecs.bytes.scodecs.valuetypes
 
 import cats.data.NonEmptyChain
 import cats.implicits._
+import cats.{Monad, Monoid}
 import co.topl.codecs.bytes.ZigZagEncoder._
 import co.topl.codecs.bytes.scodecs.valuetypes.Constants._
 import co.topl.codecs.bytes.scodecs.valuetypes.Types._
 import scodec.bits.BitVector
 import scodec.{Attempt, Codec, DecodeResult, Err, SizeBound}
 
+import scala.annotation.tailrec
 import scala.collection.SortedSet
-import scala.collection.immutable.ListMap
+import scala.collection.immutable.{ListMap, ListSet}
 import scala.reflect.ClassTag
+import scala.util.Try
 
 trait ValuetypesCodecs {
+
+  implicit private val bitVectorMonoid: Monoid[BitVector] =
+    Monoid.instance(BitVector.empty, _ ++ _)
+
+  implicit val attemptMonad: Monad[Attempt] =
+    new Monad[Attempt] {
+      def flatMap[A, B](fa: Attempt[A])(f: A => Attempt[B]): Attempt[B] = fa.flatMap(f)
+
+      @tailrec
+      def tailRecM[A, B](a: A)(f: A => Attempt[Either[A, B]]): Attempt[B] =
+        f(a) match {
+          case Attempt.Successful(Left(a))  => tailRecM(a)(f)
+          case Attempt.Successful(Right(b)) => Attempt.successful(b)
+          case Attempt.Failure(cause)       => Attempt.Failure(cause)
+        }
+
+      def pure[A](x: A): Attempt[A] = Attempt.successful(x)
+    }
 
   /**
    * A valuetype codec which encodes zero bytes and decodes zero bytes.
@@ -99,60 +120,109 @@ trait ValuetypesCodecs {
       Codec[B].consume[(A, B, C)](b => Codec[C].xmap[(A, B, C)](c => (a, b, c), abc => abc._3))(abc => abc._2)
     )(abc => abc._1)
 
-  def sizedListCodec[T: Codec](size: Int): Codec[List[T]] = new Codec[List[T]] {
+  def sizedArrayCodec[T: Codec: ClassTag](size: Int): Codec[Array[T]] = new Codec[Array[T]] {
 
-    override def encode(value: List[T]): Attempt[BitVector] =
-      (0 until size).foldLeft(Attempt.successful(BitVector.empty)) {
-        case (Attempt.Successful(bits), index) =>
-          for {
-            item     <- value.get(index).map(Attempt.successful).getOrElse(Attempt.failure(Err("invalid list size")))
-            itemBits <- Codec[T].encode(item)
-          } yield bits ++ itemBits
-        case (failure, _) => failure
-      }
+    override def encode(value: Array[T]): Attempt[BitVector] =
+      Attempt
+        .guard(value.length == size && size > 0, Err("invalid collection size"))
+        .flatMap(_ =>
+          value.foldLeft(Attempt.successful(BitVector.empty)) {
+            case (Attempt.Successful(bits), item) => Codec[T].encode(item).map(bits ++ _)
+            case (failure, _)                     => failure
+          }
+        )
 
     override def sizeBound: SizeBound = Codec[T].sizeBound * size
 
-    override def decode(bits: BitVector): Attempt[DecodeResult[List[T]]] =
-      (0 until size).foldLeft(Attempt.successful(DecodeResult(List[T](), bits))) {
-        case (Attempt.Successful(DecodeResult(listT, remaining)), _) =>
-          Codec[T].decode(remaining).map(result => result.map(listT :+ _))
-        case (failure, _) => failure
-      }
+    override def decode(bits: BitVector): Attempt[DecodeResult[Array[T]]] = {
+      var remaining = bits
+      Attempt
+        .fromTry(
+          Try(
+            Array.fill(size) {
+              Codec[T].decode(remaining) match {
+                case Attempt.Successful(value) =>
+                  remaining = value.remainder
+                  value.value
+                case Attempt.Failure(cause) =>
+                  throw new Exception(cause.messageWithContext)
+              }
+            }
+          )
+        )
+        .map(DecodeResult(_, remaining))
+    }
   }
+
+  def sizedSeqCodec[T: Codec](size: Int): Codec[Seq[T]] = new Codec[Seq[T]] {
+
+    override def encode(value: Seq[T]): Attempt[BitVector] =
+      Attempt
+        .guard(value.length == size && size > 0, Err("invalid collection size"))
+        .flatMap(_ =>
+          value.foldLeft(Attempt.successful(BitVector.empty)) {
+            case (Attempt.Successful(bits), item) => Codec[T].encode(item).map(bits ++ _)
+            case (failure, _)                     => failure
+          }
+        )
+
+    override def sizeBound: SizeBound = Codec[T].sizeBound * size
+
+    override def decode(bits: BitVector): Attempt[DecodeResult[Seq[T]]] = {
+      var remaining = bits
+      Attempt
+        .fromTry(
+          Try(
+            IndexedSeq.fill(size) {
+              Codec[T].decode(remaining) match {
+                case Attempt.Successful(value) =>
+                  remaining = value.remainder
+                  value.value
+                case Attempt.Failure(cause) =>
+                  throw new Exception(cause.messageWithContext)
+              }
+            }
+          )
+        )
+        .map(DecodeResult(_, remaining))
+    }
+  }
+
+  implicit def seqCodec[T: Codec]: Codec[Seq[T]] =
+    uIntCodec.consume(uInt => sizedSeqCodec[T](uInt.toInt))(listT => listT.length)
+
+  def sizedListCodec[T: Codec](size: Int): Codec[List[T]] =
+    sizedSeqCodec[T](size).xmap(_.toList, identity)
 
   implicit def listCodec[T: Codec]: Codec[List[T]] =
     uIntCodec.consume[List[T]](uInt => sizedListCodec(uInt.toInt))(listT => listT.length)
 
   implicit def setCodec[T: Codec]: Codec[Set[T]] =
-    listCodec[T].xmap(list => list.toSet, set => set.toList)
+    seqCodec[T].xmap(list => list.toSet, set => set.toSeq)
+
+  implicit def listSetCodec[T: Codec]: Codec[ListSet[T]] =
+    seqCodec[T].xmap(list => ListSet.empty[T] ++ list, set => set.toSeq)
 
   implicit def sortedSetCodec[T: Codec: Ordering]: Codec[SortedSet[T]] =
-    listCodec[T].xmap(list => SortedSet(list: _*), sortedSet => sortedSet.toList)
+    seqCodec[T].xmap(list => SortedSet.empty[T] ++ list, sortedSet => sortedSet.toSeq)
 
   implicit def indexedSeqCodec[T: Codec]: Codec[IndexedSeq[T]] =
-    listCodec[T].xmap(list => list.toIndexedSeq, seq => seq.toList)
-
-  implicit def seqCodec[T: Codec]: Codec[Seq[T]] =
-    listCodec[T].xmap(list => list.toSeq, seq => seq.toList)
+    seqCodec[T].xmap(list => list.toIndexedSeq, identity)
 
   implicit def nonEmptyChainCodec[T: Codec]: Codec[NonEmptyChain[T]] =
-    listCodec[T].exmap(
+    seqCodec[T].exmap(
       list => Attempt.fromOption(NonEmptyChain.fromSeq(list), Err("Expected non-empty seq, but empty found")),
       seq => Attempt.successful(seq.toList)
     )
 
   implicit def arrayCodec[T: Codec: ClassTag]: Codec[Array[T]] =
-    listCodec[T].xmap(list => list.toArray, array => array.toList)
+    uIntCodec.consume(uInt => sizedArrayCodec[T](uInt.toInt))(listT => listT.length)
 
   implicit def listMapCodec[A: Codec, B: Codec]: Codec[ListMap[A, B]] =
-    listCodec[(A, B)].xmap[ListMap[A, B]](list => ListMap(list: _*), listMap => listMap.toList)
+    seqCodec[(A, B)].xmap[ListMap[A, B]](list => ListMap.empty[A, B] ++ list, listMap => listMap.toSeq)
 
   implicit def mapCodec[A: Codec, B: Codec]: Codec[Map[A, B]] =
-    listMapCodec[A, B].xmap(listMap => listMap, map => ListMap(map.toList: _*))
-
-  def sizedArrayCodec[T: Codec: ClassTag](size: Int): Codec[Array[T]] =
-    sizedListCodec[T](size).xmap[Array[T]](listT => listT.toArray, arrayT => arrayT.toList)
+    listMapCodec[A, B].xmap(_.toMap, ListMap.empty[A, B] ++ _)
 
   implicit def optionCodec[T: Codec]: Codec[Option[T]] = new OptionCodec[T]
 }

--- a/byte-codecs/src/test/scala/co/topl/codecs/bytes/CodecSpec.scala
+++ b/byte-codecs/src/test/scala/co/topl/codecs/bytes/CodecSpec.scala
@@ -1,12 +1,14 @@
 package co.topl.codecs.bytes
 
 import cats.{Eq, Show}
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scodec.Codec
+
+import scala.reflect.ClassTag
 
 trait CodecSpec extends AnyFlatSpec with Matchers with EqMatcher with EitherValues with ScalaCheckDrivenPropertyChecks {
 
@@ -37,4 +39,7 @@ trait CodecSpec extends AnyFlatSpec with Matchers with EqMatcher with EitherValu
       }
     }
   }
+
+  def codecBehavior[T: Eq: Show: Codec: Arbitrary: ClassTag](): Unit =
+    codecBehavior[T](implicitly[ClassTag[T]].toString, implicitly[Codec[T]], implicitly[Arbitrary[T]].arbitrary)
 }

--- a/models/src/main/scala/co/topl/models/Block.scala
+++ b/models/src/main/scala/co/topl/models/Block.scala
@@ -7,7 +7,7 @@ import co.topl.models.utility.{Lengths, Sized}
 case class BlockV1(
   parentId:     TypedIdentifier,
   timestamp:    Timestamp,
-  generatorBox: Box[Box.Values.Arbit],
+  generatorBox: Box,
   publicKey:    Bytes,
   signature:    Bytes,
   height:       Long,

--- a/models/src/main/scala/co/topl/models/Box.scala
+++ b/models/src/main/scala/co/topl/models/Box.scala
@@ -5,7 +5,7 @@ import co.topl.models.utility.{Lengths, Sized}
 
 import scala.util.Random
 
-case class Box[V <: Box.Value](evidence: TypedEvidence, nonce: BoxNonce, value: V)
+case class Box(evidence: TypedEvidence, nonce: BoxNonce, value: Box.Value)
 
 object Box {
   sealed abstract class Value
@@ -32,7 +32,7 @@ object Box {
     case class TaktikosRegistration(commitment: Proofs.Knowledge.KesProduct) extends Value
   }
 
-  def apply(coinOutput: Transaction.CoinOutput): Box[_] = coinOutput match {
+  def apply(coinOutput: Transaction.CoinOutput): Box = coinOutput match {
     case Transaction.PolyOutput(dionAddress, value) =>
       Box(dionAddress.typedEvidence, Random.nextLong(), Box.Values.Poly(value))
     case Transaction.ArbitOutput(dionAddress, value) =>
@@ -40,5 +40,5 @@ object Box {
     case Transaction.AssetOutput(dionAddress, value) => Box(dionAddress.typedEvidence, Random.nextLong(), value)
   }
 
-  val empty: Box[Box.Values.Empty.type] = Box(TypedEvidence.empty, 0, Box.Values.Empty)
+  val empty: Box = Box(TypedEvidence.empty, 0, Box.Values.Empty)
 }

--- a/models/src/main/scala/co/topl/models/Proposition.scala
+++ b/models/src/main/scala/co/topl/models/Proposition.scala
@@ -27,7 +27,7 @@ object Propositions {
 
   object Contextual {
     case class HeightLock(height: Long) extends Proposition
-    case class RequiredBoxState(location: BoxLocation, boxes: List[(Int, Box[Box.Value])]) extends Proposition
+    case class RequiredBoxState(location: BoxLocation, boxes: List[(Int, Box)]) extends Proposition
   }
 
   object Script {

--- a/models/src/test/scala/co/topl/models/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/ModelGenerators.scala
@@ -38,6 +38,27 @@ trait ModelGenerators {
   def proofVrfEd25519Gen: Gen[Proofs.Knowledge.VrfEd25519] =
     genSizedStrictBytes[Lengths.`80`.type]().map(Proofs.Knowledge.VrfEd25519(_))
 
+  def typedEvidenceGen: Gen[TypedEvidence] =
+    for {
+      prefix   <- byteGen
+      evidence <- genSizedStrictBytes[Lengths.`32`.type]()
+    } yield TypedEvidence(prefix, evidence)
+
+  def networkPrefixGen: Gen[NetworkPrefix] =
+    byteGen.map(NetworkPrefix(_))
+
+  def dionAddressGen: Gen[DionAddress] =
+    for {
+      prefix        <- networkPrefixGen
+      typedEvidence <- typedEvidenceGen
+    } yield DionAddress(prefix, typedEvidence)
+
+  def boxReferenceGen: Gen[BoxReference] =
+    for {
+      address <- dionAddressGen
+      nonce   <- Gen.long
+    } yield (address, nonce)
+
   def eligibilityCertificateGen: Gen[EligibilityCertificate] =
     for {
       vrfProof          <- proofVrfEd25519Gen

--- a/tetra-byte-codecs/src/test/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecsSpec.scala
+++ b/tetra-byte-codecs/src/test/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecsSpec.scala
@@ -2,28 +2,15 @@ package co.topl.codecs.bytes.tetra
 
 import cats.{Eq, Show}
 import co.topl.codecs.bytes.CodecSpec
-import co.topl.models.{
-  BlockHeaderV2,
-  BoxReference,
-  DionAddress,
-  EligibilityCertificate,
-  Evidence,
-  Int128,
-  ModelGenerators,
-  Proof,
-  Proofs,
-  Proposition,
-  SecretKeys,
-  TaktikosAddress,
-  Transaction,
-  TypedEvidence,
-  VerificationKeys
-}
-import co.topl.models.utility.{KesBinaryTree, Ratio}
 import co.topl.models.utility.StringDataTypes.Latin1Data
+import co.topl.models.utility.{KesBinaryTree, Ratio}
+import co.topl.models._
 import org.scalacheck.Gen
 
 class TetraScodecCodecsSpec extends CodecSpec {
+
+  import ModelGenerators._
+  import TetraScodecCodecs._
 
   implicit def defaultShow[T]: Show[T] = Show.fromToString
   implicit def defaultEq[T]: Eq[T] = Eq.fromUniversalEquals
@@ -172,11 +159,7 @@ class TetraScodecCodecsSpec extends CodecSpec {
     ModelGenerators.partialOperationalCertificateGen
   )
 
-  codecBehavior[TaktikosAddress](
-    "TaktikosAddress",
-    TetraScodecCodecs.taktikosAddressCodec,
-    ModelGenerators.taktikosAddressGen
-  )
+  codecBehavior[TaktikosAddress]()
 
   codecBehavior[BlockHeaderV2.Unsigned](
     "BlockHeaderV2.Unsigned",
@@ -184,11 +167,7 @@ class TetraScodecCodecsSpec extends CodecSpec {
     ModelGenerators.unsignedHeaderGen()
   )
 
-  codecBehavior[BlockHeaderV2](
-    "BlockHeaderV2",
-    TetraScodecCodecs.blockHeaderV2Codec,
-    ModelGenerators.headerGen()
-  )
+  codecBehavior[BlockHeaderV2]()
 
   codecBehavior[TypedEvidence](
     "TypedEvidence",
@@ -196,33 +175,15 @@ class TetraScodecCodecsSpec extends CodecSpec {
     ModelGenerators.typedEvidenceGen
   )
 
-  codecBehavior[DionAddress](
-    "DionAddress",
-    TetraScodecCodecs.dionAddressCodec,
-    ModelGenerators.dionAddressGen
-  )
+  codecBehavior[DionAddress]()
 
-  codecBehavior[BoxReference](
-    "BoxReference",
-    TetraScodecCodecs.boxReferenceCodec,
-    ModelGenerators.boxReferenceGen
-  )
+  codecBehavior[BoxReference]()
 
-  codecBehavior[Proposition](
-    "Proposition",
-    TetraScodecCodecs.propositionCodec,
-    ModelGenerators.arbitraryProposition.arbitrary
-  )
+  codecBehavior[Proposition]()
 
-  codecBehavior[Proof](
-    "Proof",
-    TetraScodecCodecs.proofCodec,
-    ModelGenerators.arbitraryProof.arbitrary
-  )
+  codecBehavior[Proof]()
 
-  codecBehavior[Transaction](
-    "Transaction",
-    TetraScodecCodecs.transactionCodec,
-    ModelGenerators.arbitraryTransaction.arbitrary
-  )
+  codecBehavior[Box]()
+
+  codecBehavior[Transaction]()
 }

--- a/tetra-byte-codecs/src/test/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecsSpec.scala
+++ b/tetra-byte-codecs/src/test/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecsSpec.scala
@@ -4,12 +4,16 @@ import cats.{Eq, Show}
 import co.topl.codecs.bytes.CodecSpec
 import co.topl.models.{
   BlockHeaderV2,
+  BoxReference,
+  DionAddress,
   EligibilityCertificate,
+  Evidence,
   Int128,
   ModelGenerators,
   Proofs,
   SecretKeys,
   TaktikosAddress,
+  TypedEvidence,
   VerificationKeys
 }
 import co.topl.models.utility.{KesBinaryTree, Ratio}
@@ -181,5 +185,23 @@ class TetraScodecCodecsSpec extends CodecSpec {
     "BlockHeaderV2",
     TetraScodecCodecs.blockHeaderV2Codec,
     ModelGenerators.headerGen()
+  )
+
+  codecBehavior[TypedEvidence](
+    "TypedEvidence",
+    TetraScodecCodecs.typedEvidenceCodec,
+    ModelGenerators.typedEvidenceGen
+  )
+
+  codecBehavior[DionAddress](
+    "DionAddress",
+    TetraScodecCodecs.dionAddressCodec,
+    ModelGenerators.dionAddressGen
+  )
+
+  codecBehavior[BoxReference](
+    "BoxReference",
+    TetraScodecCodecs.boxReferenceCodec,
+    ModelGenerators.boxReferenceGen
   )
 }

--- a/tetra-byte-codecs/src/test/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecsSpec.scala
+++ b/tetra-byte-codecs/src/test/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecsSpec.scala
@@ -10,9 +10,12 @@ import co.topl.models.{
   Evidence,
   Int128,
   ModelGenerators,
+  Proof,
   Proofs,
+  Proposition,
   SecretKeys,
   TaktikosAddress,
+  Transaction,
   TypedEvidence,
   VerificationKeys
 }
@@ -203,5 +206,23 @@ class TetraScodecCodecsSpec extends CodecSpec {
     "BoxReference",
     TetraScodecCodecs.boxReferenceCodec,
     ModelGenerators.boxReferenceGen
+  )
+
+  codecBehavior[Proposition](
+    "Proposition",
+    TetraScodecCodecs.propositionCodec,
+    ModelGenerators.arbitraryProposition.arbitrary
+  )
+
+  codecBehavior[Proof](
+    "Proof",
+    TetraScodecCodecs.proofCodec,
+    ModelGenerators.arbitraryProof.arbitrary
+  )
+
+  codecBehavior[Transaction](
+    "Transaction",
+    TetraScodecCodecs.transactionCodec,
+    ModelGenerators.arbitraryTransaction.arbitrary
   )
 }

--- a/typeclasses/src/main/scala/co/topl/typeclasses/ProofVerifier.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ProofVerifier.scala
@@ -99,7 +99,9 @@ object ProofVerifier {
       proposition: Propositions.Knowledge.HashLock,
       proof:       Proofs.Knowledge.HashLock
     ): F[Boolean] =
-      (blake2b256.hash(proof.salt.data.toArray :+ proof.value).value sameElements proposition.digest.data.toArray)
+      (blake2b256
+        .hash((proof.salt.data :+ proof.value).toArray)
+        .value sameElements proposition.digest.data.toArray)
         .pure[F]
 
     private def requiredBoxVerifier[F[_]: Applicative](

--- a/typeclasses/src/main/scala/co/topl/typeclasses/ProofVerifier.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ProofVerifier.scala
@@ -106,7 +106,7 @@ object ProofVerifier {
       proposition: Propositions.Contextual.RequiredBoxState,
       context:     VerificationContext[F]
     ): F[Boolean] = {
-      def compareBoxes(propositionBox: Box[_])(sourceBox: Box[_]): Boolean = propositionBox match {
+      def compareBoxes(propositionBox: Box)(sourceBox: Box): Boolean = propositionBox match {
         case Box(TypedEvidence.empty, 0, value) =>
           value == sourceBox.value
         case Box(TypedEvidence.empty, nonce, Box.Values.Empty) =>
@@ -265,6 +265,6 @@ object ProofVerifier {
 trait VerificationContext[F[_]] {
   def currentTransaction: Transaction
   def currentHeight: Long
-  def inputBoxes: List[Box[Box.Value]]
+  def inputBoxes: List[Box]
   def currentSlot: Slot
 }


### PR DESCRIPTION
## Purpose
- Tetra needs the ability to serialize and deserialize a Transaction for networking and storage purposes
- Serializing a Transaction also involves serializing propositions, proofs, and boxes
## Approach
- Added codecs for Propositions, Proofs, Boxes, and Transactions
- Separated Tetra Scodec Codecs into multiple traits by Group
- Removed typed parameter from Box model for simplification

## Testing
- Added several new ModelGenerators
- Added codec tests for the new codecs

## Tickets
_* closes #2081_
