### PR TITLE
BlockBodyV2 List to ListSet

### DIFF
--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BodySemanticValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BodySemanticValidation.scala
@@ -24,7 +24,7 @@ object BodySemanticValidation {
         def validate(
           parentBlockId: TypedIdentifier
         )(body:          BlockBodyV2): F[ValidatedNec[BodySemanticError, BlockBodyV2]] =
-          body
+          body.toList
             .foldLeftM(AugmentedBoxState.StateAugmentation.empty.validNec[BodySemanticError]) {
               case (Validated.Valid(augmentation), transactionId) =>
                 validateTransaction(parentBlockId)(augmentation)(transactionId)

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
@@ -60,7 +60,7 @@ object BoxState {
     fetchTransaction: TypedIdentifier => F[Transaction]
   )(state:            State[F], blockId: TypedIdentifier): F[State[F]] =
     for {
-      body         <- fetchBlockBody(blockId)
+      body         <- fetchBlockBody(blockId).map(_.toList)
       transactions <- body.traverse(fetchTransaction)
       _ <- transactions.traverse(transaction =>
         transaction.inputs.traverse(input =>
@@ -91,7 +91,7 @@ object BoxState {
     fetchTransaction: TypedIdentifier => F[Transaction]
   )(state:            State[F], blockId: TypedIdentifier): F[State[F]] =
     for {
-      body         <- fetchBlockBody(blockId)
+      body         <- fetchBlockBody(blockId).map(_.toList)
       transactions <- body.traverse(fetchTransaction)
       _ <- transactions.traverse(transaction =>
         state.remove(transaction.id) >>

--- a/ledger/src/main/scala/co/topl/ledger/models/BodySyntaxError.scala
+++ b/ledger/src/main/scala/co/topl/ledger/models/BodySyntaxError.scala
@@ -1,7 +1,7 @@
 package co.topl.ledger.models
 
-import cats.data.NonEmptyChain
-import co.topl.models.Transaction
+import cats.data.{NonEmptyChain, NonEmptySet}
+import co.topl.models.{Box, Transaction}
 
 trait BodySyntaxError
 
@@ -11,4 +11,6 @@ object BodySyntaxErrors {
     transaction:    Transaction,
     semanticErrors: NonEmptyChain[TransactionSyntaxError]
   ) extends BodySyntaxError
+
+  case class DoubleSpend(boxIds: NonEmptySet[Box.Id]) extends BodySyntaxError
 }

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BodySemanticValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BodySemanticValidationSpec.scala
@@ -14,6 +14,8 @@ import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 
+import scala.collection.immutable.ListSet
+
 class BodySemanticValidationSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
   type F[A] = IO[A]
@@ -22,7 +24,7 @@ class BodySemanticValidationSpec extends CatsEffectSuite with ScalaCheckEffectSu
     PropF.forAllF { (parentBlockId: TypedIdentifier, _transaction: Transaction, input: Transaction.Input) =>
       val transaction = _transaction.copy(inputs = Chain(input))
       withMock {
-        val body = List(transaction.id.asTypedBytes)
+        val body = ListSet(transaction.id.asTypedBytes)
         for {
           fetchTransaction <- mockFunction[TypedIdentifier, F[Transaction]].pure[F]
           _ = fetchTransaction.expects(transaction.id.asTypedBytes).once().returning(transaction.pure[F])
@@ -56,7 +58,7 @@ class BodySemanticValidationSpec extends CatsEffectSuite with ScalaCheckEffectSu
         val transactionA = _transactionA.copy(inputs = Chain(input))
         val transactionB = _transactionB.copy(inputs = Chain(input))
         withMock {
-          val body = List(transactionA.id.asTypedBytes, transactionB.id.asTypedBytes)
+          val body = ListSet(transactionA.id.asTypedBytes, transactionB.id.asTypedBytes)
           for {
             fetchTransaction <- mockFunction[TypedIdentifier, F[Transaction]].pure[F]
             _ = fetchTransaction

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BodySyntaxValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BodySyntaxValidationSpec.scala
@@ -7,11 +7,13 @@ import co.topl.codecs.bytes.typeclasses.implicits._
 import co.topl.ledger.algebras.TransactionSyntaxValidationAlgebra
 import co.topl.ledger.models._
 import co.topl.models.ModelGenerators._
-import co.topl.models.{ModelGenerators, Transaction, TypedIdentifier}
+import co.topl.models.{Transaction, TypedIdentifier}
 import co.topl.typeclasses.implicits._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
+
+import scala.collection.immutable.ListSet
 
 class BodySyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
@@ -20,7 +22,7 @@ class BodySyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEffectSuit
   test("validation should fail if any transaction is syntactically invalid") {
     PropF.forAllF { transaction: Transaction =>
       withMock {
-        val body = List(transaction.id.asTypedBytes)
+        val body = ListSet(transaction.id.asTypedBytes)
         for {
           fetchTransaction <- mockFunction[TypedIdentifier, F[Transaction]].pure[F]
           _ = fetchTransaction.expects(transaction.id.asTypedBytes).once().returning(transaction.pure[F])

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
@@ -13,6 +13,8 @@ import cats.implicits._
 import co.topl.algebras.testInterpreters.TestStore
 import co.topl.eventtree.ParentChildTree
 
+import scala.collection.immutable.ListSet
+
 class BoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   test("BoxState includes new outputs") {
@@ -39,8 +41,8 @@ class BoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
           underTest <- BoxState.make[IO](
             blockId0.pure[IO],
             Map(
-              blockId1 -> List(transaction1.id.asTypedBytes).pure[IO],
-              blockId2 -> List(transaction2.id.asTypedBytes).pure[IO]
+              blockId1 -> ListSet(transaction1.id.asTypedBytes).pure[IO],
+              blockId2 -> ListSet(transaction2.id.asTypedBytes).pure[IO]
             ).apply _,
             Map(
               transaction1.id.asTypedBytes -> transaction1.pure[IO],

--- a/minting/src/main/scala/co/topl/minting/BlockMint.scala
+++ b/minting/src/main/scala/co/topl/minting/BlockMint.scala
@@ -12,6 +12,8 @@ import io.circe.syntax._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
 
+import scala.collection.immutable.ListSet
+
 /**
  * A `Mint` which produces "Unsigned" Blocks.  An UnsignedBlock has all of the components needed to form a BlockV2
  * except for a KES Certificate.  This allows for a delayed creation of a KES certificate until it is actually needed,
@@ -46,7 +48,7 @@ object BlockMint {
                       metadata = None,
                       address = address
                     ),
-                    transactions.map(_.id.asTypedBytes).toList
+                    ListSet.from(transactions.map(_.id.asTypedBytes))
                   )
             )
             .flatMap(staker.certifyBlock(parent.slotId, slot, _))

--- a/models/src/main/scala/co/topl/models/package.scala
+++ b/models/src/main/scala/co/topl/models/package.scala
@@ -7,6 +7,7 @@ import io.estatico.newtype.macros.{newsubtype, newtype}
 import io.estatico.newtype.ops._
 import scodec.bits.ByteVector
 
+import scala.collection.immutable.ListSet
 import scala.language.implicitConversions
 
 package object models {
@@ -44,7 +45,7 @@ package object models {
 
   case class SlotId(slot: Slot, blockId: TypedIdentifier)
 
-  type BlockBodyV2 = List[TypedIdentifier]
+  type BlockBodyV2 = ListSet[TypedIdentifier]
 
   @newtype case class TypedBytes(allBytes: Bytes) {
     def typePrefix: TypePrefix = allBytes.head

--- a/models/src/test/scala/co/topl/models/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/ModelGenerators.scala
@@ -666,7 +666,7 @@ trait ModelGenerators {
     Arbitrary(headerGen())
 
   implicit val arbitraryBody: Arbitrary[BlockBodyV2] =
-    Arbitrary(Gen.listOf(arbitraryTypedIdentifier.arbitrary))
+    Arbitrary(Gen.listOf(arbitraryTypedIdentifier.arbitrary).map(ListSet.empty[TypedIdentifier] ++ _))
 
   implicit val arbitraryEta: Arbitrary[Eta] =
     Arbitrary(etaGen)

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainClientHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainClientHandler.scala
@@ -269,7 +269,7 @@ object BlockchainClientHandler {
       client:           BlockchainPeerClient[F],
       transactionStore: Store[F, TypedIdentifier, Transaction]
     ) =
-      (body: BlockBodyV2) => body.traverse(fetchTransaction[F](client, transactionStore))
+      (body: BlockBodyV2) => body.toList.traverse(fetchTransaction[F](client, transactionStore))
 
     private def fetchTransaction[F[_]: Async: Concurrent: Logger: FToFuture](
       client:           BlockchainPeerClient[F],

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainProtocols.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainProtocols.scala
@@ -3,6 +3,8 @@ package co.topl.networking.blockchain
 import co.topl.models._
 import co.topl.networking.typedprotocols.{NotificationProtocol, RequestResponseProtocol}
 
+import scala.collection.immutable.ListSet
+
 /**
  * Defines the various Typed Protocols which are used for the purposes of exchanging blockchain data between
  * two participating nodes.
@@ -36,7 +38,7 @@ object BlockchainProtocols {
    *
    * This protocol runs a server and client in parallel for each connection.
    */
-  object Body extends RequestResponseProtocol[TypedBytes, List[TypedBytes]]
+  object Body extends RequestResponseProtocol[TypedBytes, ListSet[TypedBytes]]
 
   /**
    * Request a Transaction by Transaction ID

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -479,6 +479,6 @@ trait TetraScodecBlockCodecs {
         stakingAddressesPoolCodec
     ).as[BlockHeaderV2.Unsigned]
 
-  implicit val blockBodyV2Codec: Codec[BlockBodyV2] = listCodec[TypedIdentifier]
+  implicit val blockBodyV2Codec: Codec[BlockBodyV2] = listSetCodec[TypedIdentifier]
 
 }

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraTransmittableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraTransmittableCodecs.scala
@@ -4,6 +4,8 @@ import co.topl.codecs.bytes.typeclasses.Transmittable
 import co.topl.models.{BlockHeaderV2, SlotData, Transaction, TypedBytes, TypedIdentifier}
 import co.topl.models.utility.Ratio
 
+import scala.collection.immutable.ListSet
+
 trait TetraTransmittableCodecs {
 
   import TetraScodecCodecs._
@@ -11,7 +13,7 @@ trait TetraTransmittableCodecs {
 
   implicit val ratioTransmittable: Transmittable[Ratio] = Transmittable.instanceFromCodec
   implicit val typedIdentifierTransmittable: Transmittable[TypedBytes] = Transmittable.instanceFromCodec
-  implicit val typedIdentifierListTransmittable: Transmittable[List[TypedBytes]] = Transmittable.instanceFromCodec
+  implicit val typedIdentifierListSetTransmittable: Transmittable[ListSet[TypedBytes]] = Transmittable.instanceFromCodec
   implicit val blockHeaderV2Transmittable: Transmittable[BlockHeaderV2] = Transmittable.instanceFromCodec
   implicit val slotDataTransmittable: Transmittable[SlotData] = Transmittable.instanceFromCodec
   implicit val transactionTransmittable: Transmittable[Transaction] = Transmittable.instanceFromCodec

--- a/typeclasses/src/main/scala/co/topl/typeclasses/BlockGenesis.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/BlockGenesis.scala
@@ -12,6 +12,7 @@ import co.topl.models.utility.{Length, Lengths, Sized}
 import co.topl.typeclasses.implicits._
 
 import java.nio.charset.StandardCharsets
+import scala.collection.immutable.ListSet
 
 object BlockGenesis {
 
@@ -73,6 +74,6 @@ object BlockGenesis {
         metadata = None,
         address = address
       )
-    BlockV2(header, transactions.toList.map(_.id.asTypedBytes))
+    BlockV2(header, ListSet.empty ++ transactions.map(_.id.asTypedBytes))
   }
 }


### PR DESCRIPTION
## Purpose
- Naturally enforces a transaction isn't duplicated within a block
- Also validates that a block does not attempt to spend the same Transaction Output more than once
## Approach
- Change BlockBodyV2 type from List to ListSet
- Added new BodySyntaxValidation check to detect duplicate spends
## Testing
- New unit test for Body duplicate spend prevention
## Tickets
- #2255