### PR TITLE
Tetra Broadcast Transaction RPC

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
@@ -3,5 +3,5 @@ package co.topl.algebras
 import co.topl.models.Transaction
 
 trait ToplRpc[F[_]] {
-  def broadcastTx(transaction: Transaction): F[Unit]
+  def broadcastTransaction(transaction: Transaction): F[Unit]
 }

--- a/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
@@ -1,0 +1,7 @@
+package co.topl.algebras
+
+import co.topl.models.Transaction
+
+trait ToplRpc[F[_]] {
+  def broadcastTx(transaction: Transaction): F[Unit]
+}

--- a/brambl/src/main/resources/application.conf
+++ b/brambl/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+akka.http.server.preview.enable-http2 = on

--- a/brambl/src/main/resources/logback.xml
+++ b/brambl/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<configuration debug="false">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are by default assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS}| %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <logger name="node" level="INFO" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/brambl/src/main/scala/co/topl/client/BramblTetra.scala
+++ b/brambl/src/main/scala/co/topl/client/BramblTetra.scala
@@ -1,0 +1,49 @@
+package co.topl.client
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import cats.Applicative
+import cats.data.Chain
+import cats.effect.{Async, IO, IOApp, Resource, Sync}
+import co.topl.algebras.ToplRpc
+import co.topl.grpc.ToplGrpc
+import cats.implicits._
+import co.topl.models._
+import co.topl.models.utility.HasLength.instances.bigIntLength
+import co.topl.models.utility.Lengths._
+import co.topl.models.utility.Sized
+
+object BramblTetra extends IOApp.Simple {
+
+  type F[A] = IO[A]
+
+  override def run: IO[Unit] =
+    Resource
+      .make(
+        Sync[F].delay(ActorSystem(Behaviors.empty, "Brambl"))
+      )(system => Sync[F].delay(system.terminate()) >> Async[F].fromFuture(Sync[F].delay(system.whenTerminated)).void)
+      .use(implicit system =>
+        Resource
+          .make(ToplGrpc.Client.make[F]("localhost", 8090))(_ => Applicative[F].unit)
+          .use(implicit rpcClient =>
+            Transaction(
+              inputs = Chain(
+                Transaction.Input(
+                  boxId = Box.Id(TypedBytes(3: Byte, Bytes.fill(32)(0: Byte)), 0),
+                  proposition = Propositions.PermanentlyLocked,
+                  proof = Proofs.False,
+                  value = Box.Values.Poly(Sized.maxUnsafe(BigInt(10)))
+                )
+              ),
+              outputs = Chain.empty,
+              chronology = Transaction.Chronology(System.currentTimeMillis(), 0L, Long.MaxValue),
+              data = none
+            ).broadcast[F]
+          )
+      )
+
+  implicit class TransactionOps(transaction: Transaction) {
+    def broadcast[F[_]: ToplRpc]: F[Unit] = implicitly[ToplRpc[F]].broadcastTx(transaction)
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ lazy val commonSettings = Seq(
     }
   },
   crossScalaVersions := Seq(scala212, scala213),
+  testFrameworks += new TestFramework("munit.Framework"),
   Test / testOptions ++= Seq(
     Tests.Argument("-oD", "-u", "target/test-reports"),
     Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "2"),
@@ -605,7 +606,7 @@ lazy val toplGrpc = project
     libraryDependencies ++= Dependencies.toplGrpc,
   )
   .enablePlugins(AkkaGrpcPlugin)
-  .dependsOn(models, byteCodecs, tetraByteCodecs, algebras, catsAkka)
+  .dependsOn(models % "compile->compile;test->test", byteCodecs, tetraByteCodecs, algebras, catsAkka)
 
 // This module has fallen out of sync with the rest of the codebase and is not currently needed
 //lazy val gjallarhorn = project

--- a/build.sbt
+++ b/build.sbt
@@ -274,7 +274,7 @@ lazy val brambl = project
     buildInfoPackage := "co.topl.buildinfo.brambl"
   )
   .settings(scalamacrosParadiseSettings)
-  .dependsOn(toplRpc, common, typeclasses, models % "compile->compile;test->test", scripting, tetraByteCodecs)
+  .dependsOn(toplRpc, common, typeclasses, models % "compile->compile;test->test", scripting, tetraByteCodecs, toplGrpc)
 
 lazy val akkaHttpRpc = project
   .in(file("akka-http-rpc"))
