### PR TITLE
Partial Integration Test Fixes

### DIFF
--- a/.github/workflows/postman_integration_tests.yml
+++ b/.github/workflows/postman_integration_tests.yml
@@ -21,7 +21,7 @@ jobs:
         java-version: graalvm-ce-java11@21.1.0
         
     - name: Stage Docker Image
-      run: sbt bifrost/docker:stage
+      run: sbt node/docker:stage
 
     - name: Integration Tests
       run: docker-compose -f ./node/src/it/resources/postman-tests/docker-compose.yml up --exit-code-from postman

--- a/build.sbt
+++ b/build.sbt
@@ -196,7 +196,6 @@ lazy val bifrost = project
     akkaHttpRpc,
     typeclasses,
     toplRpc,
-    benchmarking,
     crypto,
     catsAkka,
     brambl,
@@ -666,5 +665,5 @@ lazy val genus = project
   .enablePlugins(AkkaGrpcPlugin)
   .dependsOn(common)
 
-addCommandAlias("checkPR", s"; scalafixAll --check; scalafmtCheckAll; + test")
-addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; + test")
+addCommandAlias("checkPR", s"; scalafixAll --check; scalafmtCheckAll; +test; it:compile")
+addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; +test; it:compile")

--- a/common/src/main/scala/co/topl/codecs/json/genesisBlob/GenesisBlobJsonCodecs.scala
+++ b/common/src/main/scala/co/topl/codecs/json/genesisBlob/GenesisBlobJsonCodecs.scala
@@ -1,9 +1,8 @@
 package co.topl.codecs.json.genesisBlob
 
 import cats.implicits._
-import co.topl.codecs.base58JsonEncoder
 import co.topl.codecs.binary._
-import co.topl.codecs.json.valuetypes.base58JsonDecoder
+import co.topl.codecs.json.valuetypes._
 import co.topl.modifier.block.GenesisBlob
 import co.topl.utils.StringDataTypes.Base58Data
 import io.circe.syntax.EncoderOps

--- a/node/src/it/scala/co/topl/it/BootstrapFromGenesisTest.scala
+++ b/node/src/it/scala/co/topl/it/BootstrapFromGenesisTest.scala
@@ -22,7 +22,7 @@ class BootstrapFromGenesisTest
 
   val initialForgeTarget: Int128 = 1500
   val newNodeForgeDuration: FiniteDuration = 10.seconds
-  val targetBlockTime: FiniteDuration = 50.milli
+  val targetBlockTime: FiniteDuration = 500.milli
   val syncWindow: FiniteDuration = 10.seconds
   val seed: String = "BootstrapFromGenesisTest" + System.currentTimeMillis()
 
@@ -34,19 +34,24 @@ class BootstrapFromGenesisTest
              |bifrost.rpcApi.namespaceSelector.debug = true
              |bifrost.forging.forgeOnStartup = false
              |bifrost.forging.blockGenerationDelay = $targetBlockTime
-             |bifrost.forging.privateTestnet.numTestnetAccts = 2
-             |bifrost.forging.privateTestnet.genesisSeed = "$seed"
+             |bifrost.forging.addressGenerationSettings.numberOfAddresses = 2
+             |bifrost.forging.addressGenerationSettings.strategy = fromSeed
+             |bifrost.forging.addressGenerationSettings.addressSeedOpt = "$seed"
              |bifrost.forging.protocolVersions = [
              |      {
-             |        version { value = 1.0.0 }
+             |        minAppVersion {value = 1.0.0}
              |        startBlock = 0
              |        blockVersion = 1
-             |        targetBlockTime = $targetBlockTime
-             |        numTxPerBlock = 100
+             |        value {
+             |          targetBlockTime = $targetBlockTime
+             |          numTxPerBlock = 100
+             |          inflationRate = 0
+             |          lookBackDepth = 3
+             |        }
              |      }
              |    ]
-             |bifrost.network.syncInterval = 250ms
-             |bifrost.network.syncIntervalStable = 1s
+             |bifrost.network.syncInterval = 50ms
+             |bifrost.network.syncIntervalStable = 500s
              |""".stripMargin
       )
 

--- a/node/src/it/scala/co/topl/it/BootstrapFromGenesisTest.scala
+++ b/node/src/it/scala/co/topl/it/BootstrapFromGenesisTest.scala
@@ -22,8 +22,8 @@ class BootstrapFromGenesisTest
 
   val initialForgeTarget: Int128 = 1500
   val newNodeForgeDuration: FiniteDuration = 10.seconds
-  val targetBlockTime: FiniteDuration = 500.milli
-  val syncWindow: FiniteDuration = 10.seconds
+  val targetBlockTime: FiniteDuration = 250.milli
+  val syncWindow: FiniteDuration = 60.seconds
   val seed: String = "BootstrapFromGenesisTest" + System.currentTimeMillis()
 
   "A new node can sync its genesis block with an old node" in {
@@ -76,7 +76,7 @@ class BootstrapFromGenesisTest
 
     logger.info(s"Allowing oldNode to forge $initialForgeTarget blocks.  This may take a while.")
 
-    oldNode.pollUntilHeight(initialForgeTarget).futureValue(Timeout(20.minutes)).value
+    oldNode.pollUntilHeight(initialForgeTarget).futureValue(Timeout(45.minutes)).value
 
     logger.info("Starting newNode")
 

--- a/node/src/it/scala/co/topl/it/ChainSelectionTest.scala
+++ b/node/src/it/scala/co/topl/it/ChainSelectionTest.scala
@@ -42,9 +42,10 @@ class ChainSelectionTest
     ConfigFactory.parseString(
       raw"""bifrost.network.knownPeers = []
            |bifrost.rpcApi.namespaceSelector.debug = true
