### PR TITLE
CORE-1216: Update action branch filters to include our GitFlow branches

### DIFF
--- a/.github/workflows/postman_integration_tests.yml
+++ b/.github/workflows/postman_integration_tests.yml
@@ -2,7 +2,7 @@ name: Postman Integration Tests
 
 on:
   pull_request:
-    branches: [dev, main]
+    branches: [dev, main, release-*, rc-*]
 
 jobs:
 

--- a/.github/workflows/sbt_checkPR.yml
+++ b/.github/workflows/sbt_checkPR.yml
@@ -2,9 +2,9 @@ name: SBT checkPR
 
 on:
   pull_request:
-    branches: ['*']
+    branches: [dev, main, release-*, rc-*]
   push:
-    branches: [dev, main]
+    branches: [dev, main, release-*, rc-*]
 
 jobs:
   build:


### PR DESCRIPTION
## Purpose
After updating our branching strategy, some of our GitHub actions have filters that don't match the new naming schemes (for example, this PR didn't run a check: https://github.com/Topl/Bifrost/pull/2112).

## Approach
* Update the filters to include our release branch patterns on PR and push.

## Testing

## Tickets
_* closes #1216_