@@ -491,7 +491,8 @@ lazy val networking = project
     consensus,
     commonInterpreters,
     catsAkka,
-    eventTree
+    eventTree,
+    ledger
   )
 
 lazy val ledger = project
@@ -542,7 +543,8 @@ lazy val demo = project
     scripting,
     commonInterpreters,
     networking,
-    catsAkka
+    catsAkka,
+    toplGrpc
   )
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, DockerPlugin)
 
@@ -593,6 +595,17 @@ lazy val toplRpc = project
     buildInfoPackage := "co.topl.buildinfo.toplrpc"
   )
   .dependsOn(akkaHttpRpc, common)
+
+lazy val toplGrpc = project
+  .in(file("topl-grpc"))
+  .settings(
+    name := "topl-grpc",
+    commonSettings,
+    scalamacrosParadiseSettings,
+    libraryDependencies ++= Dependencies.toplGrpc,
+  )
+  .enablePlugins(AkkaGrpcPlugin)
+  .dependsOn(models, byteCodecs, tetraByteCodecs, algebras, catsAkka)
 
 // This module has fallen out of sync with the rest of the codebase and is not currently needed
 //lazy val gjallarhorn = project

--- a/demo/src/main/resources/application.conf
+++ b/demo/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+akka.http.server.preview.enable-http2 = on

