### PR TITLE
Environment Variable Configurations

### DIFF
--- a/node/src/main/resources/environment.conf
+++ b/node/src/main/resources/environment.conf
@@ -1,0 +1,22 @@
+bifrost {
+  application {
+    dataDir = ${?BIFROST_APPLICATION_DATA_DIR}
+    keyFileDir = ${?BIFROST_APPLICATION_KEY_FILE_DIR}
+  }
+
+  rpcApi {
+    bindAddress = ${?BIFROST_RPC_API_BIND_ADDRESS}
+    disableAuth = ${?BIFROST_RPC_API_DISABLE_AUTH}
+    apiKeyHash = ${?BIFROST_RPC_API_API_KEY_HASH}
+  }
+
+  network {
+    bindAddress = ${?BIFROST_NETWORK_BIND_ADDRESS}
+    knownPeers = ${?BIFROST_NETWORK_KNOWN_PEERS}
+  }
+
+  forging {
+    forgeOnStartup = ${?BIFROST_FORGING_FORGE_ON_STARTUP}
+    rewardsAddress = ${?BIFROST_FORGING_REWARDS_ADDRESS}
+  }
+}

--- a/node/src/main/scala/co/topl/settings/AppSettings.scala
+++ b/node/src/main/scala/co/topl/settings/AppSettings.scala
@@ -170,6 +170,12 @@ object AppSettings extends Logging with SettingsReaders {
    */
   private def readConfig(args: StartupOpts): Config = {
 
+    log.info(s"${Console.YELLOW}Loading environment.conf settings${Console.RESET}")
+    val environmentConfig = {
+      val base = ConfigFactory.load(this.getClass.getClassLoader, "environment.conf")
+      listConfigFix("bifrost.network.knownPeers")(base)
+    }
+
     val userConfig = args.userConfigPathOpt.fold(ConfigFactory.empty()) { uc =>
       val userFile = new File(uc)
       log.info(
@@ -192,12 +198,31 @@ object AppSettings extends Logging with SettingsReaders {
     // load config files from disk, if the above strings are empty then ConFigFactory will skip loading them
     ConfigFactory
       .defaultOverrides()
+      .withFallback(environmentConfig)
       .withFallback(userConfig)
       .withFallback(networkConfig)
       .withFallback(ConfigFactory.defaultApplication())
       .resolve()
 
   }
+
+  /**
+   * HOCON allows for _string_ environment variable substitutions.  When dealing with arrays, an extra step must be taken
+   * to re-parse the setting into a list.
+   *
+   * If a String value is not provided at the given path, the original config is returned
+   *
+   * @param path The dot-separated HOCON config path within the provided config
+   * @param config The base configuration to correct
+   * @return An updated configuration
+   */
+  private def listConfigFix(path: String)(config: Config): Config =
+    if (config.hasPath(path)) {
+      // The top-level item of HOCON can't be an array, so embed it inside of a temporary object before extracting
+      val list = ConfigFactory.parseString(s"{tmp = ${config.getString(path)}}").getValue("tmp")
+      // Now overwrite the value in the original config with the newly parsed value
+      config.withValue(path, list)
+    } else config
 
   private def clusterConfig(settings: AppSettings, config: Config): Config =
     if (settings.gjallarhorn.clusterEnabled) {


### PR DESCRIPTION
## Purpose
- Many modern deployment systems prefer environment variables to command-line arguments
  - But when _developing_ locally, environment variables can be a nuisance
- Adds optional support for environment variable setting overrides for a subset of configurations

## Approach
- Added `environment.conf` resource that implements environment variable substitutions for a few common settings
- Updated AppSettings config parser to parse environment.conf
  - Also added a helper to fix array-like setting overrides

## Testing
- Manually tested
- RPC Bind Address set via environment.  Forging disabled through environment but overridden by command-line.
  - ![image](https://user-images.githubusercontent.com/2218886/168847072-dd5b21db-e141-4bff-bece-8d8134c5b186.png)
  - ![image](https://user-images.githubusercontent.com/2218886/168847175-7870e1ce-a423-40ad-bcd1-0a06653a46b4.png)
  - ![image](https://user-images.githubusercontent.com/2218886/168847296-ba23292b-d201-4e45-9017-198594d6e85f.png)
- P2P Known Peers set via environment.
  - ![image](https://user-images.githubusercontent.com/2218886/168847749-790a3722-c5a0-463b-ae6a-3e3e8a6a8dd2.png)
  - ![image](https://user-images.githubusercontent.com/2218886/168847834-c4d76cd6-dd6d-47dd-a4cf-8b47ee1824ee.png)

## Tickets
_* closes #1116_
