### PR TITLE
Tetra Box State

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
@@ -1,7 +1,9 @@
 package co.topl.algebras
 
-import co.topl.models.Transaction
+import co.topl.models.{Transaction, TypedIdentifier}
 
 trait ToplRpc[F[_]] {
   def broadcastTransaction(transaction: Transaction): F[Unit]
+
+  def currentMempool(): F[Set[TypedIdentifier]]
 }

--- a/brambl/src/main/scala/co/topl/client/BramblTetra.scala
+++ b/brambl/src/main/scala/co/topl/client/BramblTetra.scala
@@ -23,9 +23,6 @@ object BramblTetra extends IOApp.Simple {
 
   type F[A] = IO[A]
 
-  implicit private val logger: F[SelfAwareStructuredLogger[F]] =
-    Slf4jLogger.create[F]
-
   override def run: IO[Unit] =
     AkkaCatsRuntime
       .systemResource[F, Nothing](ActorSystem(Behaviors.empty, "Brambl"))
@@ -35,7 +32,7 @@ object BramblTetra extends IOApp.Simple {
           .flatMap(implicit rpcClient =>
             Slf4jLogger
               .fromName[F]("Brambl@localhost:8090")
-              .flatMap(implicit logger => infiniteTransactions(1500.milli))
+              .flatMap(implicit logger => infiniteTransactions(500.milli))
           )
           .parProduct(
             Async[F].sleep(200.milli) >>
@@ -44,7 +41,7 @@ object BramblTetra extends IOApp.Simple {
               .flatMap(implicit rpcClient =>
                 Slf4jLogger
                   .fromName[F]("Brambl@localhost:8091")
-                  .flatMap(implicit logger => infiniteTransactions(1500.milli))
+                  .flatMap(implicit logger => infiniteTransactions(500.milli))
               )
           )
           .void

--- a/brambl/src/main/scala/co/topl/client/BramblTetra.scala
+++ b/brambl/src/main/scala/co/topl/client/BramblTetra.scala
@@ -3,7 +3,7 @@ package co.topl.client
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import cats.data.Chain
-import cats.effect.{IO, IOApp}
+import cats.effect.{Async, IO, IOApp, Sync}
 import cats.implicits._
 import co.topl.algebras.ToplRpc
 import co.topl.catsakka.AkkaCatsRuntime
@@ -12,10 +12,19 @@ import co.topl.models._
 import co.topl.models.utility.HasLength.instances.bigIntLength
 import co.topl.models.utility.Lengths._
 import co.topl.models.utility.Sized
+import org.typelevel.log4cats.{Logger, SelfAwareStructuredLogger}
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import co.topl.codecs.bytes.typeclasses.implicits._
+import co.topl.codecs.bytes.tetra.instances._
+import scala.concurrent.duration._
+import co.topl.typeclasses.implicits._
 
 object BramblTetra extends IOApp.Simple {
 
   type F[A] = IO[A]
+
+  implicit private val logger: F[SelfAwareStructuredLogger[F]] =
+    Slf4jLogger.create[F]
 
   override def run: IO[Unit] =
     AkkaCatsRuntime
@@ -24,21 +33,47 @@ object BramblTetra extends IOApp.Simple {
         ToplGrpc.Client
           .make[F]("localhost", 8090, tls = false)
           .flatMap(implicit rpcClient =>
-            Transaction(
-              inputs = Chain(
-                Transaction.Input(
-                  boxId = Box.Id(TypedBytes(3: Byte, Bytes.fill(32)(0: Byte)), 0),
-                  proposition = Propositions.PermanentlyLocked,
-                  proof = Proofs.False,
-                  value = Box.Values.Poly(Sized.maxUnsafe(BigInt(10)))
-                )
-              ),
-              outputs = Chain.empty,
-              chronology = Transaction.Chronology(System.currentTimeMillis(), 0L, Long.MaxValue),
-              data = none
-            ).broadcast[F]
+            Slf4jLogger
+              .fromName[F]("Brambl@localhost:8090")
+              .flatMap(implicit logger => infiniteTransactions(1500.milli))
           )
+          .parProduct(
+            Async[F].sleep(200.milli) >>
+            ToplGrpc.Client
+              .make[F]("localhost", 8091, tls = false)
+              .flatMap(implicit rpcClient =>
+                Slf4jLogger
+                  .fromName[F]("Brambl@localhost:8091")
+                  .flatMap(implicit logger => infiniteTransactions(1500.milli))
+              )
+          )
+          .void
       )
+
+  private def infiniteTransactions(sleepDuration: FiniteDuration)(implicit rpcClient: ToplRpc[F], logger: Logger[F]) =
+    Sync[F]
+      .defer(
+        for {
+          transaction <- Transaction(
+            inputs = Chain(
+              Transaction.Input(
+                boxId = Box.Id(TypedBytes(3: Byte, Bytes.fill(32)(0: Byte)), 0),
+                proposition = Propositions.PermanentlyLocked,
+                proof = Proofs.False,
+                value = Box.Values.Poly(Sized.maxUnsafe(BigInt(10)))
+              )
+            ),
+            outputs = Chain.empty,
+            chronology = Transaction.Chronology(System.currentTimeMillis(), 0L, Long.MaxValue),
+            data = none
+          ).pure[F]
+          _ <- Logger[F].info(show"Broadcasting transaction id=${transaction.id.asTypedBytes}")
+          _ <- transaction.broadcast[F]
+          _ <- Async[F].sleep(sleepDuration)
+        } yield ()
+      )
+      .foreverM
+      .void
 
   implicit class TransactionOps(transaction: Transaction) {
     def broadcast[F[_]: ToplRpc]: F[Unit] = implicitly[ToplRpc[F]].broadcastTransaction(transaction)

--- a/brambl/src/main/scala/co/topl/client/BramblTetraMempoolReader.scala
+++ b/brambl/src/main/scala/co/topl/client/BramblTetraMempoolReader.scala
@@ -1,0 +1,61 @@
+package co.topl.client
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import cats.effect.{Async, IO, IOApp, Sync}
+import cats.implicits._
+import co.topl.algebras.ToplRpc
+import co.topl.catsakka.AkkaCatsRuntime
+import co.topl.grpc.ToplGrpc
+import co.topl.models._
+import co.topl.typeclasses.implicits._
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import scala.concurrent.duration._
+
+object BramblTetraMempoolReader extends IOApp.Simple {
+
+  type F[A] = IO[A]
+
+  override def run: IO[Unit] =
+    AkkaCatsRuntime
+      .systemResource[F, Nothing](ActorSystem(Behaviors.empty, "Brambl"))
+      .use(implicit system =>
+        ToplGrpc.Client
+          .make[F]("localhost", 8090, tls = false)
+          .flatMap(implicit rpcClient =>
+            Slf4jLogger
+              .fromName[F]("Brambl@localhost:8090")
+              .flatMap(implicit logger => infiniteMempool(1500.milli))
+          )
+          .parProduct(
+            Async[F].sleep(200.milli) >>
+            ToplGrpc.Client
+              .make[F]("localhost", 8091, tls = false)
+              .flatMap(implicit rpcClient =>
+                Slf4jLogger
+                  .fromName[F]("Brambl@localhost:8091")
+                  .flatMap(implicit logger => infiniteMempool(1500.milli))
+              )
+          )
+          .void
+      )
+
+  private def infiniteMempool(sleepDuration: FiniteDuration)(implicit rpcClient: ToplRpc[F], logger: Logger[F]) =
+    Sync[F]
+      .defer(
+        for {
+          mempool <- rpcClient.currentMempool()
+          _       <- Logger[F].info(show"Current mempool=$mempool")
+          _       <- Async[F].sleep(sleepDuration)
+        } yield ()
+      )
+      .foreverM
+      .void
+
+  implicit class TransactionOps(transaction: Transaction) {
+    def broadcast[F[_]: ToplRpc]: F[Unit] = implicitly[ToplRpc[F]].broadcastTransaction(transaction)
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,9 @@ inThisBuild(
       val d = new java.util.Date
       sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(versionFmt, fallbackVersion(d))
     },
-    parallelExecution := false
+    parallelExecution := false,
+    testFrameworks += TestFrameworks.MUnit,
+    libraryDependencies ++= Dependencies.mUnitTest
   )
 )
 
@@ -37,7 +39,8 @@ lazy val commonSettings = Seq(
     }
   },
   crossScalaVersions := Seq(scala212, scala213),
-  testFrameworks += new TestFramework("munit.Framework"),
+  testFrameworks += TestFrameworks.MUnit,
+  libraryDependencies ++= Dependencies.mUnitTest,
   Test / testOptions ++= Seq(
     Tests.Argument("-oD", "-u", "target/test-reports"),
     Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "2"),
@@ -511,6 +514,7 @@ lazy val ledger = project
   .settings(scalamacrosParadiseSettings)
   .dependsOn(
     models % "compile->compile;test->test",
+    algebras % "compile->compile;test->test",
     typeclasses,
     eventTree
   )

--- a/demo/src/main/scala/co/topl/demo/TetraSuperDemo.scala
+++ b/demo/src/main/scala/co/topl/demo/TetraSuperDemo.scala
@@ -59,7 +59,7 @@ object TetraSuperDemo extends IOApp {
   private val OperationalPeriodLength = 180L
   private val OperationalPeriodsPerEpoch = 4L
   private val EpochLength = OperationalPeriodLength * OperationalPeriodsPerEpoch
-  private val SlotDuration = 100.milli
+  private val SlotDuration = 1000.milli
 
   require(
     EpochLength % OperationalPeriodLength === 0L,
@@ -233,7 +233,7 @@ object TetraSuperDemo extends IOApp {
         (
           localPeers(1)._1,
           Source
-            .future(akka.pattern.after(40.seconds)(Future.unit))
+            .future(akka.pattern.after(8.seconds)(Future.unit))
             .flatMapConcat(_ => Source(List(DisconnectedPeer.tupled(LocalPeer.unapply(localPeers(0)._1).get)))),
           true,
           localPeers(1)._2,

--- a/demo/src/main/scala/co/topl/demo/TetraSuperDemo.scala
+++ b/demo/src/main/scala/co/topl/demo/TetraSuperDemo.scala
@@ -59,7 +59,7 @@ object TetraSuperDemo extends IOApp {
   private val OperationalPeriodLength = 180L
   private val OperationalPeriodsPerEpoch = 4L
   private val EpochLength = OperationalPeriodLength * OperationalPeriodsPerEpoch
-  private val SlotDuration = 1000.milli
+  private val SlotDuration = 200.milli
 
   require(
     EpochLength % OperationalPeriodLength === 0L,

--- a/ledger/src/main/scala/co/topl/ledger/algebras/BoxStateAlgebra.scala
+++ b/ledger/src/main/scala/co/topl/ledger/algebras/BoxStateAlgebra.scala
@@ -1,0 +1,14 @@
+package co.topl.ledger.algebras
+
+import co.topl.models.{Box, TypedIdentifier}
+
+trait BoxStateAlgebra[F[_]] {
+
+  /**
+   * Indicates if a particular box is spendable at the given block ID
+   * @return F[true] if the box exists and is spendable
+   *         F[false] if the box either never existed or has been spent already.  The interpretation should make no
+   *         distinction between the two scenarios.
+   */
+  def boxExistsAt(blockId: TypedIdentifier)(boxId: Box.Id): F[Boolean]
+}

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
@@ -1,0 +1,99 @@
+package co.topl.ledger.interpreters
+
+import cats.data.{NonEmptySet, OptionT}
+import cats.effect.Async
+import cats.implicits._
+import cats.{Applicative, MonadThrow}
+import co.topl.algebras.Store
+import co.topl.codecs.bytes.tetra.instances._
+import co.topl.codecs.bytes.typeclasses.implicits._
+import co.topl.eventtree.{EventSourcedState, ParentChildTree}
+import co.topl.ledger.algebras.BoxStateAlgebra
+import co.topl.models.{BlockBodyV2, Box, Transaction, TypedIdentifier}
+import co.topl.typeclasses.implicits._
+
+import scala.collection.immutable.SortedSet
+
+object BoxState {
+
+  type State[F[_]] = Store[F, TypedIdentifier, NonEmptySet[Short]]
+
+  def make[F[_]: Async](
+    currentBlockId:   F[TypedIdentifier],
+    fetchBlockBody:   TypedIdentifier => F[BlockBodyV2],
+    fetchTransaction: TypedIdentifier => F[Transaction],
+    parentChildTree:  ParentChildTree[F, TypedIdentifier],
+    initialState:     F[State[F]]
+  ): F[BoxStateAlgebra[F]] =
+    for {
+      eventSourcedState <- EventSourcedState.OfTree.make[F, State[F]](
+        initialState,
+        currentBlockId,
+        applyEvent = applyBlock(fetchBlockBody, fetchTransaction),
+        unapplyEvent = unapplyBlock(fetchBlockBody, fetchTransaction),
+        parentChildTree
+      )
+    } yield new BoxStateAlgebra[F] {
+
+      def boxExistsAt(blockId: TypedIdentifier)(boxId: Box.Id): F[Boolean] =
+        eventSourcedState
+          .useStateAt(blockId)(_.get(boxId.transactionId))
+          .map(_.exists(_.contains(boxId.transactionOutputIndex)))
+    }
+
+  /**
+   * Apply the given block to the state.
+   *
+   * - For each transaction
+   *   - Each input is removed from the state
+   *   - Each output is added to the state
+   */
+  private def applyBlock[F[_]: MonadThrow](
+    fetchBlockBody:   TypedIdentifier => F[BlockBodyV2],
+    fetchTransaction: TypedIdentifier => F[Transaction]
+  )(state:            State[F], blockId: TypedIdentifier): F[State[F]] =
+    for {
+      body         <- fetchBlockBody(blockId)
+      transactions <- body.traverse(fetchTransaction)
+      _ <- transactions.traverse(transaction =>
+        transaction.inputs.traverse(input =>
+          state
+            .getOrRaise(input.boxId.transactionId)
+            .flatMap(unspentIndices =>
+              OptionT
+                .fromOption[F](NonEmptySet.fromSet(unspentIndices - input.boxId.transactionOutputIndex))
+                .foldF(state.remove(input.boxId.transactionId))(state.put(input.boxId.transactionId, _))
+            )
+        ) >> OptionT
+          .fromOption[F](
+            NonEmptySet.fromSet(SortedSet.from(transaction.outputs.void.zipWithIndex.map(_._2.toShort).toIterable))
+          )
+          .foldF(Applicative[F].unit)(state.put(transaction.id, _))
+      )
+    } yield state
+
+  /**
+   * Unapply the given block from the state.
+   *
+   * - For each transaction
+   *   - Each output is removed from the state
+   *   - Each input is added to the state
+   */
+  private def unapplyBlock[F[_]: MonadThrow](
+    fetchBlockBody:   TypedIdentifier => F[BlockBodyV2],
+    fetchTransaction: TypedIdentifier => F[Transaction]
+  )(state:            State[F], blockId: TypedIdentifier): F[State[F]] =
+    for {
+      body         <- fetchBlockBody(blockId)
+      transactions <- body.traverse(fetchTransaction)
+      _ <- transactions.traverse(transaction =>
+        state.remove(transaction.id) >>
+        transaction.inputs.traverse(input =>
+          state
+            .getOrRaise(input.boxId.transactionId)
+            .map(_.add(input.boxId.transactionOutputIndex))
+            .flatMap(state.put(input.boxId.transactionId, _))
+        )
+      )
+    } yield state
+}

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
@@ -16,8 +16,15 @@ import scala.collection.immutable.SortedSet
 
 object BoxState {
 
+  /**
+   * Store Key: Transaction ID
+   * Store Value: Array of Shorts, representing the currently spendable indices of the original transaction output array
+   */
   type State[F[_]] = Store[F, TypedIdentifier, NonEmptySet[Short]]
 
+  /**
+   * Creates a BoxStateAlgebra interpreter that is backed by an event-sourced tree
+   */
   def make[F[_]: Async](
     currentBlockId:   F[TypedIdentifier],
     fetchBlockBody:   TypedIdentifier => F[BlockBodyV2],

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
@@ -5,7 +5,6 @@ import cats.effect.IO
 import co.topl.models.{Box, Transaction, TypedIdentifier}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
-import org.scalamock.scalatest.MockFactory
 import co.topl.models.ModelGenerators._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
@@ -14,7 +13,7 @@ import cats.implicits._
 import co.topl.algebras.testInterpreters.TestStore
 import co.topl.eventtree.ParentChildTree
 
-class BoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite with MockFactory {
+class BoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   test("BoxState includes new outputs") {
     PropF.forAllF {
@@ -53,7 +52,6 @@ class BoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite with MockF
 
           _ <- underTest.boxExistsAt(blockId1)(outputBoxId).assert
           _ <- underTest.boxExistsAt(blockId2)(outputBoxId).map(!_).assert
-          _ <- IO(false).assert
         } yield ()
     }
   }

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
@@ -1,0 +1,60 @@
+package co.topl.ledger.interpreters
+
+import cats.data.{Chain, NonEmptySet}
+import cats.effect.IO
+import co.topl.models.{Box, Transaction, TypedIdentifier}
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF
+import org.scalamock.scalatest.MockFactory
+import co.topl.models.ModelGenerators._
+import co.topl.codecs.bytes.tetra.instances._
+import co.topl.codecs.bytes.typeclasses.implicits._
+import co.topl.typeclasses.implicits._
+import cats.implicits._
+import co.topl.algebras.testInterpreters.TestStore
+import co.topl.eventtree.ParentChildTree
+
+class BoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite with MockFactory {
+
+  test("BoxState includes new outputs") {
+    PropF.forAllF {
+      (
+        blockId0:         TypedIdentifier,
+        transaction1Base: Transaction,
+        output:           Transaction.Output,
+        blockId1:         TypedIdentifier,
+        transaction2Base: Transaction,
+        input:            Transaction.Input,
+        blockId2:         TypedIdentifier
+      ) =>
+        val transaction1 =
+          transaction1Base.copy(inputs = Chain.empty, outputs = transaction1Base.outputs.append(output))
+        val outputBoxId =
+          Box.Id(transaction1.id, (transaction1.outputs.length - 1).toShort)
+        val transaction2 = transaction2Base.copy(inputs = Chain(input.copy(boxId = outputBoxId)))
+
+        for {
+          parentChildTree <- ParentChildTree.FromSemaphore.make[IO, TypedIdentifier]
+          _               <- parentChildTree.associate(blockId1, blockId0)
+          _               <- parentChildTree.associate(blockId2, blockId1)
+          underTest <- BoxState.make[IO](
+            blockId0.pure[IO],
+            Map(
+              blockId1 -> List(transaction1.id.asTypedBytes).pure[IO],
+              blockId2 -> List(transaction2.id.asTypedBytes).pure[IO]
+            ).apply _,
+            Map(
+              transaction1.id.asTypedBytes -> transaction1.pure[IO],
+              transaction2.id.asTypedBytes -> transaction2.pure[IO]
+            ),
+            parentChildTree,
+            TestStore.make[IO, TypedIdentifier, NonEmptySet[Short]].widen
+          )
+
+          _ <- underTest.boxExistsAt(blockId1)(outputBoxId).assert
+          _ <- underTest.boxExistsAt(blockId2)(outputBoxId).map(!_).assert
+          _ <- IO(false).assert
+        } yield ()
+    }
+  }
+}

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/MempoolSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/MempoolSpec.scala
@@ -12,15 +12,19 @@ import co.topl.models.ModelGenerators._
 import co.topl.models.{BlockBodyV2, Slot, Transaction, TypedIdentifier}
 import co.topl.typeclasses.implicits._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.scalacheck.Gen
+import org.scalacheck.{Gen, Test}
 import org.scalacheck.effect.PropF
-import org.scalamock.scalatest.MockFactory
+import org.scalamock.munit.AsyncMockFactory
 
 import scala.concurrent.duration._
 
-class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with MockFactory {
+class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
   type F[A] = IO[A]
+
+  override def scalaCheckTestParameters: Test.Parameters =
+    super.scalaCheckTestParameters
+      .withMaxSize(3)
 
   test("expose a Set of Transaction IDs at a specific block") {
     PropF.forAllF(
@@ -29,111 +33,73 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with MockFa
       ),
       arbitraryTransaction.arbitrary
     ) { case (bodies, newTx) =>
-      val bodiesMap = bodies.toList.toMap
-      val transactions = bodies.flatMap(_._2).toList.map(t => t.id.asTypedBytes -> t).toMap.updated(newTx.id, newTx)
-      val fetchBody = (id: TypedIdentifier) => bodiesMap(id).map(_.id: TypedIdentifier).toList.pure[F]
-      val fetchTransaction = (id: TypedIdentifier) => transactions(id).pure[F]
-      val clock = mock[ClockAlgebra[F]]
-      (() => clock.globalSlot)
-        .expects()
-        .anyNumberOfTimes()
-        .returning(0L.pure[F])
-      (clock
-        .delayedUntilSlot(_: Slot))
-        .expects(*)
-        .anyNumberOfTimes()
-        .returning(MonadCancel[F].never[Unit])
-      for {
-        tree <- ParentChildTree.FromRef.make[F, TypedIdentifier]
-        _    <- bodies.map(_._1).sliding2.traverse { case (id1, id2) => tree.associate(id2, id1) }
-        underTest <- Mempool
-          .make[F](
-            bodies.head._1.pure[F],
-            fetchBody,
-            fetchTransaction,
-            tree,
-            clock,
-            _ => Applicative[F].unit,
-            Long.MaxValue,
-            Long.MaxValue
-          )
+      withMock {
+        val bodiesMap = bodies.toList.toMap
+        val transactions = bodies.flatMap(_._2).toList.map(t => t.id.asTypedBytes -> t).toMap.updated(newTx.id, newTx)
+        val fetchBody = (id: TypedIdentifier) => bodiesMap(id).map(_.id: TypedIdentifier).toList.pure[F]
+        val fetchTransaction = (id: TypedIdentifier) => transactions(id).pure[F]
+        val clock = mock[ClockAlgebra[F]]
+        (() => clock.globalSlot)
+          .expects()
+          .anyNumberOfTimes()
+          .returning(0L.pure[F])
+        (clock
+          .delayedUntilSlot(_: Slot))
+          .expects(*)
+          .anyNumberOfTimes()
+          .returning(MonadCancel[F].never[Unit])
+        for {
+          tree <- ParentChildTree.FromRef.make[F, TypedIdentifier]
+          _    <- bodies.map(_._1).sliding2.traverse { case (id1, id2) => tree.associate(id2, id1) }
+          underTest <- Mempool
+            .make[F](
+              bodies.head._1.pure[F],
+              fetchBody,
+              fetchTransaction,
+              tree,
+              clock,
+              _ => Applicative[F].unit,
+              Long.MaxValue,
+              Long.MaxValue
+            )
 
-        _ <- underTest.read(bodies.last._1).assertEquals(Set.empty[TypedIdentifier])
-        _ <- underTest.add(newTx.id)
-        _ <- underTest.read(bodies.last._1).assertEquals(Set(newTx.id.asTypedBytes))
-        _ <- underTest.remove(newTx.id)
-        _ <- underTest.read(bodies.last._1).assertEquals(Set.empty[TypedIdentifier])
-        _ <- underTest
-          .read(bodies.head._1)
-          .assertEquals(
-            bodies.tail.toList
-              .flatMap(_._2.toList.map(_.id.asTypedBytes))
-              .toSet
-          )
-      } yield ()
+          _ <- underTest.read(bodies.last._1).assertEquals(Set.empty[TypedIdentifier])
+          _ <- underTest.add(newTx.id)
+          _ <- underTest.read(bodies.last._1).assertEquals(Set(newTx.id.asTypedBytes))
+          _ <- underTest.remove(newTx.id)
+          _ <- underTest.read(bodies.last._1).assertEquals(Set.empty[TypedIdentifier])
+          _ <- underTest
+            .read(bodies.head._1)
+            .assertEquals(
+              bodies.tail.toList
+                .flatMap(_._2.toList.map(_.id.asTypedBytes))
+                .toSet
+            )
+        } yield ()
+      }
     }
   }
 
   test("allow transactions to be added externally") {
     PropF.forAllF { (currentBlockId: TypedIdentifier, transaction: Transaction) =>
-      val fetchTransaction = mockFunction[TypedIdentifier, F[Transaction]]
-      fetchTransaction
-        .expects(transaction.id: TypedIdentifier)
-        .once()
-        .returning(transaction.pure[F])
-      val clock = mock[ClockAlgebra[F]]
-      (() => clock.globalSlot)
-        .expects()
-        .once()
-        .returning(0L.pure[F])
-      (clock
-        .delayedUntilSlot(_: Slot))
-        .expects(*)
-        .once()
-        .returning(MonadCancel[F].never[Unit])
-      for {
-        underTest <- Mempool
-          .make[F](
-            currentBlockId.pure[F],
-            mockFunction[TypedIdentifier, F[BlockBodyV2]],
-            fetchTransaction,
-            mock[ParentChildTree[F, TypedIdentifier]],
-            clock,
-            _ => Applicative[F].unit,
-            Long.MaxValue,
-            Long.MaxValue
-          )
-
-        _ <- underTest.add(transaction.id).assert
-      } yield ()
-    }
-  }
-
-  test("expire transactions at the user-defined slot") {
-    PropF.forAllF { (currentBlockId: TypedIdentifier, transactionWithRandomTime: Transaction) =>
-      val transaction =
-        transactionWithRandomTime.copy(chronology = transactionWithRandomTime.chronology.copy(maximumSlot = 2))
-      val fetchTransaction = mockFunction[TypedIdentifier, F[Transaction]]
-      fetchTransaction
-        .expects(transaction.id: TypedIdentifier)
-        .once()
-        .returning(transaction.pure[F])
-      val clock = mock[ClockAlgebra[F]]
-      (() => clock.globalSlot)
-        .expects()
-        .once()
-        .returning(0L.pure[F])
-      for {
-        deferred <- Deferred[F, Unit]
-        _ =
-          (clock
-            .delayedUntilSlot(_: Slot))
-            // This is the real thing being tested here
-            .expects(transaction.chronology.maximumSlot)
-            .once()
-            .returning(deferred.get)
-        underTest <-
-          Mempool
+      withMock {
+        val fetchTransaction = mockFunction[TypedIdentifier, F[Transaction]]
+        fetchTransaction
+          .expects(transaction.id: TypedIdentifier)
+          .once()
+          .returning(transaction.pure[F])
+        val clock = mock[ClockAlgebra[F]]
+        (() => clock.globalSlot)
+          .expects()
+          .once()
+          .returning(0L.pure[F])
+        (clock
+          .delayedUntilSlot(_: Slot))
+          .expects(*)
+          .once()
+          .returning(MonadCancel[F].never[Unit])
+        for {
+          underTest <- Mempool
             .make[F](
               currentBlockId.pure[F],
               mockFunction[TypedIdentifier, F[BlockBodyV2]],
@@ -145,57 +111,103 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with MockFa
               Long.MaxValue
             )
 
-        _ <- underTest.add(transaction.id)
-        _ <- underTest.read(currentBlockId).assertEquals(Set(transaction.id.asTypedBytes))
-        _ <- deferred.complete(())
-        _ <- retry(underTest.read(currentBlockId).assertEquals(Set.empty[TypedIdentifier]))
-      } yield ()
+          _ <- underTest.add(transaction.id).assert
+        } yield ()
+      }
+    }
+  }
+
+  test("expire transactions at the user-defined slot") {
+    PropF.forAllF { (currentBlockId: TypedIdentifier, transactionWithRandomTime: Transaction) =>
+      withMock {
+        val transaction =
+          transactionWithRandomTime.copy(chronology = transactionWithRandomTime.chronology.copy(maximumSlot = 2))
+        val fetchTransaction = mockFunction[TypedIdentifier, F[Transaction]]
+        fetchTransaction
+          .expects(transaction.id: TypedIdentifier)
+          .once()
+          .returning(transaction.pure[F])
+        val clock = mock[ClockAlgebra[F]]
+        (() => clock.globalSlot)
+          .expects()
+          .once()
+          .returning(0L.pure[F])
+        for {
+          deferred <- Deferred[F, Unit]
+          _ =
+            (clock
+              .delayedUntilSlot(_: Slot))
+              // This is the real thing being tested here
+              .expects(transaction.chronology.maximumSlot)
+              .once()
+              .returning(deferred.get)
+          underTest <-
+            Mempool
+              .make[F](
+                currentBlockId.pure[F],
+                mockFunction[TypedIdentifier, F[BlockBodyV2]],
+                fetchTransaction,
+                mock[ParentChildTree[F, TypedIdentifier]],
+                clock,
+                _ => Applicative[F].unit,
+                Long.MaxValue,
+                Long.MaxValue
+              )
+
+          _ <- underTest.add(transaction.id)
+          _ <- underTest.read(currentBlockId).assertEquals(Set(transaction.id.asTypedBytes))
+          _ <- deferred.complete(())
+          _ <- retry(underTest.read(currentBlockId).assertEquals(Set.empty[TypedIdentifier]))
+        } yield ()
+      }
     }
   }
 
   test("expire transactions at the node-configured slot if the user-defined slot is too high") {
     PropF.forAllF { (currentBlockId: TypedIdentifier, transactionWithRandomTime: Transaction) =>
-      val transaction =
-        transactionWithRandomTime.copy(chronology =
-          transactionWithRandomTime.chronology.copy(maximumSlot = Long.MaxValue)
-        )
-      val fetchTransaction = mockFunction[TypedIdentifier, F[Transaction]]
-      fetchTransaction
-        .expects(transaction.id: TypedIdentifier)
-        .once()
-        .returning(transaction.pure[F])
-      val clock = mock[ClockAlgebra[F]]
-      (() => clock.globalSlot)
-        .expects()
-        .once()
-        .returning(0L.pure[F])
-      for {
-        deferred <- Deferred[F, Unit]
-        _ =
-          (clock
-            .delayedUntilSlot(_: Slot))
-            // This is the real thing being tested here
-            .expects(100L)
-            .once()
-            .returning(deferred.get)
-        underTest <-
-          Mempool
-            .make[F](
-              currentBlockId.pure[F],
-              mockFunction[TypedIdentifier, F[BlockBodyV2]],
-              fetchTransaction,
-              mock[ParentChildTree[F, TypedIdentifier]],
-              clock,
-              _ => Applicative[F].unit,
-              100L,
-              Long.MaxValue
-            )
+      withMock {
+        val transaction =
+          transactionWithRandomTime.copy(chronology =
+            transactionWithRandomTime.chronology.copy(maximumSlot = Long.MaxValue)
+          )
+        val fetchTransaction = mockFunction[TypedIdentifier, F[Transaction]]
+        fetchTransaction
+          .expects(transaction.id: TypedIdentifier)
+          .once()
+          .returning(transaction.pure[F])
+        val clock = mock[ClockAlgebra[F]]
+        (() => clock.globalSlot)
+          .expects()
+          .once()
+          .returning(0L.pure[F])
+        for {
+          deferred <- Deferred[F, Unit]
+          _ =
+            (clock
+              .delayedUntilSlot(_: Slot))
+              // This is the real thing being tested here
+              .expects(100L)
+              .once()
+              .returning(deferred.get)
+          underTest <-
+            Mempool
+              .make[F](
+                currentBlockId.pure[F],
+                mockFunction[TypedIdentifier, F[BlockBodyV2]],
+                fetchTransaction,
+                mock[ParentChildTree[F, TypedIdentifier]],
+                clock,
+                _ => Applicative[F].unit,
+                100L,
+                Long.MaxValue
+              )
 
-        _ <- underTest.add(transaction.id)
-        _ <- underTest.read(currentBlockId).assertEquals(Set(transaction.id.asTypedBytes))
-        _ <- deferred.complete(())
-        _ <- retry(underTest.read(currentBlockId).assertEquals(Set.empty[TypedIdentifier]))
-      } yield ()
+          _ <- underTest.add(transaction.id)
+          _ <- underTest.read(currentBlockId).assertEquals(Set(transaction.id.asTypedBytes))
+          _ <- deferred.complete(())
+          _ <- retry(underTest.read(currentBlockId).assertEquals(Set.empty[TypedIdentifier]))
+        } yield ()
+      }
     }
   }
 
@@ -208,66 +220,68 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with MockFa
         blockIdA:        TypedIdentifier,
         blockIdB:        TypedIdentifier
       ) =>
-        val transactionWithSingleInput = baseTransaction.copy(inputs = Chain(input))
-        // Transaction A and Transaction B are exactly the same, except for the creation timestamp to force a different ID
-        val transactionA =
-          transactionWithSingleInput.copy(chronology = transactionWithSingleInput.chronology.copy(creation = 0))
-        val transactionAId = transactionA.id.asTypedBytes
-        val transactionB =
-          transactionWithSingleInput.copy(chronology = transactionWithSingleInput.chronology.copy(creation = 1))
-        val transactionBId = transactionB.id.asTypedBytes
-        val bodies =
-          Map(
-            blockIdA -> List(transactionAId),
-            blockIdB -> List(transactionBId)
-          )
-        val transactions =
-          Map(
-            transactionAId -> transactionA,
-            transactionBId -> transactionB
-          )
-
-        val fetchBody = (id: TypedIdentifier) => bodies(id).pure[F]
-        val fetchTransaction = (id: TypedIdentifier) => transactions(id).pure[F]
-        val clock = mock[ClockAlgebra[F]]
-        (() => clock.globalSlot)
-          .expects()
-          .anyNumberOfTimes()
-          .returning(0L.pure[F])
-        for {
-          tree <- ParentChildTree.FromSemaphore.make[F, TypedIdentifier]
-          _    <- tree.associate(blockIdA, ancestorBlockId)
-          _    <- tree.associate(blockIdB, ancestorBlockId)
-          underTest <- Mempool
-            .make[F](
-              ancestorBlockId.pure[F],
-              fetchBody,
-              fetchTransaction,
-              tree,
-              clock,
-              _ => Applicative[F].unit,
-              Long.MaxValue,
-              1L
+        withMock {
+          val transactionWithSingleInput = baseTransaction.copy(inputs = Chain(input))
+          // Transaction A and Transaction B are exactly the same, except for the creation timestamp to force a different ID
+          val transactionA =
+            transactionWithSingleInput.copy(chronology = transactionWithSingleInput.chronology.copy(creation = 0))
+          val transactionAId = transactionA.id.asTypedBytes
+          val transactionB =
+            transactionWithSingleInput.copy(chronology = transactionWithSingleInput.chronology.copy(creation = 1))
+          val transactionBId = transactionB.id.asTypedBytes
+          val bodies =
+            Map(
+              blockIdA -> List(transactionAId),
+              blockIdB -> List(transactionBId)
             )
-          _ <- underTest.read(blockIdA).assertEquals(Set.empty[TypedIdentifier])
-          _ =
-            inSequence {
-              // The "unapply" operation will schedule a normal expiration
-              (clock
-                .delayedUntilSlot(_: Slot))
-                .expects(transactionA.chronology.maximumSlot)
-                .once()
-                .returning(MonadCancel[F].never[Unit])
-              // But the "apply" operation will re-schedule the expiration
-              (clock
-                .delayedUntilSlot(_: Slot))
-                .expects(1L)
-                .once()
-                .returning(MonadCancel[F].never[Unit])
-            }
-          _ <- underTest.read(blockIdB).assertEquals(Set(transactionAId))
-        } yield ()
+          val transactions =
+            Map(
+              transactionAId -> transactionA,
+              transactionBId -> transactionB
+            )
 
+          val fetchBody = (id: TypedIdentifier) => bodies(id).pure[F]
+          val fetchTransaction = (id: TypedIdentifier) => transactions(id).pure[F]
+          val clock = mock[ClockAlgebra[F]]
+          (() => clock.globalSlot)
+            .expects()
+            .anyNumberOfTimes()
+            .returning(0L.pure[F])
+          for {
+            tree <- ParentChildTree.FromSemaphore.make[F, TypedIdentifier]
+            _    <- tree.associate(blockIdA, ancestorBlockId)
+            _    <- tree.associate(blockIdB, ancestorBlockId)
+            underTest <- Mempool
+              .make[F](
+                ancestorBlockId.pure[F],
+                fetchBody,
+                fetchTransaction,
+                tree,
+                clock,
+                _ => Applicative[F].unit,
+                Long.MaxValue,
+                1L
+              )
+            _ <- underTest.read(blockIdA).assertEquals(Set.empty[TypedIdentifier])
+            _ <-
+              inSequence {
+                // The "unapply" operation will schedule a normal expiration
+                (clock
+                  .delayedUntilSlot(_: Slot))
+                  .expects(transactionA.chronology.maximumSlot)
+                  .once()
+                  .returning(MonadCancel[F].never[Unit])
+                // But the "apply" operation will re-schedule the expiration
+                (clock
+                  .delayedUntilSlot(_: Slot))
+                  .expects(1L)
+                  .once()
+                  .returning(MonadCancel[F].never[Unit])
+                underTest.read(blockIdB).assertEquals(Set(transactionAId))
+              }
+          } yield ()
+
+        }
     }
   }
 

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/MempoolSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/MempoolSpec.scala
@@ -1,10 +1,9 @@
 package co.topl.ledger.interpreters
 
-import cats.{Applicative, MonadThrow}
 import cats.data.{Chain, NonEmptyChain}
-import cats.effect.unsafe.implicits.global
 import cats.effect.{Deferred, IO, MonadCancel}
 import cats.implicits._
+import cats.{Applicative, MonadThrow}
 import co.topl.algebras.ClockAlgebra
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
@@ -12,32 +11,19 @@ import co.topl.eventtree.ParentChildTree
 import co.topl.models.ModelGenerators._
 import co.topl.models.{BlockBodyV2, Slot, Transaction, TypedIdentifier}
 import co.topl.typeclasses.implicits._
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.Gen
+import org.scalacheck.effect.PropF
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.{EitherValues, OptionValues}
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.concurrent.duration._
 
-class MempoolSpec
-    extends AnyFlatSpec
-    with Matchers
-    with ScalaCheckPropertyChecks
-    with EitherValues
-    with OptionValues
-    with MockFactory {
-
-  behavior of "Mempool"
+class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with MockFactory {
 
   type F[A] = IO[A]
 
-  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
-    PropertyCheckConfiguration(sizeRange = 3)
-
-  it should "expose a Set of Transaction IDs at a specific block" in {
-    forAll(
+  test("expose a Set of Transaction IDs at a specific block") {
+    PropF.forAllF(
       nonEmptyChainOf[(TypedIdentifier, NonEmptyChain[Transaction])](
         Gen.zip(arbitraryTypedIdentifier.arbitrary, nonEmptyChainOf(arbitraryTransaction.arbitrary))
       ),
@@ -57,10 +43,10 @@ class MempoolSpec
         .expects(*)
         .anyNumberOfTimes()
         .returning(MonadCancel[F].never[Unit])
-      val tree = ParentChildTree.FromRef.make[F, TypedIdentifier].unsafeRunSync()
-      bodies.map(_._1).sliding2.foreach { case (id1, id2) => tree.associate(id2, id1).unsafeRunSync() }
-      val underTest =
-        Mempool
+      for {
+        tree <- ParentChildTree.FromRef.make[F, TypedIdentifier]
+        _    <- bodies.map(_._1).sliding2.traverse { case (id1, id2) => tree.associate(id2, id1) }
+        underTest <- Mempool
           .make[F](
             bodies.head._1.pure[F],
             fetchBody,
@@ -71,21 +57,25 @@ class MempoolSpec
             Long.MaxValue,
             Long.MaxValue
           )
-          .unsafeRunSync()
 
-      underTest.read(bodies.last._1).unsafeRunSync() shouldBe Set.empty[TypedIdentifier]
-      underTest.add(newTx.id).unsafeRunSync()
-      underTest.read(bodies.last._1).unsafeRunSync() shouldBe Set(newTx.id.asTypedBytes)
-      underTest.remove(newTx.id).unsafeRunSync()
-      underTest.read(bodies.last._1).unsafeRunSync() shouldBe Set.empty[TypedIdentifier]
-      underTest.read(bodies.head._1).unsafeRunSync() shouldBe bodies.tail.toList
-        .flatMap(_._2.toList.map(_.id.asTypedBytes))
-        .toSet
+        _ <- underTest.read(bodies.last._1).assertEquals(Set.empty[TypedIdentifier])
+        _ <- underTest.add(newTx.id)
+        _ <- underTest.read(bodies.last._1).assertEquals(Set(newTx.id.asTypedBytes))
+        _ <- underTest.remove(newTx.id)
+        _ <- underTest.read(bodies.last._1).assertEquals(Set.empty[TypedIdentifier])
+        _ <- underTest
+          .read(bodies.head._1)
+          .assertEquals(
+            bodies.tail.toList
+              .flatMap(_._2.toList.map(_.id.asTypedBytes))
+              .toSet
+          )
+      } yield ()
     }
   }
 
-  it should "allow transactions to be added externally" in {
-    forAll { (currentBlockId: TypedIdentifier, transaction: Transaction) =>
+  test("allow transactions to be added externally") {
+    PropF.forAllF { (currentBlockId: TypedIdentifier, transaction: Transaction) =>
       val fetchTransaction = mockFunction[TypedIdentifier, F[Transaction]]
       fetchTransaction
         .expects(transaction.id: TypedIdentifier)
@@ -101,8 +91,8 @@ class MempoolSpec
         .expects(*)
         .once()
         .returning(MonadCancel[F].never[Unit])
-      val underTest =
-        Mempool
+      for {
+        underTest <- Mempool
           .make[F](
             currentBlockId.pure[F],
             mockFunction[TypedIdentifier, F[BlockBodyV2]],
@@ -113,17 +103,16 @@ class MempoolSpec
             Long.MaxValue,
             Long.MaxValue
           )
-          .unsafeRunSync()
 
-      underTest.add(transaction.id).unsafeRunSync()
+        _ <- underTest.add(transaction.id).assert
+      } yield ()
     }
   }
 
-  it should "expire transactions at the user-defined slot" in {
-    forAll { (currentBlockId: TypedIdentifier, transactionWithRandomTime: Transaction) =>
+  test("expire transactions at the user-defined slot") {
+    PropF.forAllF { (currentBlockId: TypedIdentifier, transactionWithRandomTime: Transaction) =>
       val transaction =
         transactionWithRandomTime.copy(chronology = transactionWithRandomTime.chronology.copy(maximumSlot = 2))
-      val deferred = Deferred[F, Unit].unsafeRunSync()
       val fetchTransaction = mockFunction[TypedIdentifier, F[Transaction]]
       fetchTransaction
         .expects(transaction.id: TypedIdentifier)
@@ -134,40 +123,42 @@ class MempoolSpec
         .expects()
         .once()
         .returning(0L.pure[F])
-      (clock
-        .delayedUntilSlot(_: Slot))
-        // This is the real thing being tested here
-        .expects(transaction.chronology.maximumSlot)
-        .once()
-        .returning(deferred.get)
-      val underTest =
-        Mempool
-          .make[F](
-            currentBlockId.pure[F],
-            mockFunction[TypedIdentifier, F[BlockBodyV2]],
-            fetchTransaction,
-            mock[ParentChildTree[F, TypedIdentifier]],
-            clock,
-            _ => Applicative[F].unit,
-            Long.MaxValue,
-            Long.MaxValue
-          )
-          .unsafeRunSync()
+      for {
+        deferred <- Deferred[F, Unit]
+        _ =
+          (clock
+            .delayedUntilSlot(_: Slot))
+            // This is the real thing being tested here
+            .expects(transaction.chronology.maximumSlot)
+            .once()
+            .returning(deferred.get)
+        underTest <-
+          Mempool
+            .make[F](
+              currentBlockId.pure[F],
+              mockFunction[TypedIdentifier, F[BlockBodyV2]],
+              fetchTransaction,
+              mock[ParentChildTree[F, TypedIdentifier]],
+              clock,
+              _ => Applicative[F].unit,
+              Long.MaxValue,
+              Long.MaxValue
+            )
 
-      underTest.add(transaction.id).unsafeRunSync()
-      underTest.read(currentBlockId).unsafeRunSync() shouldBe Set(transaction.id.asTypedBytes)
-      deferred.complete(()).unsafeRunSync()
-      retry(underTest.read(currentBlockId).map(_ shouldBe Set.empty[TypedIdentifier])).unsafeRunSync()
+        _ <- underTest.add(transaction.id)
+        _ <- underTest.read(currentBlockId).assertEquals(Set(transaction.id.asTypedBytes))
+        _ <- deferred.complete(())
+        _ <- retry(underTest.read(currentBlockId).assertEquals(Set.empty[TypedIdentifier]))
+      } yield ()
     }
   }
 
-  it should "expire transactions at the node-configured slot if the user-defined slot is too high" in {
-    forAll { (currentBlockId: TypedIdentifier, transactionWithRandomTime: Transaction) =>
+  test("expire transactions at the node-configured slot if the user-defined slot is too high") {
+    PropF.forAllF { (currentBlockId: TypedIdentifier, transactionWithRandomTime: Transaction) =>
       val transaction =
         transactionWithRandomTime.copy(chronology =
           transactionWithRandomTime.chronology.copy(maximumSlot = Long.MaxValue)
         )
-      val deferred = Deferred[F, Unit].unsafeRunSync()
       val fetchTransaction = mockFunction[TypedIdentifier, F[Transaction]]
       fetchTransaction
         .expects(transaction.id: TypedIdentifier)
@@ -178,34 +169,38 @@ class MempoolSpec
         .expects()
         .once()
         .returning(0L.pure[F])
-      (clock
-        .delayedUntilSlot(_: Slot))
-        .expects(100L)
-        .once()
-        .returning(deferred.get)
-      val underTest =
-        Mempool
-          .make[F](
-            currentBlockId.pure[F],
-            mockFunction[TypedIdentifier, F[BlockBodyV2]],
-            fetchTransaction,
-            mock[ParentChildTree[F, TypedIdentifier]],
-            clock,
-            _ => Applicative[F].unit,
-            100L,
-            Long.MaxValue
-          )
-          .unsafeRunSync()
+      for {
+        deferred <- Deferred[F, Unit]
+        _ =
+          (clock
+            .delayedUntilSlot(_: Slot))
+            // This is the real thing being tested here
+            .expects(100L)
+            .once()
+            .returning(deferred.get)
+        underTest <-
+          Mempool
+            .make[F](
+              currentBlockId.pure[F],
+              mockFunction[TypedIdentifier, F[BlockBodyV2]],
+              fetchTransaction,
+              mock[ParentChildTree[F, TypedIdentifier]],
+              clock,
+              _ => Applicative[F].unit,
+              100L,
+              Long.MaxValue
+            )
 
-      underTest.add(transaction.id).unsafeRunSync()
-      underTest.read(currentBlockId).unsafeRunSync() shouldBe Set(transaction.id.asTypedBytes)
-      deferred.complete(()).unsafeRunSync()
-      retry(underTest.read(currentBlockId).map(_ shouldBe Set.empty[TypedIdentifier])).unsafeRunSync()
+        _ <- underTest.add(transaction.id)
+        _ <- underTest.read(currentBlockId).assertEquals(Set(transaction.id.asTypedBytes))
+        _ <- deferred.complete(())
+        _ <- retry(underTest.read(currentBlockId).assertEquals(Set.empty[TypedIdentifier]))
+      } yield ()
     }
   }
 
-  it should "expire a transaction more aggressively when a double-spend is detected" in {
-    forAll {
+  test("expire a transaction more aggressively when a double-spend is detected") {
+    PropF.forAllF {
       (
         baseTransaction: Transaction,
         input:           Transaction.Input,
@@ -234,16 +229,16 @@ class MempoolSpec
 
         val fetchBody = (id: TypedIdentifier) => bodies(id).pure[F]
         val fetchTransaction = (id: TypedIdentifier) => transactions(id).pure[F]
-        val tree = ParentChildTree.FromSemaphore.make[F, TypedIdentifier].unsafeRunSync()
-        tree.associate(blockIdA, ancestorBlockId).unsafeRunSync()
-        tree.associate(blockIdB, ancestorBlockId).unsafeRunSync()
         val clock = mock[ClockAlgebra[F]]
         (() => clock.globalSlot)
           .expects()
           .anyNumberOfTimes()
           .returning(0L.pure[F])
-        val underTest =
-          Mempool
+        for {
+          tree <- ParentChildTree.FromSemaphore.make[F, TypedIdentifier]
+          _    <- tree.associate(blockIdA, ancestorBlockId)
+          _    <- tree.associate(blockIdB, ancestorBlockId)
+          underTest <- Mempool
             .make[F](
               ancestorBlockId.pure[F],
               fetchBody,
@@ -254,25 +249,25 @@ class MempoolSpec
               Long.MaxValue,
               1L
             )
-            .unsafeRunSync()
+          _ <- underTest.read(blockIdA).assertEquals(Set.empty[TypedIdentifier])
+          _ =
+            inSequence {
+              // The "unapply" operation will schedule a normal expiration
+              (clock
+                .delayedUntilSlot(_: Slot))
+                .expects(transactionA.chronology.maximumSlot)
+                .once()
+                .returning(MonadCancel[F].never[Unit])
+              // But the "apply" operation will re-schedule the expiration
+              (clock
+                .delayedUntilSlot(_: Slot))
+                .expects(1L)
+                .once()
+                .returning(MonadCancel[F].never[Unit])
+            }
+          _ <- underTest.read(blockIdB).assertEquals(Set(transactionAId))
+        } yield ()
 
-        underTest.read(blockIdA).unsafeRunSync() shouldBe Set.empty[TypedIdentifier]
-
-        inSequence {
-          // The "unapply" operation will schedule a normal expiration
-          (clock
-            .delayedUntilSlot(_: Slot))
-            .expects(transactionA.chronology.maximumSlot)
-            .once()
-            .returning(MonadCancel[F].never[Unit])
-          // But the "apply" operation will re-schedule the expiration
-          (clock
-            .delayedUntilSlot(_: Slot))
-            .expects(1L)
-            .once()
-            .returning(MonadCancel[F].never[Unit])
-        }
-        underTest.read(blockIdB).unsafeRunSync() shouldBe Set(transactionAId)
     }
   }
 

--- a/models/src/test/scala/co/topl/models/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/ModelGenerators.scala
@@ -7,8 +7,9 @@ import co.topl.models.utility.StringDataTypes.Latin1Data
 import co.topl.models.utility._
 import org.scalacheck.rng.Seed
 import org.scalacheck.{Arbitrary, Gen}
+import org.scalactic.anyvals.NonEmptyMap
 
-import scala.collection.immutable.ListSet
+import scala.collection.immutable.{ListSet, SortedSet}
 
 trait ModelGenerators {
 

--- a/models/src/test/scala/co/topl/models/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/ModelGenerators.scala
@@ -643,7 +643,7 @@ trait ModelGenerators {
       for {
         inputs <-
           Gen
-            .chooseNum[Int](1, 10)
+            .chooseNum[Int](1, 4)
             .flatMap(count =>
               Gen
                 .listOfN(count, arbitraryTransactionInput.arbitrary)
@@ -651,7 +651,7 @@ trait ModelGenerators {
             )
         outputs <-
           Gen
-            .chooseNum[Int](1, 10)
+            .chooseNum[Int](1, 4)
             .flatMap(count =>
               Gen
                 .listOfN(count, arbitraryTransactionOutput.arbitrary)

--- a/munit-scalamock/src/test/scala/org/scalamock/munit/AsyncMockFactory.scala
+++ b/munit-scalamock/src/test/scala/org/scalamock/munit/AsyncMockFactory.scala
@@ -1,0 +1,86 @@
+package org.scalamock.munit
+
+import cats.effect.IO
+import org.scalamock.clazz.Mock
+import org.scalamock.context.{CallLog, MockContext}
+import org.scalamock.function.MockFunctions
+import org.scalamock.handlers.{Handlers, OrderedHandlers, UnorderedHandlers}
+import org.scalamock.matchers.Matchers
+
+trait AsyncMockFactory extends MockContext with Mock with MockFunctions with Matchers {
+  type ExpectationException = AssertionError
+
+  override def newExpectationException(message: String, methodName: Option[Symbol]): AssertionError =
+    new AssertionError(message)
+
+  implicit val _factory = this
+
+  def withMock[Res](test: => IO[Res]): IO[Res] = {
+    if (expectationContext == null) {
+      // we don't reset expectations for the first test case to allow
+      // defining expectations in Suite scope and writing tests in OneInstancePerTest/isolated style
+      initializeExpectations()
+    }
+
+    val testResult = test
+      .map { result =>
+        verifyExpectations()
+        result
+      }
+      .redeemWith(e => IO(clearExpectations()).flatMap(_ => IO.raiseError[Res](e)), r => IO.pure(r))
+    testResult
+  }
+
+  protected def inAnyOrder[T](what: => IO[T]): IO[T] =
+    inContext(new UnorderedHandlers)(what)
+
+  protected def inSequence[T](what: => IO[T]): IO[T] =
+    inContext(new OrderedHandlers)(what)
+
+  def inAnyOrderWithLogging[T](what: => IO[T]): IO[T] =
+    inContext(new UnorderedHandlers(logging = true))(what)
+
+  def inSequenceWithLogging[T](what: => IO[T]): IO[T] =
+    inContext(new OrderedHandlers(logging = true))(what)
+
+  private def inContext[T](context: Handlers)(what: => IO[T]): IO[T] =
+    for {
+      previous <- IO.delay {
+        currentExpectationContext.add(context)
+        val prevContext = currentExpectationContext
+        currentExpectationContext = context
+        prevContext
+      }
+      result <- what
+      _ <- IO.delay {
+        currentExpectationContext = previous
+      }
+    } yield result
+
+  private def initializeExpectations(): Unit = {
+    val initialHandlers = new UnorderedHandlers
+    callLog = new CallLog
+
+    expectationContext = initialHandlers
+    currentExpectationContext = initialHandlers
+  }
+
+  private def clearExpectations(): Unit = {
+    // to forbid setting expectations after verification is done
+    callLog = null
+    expectationContext = null
+    currentExpectationContext = null
+  }
+
+  private def verifyExpectations(): Unit = {
+    callLog.foreach(expectationContext.verify(_))
+
+    val oldCallLog = callLog
+    val oldExpectationContext = expectationContext
+
+    clearExpectations()
+
+    if (!oldExpectationContext.isSatisfied)
+      reportUnsatisfiedExpectation(oldCallLog, oldExpectationContext)
+  }
+}

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
@@ -28,6 +28,11 @@ trait BlockchainPeerClient[F[_]] {
   def remotePeerAdoptions: F[Source[TypedIdentifier, NotUsed]]
 
   /**
+   * A Source of transaction IDs that were observed by the remote node
+   */
+  def remoteTransactionNotifications: F[Source[TypedIdentifier, NotUsed]]
+
+  /**
    * A Lookup to retrieve a remote block header by ID
    */
   def getRemoteHeader(id: TypedIdentifier): F[Option[BlockHeaderV2]]

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServer.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServer.scala
@@ -16,6 +16,7 @@ import org.typelevel.log4cats.Logger
  */
 trait BlockchainPeerServer[F[_]] {
   def localBlockAdoptions: F[Source[TypedIdentifier, NotUsed]]
+  def localTransactionNotifications: F[Source[TypedIdentifier, NotUsed]]
   def getLocalHeader(id:            TypedIdentifier): F[Option[BlockHeaderV2]]
   def getLocalBody(id:              TypedIdentifier): F[Option[BlockBodyV2]]
   def getLocalTransaction(id:       TypedIdentifier): F[Option[Transaction]]
@@ -27,17 +28,21 @@ object BlockchainPeerServer {
   object FromStores {
 
     def make[F[_]: Monad: Logger](
-      headerStore:            Store[F, TypedIdentifier, BlockHeaderV2],
-      bodyStore:              Store[F, TypedIdentifier, BlockBodyV2],
-      transactionStore:       Store[F, TypedIdentifier, Transaction],
-      blockHeights:           EventSourcedState[F, Long => F[Option[TypedIdentifier]]],
-      localChain:             LocalChainAlgebra[F],
-      locallyAdoptedBlockIds: Source[TypedIdentifier, NotUsed]
+      headerStore:                  Store[F, TypedIdentifier, BlockHeaderV2],
+      bodyStore:                    Store[F, TypedIdentifier, BlockBodyV2],
+      transactionStore:             Store[F, TypedIdentifier, Transaction],
+      blockHeights:                 EventSourcedState[F, Long => F[Option[TypedIdentifier]]],
+      localChain:                   LocalChainAlgebra[F],
+      locallyAdoptedBlockIds:       Source[TypedIdentifier, NotUsed],
+      locallyAdoptedTransactionIds: Source[TypedIdentifier, NotUsed]
     ): F[BlockchainPeerServer[F]] =
       new BlockchainPeerServer[F] {
 
         def localBlockAdoptions: F[Source[TypedIdentifier, NotUsed]] =
           locallyAdoptedBlockIds.buffer(1, OverflowStrategy.dropHead).pure[F]
+
+        def localTransactionNotifications: F[Source[TypedIdentifier, NotUsed]] =
+          locallyAdoptedTransactionIds.buffer(5, OverflowStrategy.dropHead).pure[F]
 
         def getLocalHeader(id: TypedIdentifier): F[Option[BlockHeaderV2]] = headerStore.get(id)
 

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
@@ -42,6 +42,8 @@ class BlockchainClientSpec
 
           def remotePeerAdoptions: F[Source[TypedIdentifier, NotUsed]] = ???
 
+          def remoteTransactionNotifications: F[Source[TypedIdentifier, NotUsed]] = ???
+
           def getRemoteHeader(id: TypedIdentifier): F[Option[BlockHeaderV2]] = ???
 
           def getRemoteBody(id: TypedIdentifier): F[Option[BlockBodyV2]] = ???

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactorySpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactorySpec.scala
@@ -44,12 +44,17 @@ class BlockchainPeerConnectionFlowFactorySpec
         .once()
         .returning(Source.never[TypedIdentifier].pure[F])
 
+      (() => server.localTransactionNotifications)
+        .expects()
+        .once()
+        .returning(Source.never[TypedIdentifier].pure[F])
+
       val factory = BlockchainPeerConnectionFlowFactory.createFactory[F](server)
 
       val (protocols, _) = factory.protocolsForPeer(connectedPeer, connectionLeader).unsafeRunSync()
 
-      protocols.length shouldBe 10L
-      protocols.map(_.sessionId).toNes[Byte].toSortedSet shouldBe SortedSet[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+      protocols.length shouldBe 12L
+      protocols.map(_.sessionId).toNes[Byte].toSortedSet shouldBe SortedSet[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,8 +39,8 @@ object Dependencies {
 
   val mUnitTest = Seq(
     "org.scalameta" %% "munit"                   % "0.7.29" % Test,
-    "org.typelevel" %% "munit-cats-effect-3"     % "1.0.7"  % Test,
     "org.scalameta" %% "munit-scalacheck"        % "0.7.29" % Test,
+    "org.typelevel" %% "munit-cats-effect-3"     % "1.0.7"  % Test,
     "org.typelevel" %% "scalacheck-effect-munit" % "1.0.4"  % Test
   ) ++ scalamock
 
@@ -332,4 +332,7 @@ object Dependencies {
     mainargs ++
     misc ++
     test
+
+  lazy val munitScalamock =
+    mUnitTest
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -273,7 +273,7 @@ object Dependencies {
     ) ++ fleam
 
   lazy val ledger: Seq[ModuleID] =
-    Dependencies.test ++ Dependencies.catsEffect
+    Dependencies.mUnitTest ++ Dependencies.catsEffect
 
   lazy val demo: Seq[ModuleID] =
     Seq(akka("actor"), akka("actor-typed"), akka("stream"), akkaHttp("http2-support")) ++ logging

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.2

--- a/topl-grpc/src/main/protobuf/topl_grpc.proto
+++ b/topl-grpc/src/main/protobuf/topl_grpc.proto
@@ -4,6 +4,7 @@ package co.topl.grpc.services;
 
 service ToplGrpc {
   rpc BroadcastTransaction (BroadcastTransactionReq) returns (BroadcastTransactionRes);
+  rpc CurrentMempool (CurrentMempoolReq) returns (CurrentMempoolRes);
 }
 
 message BroadcastTransactionReq {
@@ -14,3 +15,9 @@ message BroadcastTransactionReq {
 }
 
 message BroadcastTransactionRes {}
+
+message CurrentMempoolReq {}
+
+message CurrentMempoolRes {
+  repeated bytes transactionIds = 1;
+}

--- a/typeclasses/src/main/scala/co/topl/typeclasses/NonEmpty.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/NonEmpty.scala
@@ -1,16 +1,17 @@
 package co.topl.typeclasses
 
 import cats.data.{NonEmptyChain, NonEmptyVector}
-import simulacrum.typeclass
 
 /**
  * Typeclass indicating something is non-empty
  */
-@typeclass trait NonEmpty[F[_]] {
+trait NonEmpty[F[_]] {
   def head[A](c: F[A]): A
 }
 
 object NonEmpty {
+
+  def apply[F[_]: NonEmpty]: NonEmpty[F] = implicitly
 
   trait Instances {
 

--- a/typeclasses/src/main/scala/co/topl/typeclasses/Prepend.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/Prepend.scala
@@ -1,16 +1,17 @@
 package co.topl.typeclasses
 
 import cats.data.{NonEmptyChain, NonEmptyVector}
-import simulacrum.typeclass
 
 /**
  * Typeclass indicating that something can prepend elements
  */
-@typeclass trait Prepend[F[_]] {
+trait Prepend[F[_]] {
   def prepend[A](a: A, c: F[A]): F[A]
 }
 
 object Prepend {
+
+  def apply[F[_]: Prepend]: Prepend[F] = implicitly
 
   trait Instances {
 

--- a/typeclasses/src/main/scala/co/topl/typeclasses/package.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/package.scala
@@ -1,7 +1,5 @@
 package co.topl
 
-import co.topl.models.{Bytes, TypedBytes}
-
 package object typeclasses {
 
   object implicits
@@ -38,9 +36,7 @@ package object typeclasses {
       with SpendingAddressable.Instances
       with SpendingAddressable.ToSpendingAddressableOps
       with Prepend.Instances
-      with Prepend.ToPrependOps
       with NonEmpty.Instances
-      with NonEmpty.ToNonEmptyOps
       with TransactionOps.Instances
       with IdentityOps
 }


### PR DESCRIPTION
## Purpose
- To support semantic validation, the system needs to know if a Box is spendable at some point in some chain of blocks
- A transaction outputs boxes.  These boxes can be spent by subsequent transactions and are included in box state.
- A transaction's input spend a previous transaction's output.  Once spent, the box is no longer spendable and is removed from box state
## Approach
- Implement BoxStateAlgebra and interpreter
- Interpreter based on Event Sourced Trees
## Testing
- Added unit test for BoxState
- Modified other ledger test suites to use MUnit
  - This involved some other modifications to build.sbt
  - This required a new SBT module which provides helpers/support for mocking in MUnit
## Tickets
_* closes #2076_