--- a/demo/src/main/scala/co/topl/demo/DemoProgram.scala
+++ b/demo/src/main/scala/co/topl/demo/DemoProgram.scala
@@ -15,6 +15,8 @@ import co.topl.consensus.algebras.{BlockHeaderValidationAlgebra, LocalChainAlgeb
 import co.topl.consensus.{BlockHeaderV2Ops, BlockHeaderValidationFailure}
 import co.topl.crypto.signing.Ed25519VRF
 import co.topl.eventtree.{EventSourcedState, ParentChildTree}
+import co.topl.grpc.ToplGrpc
+import co.topl.ledger.algebras.{MempoolAlgebra, SyntacticValidationAlgebra}
 import co.topl.minting.algebras.PerpetualBlockMintAlgebra
 import co.topl.models._
 import co.topl.networking.blockchain._
@@ -47,8 +49,12 @@ object DemoProgram {
     peerFlowModifier: (
       ConnectedPeer,
       Flow[ByteString, ByteString, F[BlockchainPeerClient[F]]]
-    ) => Flow[ByteString, ByteString, F[BlockchainPeerClient[F]]]
-  )(implicit system: ActorSystem[_], random: Random): F[Unit] =
+    ) => Flow[ByteString, ByteString, F[BlockchainPeerClient[F]]],
+    syntacticValidation: SyntacticValidationAlgebra[F],
+    mempool:             MempoolAlgebra[F],
+    rpcHost:             String,
+    rpcPort:             Int
+  )(implicit system:     ActorSystem[_], random: Random): F[Unit] =
     for {
       (locallyAdoptedBlocksSource, locallyAdoptedBlocksSink) <-
         BroadcastHub.sink[TypedIdentifier].preMaterialize().pure[F]
@@ -93,6 +99,36 @@ object DemoProgram {
       (p2pServer, p2pFiber) <- BlockchainNetwork
         .make[F](host, bindPort, localPeer, remotePeers, clientHandler, peerServer, peerFlowModifier)
       mintedBlockStream <- mint.fold(Source.never[BlockV2].pure[F])(_.blocks)
+      rpcServer = ToplGrpc.Server.serve(
+        rpcHost,
+        rpcPort,
+        tx =>
+          transactionStore
+            .contains(tx.id)
+            .ifM(
+              Sync[F].defer(Logger[F].info(show"Received duplicate transaction id=${tx.id.asTypedBytes}")),
+              Sync[F].defer(
+                Logger[F].info(show"Received RPC Transaction id=${tx.id.asTypedBytes}") >>
+                EitherT(syntacticValidation.validateSyntax(tx).map(_.toEither))
+                  .leftSemiflatTap(errors =>
+                    errors.traverse(error =>
+                      Logger[F]
+                        .warn(s"Transaction id=${tx.id.asTypedBytes.show} was syntactically invalid.  reason=$error")
+                    )
+                  )
+                  // TODO: Semantic and Authorization Validation
+                  .semiflatTap(_ =>
+                    Logger[F].info(show"Inserting Transaction id=${tx.id.asTypedBytes} into transaction store") >>
+                    transactionStore.put(tx.id, tx) >>
+                    Logger[F].info(show"Inserting Transaction id=${tx.id.asTypedBytes} into mempool") >>
+                    mempool.add(tx.id)
+                  // TODO: Broadcast to P2P
+                  )
+                  .value
+                  .void
+              )
+            )
+      )
       streamCompletionFuture =
         mintedBlockStream
           .tapAsyncF(1)(block => Logger[F].info(show"Minted block ${block.headerV2}"))
@@ -103,8 +139,11 @@ object DemoProgram {
           .alsoTo(locallyAdoptedBlocksSink)
           .toMat(Sink.ignore)(Keep.right)
           .liftTo[F]
-      _ <- Async[F].fromFuture(streamCompletionFuture)
-      _ <- p2pFiber.join
+      _ <- rpcServer.use(binding =>
+        Logger[F].info(s"RPC Server bound at ${binding.localAddress}") >>
+        Async[F].fromFuture(streamCompletionFuture) >>
+        p2pFiber.join
+      )
     } yield ()
 
   implicit private val showBlockHeaderValidationFailure: Show[BlockHeaderValidationFailure] =

--- a/demo/src/main/scala/co/topl/demo/DemoProgram.scala
+++ b/demo/src/main/scala/co/topl/demo/DemoProgram.scala
@@ -7,7 +7,7 @@ import cats.data.{EitherT, OptionT, Validated}
 import cats.effect._
 import cats.implicits._
 import cats.{Applicative, MonadThrow, Parallel, Show}
-import co.topl.algebras.{Store, StoreReader, UnsafeResource}
+import co.topl.algebras.{Store, StoreReader, ToplRpc, UnsafeResource}
 import co.topl.catsakka._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
@@ -99,36 +99,8 @@ object DemoProgram {
       (p2pServer, p2pFiber) <- BlockchainNetwork
         .make[F](host, bindPort, localPeer, remotePeers, clientHandler, peerServer, peerFlowModifier)
       mintedBlockStream <- mint.fold(Source.never[BlockV2].pure[F])(_.blocks)
-      rpcServer = ToplGrpc.Server.serve(
-        rpcHost,
-        rpcPort,
-        tx =>
-          transactionStore
-            .contains(tx.id)
-            .ifM(
-              Sync[F].defer(Logger[F].info(show"Received duplicate transaction id=${tx.id.asTypedBytes}")),
-              Sync[F].defer(
-                Logger[F].info(show"Received RPC Transaction id=${tx.id.asTypedBytes}") >>
-                EitherT(syntacticValidation.validateSyntax(tx).map(_.toEither))
-                  .leftSemiflatTap(errors =>
-                    errors.traverse(error =>
-                      Logger[F]
-                        .warn(s"Transaction id=${tx.id.asTypedBytes.show} was syntactically invalid.  reason=$error")
-                    )
-                  )
-                  // TODO: Semantic and Authorization Validation
-                  .semiflatTap(_ =>
-                    Logger[F].info(show"Inserting Transaction id=${tx.id.asTypedBytes} into transaction store") >>
-                    transactionStore.put(tx.id, tx) >>
-                    Logger[F].info(show"Inserting Transaction id=${tx.id.asTypedBytes} into mempool") >>
-                    mempool.add(tx.id)
-                  // TODO: Broadcast to P2P
-                  )
-                  .value
-                  .void
-              )
-            )
-      )
+      rpcInterpreter = toplRpcInterpreter(transactionStore, mempool, syntacticValidation)
+      rpcServer = ToplGrpc.Server.serve(rpcHost, rpcPort, rpcInterpreter)
       streamCompletionFuture =
         mintedBlockStream
           .tapAsyncF(1)(block => Logger[F].info(show"Minted block ${block.headerV2}"))
@@ -201,5 +173,40 @@ object DemoProgram {
               .as(false)
           )
     } yield adopted
+
+  private def toplRpcInterpreter[F[_]: Async: Logger: FToFuture](
+    transactionStore:    Store[F, TypedIdentifier, Transaction],
+    mempool:             MempoolAlgebra[F],
+    syntacticValidation: SyntacticValidationAlgebra[F]
+  ) =
+    new ToplRpc[F] {
+
+      def broadcastTransaction(tx: Transaction): F[Unit] =
+        transactionStore
+          .contains(tx.id)
+          .ifM(
+            Sync[F].defer(Logger[F].info(show"Received duplicate transaction id=${tx.id.asTypedBytes}")),
+            Sync[F].defer(
+              Logger[F].info(show"Received RPC Transaction id=${tx.id.asTypedBytes}") >>
+              EitherT(syntacticValidation.validateSyntax(tx).map(_.toEither))
+                .leftSemiflatTap(errors =>
+                  errors.traverse(error =>
+                    Logger[F]
+                      .warn(s"Transaction id=${tx.id.asTypedBytes.show} was syntactically invalid.  reason=$error")
+                  )
+                )
+                // TODO: Semantic and Authorization Validation
+                .semiflatTap(_ =>
+                  Logger[F].info(show"Inserting Transaction id=${tx.id.asTypedBytes} into transaction store") >>
+                  transactionStore.put(tx.id, tx) >>
+                  Logger[F].info(show"Inserting Transaction id=${tx.id.asTypedBytes} into mempool") >>
+                  mempool.add(tx.id)
+                // TODO: Broadcast to P2P
+                )
+                .value
+                .void
+            )
+          )
+    }
 
 }

--- a/demo/src/main/scala/co/topl/demo/TetraDemo.scala
+++ b/demo/src/main/scala/co/topl/demo/TetraDemo.scala
@@ -22,7 +22,7 @@ import co.topl.crypto.hash.{Blake2b256, Blake2b512}
 import co.topl.crypto.signing.{Ed25519, Ed25519VRF, KesProduct}
 import co.topl.interpreters._
 import co.topl.ledger.algebras.MempoolAlgebra
-import co.topl.ledger.interpreters.Mempool
+import co.topl.ledger.interpreters.{Mempool, SyntacticValidation}
 import co.topl.minting._
 import co.topl.minting.algebras.PerpetualBlockMintAlgebra
 import co.topl.models._
@@ -259,6 +259,7 @@ object TetraDemo extends IOApp {
         genesis.headerV2.slotData(Ed25519VRF.precomputed()),
         ChainSelection.orderT[F](slotDataCache, blake2b512Resource, ChainSelectionKLookback, ChainSelectionSWindow)
       )
+      syntacticValidation <- SyntacticValidation.make[F]
       mempool <- Mempool.make[F](
         genesis.headerV2.id.asTypedBytes.pure[F],
         blockBodyStore.getOrRaise,
@@ -305,7 +306,11 @@ object TetraDemo extends IOApp {
           demoArgs.port,
           LocalPeer(InetSocketAddress.createUnresolved("localhost", demoArgs.port), (0, 0)),
           Source(demoArgs.remotes).delay(2.seconds).concat(Source.never),
-          (_, flow) => flow
+          (_, flow) => flow,
+          syntacticValidation,
+          mempool,
+          ???,
+          ???
         )
     } yield ()
   }

