### PR TITLE
Genus Subscriptions Creation Error Handling

### DIFF
--- a/genus/src/main/scala/co/topl/genus/interpreters/services/BlocksSubscriptionService.scala
+++ b/genus/src/main/scala/co/topl/genus/interpreters/services/BlocksSubscriptionService.scala
@@ -2,25 +2,26 @@ package co.topl.genus.interpreters.services
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import cats.Functor
+import cats.MonadThrow
 import cats.data.EitherT
-import cats.implicits._
 import co.topl.genus.algebras.{MongoSubscription, SubscriptionService}
 import co.topl.genus.typeclasses.MongoFilter
 import co.topl.genus.types.Block
 
 object BlocksSubscriptionService {
 
-  def make[F[_]: Functor](subscriptions: MongoSubscription[F]): SubscriptionService[F, Block] =
+  def make[F[_]: MonadThrow](subscriptions: MongoSubscription[F]): SubscriptionService[F, Block] =
     new SubscriptionService[F, Block] {
 
       override def create[Filter: MongoFilter](
         request: SubscriptionService.CreateRequest[Filter]
       ): EitherT[F, SubscriptionService.CreateSubscriptionFailure, Source[Block, NotUsed]] =
-        EitherT.right[SubscriptionService.CreateSubscriptionFailure](
-          subscriptions
-            .create(request.filter)
-            .map(_.mapConcat(documentToBlock(_).toSeq))
-        )
+        MonadThrow[F]
+          // catch a possible failure with creating the subscription
+          .attemptT(subscriptions.create(request.filter))
+          .leftMap[SubscriptionService.CreateSubscriptionFailure](failure =>
+            SubscriptionService.CreateSubscriptionFailures.DataConnectionFailure(failure.getMessage)
+          )
+          .map(source => source.mapConcat(documentToBlock(_).toSeq))
     }
 }

--- a/genus/src/main/scala/co/topl/genus/interpreters/services/BlocksSubscriptionService.scala
+++ b/genus/src/main/scala/co/topl/genus/interpreters/services/BlocksSubscriptionService.scala
@@ -20,7 +20,9 @@ object BlocksSubscriptionService {
       ): EitherT[F, SubscriptionService.CreateSubscriptionFailure, Source[Block, NotUsed]] =
         MonadThrow[F]
           // catch a possible failure with creating the subscription
-          .attemptT(subscriptions.create(request.filter))
+          .attemptT(
+            subscriptions.create(request.filter, BlockSorting(BlockSorting.SortBy.Height(BlockSorting.Height())))
+          )
           .leftMap[SubscriptionService.CreateSubscriptionFailure](failure =>
             SubscriptionService.CreateSubscriptionFailures.DataConnectionFailure(failure.getMessage)
           )

--- a/genus/src/main/scala/co/topl/genus/interpreters/services/TransactionsSubscriptionService.scala
+++ b/genus/src/main/scala/co/topl/genus/interpreters/services/TransactionsSubscriptionService.scala
@@ -20,7 +20,10 @@ object TransactionsSubscriptionService {
       ): EitherT[F, SubscriptionService.CreateSubscriptionFailure, Source[Transaction, NotUsed]] =
         MonadThrow[F]
           // catch a possible failure with creating the subscription
-          .attemptT(subscriptions.create(request.filter))
+          .attemptT(
+            subscriptions
+              .create(request.filter, TransactionSorting(TransactionSorting.SortBy.Height(TransactionSorting.Height())))
+          )
           .leftMap[SubscriptionService.CreateSubscriptionFailure](failure =>
             SubscriptionService.CreateSubscriptionFailures.DataConnectionFailure(failure.getMessage)
           )


### PR DESCRIPTION
## Purpose

The Genus service should send the client a failure result if there is any sort of error with creating a subscription.

## Approach

Wrap creation of the subscription akka `Source` value with the `MonadThrow[F].attemptT` type to capture a possible a exception with instantiating the `Stream`. Then, convert the error message to the `CreateSubscriptionFailure` type which can be sent to the client.

## Testing

No new tests have been added.

## Tickets
* closes CORE-1209 task in Jira