### PR TITLE
Tetra Syntactic Validation

### DIFF
--- a/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundSean.scala
+++ b/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundSean.scala
@@ -58,7 +58,7 @@ object CredentialPlaygroundSean extends App {
     """(ctx, args, utils) => ctx.currentSlot > 400""".stripMargin.jsProposition
 
   val script3Proposition =
-    """(ctx, args, utils) => ctx.currentTransaction.outputs[0].value.value == "10"""".stripMargin.jsProposition
+    """(ctx, args, utils) => ctx.currentTransaction.outputs[0].value.quantity == "10"""".stripMargin.jsProposition
 
   val script4Proposition =
     """(ctx, args, utils) => {

--- a/build.sbt
+++ b/build.sbt
@@ -507,7 +507,8 @@ lazy val ledger = project
   .settings(libraryDependencies ++= Dependencies.ledger)
   .settings(scalamacrosParadiseSettings)
   .dependsOn(
-    models % "compile->compile;test->test"
+    models % "compile->compile;test->test",
+    typeclasses
   )
 
 lazy val demo = project

--- a/build.sbt
+++ b/build.sbt
@@ -210,6 +210,7 @@ lazy val bifrost = project
     byteCodecs,
     tetraByteCodecs,
     consensus,
+    ledger,
     demo,
     tools,
     scripting,
@@ -490,6 +491,23 @@ lazy val networking = project
     commonInterpreters,
     catsAkka,
     eventTree
+  )
+
+lazy val ledger = project
+  .in(file("ledger"))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
+    name := "ledger",
+    commonSettings,
+    crossScalaVersions := Seq(scala213),
+    publishSettings,
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoPackage := "co.topl.buildinfo.ledger"
+  )
+  .settings(libraryDependencies ++= Dependencies.ledger)
+  .settings(scalamacrosParadiseSettings)
+  .dependsOn(
+    models % "compile->compile;test->test"
   )
 
 lazy val demo = project

--- a/common/src/main/scala/co/topl/modifier/ops/AssetOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/AssetOps.scala
@@ -19,7 +19,7 @@ class AssetOps(private val asset: Box.Values.Asset) extends AnyVal {
         Address(Evidence(asset.assetCode.issuer.typedEvidence.allBytes.toArray)),
         Latin1Data.fromData(asset.assetCode.shortName.data.bytes)
       ),
-      SecurityRoot(asset.securityRoot.toArray),
+      SecurityRoot(asset.securityRoot.data.toArray),
       asset.metadata.map(data => Latin1Data.fromData(data.data.bytes))
     )
 }

--- a/common/src/main/scala/co/topl/modifier/ops/AssetValueOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/AssetValueOps.scala
@@ -3,7 +3,7 @@ package co.topl.modifier.ops
 import cats.implicits._
 import co.topl.attestation.Address
 import co.topl.models.{Box, Bytes, FullAddress, SpendingAddress, Transaction}
-import co.topl.models.utility.HasLength.instances.{bigIntLength, latin1DataLength}
+import co.topl.models.utility.HasLength.instances.{bigIntLength, bytesLength, latin1DataLength}
 import co.topl.models.utility.{Lengths, Sized}
 import co.topl.modifier.box.AssetValue
 import co.topl.utils.{Int128 => DionInt128}
@@ -50,7 +50,7 @@ class AssetValueOps(private val assetValue: AssetValue) extends AnyVal {
             case ToTetraAssetCodeFailures.InvalidShortName(shortName) =>
               ToAssetOutputFailures.InvalidShortName(shortName)
           }
-      securityRoot = Bytes(assetValue.securityRoot.root)
+      securityRoot = Sized.strictUnsafe[Bytes, Lengths.`32`.type](Bytes(assetValue.securityRoot.root))
       metadata <-
         assetValue.metadata.traverse[ToAssetOutputResult, Sized.Max[Latin1Data, Lengths.`127`.type]](data =>
           Sized

--- a/common/src/main/scala/co/topl/modifier/ops/TetraTransactionOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/TetraTransactionOps.scala
@@ -321,7 +321,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
     transaction.outputs
       .traverse[ToDionTxResult, (Address, SimpleValue)] {
         case Transaction.Output(address, poly: TetraBox.Values.Poly, _) =>
-          (toAddress(address), SimpleValue(Int128(poly.value.data))).asRight
+          (toAddress(address), SimpleValue(Int128(poly.quantity.data))).asRight
         case invalidCoin => ToDionTxFailures.InvalidOutput(invalidCoin).asLeft
       }
 
@@ -329,7 +329,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
     transaction.outputs
       .traverse[ToDionTxResult, (Address, SimpleValue)] {
         case Transaction.Output(address, arbit: TetraBox.Values.Arbit, _) =>
-          (toAddress(address), SimpleValue(Int128(arbit.value.data))).asRight
+          (toAddress(address), SimpleValue(Int128(arbit.quantity.data))).asRight
         case invalidCoin => ToDionTxFailures.InvalidOutput(invalidCoin).asLeft
       }
 

--- a/common/src/main/scala/co/topl/modifier/ops/TetraTransactionOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/TetraTransactionOps.scala
@@ -346,7 +346,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
                 Address(Evidence(asset.assetCode.issuer.typedEvidence.allBytes.toArray))(???),
                 Latin1Data.fromData(asset.assetCode.shortName.data.bytes)
               ),
-              SecurityRoot(asset.securityRoot.toArray),
+              SecurityRoot(asset.securityRoot.data.toArray),
               asset.metadata.map(data => Latin1Data.fromData(data.data.bytes))
             ): TokenValueHolder
           ).asRight

--- a/common/src/main/scala/co/topl/modifier/transaction/builder/TransferBuilder.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/builder/TransferBuilder.scala
@@ -2,6 +2,8 @@ package co.topl.modifier.transaction.builder
 
 import cats.implicits._
 import co.topl.attestation.{Address, EvidenceProducer, Proposition}
+import co.topl.models.utility.HasLength.instances.bytesLength
+import co.topl.models.utility.Sized
 import co.topl.models.{Box => TetraBox, Bytes, FullAddress, Transaction}
 import co.topl.modifier.box._
 import co.topl.modifier.implicits._
@@ -386,7 +388,7 @@ object TransferBuilder {
           .map(assetCode =>
             Transaction.Output(
               consolidationAddress,
-              TetraBox.Values.Asset(asset._2.toSized, assetCode, Bytes.empty, None),
+              TetraBox.Values.Asset(asset._2.toSized, assetCode, Sized.strictUnsafe(Bytes.fill(32)(0: Byte)), None),
               minting
             )
           )

--- a/common/src/test/scala/co/topl/modifier/transaction/builder/package.scala
+++ b/common/src/test/scala/co/topl/modifier/transaction/builder/package.scala
@@ -9,12 +9,12 @@ package object builder {
 
   def arbitOutputsAmount(from: List[TetraTransaction.Output]): BigInt =
     from.collect { case TetraTransaction.Output(_, value: TetraBox.Values.Arbit, _) =>
-      value.value.data
+      value.quantity.data
     }.sum
 
   def polyOutputsAmount(from: List[TetraTransaction.Output]): BigInt =
     from.collect { case TetraTransaction.Output(_, value: TetraBox.Values.Poly, _) =>
-      value.value.data
+      value.quantity.data
     }.sum
 
   def boxesAmount(from: List[TokenBox[TokenValueHolder]]): BigInt =

--- a/common/src/test/scala/co/topl/modifier/transaction/ops/AssetValueOpsSpec.scala
+++ b/common/src/test/scala/co/topl/modifier/transaction/ops/AssetValueOpsSpec.scala
@@ -73,7 +73,7 @@ class AssetValueOpsSpec
           val Transaction.Output(_, v: TetraBox.Values.Asset, _) =
             assetValue.toAssetOutput(address, minting = true).value
 
-          v.securityRoot.toArray shouldBe assetValue.securityRoot.root
+          v.securityRoot.data.toArray shouldBe assetValue.securityRoot.root
         }
       }
 

--- a/common/src/test/scala/co/topl/modifier/transaction/ops/SimpleValueOpsSpec.scala
+++ b/common/src/test/scala/co/topl/modifier/transaction/ops/SimpleValueOpsSpec.scala
@@ -28,7 +28,7 @@ class SimpleValueOpsSpec
           val Transaction.Output(_, polyValue: TetraBox.Values.Poly, _) =
             simpleValue.toPolyOutput(address).value
 
-          polyValue.value.data shouldBe BigInt(simpleValue.quantity.toByteArray)
+          polyValue.quantity.data shouldBe BigInt(simpleValue.quantity.toByteArray)
         }
       }
 
@@ -53,7 +53,7 @@ class SimpleValueOpsSpec
 
           val arbitValue = v.asInstanceOf[TetraBox.Values.Arbit]
 
-          arbitValue.value.data shouldBe BigInt(simpleValue.quantity.toByteArray)
+          arbitValue.quantity.data shouldBe BigInt(simpleValue.quantity.toByteArray)
         }
       }
 

--- a/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
+++ b/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
@@ -318,13 +318,13 @@ trait ModelsJsonCodecs {
     _ => Json.Null
 
   implicit val polyBoxValueEncoder: Encoder[Box.Values.Poly] =
-    t => Json.obj("value" -> t.value.asJson)
+    t => Json.obj("value" -> t.quantity.asJson)
 
   implicit val polyBoxValueDecoder: Decoder[Box.Values.Poly] =
     hcursor => hcursor.downField("value").as[Int128].map(Box.Values.Poly)
 
   implicit val arbitBoxValueEncoder: Encoder[Box.Values.Arbit] =
-    t => Json.obj("value" -> t.value.asJson)
+    t => Json.obj("value" -> t.quantity.asJson)
 
   implicit val arbitBoxValueDecoder: Decoder[Box.Values.Arbit] =
     hcursor => hcursor.downField("value").as[Int128].map(Box.Values.Arbit)
@@ -376,7 +376,7 @@ trait ModelsJsonCodecs {
       case _: Box.Values.Poly                   => "Poly"
       case _: Box.Values.Arbit                  => "Arbit"
       case _: Box.Values.Asset                  => "Asset"
-      case _: Box.Values.Registrations.Operator => "Registration.Pool"
+      case _: Box.Values.Registrations.Operator => "Registration.Operator"
     }
 
   implicit val boxValueEncoder: Encoder[Box.Value] = {
@@ -416,10 +416,10 @@ trait ModelsJsonCodecs {
         valueType              <- hcursor.downField("valueType").as[String]
         valueJson = hcursor.downField("value")
         value <- valueType match {
-          case "Poly"              => valueJson.as[Box.Values.Poly]
-          case "Arbit"             => valueJson.as[Box.Values.Arbit]
-          case "Asset"             => valueJson.as[Box.Values.Asset]
-          case "Registration.Pool" => valueJson.as[Box.Values.Registrations.Operator]
+          case "Poly"                  => valueJson.as[Box.Values.Poly]
+          case "Arbit"                 => valueJson.as[Box.Values.Arbit]
+          case "Asset"                 => valueJson.as[Box.Values.Asset]
+          case "Registration.Operator" => valueJson.as[Box.Values.Registrations.Operator]
         }
       } yield Transaction.Input(transactionId, transactionOutputIndex, proposition, proof, value)
 

--- a/ledger/src/main/scala/co/topl/ledger/algebras/SyntacticValidationAlgebra.scala
+++ b/ledger/src/main/scala/co/topl/ledger/algebras/SyntacticValidationAlgebra.scala
@@ -1,6 +1,6 @@
 package co.topl.ledger.algebras
 
-import cats.data.ValidatedNec
+import cats.data.{Chain, ValidatedNec}
 import co.topl.models.{Box, Timestamp, Transaction}
 
 trait SyntacticValidationAlgebra[F[_]] {
@@ -17,4 +17,5 @@ object InvalidSyntaxErrors {
   case object EmptyInputs extends InvalidSyntaxError
   case class InvalidTimestamp(timestamp: Timestamp) extends InvalidSyntaxError
   case class NonPositiveOutputValue(outputValue: Box.Value) extends InvalidSyntaxError
+  case class InsufficientInputFunds[V <: Box.Value](inputs: Chain[V], outputs: Chain[V]) extends InvalidSyntaxError
 }

--- a/ledger/src/main/scala/co/topl/ledger/algebras/SyntacticValidationAlgebra.scala
+++ b/ledger/src/main/scala/co/topl/ledger/algebras/SyntacticValidationAlgebra.scala
@@ -1,0 +1,20 @@
+package co.topl.ledger.algebras
+
+import cats.data.ValidatedNec
+import co.topl.models.{Box, Timestamp, Transaction}
+
+trait SyntacticValidationAlgebra[F[_]] {
+
+  /**
+   * Determines the syntactic integrity of the given transaction
+   */
+  def validateSyntax(transaction: Transaction): F[ValidatedNec[InvalidSyntaxError, Transaction]]
+}
+
+sealed abstract class InvalidSyntaxError
+
+object InvalidSyntaxErrors {
+  case object EmptyInputs extends InvalidSyntaxError
+  case class InvalidTimestamp(timestamp: Timestamp) extends InvalidSyntaxError
+  case class NonPositiveOutputValue(outputValue: Box.Value) extends InvalidSyntaxError
+}

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/SyntacticValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/SyntacticValidation.scala
@@ -61,7 +61,7 @@ object SyntacticValidation {
       val (in, out) =
         (
           transaction.inputs.map(_.value).filter(f.isDefinedAt),
-          transaction.outputs.map(_.value).filter(f.isDefinedAt)
+          transaction.outputs.filterNot(_.minting).map(_.value).filter(f.isDefinedAt)
         )
       val outSum = out.map(f).sumAll
       val inSum = in.map(f).sumAll

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/SyntacticValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/SyntacticValidation.scala
@@ -1,78 +1,107 @@
 package co.topl.ledger.interpreters
 
-import cats.data.{NonEmptyChain, Validated, ValidatedNec}
+import cats.data.{Chain, NonEmptyChain, Validated, ValidatedNec}
 import cats.effect.Sync
 import cats.implicits._
 import co.topl.ledger.algebras.{InvalidSyntaxError, InvalidSyntaxErrors, SyntacticValidationAlgebra}
 import co.topl.models.{Box, Transaction}
+import co.topl.typeclasses.implicits._
 
 object SyntacticValidation {
 
   def make[F[_]: Sync]: F[SyntacticValidationAlgebra[F]] =
     Sync[F].delay(
       (
-        transaction =>
-          Sync[F].delay(
-            NonEmptyChain(
-              nonEmptyInputsValidation _,
-              positiveTimestampValidation _,
-              positiveOutputValuesValidation _,
-              sufficientFundsValidation _
-            ).ap(transaction.pure[NonEmptyChain])
-              .foldMap(_.void)
-              .as(transaction)
-          )
+        transaction => Sync[F].delay(validators.ap(transaction.pure[Chain]).combineAll.as(transaction))
       ): SyntacticValidationAlgebra[F]
     )
 
-  private def nonEmptyInputsValidation(transaction: Transaction): ValidatedNec[InvalidSyntaxError, Transaction] =
-    Validated.condNec(transaction.inputs.nonEmpty, transaction, InvalidSyntaxErrors.EmptyInputs: InvalidSyntaxError)
+  private val validators: Chain[Transaction => ValidatedNec[InvalidSyntaxError, Unit]] =
+    Chain(
+      nonEmptyInputsValidation,
+      positiveTimestampValidation,
+      positiveOutputValuesValidation,
+      sufficientFundsValidation
+    )
 
-  private def positiveTimestampValidation(transaction: Transaction): ValidatedNec[InvalidSyntaxError, Transaction] =
+  /**
+   * Verify that this transaction contains at least one input
+   */
+  private def nonEmptyInputsValidation(transaction: Transaction): ValidatedNec[InvalidSyntaxError, Unit] =
+    Validated.condNec(transaction.inputs.nonEmpty, (), InvalidSyntaxErrors.EmptyInputs: InvalidSyntaxError)
+
+  /**
+   * Verify that the timestamp of the transaction is positive (greater than 0).  Transactions _can_ be created
+   * in the past.
+   */
+  private def positiveTimestampValidation(transaction: Transaction): ValidatedNec[InvalidSyntaxError, Unit] =
     Validated.condNec(
       transaction.timestamp > 0,
-      transaction,
+      (),
       InvalidSyntaxErrors.InvalidTimestamp(transaction.timestamp): InvalidSyntaxError
     )
 
+  /**
+   * Verify that each transaction output contains a positive quantity (where applicable)
+   */
   private def positiveOutputValuesValidation(
     transaction: Transaction
-  ): ValidatedNec[InvalidSyntaxError, Transaction] = {
-    def validateByValueType(f: PartialFunction[Box.Value, BigInt]): ValidatedNec[InvalidSyntaxError, Unit] =
-      transaction.outputs
-        .map(_.value)
-        .collect {
-          case t if f.isDefinedAt(t) =>
-            Validated.condNec(f(t) > BigInt(0), (), InvalidSyntaxErrors.NonPositiveOutputValue(t): InvalidSyntaxError)
-        }
-        .combineAllOption
-        .getOrElse(Validated.validNec(()))
-
-    NonEmptyChain(
-      validateByValueType { case Box.Values.Poly(quantity) => quantity.data },
-      validateByValueType { case Box.Values.Arbit(quantity) => quantity.data },
-      validateByValueType { case a: Box.Values.Asset => a.quantity.data }
-    ).combineAll
-      .as(transaction)
-  }
-
-  private def sufficientFundsValidation(transaction: Transaction): ValidatedNec[InvalidSyntaxError, Transaction] = {
-    def validateByValueType(f: PartialFunction[Box.Value, BigInt]): ValidatedNec[InvalidSyntaxError, Unit] = {
-      val (in, out) =
-        (
-          transaction.inputs.map(_.value).filter(f.isDefinedAt),
-          transaction.outputs.filterNot(_.minting).map(_.value).filter(f.isDefinedAt)
+  ): ValidatedNec[InvalidSyntaxError, Unit] =
+    transaction.outputs
+      .foldMap(output =>
+        (output.value match {
+          case t: Box.Values.Poly  => t.quantity.data.some
+          case t: Box.Values.Arbit => t.quantity.data.some
+          case t: Box.Values.Asset => t.quantity.data.some
+          case _                   => none
+        }).foldMap(quantity =>
+          Validated
+            .condNec(
+              quantity > BigInt(0),
+              (),
+              InvalidSyntaxErrors.NonPositiveOutputValue(output.value): InvalidSyntaxError
+            )
         )
-      val outSum = out.map(f).sumAll
-      val inSum = in.map(f).sumAll
-      Validated.condNec(inSum >= outSum, (), InvalidSyntaxErrors.InsufficientInputFunds(in, out): InvalidSyntaxError)
+      )
+
+  /**
+   * Ensure the input value quantities exceed or equal the (non-minting) output value quantities
+   */
+  private def sufficientFundsValidation(transaction: Transaction): ValidatedNec[InvalidSyntaxError, Unit] =
+    quantityBasedValidation(transaction) { f =>
+      val filteredInputs = transaction.inputs.map(_.value).filter(f.isDefinedAt)
+      val filteredOutputs = transaction.outputs.filterNot(_.minting).map(_.value).filter(f.isDefinedAt)
+      val inputsSum = filteredInputs.map(f).sumAll
+      val outputsSum = filteredOutputs.map(f).sumAll
+      Validated.condNec(
+        inputsSum >= outputsSum,
+        (),
+        InvalidSyntaxErrors.InsufficientInputFunds(filteredInputs, filteredOutputs): InvalidSyntaxError
+      )
     }
+
+  /**
+   * Perform validation based on the quantities of boxes grouped by type
+   * @param f an extractor function which retrieves a BigInt from a Box.Value
+   */
+  private def quantityBasedValidation(transaction: Transaction)(
+    f: PartialFunction[Box.Value, BigInt] => ValidatedNec[InvalidSyntaxError, Unit]
+  ): ValidatedNec[InvalidSyntaxError, Unit] =
     NonEmptyChain(
-      validateByValueType { case Box.Values.Poly(quantity) => quantity.data },
-      validateByValueType { case Box.Values.Arbit(quantity) => quantity.data },
-      validateByValueType { case a: Box.Values.Asset => a.quantity.data }
-    )
-      .foldMap(_.void)
-      .as(transaction)
-  }
+      // Extract all Poly values and their quantities
+      f { case Box.Values.Poly(quantity) => quantity.data },
+      // Extract all Asset values and their quantities
+      f { case Box.Values.Arbit(quantity) => quantity.data }
+    ).appendChain(
+      // Extract all Asset values (grouped by asset code) and their quantities
+      Chain.fromSeq(
+        (transaction.inputs.map(_.value) ++ transaction.outputs.map(_.value))
+          .collect { case a: Box.Values.Asset =>
+            a.assetCode
+          }
+          .toList
+          .distinct
+          .map(code => f { case a: Box.Values.Asset if a.assetCode === code => a.quantity.data })
+      )
+    ).combineAll
 }

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/SyntacticValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/SyntacticValidation.scala
@@ -1,0 +1,65 @@
+package co.topl.ledger.interpreters
+
+import cats.implicits._
+import cats.data.{Validated, ValidatedNec}
+import cats.effect.Sync
+import co.topl.ledger.algebras.InvalidSyntaxErrors.NonPositiveOutputValue
+import co.topl.ledger.algebras.{InvalidSyntaxError, InvalidSyntaxErrors, SyntacticValidationAlgebra}
+import co.topl.models.{Box, Transaction}
+
+object SyntacticValidation {
+
+  def make[F[_]: Sync]: F[SyntacticValidationAlgebra[F]] =
+    Sync[F].delay(
+      (
+        transaction =>
+          Sync[F].delay(
+            (
+              nonEmptyInputsValidation(transaction),
+              positiveTimestampValidation(transaction),
+              positiveOutputValuesValidation(transaction)
+            ).tupled
+              .as(transaction)
+          )
+      ): SyntacticValidationAlgebra[F]
+    )
+
+  private def nonEmptyInputsValidation(transaction: Transaction) =
+    Validated.condNec(transaction.inputs.nonEmpty, transaction, InvalidSyntaxErrors.EmptyInputs: InvalidSyntaxError)
+
+  private def positiveTimestampValidation(transaction: Transaction) =
+    Validated.condNec(
+      transaction.timestamp > 0,
+      transaction,
+      InvalidSyntaxErrors.InvalidTimestamp(transaction.timestamp): InvalidSyntaxError
+    )
+
+  private def positiveOutputValuesValidation(transaction: Transaction): ValidatedNec[InvalidSyntaxError, Transaction] =
+    transaction.outputs
+      .map(output =>
+        output.value match {
+          case Box.Values.Poly(quantity) =>
+            Validated.condNec(
+              quantity.data > BigInt(0L),
+              (),
+              NonPositiveOutputValue(output.value): InvalidSyntaxError
+            )
+          case Box.Values.Arbit(quantity) =>
+            Validated.condNec(
+              quantity.data > BigInt(0L),
+              (),
+              NonPositiveOutputValue(output.value): InvalidSyntaxError
+            )
+          case Box.Values.Asset(quantity, _, _, _) =>
+            Validated.condNec(
+              quantity.data > BigInt(0L),
+              (),
+              NonPositiveOutputValue(output.value): InvalidSyntaxError
+            )
+          case _ =>
+            Validated.validNec(())
+        }
+      )
+      .combineAll
+      .as(transaction)
+}

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/SyntacticValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/SyntacticValidation.scala
@@ -1,9 +1,8 @@
 package co.topl.ledger.interpreters
 
-import cats.implicits._
-import cats.data.{Validated, ValidatedNec}
+import cats.data.{NonEmptyChain, Validated, ValidatedNec}
 import cats.effect.Sync
-import co.topl.ledger.algebras.InvalidSyntaxErrors.NonPositiveOutputValue
+import cats.implicits._
 import co.topl.ledger.algebras.{InvalidSyntaxError, InvalidSyntaxErrors, SyntacticValidationAlgebra}
 import co.topl.models.{Box, Transaction}
 
@@ -14,52 +13,66 @@ object SyntacticValidation {
       (
         transaction =>
           Sync[F].delay(
-            (
-              nonEmptyInputsValidation(transaction),
-              positiveTimestampValidation(transaction),
-              positiveOutputValuesValidation(transaction)
-            ).tupled
+            NonEmptyChain(
+              nonEmptyInputsValidation _,
+              positiveTimestampValidation _,
+              positiveOutputValuesValidation _,
+              sufficientFundsValidation _
+            ).ap(transaction.pure[NonEmptyChain])
+              .foldMap(_.void)
               .as(transaction)
           )
       ): SyntacticValidationAlgebra[F]
     )
 
-  private def nonEmptyInputsValidation(transaction: Transaction) =
+  private def nonEmptyInputsValidation(transaction: Transaction): ValidatedNec[InvalidSyntaxError, Transaction] =
     Validated.condNec(transaction.inputs.nonEmpty, transaction, InvalidSyntaxErrors.EmptyInputs: InvalidSyntaxError)
 
-  private def positiveTimestampValidation(transaction: Transaction) =
+  private def positiveTimestampValidation(transaction: Transaction): ValidatedNec[InvalidSyntaxError, Transaction] =
     Validated.condNec(
       transaction.timestamp > 0,
       transaction,
       InvalidSyntaxErrors.InvalidTimestamp(transaction.timestamp): InvalidSyntaxError
     )
 
-  private def positiveOutputValuesValidation(transaction: Transaction): ValidatedNec[InvalidSyntaxError, Transaction] =
-    transaction.outputs
-      .map(output =>
-        output.value match {
-          case Box.Values.Poly(quantity) =>
-            Validated.condNec(
-              quantity.data > BigInt(0L),
-              (),
-              NonPositiveOutputValue(output.value): InvalidSyntaxError
-            )
-          case Box.Values.Arbit(quantity) =>
-            Validated.condNec(
-              quantity.data > BigInt(0L),
-              (),
-              NonPositiveOutputValue(output.value): InvalidSyntaxError
-            )
-          case Box.Values.Asset(quantity, _, _, _) =>
-            Validated.condNec(
-              quantity.data > BigInt(0L),
-              (),
-              NonPositiveOutputValue(output.value): InvalidSyntaxError
-            )
-          case _ =>
-            Validated.validNec(())
+  private def positiveOutputValuesValidation(
+    transaction: Transaction
+  ): ValidatedNec[InvalidSyntaxError, Transaction] = {
+    def validateByValueType(f: PartialFunction[Box.Value, BigInt]): ValidatedNec[InvalidSyntaxError, Unit] =
+      transaction.outputs
+        .map(_.value)
+        .collect {
+          case t if f.isDefinedAt(t) =>
+            Validated.condNec(f(t) > BigInt(0), (), InvalidSyntaxErrors.NonPositiveOutputValue(t): InvalidSyntaxError)
         }
-      )
-      .combineAll
+        .combineAllOption
+        .getOrElse(Validated.validNec(()))
+
+    NonEmptyChain(
+      validateByValueType { case Box.Values.Poly(quantity) => quantity.data },
+      validateByValueType { case Box.Values.Arbit(quantity) => quantity.data },
+      validateByValueType { case a: Box.Values.Asset => a.quantity.data }
+    ).combineAll
       .as(transaction)
+  }
+
+  private def sufficientFundsValidation(transaction: Transaction): ValidatedNec[InvalidSyntaxError, Transaction] = {
+    def validateByValueType(f: PartialFunction[Box.Value, BigInt]): ValidatedNec[InvalidSyntaxError, Unit] = {
+      val (in, out) =
+        (
+          transaction.inputs.map(_.value).filter(f.isDefinedAt),
+          transaction.outputs.map(_.value).filter(f.isDefinedAt)
+        )
+      val outSum = out.map(f).sumAll
+      val inSum = in.map(f).sumAll
+      Validated.condNec(inSum >= outSum, (), InvalidSyntaxErrors.InsufficientInputFunds(in, out): InvalidSyntaxError)
+    }
+    NonEmptyChain(
+      validateByValueType { case Box.Values.Poly(quantity) => quantity.data },
+      validateByValueType { case Box.Values.Arbit(quantity) => quantity.data },
+      validateByValueType { case a: Box.Values.Asset => a.quantity.data }
+    )
+      .foldMap(_.void)
+      .as(transaction)
+  }
 }

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/SyntacticValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/SyntacticValidationSpec.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import co.topl.ledger.algebras.InvalidSyntaxErrors
 import co.topl.models.ModelGenerators._
 import co.topl.models.utility.HasLength.instances.bigIntLength
-import co.topl.models.utility.{Lengths, Sized}
+import co.topl.models.utility.Sized
 import co.topl.models.{Box, Transaction}
 import org.scalacheck.Gen
 import org.scalatest.EitherValues

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/SyntacticValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/SyntacticValidationSpec.scala
@@ -1,15 +1,15 @@
 package co.topl.ledger.interpreters
 
-import cats.implicits._
 import cats.data.Chain
 import cats.effect._
 import cats.effect.unsafe.implicits.global
+import cats.implicits._
 import co.topl.ledger.algebras.InvalidSyntaxErrors
 import co.topl.models.ModelGenerators._
 import co.topl.models.utility.HasLength.instances.bigIntLength
-import co.topl.models.utility.Sized
+import co.topl.models.utility.{Lengths, Sized}
 import co.topl.models.{Box, Transaction}
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Gen
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -44,31 +44,31 @@ class SyntacticValidationSpec extends AnyFlatSpec with Matchers with ScalaCheckP
   }
 
   it should "validate positive output quantities" in {
-    val negativeBoxValueGen =
-      arbitraryBoxValue.arbitrary.map {
-        case Box.Values.Poly(_)  => Box.Values.Poly(Sized.maxUnsafe(BigInt(-1)))
-        case Box.Values.Arbit(_) => Box.Values.Arbit(Sized.maxUnsafe(BigInt(-1)))
-        case a: Box.Values.Asset => a.copy(quantity = Sized.maxUnsafe(BigInt(-1)))
-        case v                   => v
+    val boxValueGen =
+      arbitraryBoxValue.arbitrary.flatMap {
+        case Box.Values.Poly(_)  => arbitraryInt128.arbitrary.map(Box.Values.Poly)
+        case Box.Values.Arbit(_) => arbitraryInt128.arbitrary.map(Box.Values.Arbit)
+        case a: Box.Values.Asset => arbitraryInt128.arbitrary.map(q => a.copy(quantity = q))
+        case v                   => Gen.const(v)
       }
-    val negativeOutputGen =
+    val outputGen =
       for {
         o <- arbitraryTransactionOutput.arbitrary
-        v <- negativeBoxValueGen
+        v <- boxValueGen
       } yield o.copy(value = v)
     val negativeTransactionGen =
       for {
         tx      <- arbitraryTransaction.arbitrary
-        outputs <- nonEmptyChainOf(negativeOutputGen)
-      } yield tx.copy(outputs = outputs.toChain)
+        outputs <- Gen.listOf(outputGen)
+      } yield tx.copy(outputs = Chain.fromSeq(outputs))
 
     forAll(negativeTransactionGen) { transaction: Transaction =>
       whenever(
         transaction.outputs.exists(o =>
           o.value match {
-            case v: Box.Values.Poly  => true
-            case v: Box.Values.Arbit => true
-            case v: Box.Values.Asset => true
+            case v: Box.Values.Poly  => v.quantity.data <= 0
+            case v: Box.Values.Arbit => v.quantity.data <= 0
+            case v: Box.Values.Asset => v.quantity.data <= 0
             case _                   => false
           }
         )
@@ -87,64 +87,125 @@ class SyntacticValidationSpec extends AnyFlatSpec with Matchers with ScalaCheckP
   }
 
   it should "validate sufficient input funds" in {
-    def typedInGen[T <: Box.Value: Arbitrary] =
-      for {
-        o <- arbitraryTransactionInput.arbitrary
-        v <- implicitly[Arbitrary[T]].arbitrary
-      } yield o.copy(value = v)
-    def typedOutGen[T <: Box.Value: Arbitrary] =
-      for {
-        o       <- arbitraryTransactionOutput.arbitrary
-        v       <- implicitly[Arbitrary[T]].arbitrary
-        minting <- Gen.prob(0.05)
-      } yield o.copy(value = v, minting = minting)
-    def txGen[T <: Box.Value: Arbitrary] =
-      for {
-        tx      <- arbitraryTransaction.arbitrary
-        inputs  <- Gen.listOf(typedInGen[T])
-        outputs <- Gen.listOf(typedOutGen[T])
-      } yield tx.copy(inputs = Chain.fromSeq(inputs), outputs = Chain.fromSeq(outputs))
-
-    def runTest[T <: Box.Value: Arbitrary](quantity: T => BigInt) = {
-      forAll(txGen[T], maxDiscardedFactor(100)) { transaction: Transaction =>
+    // Manual tests
+    forAll { (baseTransaction: Transaction, input: Transaction.Input, output: Transaction.Output) =>
+      // Poly Test
+      {
+        val tx = baseTransaction.copy(
+          inputs = Chain(
+            input.copy(value = Box.Values.Poly(Sized.maxUnsafe(BigInt(1))))
+          ),
+          outputs = Chain(
+            output.copy(value = Box.Values.Poly(Sized.maxUnsafe(BigInt(2))), minting = false)
+          )
+        )
         val result = SyntacticValidation
           .make[F]
-          .flatMap(_.validateSyntax(transaction))
+          .flatMap(_.validateSyntax(tx))
           .unsafeRunSync()
-        val inSum = transaction.inputs.map(_.value.asInstanceOf[T]).map(quantity).sumAll
-        val outSum = transaction.outputs.filterNot(_.minting).map(_.value.asInstanceOf[T]).map(quantity).sumAll
-        whenever(outSum > inSum)(
-          result.toEither.left.value.exists {
-            case _: InvalidSyntaxErrors.InsufficientInputFunds[_] => true
-            case _                                                => false
-          } shouldBe true
-        )
+        result.toEither.left.value.exists {
+          case _: InvalidSyntaxErrors.InsufficientInputFunds[_] => true
+          case _                                                => false
+        } shouldBe true
       }
-      forAll(txGen[T], maxDiscardedFactor(100)) { transaction: Transaction =>
+      // Arbit Test
+      {
+        val tx = baseTransaction.copy(
+          inputs = Chain(
+            input.copy(value = Box.Values.Arbit(Sized.maxUnsafe(BigInt(1))))
+          ),
+          outputs = Chain(
+            output.copy(value = Box.Values.Arbit(Sized.maxUnsafe(BigInt(2))), minting = false)
+          )
+        )
         val result = SyntacticValidation
           .make[F]
-          .flatMap(_.validateSyntax(transaction))
+          .flatMap(_.validateSyntax(tx))
           .unsafeRunSync()
-        val inSum = transaction.inputs.map(_.value.asInstanceOf[T]).map(quantity).sumAll
-        val outSum = transaction.outputs.filterNot(_.minting).map(_.value.asInstanceOf[T]).map(quantity).sumAll
-        whenever(inSum >= outSum)(
-          result.toEither match {
-            case Right(_) =>
-              assert(true)
-            case Left(errors) =>
-              assert(
-                !errors.exists {
-                  case _: InvalidSyntaxErrors.InsufficientInputFunds[_] => true
-                  case _                                                => false
-                }
-              )
-          }
+        result.toEither.left.value.exists {
+          case _: InvalidSyntaxErrors.InsufficientInputFunds[_] => true
+          case _                                                => false
+        } shouldBe true
+      }
+      // Asset Test
+      {
+        val assetCode = arbitraryAssetCode.arbitrary.first
+        val tx = baseTransaction.copy(
+          inputs = Chain(
+            input.copy(value =
+              arbitraryAssetBox.arbitrary.first.copy(quantity = Sized.maxUnsafe(BigInt(1)), assetCode = assetCode)
+            )
+          ),
+          outputs = Chain(
+            output.copy(
+              value =
+                arbitraryAssetBox.arbitrary.first.copy(quantity = Sized.maxUnsafe(BigInt(2)), assetCode = assetCode),
+              minting = false
+            )
+          )
         )
+        val result = SyntacticValidation
+          .make[F]
+          .flatMap(_.validateSyntax(tx))
+          .unsafeRunSync()
+        result.toEither.left.value.exists {
+          case _: InvalidSyntaxErrors.InsufficientInputFunds[_] => true
+          case _                                                => false
+        } shouldBe true
       }
     }
 
-    runTest[Box.Values.Poly](_.quantity.data)
-    runTest[Box.Values.Arbit](_.quantity.data)
-    runTest[Box.Values.Asset](_.quantity.data)
+    // Arbitrary/generator tests
+    forAll(arbitraryTransaction.arbitrary, maxDiscardedFactor(100)) { transaction: Transaction =>
+      val result = SyntacticValidation
+        .make[F]
+        .flatMap(_.validateSyntax(transaction))
+        .unsafeRunSync()
+
+      val polyInSum =
+        transaction.inputs.collect { case Transaction.Input(_, _, _, _, Box.Values.Poly(quantity)) =>
+          quantity.data
+        }.sumAll
+      val polyOutSum =
+        transaction.outputs.collect { case Transaction.Output(_, Box.Values.Poly(quantity), false) =>
+          quantity.data
+        }.sumAll
+      whenever(polyOutSum > polyInSum) {
+        result.toEither.left.value.exists {
+          case _: InvalidSyntaxErrors.InsufficientInputFunds[_] => true
+          case _                                                => false
+        } shouldBe true
+      }
+
+      val arbitInSum =
+        transaction.inputs.collect { case Transaction.Input(_, _, _, _, Box.Values.Arbit(quantity)) =>
+          quantity.data
+        }.sumAll
+      val arbitOutSum =
+        transaction.outputs.collect { case Transaction.Output(_, Box.Values.Arbit(quantity), false) =>
+          quantity.data
+        }.sumAll
+      whenever(arbitOutSum > arbitInSum) {
+        result.toEither.left.value.exists {
+          case _: InvalidSyntaxErrors.InsufficientInputFunds[_] => true
+          case _                                                => false
+        } shouldBe true
+      }
+
+      val assetInSum =
+        transaction.inputs.collect { case Transaction.Input(_, _, _, _, v: Box.Values.Asset) =>
+          v.quantity.data
+        }.sumAll
+      val assetOutSum =
+        transaction.outputs.collect { case Transaction.Output(_, v: Box.Values.Asset, false) =>
+          v.quantity.data
+        }.sumAll
+      whenever(assetOutSum > assetInSum) {
+        result.toEither.left.value.exists {
+          case _: InvalidSyntaxErrors.InsufficientInputFunds[_] => true
+          case _                                                => false
+        } shouldBe true
+      }
+    }
   }
 }

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/SyntacticValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/SyntacticValidationSpec.scala
@@ -111,7 +111,7 @@ class SyntacticValidationSpec extends AnyFlatSpec with Matchers with ScalaCheckP
           .flatMap(_.validateSyntax(transaction))
           .unsafeRunSync()
         val inSum = transaction.inputs.map(_.value.asInstanceOf[T]).map(quantity).sumAll
-        val outSum = transaction.outputs.map(_.value.asInstanceOf[T]).map(quantity).sumAll
+        val outSum = transaction.outputs.filterNot(_.minting).map(_.value.asInstanceOf[T]).map(quantity).sumAll
         whenever(outSum > inSum)(
           result.toEither.left.value.exists {
             case _: InvalidSyntaxErrors.InsufficientInputFunds[_] => true
@@ -125,7 +125,7 @@ class SyntacticValidationSpec extends AnyFlatSpec with Matchers with ScalaCheckP
           .flatMap(_.validateSyntax(transaction))
           .unsafeRunSync()
         val inSum = transaction.inputs.map(_.value.asInstanceOf[T]).map(quantity).sumAll
-        val outSum = transaction.outputs.map(_.value.asInstanceOf[T]).map(quantity).sumAll
+        val outSum = transaction.outputs.filterNot(_.minting).map(_.value.asInstanceOf[T]).map(quantity).sumAll
         whenever(inSum >= outSum)(
           result.toEither match {
             case Right(_) =>

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/SyntacticValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/SyntacticValidationSpec.scala
@@ -1,5 +1,6 @@
 package co.topl.ledger.interpreters
 
+import cats.implicits._
 import cats.data.Chain
 import cats.effect._
 import cats.effect.unsafe.implicits.global
@@ -8,6 +9,7 @@ import co.topl.models.ModelGenerators._
 import co.topl.models.utility.HasLength.instances.bigIntLength
 import co.topl.models.utility.Sized
 import co.topl.models.{Box, Transaction}
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -71,5 +73,66 @@ class SyntacticValidationSpec extends AnyFlatSpec with Matchers with ScalaCheckP
         case _                                             => false
       } shouldBe true
     }
+  }
+
+  it should "validate sufficient input funds" in {
+    def typedInGen[T <: Box.Value: Arbitrary] =
+      for {
+        o <- arbitraryTransactionInput.arbitrary
+        v <- implicitly[Arbitrary[T]].arbitrary
+      } yield o.copy(value = v)
+    def typedOutGen[T <: Box.Value: Arbitrary] =
+      for {
+        o <- arbitraryTransactionOutput.arbitrary
+        v <- implicitly[Arbitrary[T]].arbitrary
+      } yield o.copy(value = v)
+    def txGen[T <: Box.Value: Arbitrary] =
+      for {
+        tx      <- arbitraryTransaction.arbitrary
+        inputs  <- Gen.listOf(typedInGen[T])
+        outputs <- Gen.listOf(typedOutGen[T])
+      } yield tx.copy(inputs = Chain.fromSeq(inputs), outputs = Chain.fromSeq(outputs))
+
+    def runTest[T <: Box.Value: Arbitrary](quantity: T => BigInt) = {
+      forAll(txGen[T]) { transaction: Transaction =>
+        val result = SyntacticValidation
+          .make[F]
+          .flatMap(_.validateSyntax(transaction))
+          .unsafeRunSync()
+        val inSum = transaction.inputs.map(_.value.asInstanceOf[T]).map(quantity).sumAll
+        val outSum = transaction.outputs.map(_.value.asInstanceOf[T]).map(quantity).sumAll
+        whenever(outSum > inSum)(
+          result.toEither.left.value.exists {
+            case _: InvalidSyntaxErrors.InsufficientInputFunds[_] => true
+            case _                                                => false
+          } shouldBe true
+        )
+      }
+      forAll(txGen[T]) { transaction: Transaction =>
+        val result = SyntacticValidation
+          .make[F]
+          .flatMap(_.validateSyntax(transaction))
+          .unsafeRunSync()
+        val inSum = transaction.inputs.map(_.value.asInstanceOf[T]).map(quantity).sumAll
+        val outSum = transaction.outputs.map(_.value.asInstanceOf[T]).map(quantity).sumAll
+        whenever(inSum >= outSum)(
+          result.toEither match {
+            case Right(_) =>
+              assert(true)
+            case Left(errors) =>
+              assert(
+                !errors.exists {
+                  case _: InvalidSyntaxErrors.InsufficientInputFunds[_] => true
+                  case _                                                => false
+                }
+              )
+          }
+        )
+      }
+    }
+
+    runTest[Box.Values.Poly](_.quantity.data)
+    runTest[Box.Values.Arbit](_.quantity.data)
+    runTest[Box.Values.Asset](_.quantity.data)
   }
 }

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/SyntacticValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/SyntacticValidationSpec.scala
@@ -1,0 +1,75 @@
+package co.topl.ledger.interpreters
+
+import cats.data.Chain
+import cats.effect._
+import cats.effect.unsafe.implicits.global
+import co.topl.ledger.algebras.InvalidSyntaxErrors
+import co.topl.models.ModelGenerators._
+import co.topl.models.utility.HasLength.instances.bigIntLength
+import co.topl.models.utility.Sized
+import co.topl.models.{Box, Transaction}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class SyntacticValidationSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks with EitherValues {
+
+  type F[A] = IO[A]
+
+  behavior of "SyntacticValidation"
+
+  it should "validate non-empty inputs" in {
+    forAll(arbitraryTransaction.arbitrary.map(_.copy(inputs = Chain.empty))) { transaction: Transaction =>
+      val result = SyntacticValidation
+        .make[F]
+        .flatMap(_.validateSyntax(transaction))
+        .unsafeRunSync()
+
+      result.toEither.left.value.toChain.toList should contain(InvalidSyntaxErrors.EmptyInputs)
+    }
+  }
+
+  it should "validate positive timestamp" in {
+    forAll(arbitraryTransaction.arbitrary.map(_.copy(timestamp = -1))) { transaction: Transaction =>
+      val result = SyntacticValidation
+        .make[F]
+        .flatMap(_.validateSyntax(transaction))
+        .unsafeRunSync()
+
+      result.toEither.left.value.toChain.toList should contain(InvalidSyntaxErrors.InvalidTimestamp(-1))
+    }
+  }
+
+  it should "validate positive output quantities" in {
+    val negativeBoxValueGen =
+      arbitraryBoxValue.arbitrary.map {
+        case Box.Values.Poly(_)  => Box.Values.Poly(Sized.maxUnsafe(BigInt(-1)))
+        case Box.Values.Arbit(_) => Box.Values.Arbit(Sized.maxUnsafe(BigInt(-1)))
+        case a: Box.Values.Asset => a.copy(quantity = Sized.maxUnsafe(BigInt(-1)))
+        case v                   => v
+      }
+    val negativeOutputGen =
+      for {
+        o <- arbitraryTransactionOutput.arbitrary
+        v <- negativeBoxValueGen
+      } yield o.copy(value = v)
+    val negativeTransactionGen =
+      for {
+        tx      <- arbitraryTransaction.arbitrary
+        outputs <- nonEmptyChainOf(negativeOutputGen)
+      } yield tx.copy(outputs = outputs.toChain)
+
+    forAll(negativeTransactionGen) { transaction: Transaction =>
+      val result = SyntacticValidation
+        .make[F]
+        .flatMap(_.validateSyntax(transaction))
+        .unsafeRunSync()
+
+      result.toEither.left.value.exists {
+        case _: InvalidSyntaxErrors.NonPositiveOutputValue => true
+        case _                                             => false
+      } shouldBe true
+    }
+  }
+}

--- a/models/src/main/scala/co/topl/models/Box.scala
+++ b/models/src/main/scala/co/topl/models/Box.scala
@@ -10,14 +10,14 @@ object Box {
 
   object Values {
     case object Empty extends Value
-    case class Poly(value: Int128) extends Value
-    case class Arbit(value: Int128) extends Value
+    case class Poly(quantity: Int128) extends Value
+    case class Arbit(quantity: Int128) extends Value
 
     // TODO: AssetV1
     case class Asset(
       quantity:     Int128,
       assetCode:    Asset.Code,
-      securityRoot: Bytes,
+      securityRoot: Sized.Strict[Bytes, Lengths.`32`.type],
       metadata:     Option[Sized.Max[Latin1Data, Lengths.`127`.type]]
     ) extends Value
 

--- a/models/src/test/scala/co/topl/models/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/ModelGenerators.scala
@@ -356,12 +356,18 @@ trait ModelGenerators {
       } yield box
     )
 
+  implicit val arbitraryPolyBox: Arbitrary[Box.Values.Poly] =
+    Arbitrary(arbitraryPositiveInt128.arbitrary.map(Box.Values.Poly))
+
+  implicit val arbitraryArbitBox: Arbitrary[Box.Values.Arbit] =
+    Arbitrary(arbitraryPositiveInt128.arbitrary.map(Box.Values.Arbit))
+
   implicit val arbitraryBoxValue: Arbitrary[Box.Value] =
     Arbitrary(
       Gen.oneOf(
         Gen.const(Box.Values.Empty),
-        arbitraryPositiveInt128.arbitrary.map(Box.Values.Poly),
-        arbitraryPositiveInt128.arbitrary.map(Box.Values.Arbit),
+        arbitraryPolyBox.arbitrary,
+        arbitraryArbitBox.arbitrary,
         arbitraryAssetBox.arbitrary
       )
     )

--- a/models/src/test/scala/co/topl/models/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/ModelGenerators.scala
@@ -345,14 +345,14 @@ trait ModelGenerators {
       for {
         quantity <- arbitraryPositiveInt128.arbitrary
         code     <- arbitraryAssetCode.arbitrary
-        root     <- genSizedStrictBytes[Lengths.`32`.type]().map(_.data)
+        root     <- genSizedStrictBytes[Lengths.`32`.type]()
         metadata <-
           Gen.option(
             latin1DataGen
               .map(data => Latin1Data.unsafe(data.value.take(127)))
               .map(data => Sized.maxUnsafe[Latin1Data, Lengths.`127`.type](data))
           )
-        box = Box.Values.Asset(quantity, code, root, None)
+        box = Box.Values.Asset(quantity, code, root, metadata)
       } yield box
     )
 

--- a/models/src/test/scala/co/topl/models/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/ModelGenerators.scala
@@ -385,7 +385,7 @@ trait ModelGenerators {
       for {
         address <- arbitraryFullAddress.arbitrary
         value   <- arbitraryBoxValue.arbitrary
-        minting <- Gen.prob(0.5)
+        minting <- Gen.prob(0.05)
       } yield Transaction.Output(address, value, minting)
     )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -259,6 +259,9 @@ object Dependencies {
       Dependencies.akka("stream-testkit") % Test
     ) ++ fleam
 
+  lazy val ledger: Seq[ModuleID] =
+    Dependencies.test ++ Dependencies.catsEffect
+
   lazy val demo: Seq[ModuleID] =
     Seq(akka("actor"), akka("actor-typed"), akka("stream")) ++ logging
 

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -223,7 +223,7 @@ trait TetraScodecBoxCodecs {
     int128Codec.as[Box.Values.Arbit]
 
   implicit val boxValuesAssetCodec: Codec[Box.Values.Asset] =
-    (Codec[Int128] :: Codec[Box.Values.Asset.Code] :: Codec[Bytes] :: Codec[Option[
+    (Codec[Int128] :: Codec[Box.Values.Asset.Code] :: Codec[Sized.Strict[Bytes, Lengths.`32`.type]] :: Codec[Option[
       Sized.Max[Latin1Data, Lengths.`127`.type]
     ]]).as[Box.Values.Asset]
 

--- a/typeclasses/src/main/scala/co/topl/typeclasses/EqInstances.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/EqInstances.scala
@@ -5,6 +5,7 @@ import cats.implicits._
 import co.topl.crypto.mnemonic.Entropy
 import co.topl.models._
 import co.topl.models.utility.Sized
+import co.topl.models.utility.StringDataTypes.Latin1Data
 
 trait EqInstances {
 
@@ -22,6 +23,15 @@ trait EqInstances {
 
   implicit def sizedStrictEq[T: Eq, L]: Eq[Sized.Strict[T, L]] =
     (a, b) => a.data === b.data
+
+  implicit val latin1DataEq: Eq[Latin1Data] =
+    (a, b) => a.value === b.value
+
+  implicit val typedEvidenceEq: Eq[TypedEvidence] =
+    (a, b) => a.typePrefix === b.typePrefix && a.evidence === b.evidence
+
+  implicit val spendingAddressEq: Eq[SpendingAddress] =
+    (a, b) => a.typedEvidence === b.typedEvidence
 
   implicit val blockV2Eq: Eq[BlockV2] =
     Eq.fromUniversalEquals
@@ -51,4 +61,10 @@ trait EqInstances {
       a.rho === b.rho &&
       a.eta === b.eta &&
       a.height === b.height
+
+  implicit val assetCodeEq: Eq[Box.Values.Asset.Code] =
+    (a, b) =>
+      a.version === b.version &&
+      a.issuer === b.issuer &&
+      a.shortName === b.shortName
 }


### PR DESCRIPTION
## Purpose
- A Transaction case class _can_ be created with data that is invalid for the blockchain (i.e. a negative timestamp)
- Syntactic Validation performs stateless checks on the data of the transaction
- Unrelated:
  - Box.value.value renamed to Box.value.quantity
  - Transaction#securityRoot is now strict-sized to 32 bytes

## Approach
- Add new `ledger` SBT module
- Add SyntacticValidationAlgebra
- Add SyntacticValidation interpreter
  - Validate non-empty inputs
  - Validate timestamp
  - Validate positive output quantities
  - Validate sufficient input funds

## Testing
- Added SyntacticValidationSpec

## Tickets
_* closes #2077_