### PR TITLE
Core 1169 fix warnings

### DIFF
--- a/node/src/main/scala/co/topl/consensus/KeyManager.scala
+++ b/node/src/main/scala/co/topl/consensus/KeyManager.scala
@@ -94,16 +94,17 @@ class KeyManager(settings: AppSettings)(implicit networkPrefix: NetworkPrefix) e
           StartupKeyView(addresses, newRewardAddress)
         }
 
-    addressGenerationSettings match {
-      case AddressGenerationSettings(_, AddressGenerationStrategies.None, _) =>
-        Success(StartupKeyView(keyRing.addresses, rewardAddress))
-      case AddressGenerationSettings(numAddr, AddressGenerationStrategies.FromSeed, seedOpt) =>
-        addKeys(numAddr, seedOpt)
-      case AddressGenerationSettings(numAddr, AddressGenerationStrategies.Random, _) =>
-        addKeys(numAddr, Some(SecureRandom.randomBytes().mkString))
-      case AddressGenerationSettings(numAddr, AddressGenerationStrategies.None, _)
-          if networkPrefix == PrivateTestnet.netPrefix =>
-        addKeys(numAddr, Some(SecureRandom.randomBytes().mkString))
+    addressGenerationSettings.strategy match {
+      case AddressGenerationStrategies.None =>
+        if (networkPrefix == PrivateTestnet.netPrefix) {
+          addKeys(addressGenerationSettings.numberOfAddresses, Some(SecureRandom.randomBytes().mkString))
+        } else {
+          Success(StartupKeyView(keyRing.addresses, rewardAddress))
+        }
+      case AddressGenerationStrategies.FromSeed =>
+        addKeys(addressGenerationSettings.numberOfAddresses, addressGenerationSettings.addressSeedOpt)
+      case AddressGenerationStrategies.Random =>
+        addKeys(addressGenerationSettings.numberOfAddresses, Some(SecureRandom.randomBytes().mkString))
     }
   }
 

--- a/node/src/main/scala/co/topl/settings/StartupOpts.scala
+++ b/node/src/main/scala/co/topl/settings/StartupOpts.scala
@@ -107,10 +107,13 @@ final case class RuntimeOpts(
       .modify(configPeers =>
         knownPeers match {
           case Some(peersString) =>
-            peersString.split(",").map { peer =>
-              val split = peer.split(":")
-              new InetSocketAddress(split(0), split(1).toInt)
-            }
+            peersString
+              .split(",")
+              .toIndexedSeq
+              .map { peer =>
+                val split = peer.split(":")
+                new InetSocketAddress(split(0), split(1).toInt)
+              }
           case None => configPeers
         }
       )


### PR DESCRIPTION
## Purpose
Clean up warnings that were introduced in the genesis refactor

## Approach
- modified pattern matching to be exhaustive

## Testing
- passes all unit tests
- compilation no longer has warnings

## Tickets
* #2066 