### PR TITLE
CORE-1193: Add GitHub action to publish test report

### DIFF
--- a/.github/workflows/sbt_checkPR.yml
+++ b/.github/workflows/sbt_checkPR.yml
@@ -39,3 +39,31 @@ jobs:
 
       - name: Compile and Test
         run: sbt checkPR
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test Results (Java ${{ matrix.os }})
+          path: target/test-reports/*.xml
+
+  publish-test-results:
+    name: "Publish Tests Results"
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      # only needed unless run with comment_mode: off
+      pull-requests: write
+    if: always()
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.35
+        with:
+          files: "artifacts/**/*.xml"
+          check_run_annotations_branch: main, dev


### PR DESCRIPTION
## Purpose
To get a better view of failed tests, we can utilize GitHub actions to publish the `xml` test reports.

I settled on using: [Publish Unit Test Results](https://github.com/marketplace/actions/publish-unit-test-results), which adds a comment to the PR with a summary of the test results, as well as a link to the check which shows you the raw output for individual tests that fail (limited to 10).

One alternative I considered is: [Test Reporter](https://github.com/marketplace/actions/test-reporter), which doesn't give you the comment summary, but does give you a more detailed test report including a breakdown of the test suites, and individual test suite times which I liked. Unfortunately, it was a bit clunkier to use, requiring a few clicks and scrolling to get to the raw output of a failed test, which I don't think most people would prefer.

## Approach
* Implement https://github.com/marketplace/actions/publish-unit-test-results based on the instructions of the GitHub action page.
* Publish and download test results as GitHub artifacts to handle multi platform builds in the future.

## Testing
* Created a PR with a failing test, observed the behavior: https://github.com/Topl/Bifrost/runs/6478055413

## Tickets
_* closes #2125 _