### PR TITLE
(rc-1.11) Partial Integration Test Fixes

### DIFF
--- a/.github/workflows/postman_integration_tests.yml
+++ b/.github/workflows/postman_integration_tests.yml
@@ -21,7 +21,7 @@ jobs:
         java-version: graalvm-ce-java11@21.1.0
         
     - name: Stage Docker Image
-      run: sbt bifrost/docker:stage
+      run: sbt node/docker:stage
 
     - name: Integration Tests
       run: docker-compose -f ./node/src/it/resources/postman-tests/docker-compose.yml up --exit-code-from postman

--- a/build.sbt
+++ b/build.sbt
@@ -197,7 +197,6 @@ lazy val bifrost = project
     akkaHttpRpc,
     typeclasses,
     toplRpc,
-    benchmarking,
     crypto,
     catsAkka,
     brambl,
@@ -668,5 +667,5 @@ lazy val genus = project
   .enablePlugins(AkkaGrpcPlugin)
   .dependsOn(common)
 
-addCommandAlias("checkPR", s"; scalafixAll --check; scalafmtCheckAll; + test")
-addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; + test")
+addCommandAlias("checkPR", s"; scalafixAll --check; scalafmtCheckAll; +test; it:compile")
+addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; +test; it:compile")

--- a/node/src/it/scala/co/topl/it/ChainSelectionTest.scala
+++ b/node/src/it/scala/co/topl/it/ChainSelectionTest.scala
@@ -42,9 +42,10 @@ class ChainSelectionTest
     ConfigFactory.parseString(
       raw"""bifrost.network.knownPeers = []
            |bifrost.rpcApi.namespaceSelector.debug = true
-           |bifrost.forging.privateTestnet.numTestnetAccts = $nodeCount
-           |bifrost.forging.privateTestnet.testnetBalance = ${maxStake / nodeCount}
-           |bifrost.forging.privateTestnet.genesisSeed = "$seed"
+           |bifrost.application.genesis.generated.balanceForEachParticipant = ${maxStake / nodeCount}
+           |bifrost.forging.addressGenerationSettings.numberOfAddresses = $nodeCount
+           |bifrost.forging.addressGenerationSettings.strategy = fromSeed
+           |bifrost.forging.addressGenerationSettings.addressSeedOpt = "$seed"
            |bifrost.forging.forgeOnStartup = false
            |""".stripMargin
     )
