### PR TITLE
added cli option for known peers

### DIFF
--- a/node/src/main/scala/co/topl/settings/StartupOpts.scala
+++ b/node/src/main/scala/co/topl/settings/StartupOpts.scala
@@ -115,8 +115,8 @@ final case class RuntimeOpts(
       .modify(configAddr =>
         networkBindAddress match {
           case Some(addrStr) =>
-              val split = addrStr.split(":")
-              new InetSocketAddress(split(0), split(1).toInt)
+            val split = addrStr.split(":")
+            new InetSocketAddress(split(0), split(1).toInt)
           case None => configAddr
         }
       )

--- a/node/src/main/scala/co/topl/settings/StartupOpts.scala
+++ b/node/src/main/scala/co/topl/settings/StartupOpts.scala
@@ -52,11 +52,12 @@ final case class RuntimeOpts(
       "If API key protection is enabled, this argument specifies the Blake2b256 hash of API key required by the JSON-RPC server "
   )
   apiKeyHash: Option[String] = None,
-  @arg(name = "knownPeers", short = 'k', doc = "List of IP addresses and ports of known peers, separated by commas")
+  @arg(name = "knownPeers", short = 'k', doc = "List of IP addresses and ports of known peers, separated by commas. " +
+    "For example: 0.0.0.0:11,0.0.0.0:22")
   knownPeers: Option[String] = None,
-  @arg(name = "networkBindAddress", short = 'a', doc = "Network address to bind to")
+  @arg(name = "networkBindAddress", short = 'a', doc = "Network address and port to bind to")
   networkBindAddress: Option[String] = None,
-  @arg(name = "rpcBindAddress", short = 'r', doc = "Local network address to bind to")
+  @arg(name = "rpcBindAddress", short = 'r', doc = "Local network address and port to bind to")
   rpcBindAddress: Option[String] = None
 ) {
 

--- a/node/src/main/scala/co/topl/settings/StartupOpts.scala
+++ b/node/src/main/scala/co/topl/settings/StartupOpts.scala
@@ -52,8 +52,12 @@ final case class RuntimeOpts(
       "If API key protection is enabled, this argument specifies the Blake2b256 hash of API key required by the JSON-RPC server "
   )
   apiKeyHash: Option[String] = None,
-  @arg(name = "knownPeers", short = 'k', doc = "List of IP addresses and ports of known peers, separated by commas. " +
-    "For example: 0.0.0.0:11,0.0.0.0:22")
+  @arg(
+    name = "knownPeers",
+    short = 'k',
+    doc = "List of IP addresses and ports of known peers, separated by commas. " +
+      "For example: 0.0.0.0:11,0.0.0.0:22"
+  )
   knownPeers: Option[String] = None,
   @arg(name = "networkBindAddress", short = 'a', doc = "Network address and port to bind to")
   networkBindAddress: Option[String] = None,

--- a/node/src/main/scala/co/topl/settings/StartupOpts.scala
+++ b/node/src/main/scala/co/topl/settings/StartupOpts.scala
@@ -53,7 +53,11 @@ final case class RuntimeOpts(
   )
   apiKeyHash: Option[String] = None,
   @arg(name = "knownPeers", short = 'k', doc = "List of IP addresses and ports of known peers, separated by commas")
-  knowPeers: Option[String] = None
+  knownPeers: Option[String] = None,
+  @arg(name = "networkBindAddress", short = 'a', doc = "Network address to bind to")
+  networkBindAddress: Option[String] = None,
+  @arg(name = "rpcBindAddress", short = 'r', doc = "Local network address to bind to")
+  rpcBindAddress: Option[String] = None
 ) {
 
   /**
@@ -96,13 +100,35 @@ final case class RuntimeOpts(
       // knownPeers
       .focus(_.network.knownPeers)
       .modify(configPeers =>
-        knowPeers match {
+        knownPeers match {
           case Some(peersString) =>
             peersString.split(",").map { peer =>
               val split = peer.split(":")
               new InetSocketAddress(split(0), split(1).toInt)
             }
           case None => configPeers
+        }
+      )
+
+      // networkBindAddress
+      .focus(_.network.bindAddress)
+      .modify(configAddr =>
+        networkBindAddress match {
+          case Some(addrStr) =>
+              val split = addrStr.split(":")
+              new InetSocketAddress(split(0), split(1).toInt)
+          case None => configAddr
+        }
+      )
+
+      // rpcBindAddress
+      .focus(_.rpcApi.bindAddress)
+      .modify(configAddr =>
+        rpcBindAddress match {
+          case Some(addrStr) =>
+            val split = addrStr.split(":")
+            new InetSocketAddress(split(0), split(1).toInt)
+          case None => configAddr
         }
       )
 }


### PR DESCRIPTION
## Purpose
We are adding the ability to specify a list of knownPeers, network address, and rpc api address as command-line startup options to assist integration testing efforts. This will make tests with dynamic IP addresses easier.

## Approach
Added `knownPeers` `networkBindAddress` `rpcBindAddress` options for cli arguments.
`knownPeers` supports multiple peer addresses separated with commas

## Testing
Tested running with the added arguments

## Tickets
* #1120 
* #1116