--- a/demo/src/main/scala/co/topl/demo/TetraDemo.scala
+++ b/demo/src/main/scala/co/topl/demo/TetraDemo.scala
@@ -47,8 +47,8 @@ import scala.util.Random
 /**
  * Command-line args:
  *
- * port [remotes] seed stakerCount stakerIndex ?genesisTimestampMs
- * i.e.: 9094 [localhost:9095] 2348921 10 3 1648049271191
+ * port rpcPort [remotes] seed stakerCount stakerIndex ?genesisTimestampMs
+ * i.e.: 9094 8094 [localhost:9095] 2348921 10 3 1648049271191
  */
 object TetraDemo extends IOApp {
 
@@ -309,8 +309,8 @@ object TetraDemo extends IOApp {
           (_, flow) => flow,
           syntacticValidation,
           mempool,
-          ???,
-          ???
+          "localhost",
+          demoArgs.rpcPort
         )
     } yield ()
   }
@@ -330,6 +330,7 @@ private case class Staker(
 
 case class DemoArgs(
   port:             Int,
+  rpcPort:          Int,
   remotes:          List[DisconnectedPeer],
   seed:             Long,
   stakerCount:      Int,
@@ -342,6 +343,7 @@ object DemoArgs {
   def parse(args: List[String]): DemoArgs =
     DemoArgs(
       args(0).toInt,
+      args(1).toInt,
       args(1)
         .drop(1)
         .dropRight(1)

--- a/node/src/test/scala/co/topl/network/codecs/scodecs/Generators.scala
+++ b/node/src/test/scala/co/topl/network/codecs/scodecs/Generators.scala
@@ -4,7 +4,6 @@ import co.topl.modifier.NodeViewModifier.ModifierTypeId
 import co.topl.network.message.Messages.MessagesV1
 import co.topl.network.peer.{LocalAddressPeerFeature, PeerFeature, PeerMetadata}
 import co.topl.settings.Version
-import io.netty.channel.local.LocalAddress
 import org.scalacheck.Gen
 
 import java.net.{InetAddress, InetSocketAddress}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,6 +44,9 @@ object Dependencies {
   def akka(name: String): ModuleID =
     "com.typesafe.akka" %% s"akka-$name" % akkaVersion
 
+  def akkaHttp(name: String): ModuleID =
+    "com.typesafe.akka" %% s"akka-$name" % akkaHttpVersion
+
   val allAkka = Seq(
     "com.typesafe.akka" %% "akka-actor"               % akkaVersion,
     "com.typesafe.akka" %% "akka-actor-typed"         % akkaVersion,
@@ -191,7 +194,7 @@ object Dependencies {
     graal
 
   lazy val brambl: Seq[ModuleID] =
-    test ++ scodec ++ simulacrum
+    test ++ scodec ++ simulacrum ++ Seq(akkaHttp("http2-support"))
 
   lazy val akkaHttpRpc: Seq[ModuleID] =
     Seq(
@@ -263,7 +266,7 @@ object Dependencies {
     Dependencies.test ++ Dependencies.catsEffect
 
   lazy val demo: Seq[ModuleID] =
-    Seq(akka("actor"), akka("actor-typed"), akka("stream")) ++ logging
+    Seq(akka("actor"), akka("actor-typed"), akka("stream"), akkaHttp("http2-support")) ++ logging
 
   lazy val commonInterpreters =
     test ++
@@ -297,6 +300,16 @@ object Dependencies {
     allAkka ++
     circe ++
     mainargs
+
+  lazy val scalaPb =
+    "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf"
+
+  lazy val toplGrpc: Seq[ModuleID] =
+    Seq(scalaPb) ++
+    allAkka ++
+    cats ++
+    catsEffect ++
+    test
 
   lazy val genus: Seq[ModuleID] =
     Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,17 +22,27 @@ object Dependencies {
     catsSlf4j
   )
 
-  val test = Seq(
-    "org.scalatest"      %% "scalatest"                     % "3.2.12"  % "test",
-    "org.scalactic"      %% "scalactic"                     % "3.2.12"  % "test",
-    "org.scalacheck"     %% "scalacheck"                    % "1.15.4"  % "test",
-    "org.scalatestplus"  %% "scalacheck-1-14"               % "3.2.2.0" % "test",
-    "com.spotify"         % "docker-client"                 % "8.16.0"  % "test",
-    "org.asynchttpclient" % "async-http-client"             % "2.12.3"  % "test",
-    "org.scalamock"      %% "scalamock"                     % "5.2.0"   % "test",
-    "com.ironcorelabs"   %% "cats-scalatest"                % "3.1.1"   % "test",
-    "org.typelevel"      %% "cats-effect-testing-scalatest" % "1.3.0"   % "test"
+  val scalacheck = Seq(
+    "org.scalacheck"    %% "scalacheck"      % "1.15.4"  % "test",
+    "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % "test"
   )
+
+  val scalamock = Seq(
+    "org.scalamock" %% "scalamock" % "5.2.0" % "test"
+  )
+
+  val test = Seq(
+    "org.scalatest"    %% "scalatest"                     % "3.2.12" % "test",
+    "com.ironcorelabs" %% "cats-scalatest"                % "3.1.1"  % "test",
+    "org.typelevel"    %% "cats-effect-testing-scalatest" % "1.3.0"  % "test"
+  ) ++ scalacheck ++ scalamock
+
+  val mUnitTest = Seq(
+    "org.scalameta" %% "munit"                   % "0.7.29" % Test,
+    "org.typelevel" %% "munit-cats-effect-3"     % "1.0.7"  % Test,
+    "org.scalameta" %% "munit-scalacheck"        % "0.7.29" % Test,
+    "org.typelevel" %% "scalacheck-effect-munit" % "1.0.4"  % Test
+  ) ++ scalamock
 
   val it = Seq(
     "org.scalatest"     %% "scalatest"           % "3.2.6"         % "it",
@@ -309,12 +319,12 @@ object Dependencies {
     allAkka ++
     cats ++
     catsEffect ++
-    test
+    mUnitTest
 
   lazy val genus: Seq[ModuleID] =
     Seq(
-      "com.lightbend.akka"   %% "akka-stream-alpakka-mongodb" % "3.0.4",
-      "com.thesamet.scalapb" %% "scalapb-runtime"             % scalapb.compiler.Version.scalapbVersion % "protobuf"
+      "com.lightbend.akka" %% "akka-stream-alpakka-mongodb" % "3.0.4",
+      scalaPb
     ) ++
     allAkka ++
     circe ++

--- a/topl-grpc/src/main/protobuf/topl_grpc.proto
+++ b/topl-grpc/src/main/protobuf/topl_grpc.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package co.topl.grpc.services;
+
+service ToplGrpc {
+  rpc BroadcastTx (BroadcastTxReq) returns (BroadcastTxRes);
+}
+
+message BroadcastTxReq {
+  bytes transmittableBytes = 1;
+}
+
+message BroadcastTxRes {}

--- a/topl-grpc/src/main/protobuf/topl_grpc.proto
+++ b/topl-grpc/src/main/protobuf/topl_grpc.proto
@@ -3,11 +3,14 @@ syntax = "proto3";
 package co.topl.grpc.services;
 
 service ToplGrpc {
-  rpc BroadcastTx (BroadcastTxReq) returns (BroadcastTxRes);
+  rpc BroadcastTransaction (BroadcastTransactionReq) returns (BroadcastTransactionRes);
 }
 
-message BroadcastTxReq {
+message BroadcastTransactionReq {
+  // TODO: Use a Transaction structure instead of just its transmittableBytes
+  // But for now, just encode/decode the byte representation.  Re-implementing the full
+  // structure requires re-implementing the full Proposition/Proof structure.
   bytes transmittableBytes = 1;
 }
 
-message BroadcastTxRes {}
+message BroadcastTransactionRes {}

--- a/topl-grpc/src/main/scala/co/topl/grpc/ToplGrpc.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/ToplGrpc.scala
@@ -1,0 +1,76 @@
+package co.topl.grpc
+
+import akka.actor.ClassicActorSystemProvider
+import akka.grpc.GrpcClientSettings
+import akka.http.scaladsl.Http
+import cats.MonadThrow
+import cats.effect.kernel.{Async, Resource}
+import cats.implicits._
+import co.topl.algebras.ToplRpc
+import co.topl.catsakka._
+import co.topl.codecs.bytes.tetra.instances._
+import co.topl.codecs.bytes.typeclasses.implicits._
+import co.topl.grpc.services.{BroadcastTxReq, BroadcastTxRes, ToplGrpc}
+import co.topl.models._
+import com.google.protobuf.ByteString
+
+import scala.concurrent.Future
+
+object ToplGrpc {
+
+  object Client {
+
+    def make[F[_]: Async](host: String, port: Int)(implicit
+      systemProvider:           ClassicActorSystemProvider
+    ): F[ToplRpc[F]] =
+      Async[F].delay {
+        val client = services.ToplGrpcClient(GrpcClientSettings.connectToServiceAt(host, port).withTls(false))
+        new ToplRpc[F] {
+          def broadcastTx(transaction: Transaction): F[Unit] =
+            Async[F]
+              .fromFuture(
+                Async[F].delay(
+                  client.broadcastTx(
+                    services.BroadcastTxReq(
+                      ByteString.copyFrom(
+                        transaction.immutableBytes.toByteBuffer
+                      )
+                    )
+                  )
+                )
+              )
+              .void
+        }
+      }
+  }
+
+  object Server {
+
+    def serve[F[_]: Async: FToFuture](host: String, port: Int, interpreter: ToplRpc[F])(implicit
+      systemProvider:                       ClassicActorSystemProvider
+    ): Resource[F, Http.ServerBinding] =
+      Resource.make(
+        Async[F].fromFuture(
+          Async[F].delay(
+            Http()
+              .newServerAt(host, port)
+              .bind(services.ToplGrpcHandler(grpcServerImpl[F](interpreter)))
+          )
+        )
+      )(binding => Async[F].fromFuture(Async[F].delay(binding.unbind())).void)
+
+    private def grpcServerImpl[F[_]: MonadThrow: FToFuture](interpreter: ToplRpc[F]): ToplGrpc =
+      new ToplGrpc {
+
+        def broadcastTx(in: BroadcastTxReq): Future[BroadcastTxRes] =
+          implicitly[FToFuture[F]].apply(
+            Bytes(in.transmittableBytes.asReadOnlyByteBuffer())
+              .decodeTransmitted[Transaction]
+              .leftMap(err => new IllegalArgumentException(s"Invalid Transaction bytes. reason=$err"))
+              .liftTo[F]
+              .flatMap(interpreter.broadcastTx)
+              .as(BroadcastTxRes())
+          )
+      }
+  }
+}

--- a/topl-grpc/src/main/scala/co/topl/grpc/package.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/package.scala
@@ -1,0 +1,15 @@
+package co.topl
+
+import com.google.protobuf.ByteString
+import scodec.bits.ByteVector
+
+import scala.language.implicitConversions
+
+package object grpc {
+
+  implicit def byteStringToByteVector(byteString: ByteString): ByteVector =
+    ByteVector(byteString.asReadOnlyByteBuffer())
+
+  implicit def byteVectorToByteString(byteVector: ByteVector): ByteString =
+    ByteString.copyFrom(byteVector.toByteBuffer)
+}

--- a/topl-grpc/src/test/scala/co/topl/grpc/ToplGrpcSpec.scala
+++ b/topl-grpc/src/test/scala/co/topl/grpc/ToplGrpcSpec.scala
@@ -1,0 +1,37 @@
+package co.topl.grpc
+
+import cats.Applicative
+import cats.effect.{Async, IO}
+import cats.implicits._
+import co.topl.algebras.ToplRpc
+import co.topl.catsakka._
+import co.topl.codecs.bytes.tetra.instances._
+import co.topl.codecs.bytes.typeclasses.implicits._
+import co.topl.grpc.services.{BroadcastTransactionReq, BroadcastTransactionRes}
+import co.topl.models.ModelGenerators._
+import co.topl.models.Transaction
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF
+import org.scalamock.scalatest.MockFactory
+
+class ToplGrpcSpec extends CatsEffectSuite with ScalaCheckEffectSuite with MockFactory {
+  type F[A] = IO[A]
+
+  test("A transaction can be broadcast") {
+    PropF.forAllF { (transaction: Transaction) =>
+      val interpreter = mock[ToplRpc[F]]
+      val underTest = new ToplGrpc.Server.GrpcServerImpl[F](interpreter)
+
+      (interpreter.broadcastTransaction _)
+        .expects(transaction)
+        .once()
+        .returning(Applicative[F].unit)
+
+      Async[F]
+        .fromFuture(
+          underTest.broadcastTransaction(BroadcastTransactionReq(transaction.immutableBytes)).pure[F]
+        )
+        .assertEquals(BroadcastTransactionRes())
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
- Tetra needs the ability to insert transactions into the network by a "user"
  - This is necessary to begin practical testing of transaction throughput
- Tetra also needs an RPC layer to support "user input"
## Approach
- Created ToplRpc Algebra
- Created topl-grpc SBT module
  - Added new service definition with single RPC and simplified models/structures
- Run RPC server in DemoProgram
## Testing
- Added basic unit test for Broadcast Transaction
  - Implemented using MUnit to move us toward proper "async" testing
## Tickets
_* closes #2241_