@@ -53,7 +54,7 @@ class ChainSelectionTest
     ConfigFactory
       .parseString(
         raw"""bifrost.network.knownPeers = ${nodeNames.map(_ + ":" + BifrostDockerNode.NetworkPort).asJson.noSpaces}
-           |""".stripMargin
+             |""".stripMargin
       )
       .withFallback(baseConfig)
 

--- a/node/src/it/scala/co/topl/it/MultiNodeTest.scala
+++ b/node/src/it/scala/co/topl/it/MultiNodeTest.scala
@@ -117,8 +117,9 @@ class MultiNodeTest extends AnyFreeSpec with Matchers with IntegrationSuite with
       ConfigFactory.parseString(
         raw"""bifrost.network.knownPeers = ${nodeNames.map(n => s"$n:${BifrostDockerNode.NetworkPort}").asJson}
              |bifrost.rpcApi.namespaceSelector.debug = true
-             |bifrost.forging.privateTestnet.numTestnetAccts = $nodeCount
-             |bifrost.forging.privateTestnet.genesisSeed = "$seed"
+             |bifrost.forging.addressGenerationSettings.numberOfAddresses = $nodeCount
+             |bifrost.forging.addressGenerationSettings.strategy = fromSeed
+             |bifrost.forging.addressGenerationSettings.addressSeedOpt = "$seed"
              |bifrost.forging.forgeOnStartup = false
              |""".stripMargin
       )

--- a/node/src/it/scala/co/topl/it/SingleNodeTest.scala
+++ b/node/src/it/scala/co/topl/it/SingleNodeTest.scala
@@ -30,6 +30,8 @@ class SingleNodeTest extends AnyFreeSpec with Matchers with IntegrationSuite wit
 
     node.waitForStartup().futureValue(Timeout(30.seconds)).value
 
+    node.run(ToplRpc.Admin.StartForging.rpc)(ToplRpc.Admin.StartForging.Params()).value
+
     logger.info("Wait 2 seconds for forging")
     Thread.sleep(2.seconds.toMillis)
 

--- a/node/src/it/scala/co/topl/it/TransactionTest.scala
+++ b/node/src/it/scala/co/topl/it/TransactionTest.scala
@@ -43,7 +43,8 @@ class TransactionTest
     ConfigFactory.parseString(
       raw"""bifrost.network.knownPeers = []
            |bifrost.rpcApi.namespaceSelector.debug = true
-           |bifrost.forging.privateTestnet.genesisSeed = "$nodeGroupName"
+           |bifrost.forging.addressGenerationSettings.strategy = fromSeed
+           |bifrost.forging.addressGenerationSettings.addressSeedOpt = "$nodeGroupName"
            |bifrost.forging.forgeOnStartup = false
            |""".stripMargin
     )
@@ -399,7 +400,7 @@ class TransactionTest
   }
 
   private def broadcastAndAwait(name: String, signedTx: Transaction.TX): Transaction.TX = {
-    logger.info(s"Broadcasting signed $name")
+    logger.info(s"Broadcasting signed $name id=${signedTx.id}")
     val broadcastedTx =
       node
         .run(ToplRpc.Transaction.BroadcastTx.rpc)(

--- a/node/src/main/scala/co/topl/nodeView/history/History.scala
+++ b/node/src/main/scala/co/topl/nodeView/history/History.scala
@@ -1,5 +1,6 @@
 package co.topl.nodeView.history
 
+import cats.data.Validated
 import cats.implicits._
 import co.topl.consensus.BlockValidators._
 import co.topl.consensus.Hiccups.HiccupBlock
@@ -134,57 +135,60 @@ class History(
     val validationResults =
       if (!isHiccupBlock) {
         validators
-          .map(BlockValidation.handlers(block))
-          .map(_.isSuccess)
-      } else Seq(true) // skipping validation for genesis block and hiccup blocks
+          .traverse(BlockValidation.handlers(block)(_).toValidated.toValidatedNec)
+          .void
+      } else ().validNec // skipping validation for genesis block and hiccup blocks
 
-    // check if all block validation passed
-    if (validationResults.forall(_ == true)) {
-      val res: (History, ProgressInfo[Block]) =
-        if (isGenesis(block)) {
-          storage.update(block, isBest = true)
-          val progInfo = ProgressInfo(None, Seq.empty, Seq(block), Seq.empty)
+    validationResults match {
+      case Validated.Valid(_) =>
+        val res: (History, ProgressInfo[Block]) =
+          if (isGenesis(block)) {
+            storage.update(block, isBest = true)
+            val progInfo = ProgressInfo(None, Seq.empty, Seq(block), Seq.empty)
 
-          // construct result and return
-          (new History(storage, tineProcessor), progInfo)
+            // construct result and return
+            (new History(storage, tineProcessor), progInfo)
 
-        } else {
-          val progInfo: ProgressInfo[Block] =
-            // Check if the new block extends the last best block
-            if (block.parentId === storage.bestBlockId) {
-              log.debug(s"New best block ${block.id.show}")
+          } else {
+            val progInfo: ProgressInfo[Block] =
+              // Check if the new block extends the last best block
+              if (block.parentId === storage.bestBlockId) {
+                log.debug(s"New best block ${block.id.show}")
 
-              // update storage
-              storage.update(block, isBest = true)
-              ProgressInfo(None, Seq.empty, Seq(block), Seq.empty)
+                // update storage
+                storage.update(block, isBest = true)
+                ProgressInfo(None, Seq.empty, Seq(block), Seq.empty)
 
-              // if not, we'll check for a fork
-            } else {
-              // we want to check for a fork
-              val forkProgInfo =
-                tineProcessor.process(this, block, protocolVersioner.applicable(block.height).value.lookBackDepth)
+                // if not, we'll check for a fork
+              } else {
+                // we want to check for a fork
+                val forkProgInfo =
+                  tineProcessor.process(this, block, protocolVersioner.applicable(block.height).value.lookBackDepth)
 
-              // check if we need to update storage after checking for forks
-              if (forkProgInfo.branchPoint.nonEmpty) {
-                storage.rollback(forkProgInfo.branchPoint.get).getOrThrow()
+                // check if we need to update storage after checking for forks
+                forkProgInfo.branchPoint.foreach { branchPoint =>
+                  storage.rollback(branchPoint).getOrThrow()
+                  forkProgInfo.toApply.foreach(b => storage.update(b, isBest = true))
+                }
 
-                forkProgInfo.toApply.foreach(b => storage.update(b, isBest = true))
+                forkProgInfo
               }
 
-              forkProgInfo
-            }
+            // construct result and return
+            (new History(storage, tineProcessor), progInfo)
+          }
+        log.info(
+          s"${Console.CYAN} Block ${block.id} appended to parent ${block.parentId} at height ${block.height} with score ${storage
+              .scoreOf(block.id)}.${Console.RESET}"
+        )
+        res
 
-          // construct result and return
-          (new History(storage, tineProcessor), progInfo)
-        }
-      log.info(
-        s"${Console.CYAN} Block ${block.id} appended to parent ${block.parentId} at height ${block.height} with score ${storage
-            .scoreOf(block.id)}.${Console.RESET}"
-      )
-      res
-
-    } else {
-      throw new Error(s"${Console.RED}Failed to append block ${block.id} to history.${Console.RESET}")
+      case Validated.Invalid(errors) =>
+        errors.toIterable.foreach(e =>
+          log.warn(s"${Console.RED} Block id=${block.id} validation failure.${Console.RESET}", e)
+        )
+        log.error(s"${Console.RED}Failed to append block ${block.id} to history.${Console.RESET}", errors.head)
+        throw errors.head
     }
   }
 


### PR DESCRIPTION
## Purpose
- The application configuration file format has changed in recent versions of Bifrost, but the integration tests still use the old format
  - Forging is also now disabled by default
- BlockValidation failures are not explicitly logged

## Approach
- Update configurations used in integration tests to new format
- Send StartForging signal in SingleNodeTest
- Improve History BlockValidator logging
- Added integration test compilation to checkPR step
## Testing
- SingleNodeTest now passes
- The remaining integration tests still fail due to other bugs, but the tests at least start and run now
## Tickets
_* closes #1987_