### PR TITLE
Scala integration tests dockerfile fixes

### DIFF
--- a/node/src/it/resources/Dockerfile
+++ b/node/src/it/resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:22.04
 
 ARG GRAALVM_VERSION=21.1.0
 ARG JAVA_VERSION=java11
@@ -18,7 +18,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /
     echo \
       "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
       $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-      apt -y update && apt -y install docker-ce docker-ce-cli containerd.io
+      apt -y update && DEBIAN_FRONTEND=noninteractive apt -y install docker-ce docker-ce-cli containerd.io
 
 # GraalVM install
 # See: https://github.com/graalvm/container/blob/master/community/Dockerfile


### PR DESCRIPTION
## Purpose
Fix the Scala integration tests.

When trying to build the integration test Dockerfile, you will get an error like this:

```
#5 0.741 Ign:1 http://archive.ubuntu.com/ubuntu groovy InRelease
#5 0.848 Ign:2 http://security.ubuntu.com/ubuntu groovy-security InRelease
#5 0.853 Ign:3 http://archive.ubuntu.com/ubuntu groovy-updates InRelease
#5 0.960 Err:4 http://security.ubuntu.com/ubuntu groovy-security Release
#5 0.960   404  Not Found [IP: 185.125.190.36 80]
#5 0.966 Ign:5 http://archive.ubuntu.com/ubuntu groovy-backports InRelease
#5 1.078 Err:6 http://archive.ubuntu.com/ubuntu groovy Release
#5 1.078   404  Not Found [IP: 185.125.190.39 80]
#5 1.189 Err:7 http://archive.ubuntu.com/ubuntu groovy-updates Release
#5 1.189   404  Not Found [IP: 185.125.190.39 80]
#5 1.302 Err:8 http://archive.ubuntu.com/ubuntu groovy-backports Release
#5 1.302   404  Not Found [IP: 185.125.190.39 80]
#5 1.318 Reading package lists...
#5 1.341 E: The repository 'http://security.ubuntu.com/ubuntu groovy-security Release' does not have a Release file.
#5 1.341 E: The repository 'http://archive.ubuntu.com/ubuntu groovy Release' does not have a Release file.
#5 1.341 E: The repository 'http://archive.ubuntu.com/ubuntu groovy-updates Release' does not have a Release file.
#5 1.341 E: The repository 'http://archive.ubuntu.com/ubuntu groovy-backports Release' does not have a Release file.
------
executor failed running [/bin/sh -c apt -y update && apt -y upgrade]: exit code: 100
```

This is because the version of Ubuntu we are using as a base image was [EOL'd](https://lists.ubuntu.com/archives/ubuntu-announce/2021-July/000270.html).

## Approach
* Update the Ubuntu base image to the 22.04, which will give us support until [2032](https://wiki.ubuntu.com/Releases).
* Use `DEBIAN_FRONTEND=noninteractive` when installing Docker to prevent interactive prompts.

## Testing
* Confirmed I could build the Dockerfile locally now.
* Ran the integration tests, and the tests failures have not changed (there are still a few broken).

## Tickets
_* closes #2222 _