-           |bifrost.forging.privateTestnet.numTestnetAccts = $nodeCount
-           |bifrost.forging.privateTestnet.testnetBalance = ${maxStake / nodeCount}
-           |bifrost.forging.privateTestnet.genesisSeed = "$seed"
+           |bifrost.application.genesis.generated.balanceForEachParticipant = ${maxStake / nodeCount}
+           |bifrost.forging.addressGenerationSettings.numberOfAddresses = $nodeCount
+           |bifrost.forging.addressGenerationSettings.strategy = fromSeed
+           |bifrost.forging.addressGenerationSettings.addressSeedOpt = "$seed"
            |bifrost.forging.forgeOnStartup = false
            |""".stripMargin
     )

--- a/node/src/it/scala/co/topl/it/MultiNodeTest.scala
+++ b/node/src/it/scala/co/topl/it/MultiNodeTest.scala
@@ -117,8 +117,9 @@ class MultiNodeTest extends AnyFreeSpec with Matchers with IntegrationSuite with
       ConfigFactory.parseString(
         raw"""bifrost.network.knownPeers = ${nodeNames.map(n => s"$n:${BifrostDockerNode.NetworkPort}").asJson}
              |bifrost.rpcApi.namespaceSelector.debug = true
-             |bifrost.forging.privateTestnet.numTestnetAccts = $nodeCount
-             |bifrost.forging.privateTestnet.genesisSeed = "$seed"
+             |bifrost.forging.addressGenerationSettings.numberOfAddresses = $nodeCount
+             |bifrost.forging.addressGenerationSettings.strategy = fromSeed
+             |bifrost.forging.addressGenerationSettings.addressSeedOpt = "$seed"
              |bifrost.forging.forgeOnStartup = false
              |""".stripMargin
       )

--- a/node/src/it/scala/co/topl/it/SingleNodeTest.scala
+++ b/node/src/it/scala/co/topl/it/SingleNodeTest.scala
@@ -30,6 +30,8 @@ class SingleNodeTest extends AnyFreeSpec with Matchers with IntegrationSuite wit
 
     node.waitForStartup().futureValue(Timeout(30.seconds)).value
 
+    node.run(ToplRpc.Admin.StartForging.rpc)(ToplRpc.Admin.StartForging.Params()).value
+
     logger.info("Wait 2 seconds for forging")
     Thread.sleep(2.seconds.toMillis)
 

--- a/node/src/it/scala/co/topl/it/TransactionTest.scala
+++ b/node/src/it/scala/co/topl/it/TransactionTest.scala
@@ -400,7 +400,7 @@ class TransactionTest
   }
 
   private def broadcastAndAwait(name: String, signedTx: Transaction.TX): Transaction.TX = {
-    logger.info(s"Broadcasting signed $name")
+    logger.info(s"Broadcasting signed $name id=${signedTx.id}")
     val broadcastedTx =
       node
         .run(ToplRpc.Transaction.BroadcastTx.rpc)(

--- a/node/src/it/scala/co/topl/it/TransactionTest.scala
+++ b/node/src/it/scala/co/topl/it/TransactionTest.scala
@@ -43,7 +43,8 @@ class TransactionTest
     ConfigFactory.parseString(
       raw"""bifrost.network.knownPeers = []
            |bifrost.rpcApi.namespaceSelector.debug = true
-           |bifrost.forging.privateTestnet.genesisSeed = "$nodeGroupName"
+           |bifrost.forging.addressGenerationSettings.strategy = fromSeed
+           |bifrost.forging.addressGenerationSettings.addressSeedOpt = "$nodeGroupName"
            |bifrost.forging.forgeOnStartup = false
            |""".stripMargin
     )

--- a/node/src/main/scala/co/topl/nodeView/history/History.scala
+++ b/node/src/main/scala/co/topl/nodeView/history/History.scala
@@ -187,7 +187,8 @@ class History(
         errors.toIterable.foreach(e =>
           log.warn(s"${Console.RED} Block id=${block.id} validation failure.${Console.RESET}", e)
         )
-        throw new Error(s"${Console.RED}Failed to append block ${block.id} to history.${Console.RESET}", errors.head)
+        log.error(s"${Console.RED}Failed to append block ${block.id} to history.${Console.RESET}", errors.head)
+        throw errors.head
     }
   }
 

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
@@ -289,9 +289,6 @@ trait TransactionRpcResponseDecoders extends SharedCodecs {
     ToplRpc.Transaction.UnprovenPolyTransfer.Response
   ] = unprovenTransactionJsonDecoder.map(x => ToplRpc.Transaction.UnprovenPolyTransfer.Response(x))
 
-  implicit val transactionBroadcastTetraTransferResponseDecoder: Decoder[
-    ToplRpc.Transaction.BroadcastTetraTransfer.Response
-  ] = hcursor => hcursor.as[Transaction.TX]
 }
 
 trait AdminRpcResponseDecoders extends SharedCodecs {


### PR DESCRIPTION
## Purpose
- The application configuration file format has changed in recent versions of Bifrost, but the integration tests still use the old format
  - Forging is also now disabled by default
- The client side of the Topl RPC codecs has an infinite self-recursive call
- BlockValidation failures are not explicitly logged

## Approach
- Update configurations used in integration tests to new format
- Send StartForging signal in SingleNodeTest
- Remove invalid RPC Codec entry
- Improve History BlockValidator logging
- Added integration test compilation to checkPR step
## Testing
- SingleNodeTest now passes
- The remaining integration tests still fail due to other bugs, but the tests at least start and run now
## Tickets
_* closes #1987_