### PR TITLE
ContainsEvidence from ImmutableCodec

### DIFF
--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraImmutableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraImmutableCodecs.scala
@@ -42,13 +42,60 @@ trait TetraImmutableCodecs {
   implicit val unprovenTransactionStableCodec: ImmutableCodec[Transaction.Unproven] =
     ImmutableCodec.fromScodecCodec
 
+  implicit val curve25519VKImmutableCodec: ImmutableCodec[VerificationKeys.Curve25519] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val ed25519VKImmutableCodec: ImmutableCodec[VerificationKeys.Ed25519] =
+    ImmutableCodec.fromScodecCodec
+
   implicit val extendedEd25519VKStableCodec: ImmutableCodec[VerificationKeys.ExtendedEd25519] =
     ImmutableCodec.fromScodecCodec
 
   implicit val ed25519VRFVKStableCodec: ImmutableCodec[VerificationKeys.VrfEd25519] =
     ImmutableCodec.fromScodecCodec
 
-  implicit val requiredBoxStateImmutableCodec: ImmutableCodec[Propositions.Contextual.RequiredBoxState] =
+  implicit val kesSumVKStableCodec: ImmutableCodec[VerificationKeys.KesSum] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val kesProductVKStableCodec: ImmutableCodec[VerificationKeys.KesProduct] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val propositionsPermanentlyLockedImmutableCodec: ImmutableCodec[Propositions.PermanentlyLocked.type] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val propositionKnowledgeCurve25519ImmutableCodec: ImmutableCodec[Propositions.Knowledge.Curve25519] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val propositionKnowledgeEd25519ImmutableCodec: ImmutableCodec[Propositions.Knowledge.Ed25519] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val propositionKnowledgeExtendedEd25519ImmutableCodec
+    : ImmutableCodec[Propositions.Knowledge.ExtendedEd25519] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val propositionKnowledgehashLockImmutableCodec: ImmutableCodec[Propositions.Knowledge.HashLock] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val propositionCompositionalThresholdImmutableCodec: ImmutableCodec[Propositions.Compositional.Threshold] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val propositionCompositionalAndImmutableCodec: ImmutableCodec[Propositions.Compositional.And] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val propositionCompositionalOrImmutableCodec: ImmutableCodec[Propositions.Compositional.Or] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val propositionCompositionalNotImmutableCodec: ImmutableCodec[Propositions.Compositional.Not] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val propositionContextualHeightLockImmutableCodec: ImmutableCodec[Propositions.Contextual.HeightLock] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val propositionContextualRequiredBoxStateImmutableCodec
+    : ImmutableCodec[Propositions.Contextual.RequiredBoxState] =
+    ImmutableCodec.fromScodecCodec
+
+  implicit val propositionScriptJsImmutableCodec: ImmutableCodec[Propositions.Script.JS] =
     ImmutableCodec.fromScodecCodec
 
   implicit val kesSumProofStableCodec: ImmutableCodec[Proofs.Knowledge.KesSum] =

--- a/typeclasses/src/main/scala/co/topl/typeclasses/ContainsEvidence.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ContainsEvidence.scala
@@ -1,15 +1,12 @@
 package co.topl.typeclasses
 
 import co.topl.codecs.bytes.tetra.instances._
+import co.topl.codecs.bytes.typeclasses.ImmutableCodec
 import co.topl.codecs.bytes.typeclasses.implicits._
-import co.topl.crypto.hash.{blake2b256, Blake2b256}
+import co.topl.crypto.hash.Blake2b256
 import co.topl.models._
-import co.topl.models.utility.HasLength.instances._
-import co.topl.models.utility.{Ratio, Sized}
-import com.google.common.primitives.Longs
+import co.topl.models.utility.Ratio
 import simulacrum.{op, typeclass}
-
-import java.nio.charset.StandardCharsets
 
 @typeclass trait ContainsEvidence[T] {
   @op("typedEvidence") def typedEvidenceOf(t: T): TypedEvidence
@@ -17,201 +14,102 @@ import java.nio.charset.StandardCharsets
 
 object ContainsEvidence {
 
-  trait Instances {
+  def fromImmutableCodec[T: ImmutableCodec](prefix: Byte): ContainsEvidence[T] =
+    (t: T) => TypedEvidence(prefix, new Blake2b256().hash(t.immutableBytes))
 
-    implicit val ratioContainsEvidence: ContainsEvidence[Ratio] =
-      ratio => TypedEvidence(10: Byte, new Blake2b256().hash(ratio.immutableBytes))
+  trait VerificationKeyInstances {
 
     implicit val curve25519VKContainsEvidence: ContainsEvidence[VerificationKeys.Curve25519] =
-      t => TypedEvidence(1: Byte, Sized.strictUnsafe(Bytes(blake2b256.hash(t.bytes.data.toArray).value)))
+      fromImmutableCodec(1)
 
     implicit val ed25519VKContainsEvidence: ContainsEvidence[VerificationKeys.Ed25519] =
-      t => TypedEvidence(2: Byte, Sized.strictUnsafe(Bytes(blake2b256.hash(t.bytes.data.toArray).value)))
+      fromImmutableCodec(2)
 
     implicit val extended25519VKContainsEvidence: ContainsEvidence[VerificationKeys.ExtendedEd25519] =
-      t => TypedEvidence(3: Byte, new Blake2b256().hash(t.immutableBytes, t.chainCode.data))
+      fromImmutableCodec(3)
+
+    implicit val vrfEd25519VKContainsEvidence: ContainsEvidence[VerificationKeys.VrfEd25519] =
+      fromImmutableCodec(4)
+
+    implicit val kesSumVKContainsEvidence: ContainsEvidence[VerificationKeys.KesSum] =
+      fromImmutableCodec(5)
+
+    implicit val kesProductVKContainsEvidence: ContainsEvidence[VerificationKeys.KesProduct] =
+      fromImmutableCodec(6)
 
     implicit val vkContainsEvidence: ContainsEvidence[VerificationKey] = {
       case t: VerificationKeys.Curve25519      => curve25519VKContainsEvidence.typedEvidenceOf(t)
       case t: VerificationKeys.Ed25519         => ed25519VKContainsEvidence.typedEvidenceOf(t)
       case t: VerificationKeys.ExtendedEd25519 => extended25519VKContainsEvidence.typedEvidenceOf(t)
-      case t                                   => throw new MatchError(t)
+      case t: VerificationKeys.VrfEd25519      => vrfEd25519VKContainsEvidence.typedEvidenceOf(t)
+      case t: VerificationKeys.KesSum          => kesSumVKContainsEvidence.typedEvidenceOf(t)
+      case t: VerificationKeys.KesProduct      => kesProductVKContainsEvidence.typedEvidenceOf(t)
     }
+  }
+
+  trait PropositionInstances {
 
     implicit val permanentlyLockedContainsEvidence: ContainsEvidence[Propositions.PermanentlyLocked.type] =
-      _ =>
-        TypedEvidence(
-          9: Byte,
-          Sized.strictUnsafe(Bytes(blake2b256.hash("LOCKED".getBytes(StandardCharsets.UTF_8)).value))
-        )
+      fromImmutableCodec(1)
 
     implicit val curve25519KnowledgePropositionContainsEvidence: ContainsEvidence[Propositions.Knowledge.Curve25519] =
-      t => TypedEvidence(1: Byte, Sized.strictUnsafe(Bytes(blake2b256.hash(t.key.bytes.data.toArray).value)))
+      fromImmutableCodec(2)
 
     implicit val ed25519KnowledgePropositionContainsEvidence: ContainsEvidence[Propositions.Knowledge.Ed25519] =
-      t => TypedEvidence(3: Byte, Sized.strictUnsafe(Bytes(blake2b256.hash(t.key.bytes.data.toArray).value)))
+      fromImmutableCodec(3)
 
     implicit val extendedEd25519KnowledgePropositionContainsEvidence
       : ContainsEvidence[Propositions.Knowledge.ExtendedEd25519] =
-      t =>
-        TypedEvidence(
-          5: Byte,
-          Sized.strictUnsafe(Bytes(blake2b256.hash((t.key.vk.bytes.data ++ t.key.chainCode.data).toArray).value))
-        )
-
-    implicit def thresholdContainsEvidence(implicit
-      ev: ContainsEvidence[Proposition]
-    ): ContainsEvidence[Propositions.Compositional.Threshold] =
-      t =>
-        TypedEvidence(
-          2: Byte,
-          new Blake2b256()
-            .hash(
-              t.threshold.immutableBytes +:
-              t.threshold.immutableBytes +:
-              t.propositions.toList.map(p => ev.typedEvidenceOf(p).allBytes): _*
-            )
-        )
-
-    implicit def andContainsEvidence(implicit
-      ev: ContainsEvidence[Proposition]
-    ): ContainsEvidence[Propositions.Compositional.And] =
-      t =>
-        TypedEvidence(
-          6: Byte,
-          new Blake2b256()
-            .hash(
-              ev.typedEvidenceOf(t.a).allBytes,
-              ev.typedEvidenceOf(t.b).allBytes
-            )
-        )
-
-    implicit def orContainsEvidence(implicit
-      ev: ContainsEvidence[Proposition]
-    ): ContainsEvidence[Propositions.Compositional.Or] =
-      t =>
-        TypedEvidence(
-          7: Byte,
-          Sized.strictUnsafe(
-            Bytes(
-              blake2b256
-                .hash((ev.typedEvidenceOf(t.a).allBytes ++ ev.typedEvidenceOf(t.b).allBytes).toArray)
-                .value
-            )
-          )
-        )
-
-    implicit def notContainsEvidence(implicit
-      ev: ContainsEvidence[Proposition]
-    ): ContainsEvidence[Propositions.Compositional.Not] =
-      t =>
-        TypedEvidence(
-          16: Byte,
-          Sized.strictUnsafe(
-            Bytes(
-              blake2b256
-                .hash((ev.typedEvidenceOf(t.a).allBytes).toArray)
-                .value
-            )
-          )
-        )
-
-    implicit val heightLockContainsEvidence: ContainsEvidence[Propositions.Contextual.HeightLock] =
-      t =>
-        TypedEvidence(
-          8: Byte,
-          Sized.strictUnsafe(
-            Bytes(
-              blake2b256
-                .hash(Longs.toByteArray(t.height))
-                .value
-            )
-          )
-        )
-
-//    implicit val requiredOutputContainsEvidence: ContainsEvidence[Propositions.Contextual.RequiredDionOutput] =
-//      t =>
-//        TypedEvidence(
-//          9: Byte,
-//          Sized.strictUnsafe(
-//            Bytes(
-//              blake2b256
-//                .hash(Ints.toByteArray(t.index) ++ t.address.allBytes.toArray)
-//                .value
-//            )
-//          )
-//        )
-
-    implicit val requiredInputBoxStateContainsEvidence: ContainsEvidence[Propositions.Contextual.RequiredBoxState] =
-      t =>
-        TypedEvidence(
-          15: Byte,
-          new Blake2b256().hash(t.immutableBytes)
-        )
-
-//    implicit val enumeratedOutputContainsEvidence: ContainsEvidence[Propositions.Example.EnumeratedInput] =
-//      t =>
-//        TypedEvidence(
-//          10: Byte,
-//          Sized.strictUnsafe(
-//            Bytes(
-//              blake2b256
-//                .hash(t.values.map(Ints.toByteArray).foldLeft(Array.empty[Byte])((acc, a) => acc ++ a))
-//                .value
-//            )
-//          )
-//        )
+      fromImmutableCodec(4)
 
     implicit val commitRevealContainsEvidence: ContainsEvidence[Propositions.Knowledge.HashLock] =
-      t =>
-        TypedEvidence(
-          11: Byte,
-          Sized.strictUnsafe(
-            Bytes(
-              blake2b256
-                .hash(t.digest.data.toArray)
-                .value
-            )
-          )
-        )
+      fromImmutableCodec(5)
+
+    implicit val thresholdContainsEvidence: ContainsEvidence[Propositions.Compositional.Threshold] =
+      fromImmutableCodec(6)
+
+    implicit val andContainsEvidence: ContainsEvidence[Propositions.Compositional.And] =
+      fromImmutableCodec(7)
+
+    implicit val orContainsEvidence: ContainsEvidence[Propositions.Compositional.Or] =
+      fromImmutableCodec(8)
+
+    implicit val notContainsEvidence: ContainsEvidence[Propositions.Compositional.Not] =
+      fromImmutableCodec(9)
+
+    implicit val heightLockContainsEvidence: ContainsEvidence[Propositions.Contextual.HeightLock] =
+      fromImmutableCodec(10)
+
+    implicit val requiredInputBoxStateContainsEvidence: ContainsEvidence[Propositions.Contextual.RequiredBoxState] =
+      fromImmutableCodec(11)
 
     implicit val jsScriptPropositionContainsEvidence: ContainsEvidence[Propositions.Script.JS] =
-      t =>
-        TypedEvidence(
-          9: Byte,
-          Sized.strictUnsafe(
-            Bytes(
-              blake2b256
-                .hash(t.script.value.getBytes(StandardCharsets.UTF_8))
-                .value
-            )
-          )
-        )
+      fromImmutableCodec(12)
 
     implicit lazy val propositionContainsEvidence: ContainsEvidence[Proposition] = {
       case Propositions.PermanentlyLocked =>
         permanentlyLockedContainsEvidence.typedEvidenceOf(Propositions.PermanentlyLocked)
-
       case t: Propositions.Knowledge.Curve25519 => curve25519KnowledgePropositionContainsEvidence.typedEvidenceOf(t)
       case t: Propositions.Knowledge.Ed25519    => ed25519KnowledgePropositionContainsEvidence.typedEvidenceOf(t)
       case t: Propositions.Knowledge.ExtendedEd25519 =>
         extendedEd25519KnowledgePropositionContainsEvidence.typedEvidenceOf(t)
-
-      case t: Propositions.Compositional.And => andContainsEvidence(propositionContainsEvidence).typedEvidenceOf(t)
-      case t: Propositions.Compositional.Or  => orContainsEvidence(propositionContainsEvidence).typedEvidenceOf(t)
-      case t: Propositions.Compositional.Not => notContainsEvidence(propositionContainsEvidence).typedEvidenceOf(t)
-      case t: Propositions.Compositional.Threshold =>
-        thresholdContainsEvidence(propositionContainsEvidence).typedEvidenceOf(t)
-
-      case t: Propositions.Contextual.HeightLock => heightLockContainsEvidence.typedEvidenceOf(t)
-
-      case t: Propositions.Script.JS => jsScriptPropositionContainsEvidence.typedEvidenceOf(t)
-
-      case t: Propositions.Knowledge.HashLock => commitRevealContainsEvidence.typedEvidenceOf(t)
-//      case t: Propositions.Example.EnumeratedInput     => enumeratedOutputContainsEvidence.typedEvidenceOf(t)
+      case t: Propositions.Compositional.And           => andContainsEvidence.typedEvidenceOf(t)
+      case t: Propositions.Compositional.Or            => orContainsEvidence.typedEvidenceOf(t)
+      case t: Propositions.Compositional.Not           => notContainsEvidence.typedEvidenceOf(t)
+      case t: Propositions.Compositional.Threshold     => thresholdContainsEvidence.typedEvidenceOf(t)
+      case t: Propositions.Contextual.HeightLock       => heightLockContainsEvidence.typedEvidenceOf(t)
+      case t: Propositions.Script.JS                   => jsScriptPropositionContainsEvidence.typedEvidenceOf(t)
+      case t: Propositions.Knowledge.HashLock          => commitRevealContainsEvidence.typedEvidenceOf(t)
       case t: Propositions.Contextual.RequiredBoxState => requiredInputBoxStateContainsEvidence.typedEvidenceOf(t)
     }
   }
 
-  object Instances extends Instances
+  trait Instances extends VerificationKeyInstances with PropositionInstances {
+
+    implicit val ratioContainsEvidence: ContainsEvidence[Ratio] =
+      fromImmutableCodec(10)
+
+  }
+
+  object instances extends Instances
 }

--- a/typeclasses/src/test/scala/co/topl/typeclasses/ContainsEvidenceSpec.scala
+++ b/typeclasses/src/test/scala/co/topl/typeclasses/ContainsEvidenceSpec.scala
@@ -1,0 +1,41 @@
+package co.topl.typeclasses
+
+import co.topl.codecs.bytes.scodecs._
+import co.topl.codecs.bytes.typeclasses.ImmutableCodec
+import co.topl.codecs.bytes.typeclasses.implicits._
+import co.topl.crypto.hash.Blake2b256
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, EitherValues, OptionValues}
+import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}
+
+class ContainsEvidenceSpec
+    extends AnyFlatSpec
+    with BeforeAndAfterAll
+    with MockFactory
+    with Matchers
+    with ScalaCheckPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
+    with EitherValues
+    with OptionValues {
+  behavior of "ContainsEvidence#fromImmutableCodec"
+
+  it should "create a ContainsEvidence instance from an ImmutableCodec instance" in {
+    implicit val dataImmutableCodec: ImmutableCodec[Data] =
+      ImmutableCodec.fromScodecCodec(
+        (intCodec :: byteStringCodec).as[Data]
+      )
+
+    forAll { (x: Int, y: String, prefix: Byte) =>
+      val underTest = ContainsEvidence.fromImmutableCodec[Data](prefix)
+      val data = Data(x, y)
+      val evidence = underTest.typedEvidenceOf(data)
+
+      evidence.typePrefix shouldBe prefix
+      evidence.evidence shouldBe new Blake2b256().hash(data.immutableBytes)
+    }
+  }
+}
+
+case class Data(x: Int, y: String)


### PR DESCRIPTION
## Purpose
- The `ContainsEvidence[T]` typeclass instance implementations repeat the same code
  - To abide by the Don't-Repeat-Yourself principle, this can be refactored into a helper method
## Approach
- Added a helper method to ContainsEvidence which constructs the instance from an ImmutableCodec instance (plus a type prefix)
## Testing
- Added ContainsEvidenceSpec
## Tickets
_* closes #1991_