### PR TITLE
Tetra Transaction Notification Protocol

### DIFF
--- a/brambl/src/main/scala/co/topl/client/BramblTetra.scala
+++ b/brambl/src/main/scala/co/topl/client/BramblTetra.scala
@@ -3,7 +3,7 @@ package co.topl.client
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import cats.data.Chain
-import cats.effect.{IO, IOApp}
+import cats.effect.{Async, IO, IOApp, Sync}
 import cats.implicits._
 import co.topl.algebras.ToplRpc
 import co.topl.catsakka.AkkaCatsRuntime
@@ -12,10 +12,19 @@ import co.topl.models._
 import co.topl.models.utility.HasLength.instances.bigIntLength
 import co.topl.models.utility.Lengths._
 import co.topl.models.utility.Sized
+import org.typelevel.log4cats.{Logger, SelfAwareStructuredLogger}
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import co.topl.codecs.bytes.typeclasses.implicits._
+import co.topl.codecs.bytes.tetra.instances._
+import scala.concurrent.duration._
+import co.topl.typeclasses.implicits._
 
 object BramblTetra extends IOApp.Simple {
 
   type F[A] = IO[A]
+
+  implicit private val logger: F[SelfAwareStructuredLogger[F]] =
+    Slf4jLogger.create[F]
 
   override def run: IO[Unit] =
     AkkaCatsRuntime
@@ -24,21 +33,47 @@ object BramblTetra extends IOApp.Simple {
         ToplGrpc.Client
           .make[F]("localhost", 8090, tls = false)
           .flatMap(implicit rpcClient =>
-            Transaction(
-              inputs = Chain(
-                Transaction.Input(
-                  boxId = Box.Id(TypedBytes(3: Byte, Bytes.fill(32)(0: Byte)), 0),
-                  proposition = Propositions.PermanentlyLocked,
-                  proof = Proofs.False,
-                  value = Box.Values.Poly(Sized.maxUnsafe(BigInt(10)))
-                )
-              ),
-              outputs = Chain.empty,
-              chronology = Transaction.Chronology(System.currentTimeMillis(), 0L, Long.MaxValue),
-              data = none
-            ).broadcast[F]
+            Slf4jLogger
+              .fromName[F]("Brambl@localhost:8090")
+              .flatMap(implicit logger => infiniteTransactions(1500.milli))
           )
+          .parProduct(
+            Async[F].sleep(200.milli) >>
+            ToplGrpc.Client
+              .make[F]("localhost", 8091, tls = false)
+              .flatMap(implicit rpcClient =>
+                Slf4jLogger
+                  .fromName[F]("Brambl@localhost:8091")
+                  .flatMap(implicit logger => infiniteTransactions(1500.milli))
+              )
+          )
+          .void
       )
+
+  private def infiniteTransactions(sleepDuration: FiniteDuration)(implicit rpcClient: ToplRpc[F], logger: Logger[F]) =
+    Sync[F]
+      .defer(
+        for {
+          transaction <- Transaction(
+            inputs = Chain(
+              Transaction.Input(
+                boxId = Box.Id(TypedBytes(3: Byte, Bytes.fill(32)(0: Byte)), 0),
+                proposition = Propositions.PermanentlyLocked,
+                proof = Proofs.False,
+                value = Box.Values.Poly(Sized.maxUnsafe(BigInt(10)))
+              )
+            ),
+            outputs = Chain.empty,
+            chronology = Transaction.Chronology(System.currentTimeMillis(), 0L, Long.MaxValue),
+            data = none
+          ).pure[F]
+          _ <- Logger[F].info(show"Broadcasting transaction id=${transaction.id.asTypedBytes}")
+          _ <- transaction.broadcast[F]
+          _ <- Async[F].sleep(sleepDuration)
+        } yield ()
+      )
+      .foreverM
+      .void
 
   implicit class TransactionOps(transaction: Transaction) {
     def broadcast[F[_]: ToplRpc]: F[Unit] = implicitly[ToplRpc[F]].broadcastTransaction(transaction)

--- a/demo/src/main/scala/co/topl/demo/TetraSuperDemo.scala
+++ b/demo/src/main/scala/co/topl/demo/TetraSuperDemo.scala
@@ -59,7 +59,7 @@ object TetraSuperDemo extends IOApp {
   private val OperationalPeriodLength = 180L
   private val OperationalPeriodsPerEpoch = 4L
   private val EpochLength = OperationalPeriodLength * OperationalPeriodsPerEpoch
-  private val SlotDuration = 100.milli
+  private val SlotDuration = 1000.milli
 
   require(
     EpochLength % OperationalPeriodLength === 0L,
@@ -233,7 +233,7 @@ object TetraSuperDemo extends IOApp {
         (
           localPeers(1)._1,
           Source
-            .future(akka.pattern.after(40.seconds)(Future.unit))
+            .future(akka.pattern.after(8.seconds)(Future.unit))
             .flatMapConcat(_ => Source(List(DisconnectedPeer.tupled(LocalPeer.unapply(localPeers(0)._1).get)))),
           true,
           localPeers(1)._2,

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
@@ -28,6 +28,11 @@ trait BlockchainPeerClient[F[_]] {
   def remotePeerAdoptions: F[Source[TypedIdentifier, NotUsed]]
 
   /**
+   * A Source of transaction IDs that were observed by the remote node
+   */
+  def remoteTransactionNotifications: F[Source[TypedIdentifier, NotUsed]]
+
+  /**
    * A Lookup to retrieve a remote block header by ID
    */
   def getRemoteHeader(id: TypedIdentifier): F[Option[BlockHeaderV2]]

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServer.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServer.scala
@@ -16,6 +16,7 @@ import org.typelevel.log4cats.Logger
  */
 trait BlockchainPeerServer[F[_]] {
   def localBlockAdoptions: F[Source[TypedIdentifier, NotUsed]]
+  def localTransactionNotifications: F[Source[TypedIdentifier, NotUsed]]
   def getLocalHeader(id:            TypedIdentifier): F[Option[BlockHeaderV2]]
   def getLocalBody(id:              TypedIdentifier): F[Option[BlockBodyV2]]
   def getLocalTransaction(id:       TypedIdentifier): F[Option[Transaction]]
@@ -27,17 +28,21 @@ object BlockchainPeerServer {
   object FromStores {
 
     def make[F[_]: Monad: Logger](
-      headerStore:            Store[F, TypedIdentifier, BlockHeaderV2],
-      bodyStore:              Store[F, TypedIdentifier, BlockBodyV2],
-      transactionStore:       Store[F, TypedIdentifier, Transaction],
-      blockHeights:           EventSourcedState[F, Long => F[Option[TypedIdentifier]]],
-      localChain:             LocalChainAlgebra[F],
-      locallyAdoptedBlockIds: Source[TypedIdentifier, NotUsed]
+      headerStore:                  Store[F, TypedIdentifier, BlockHeaderV2],
+      bodyStore:                    Store[F, TypedIdentifier, BlockBodyV2],
+      transactionStore:             Store[F, TypedIdentifier, Transaction],
+      blockHeights:                 EventSourcedState[F, Long => F[Option[TypedIdentifier]]],
+      localChain:                   LocalChainAlgebra[F],
+      locallyAdoptedBlockIds:       Source[TypedIdentifier, NotUsed],
+      locallyAdoptedTransactionIds: Source[TypedIdentifier, NotUsed]
     ): F[BlockchainPeerServer[F]] =
       new BlockchainPeerServer[F] {
 
         def localBlockAdoptions: F[Source[TypedIdentifier, NotUsed]] =
           locallyAdoptedBlockIds.buffer(1, OverflowStrategy.dropHead).pure[F]
+
+        def localTransactionNotifications: F[Source[TypedIdentifier, NotUsed]] =
+          locallyAdoptedTransactionIds.buffer(5, OverflowStrategy.dropHead).pure[F]
 
         def getLocalHeader(id: TypedIdentifier): F[Option[BlockHeaderV2]] = headerStore.get(id)
 

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
@@ -42,6 +42,8 @@ class BlockchainClientSpec
 
           def remotePeerAdoptions: F[Source[TypedIdentifier, NotUsed]] = ???
 
+          def remoteTransactionNotifications: F[Source[TypedIdentifier, NotUsed]] = ???
+
           def getRemoteHeader(id: TypedIdentifier): F[Option[BlockHeaderV2]] = ???
 
           def getRemoteBody(id: TypedIdentifier): F[Option[BlockBodyV2]] = ???

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactorySpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactorySpec.scala
@@ -44,12 +44,17 @@ class BlockchainPeerConnectionFlowFactorySpec
         .once()
         .returning(Source.never[TypedIdentifier].pure[F])
 
+      (() => server.localTransactionNotifications)
+        .expects()
+        .once()
+        .returning(Source.never[TypedIdentifier].pure[F])
+
       val factory = BlockchainPeerConnectionFlowFactory.createFactory[F](server)
 
       val (protocols, _) = factory.protocolsForPeer(connectedPeer, connectionLeader).unsafeRunSync()
 
-      protocols.length shouldBe 10L
-      protocols.map(_.sessionId).toNes[Byte].toSortedSet shouldBe SortedSet[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+      protocols.length shouldBe 12L
+      protocols.map(_.sessionId).toNes[Byte].toSortedSet shouldBe SortedSet[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
     }
   }
 }


### PR DESCRIPTION
## Purpose
- Transactions must be exchanged over the network so that they can be included in newly minted blocks
- Peers can be *notified* of a transaction's existence using the Transaction Notification Protocol
## Approach
- Added a new typed protocol to notify of transaction IDs
- When a peer notifies us:
  - Syntactically validate
  - Save transaction
  - Add to mempool
  - Rebroadcast
- "We" notify a peer when:
  - A Transaction is added to the mempool
## Testing
- Minor unit test updates
- Verified manually
  - ![image](https://user-images.githubusercontent.com/2218886/172446595-1a36977a-1c31-4c76-aaf3-79811f193e3c.png)
## Tickets
_* closes #2073_
