### PR TITLE
Updated the sbt-akka-grpc plugin to version 2.1.4

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,5 +18,5 @@ Seq(
   "com.eed3si9n"       % "sbt-buildinfo"             % "0.11.0",
   "com.geirsson"       % "sbt-ci-release"            % "1.5.7",
   "net.bzzt"           % "sbt-reproducible-builds"   % "0.30",
-  "com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.1"
+  "com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.4"
 ).map(addSbtPlugin)


### PR DESCRIPTION
There is an issue with assembling the Genus module on an M1 Mac due to an issue with an unsupported protobuf executable. The issue has been fixed in sbt-akka-grpc 2.1.4.
