### PR TITLE
fixed merge collision with google/protobuf files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -111,6 +111,7 @@ def assemblySettings(main: String) = Seq(
       case PathList("local.conf")                      => MergeStrategy.discard
       case "META-INF/truffle/instrument"               => MergeStrategy.concat
       case "META-INF/truffle/language"                 => MergeStrategy.rename
+      case x if x.contains("google/protobuf")          => MergeStrategy.last
       case x                                           => old(x)
     }
   },
@@ -662,7 +663,7 @@ lazy val genus = project
     name := "genus",
     commonSettings,
     scalamacrosParadiseSettings,
-    libraryDependencies ++= Dependencies.genus,
+    libraryDependencies ++= Dependencies.genus
   )
   .enablePlugins(AkkaGrpcPlugin)
   .dependsOn(common)


### PR DESCRIPTION
## Purpose

Errors occur during the assembly process when trying to merge the akka-grpc and protoc-java jars due to both jars containing the same .proto files.

## Approach

Filter for `google/protobuf` files during the assembly process and use `MergeStrategy.last` to use the google types from the latest upstream source (akka-grpc). 

## Testing

No new tests have been added

## Tickets
closes #2094 