### PR TITLE
Fix order of classloaders

### DIFF
--- a/node/src/main/scala/co/topl/db/LDBFactory.scala
+++ b/node/src/main/scala/co/topl/db/LDBFactory.scala
@@ -126,7 +126,7 @@ object LDBFactory extends Logging {
   }
 
   lazy val factory: DBFactory = {
-    val loaders = List(ClassLoader.getSystemClassLoader, this.getClass.getClassLoader)
+    val loaders = List(this.getClass.getClassLoader, ClassLoader.getSystemClassLoader)
 
     // As LevelDB-JNI has problems on Mac (see https://github.com/ergoplatform/ergo/issues/1067),
     // we are using only pure-Java LevelDB on Mac


### PR DESCRIPTION
## Purpose

Make the build and tests work on a mac.

## Approach

The error message was indicating a problem loading a class. Upon inspection it was found that the class loader used was the system class loader. The code tried to load the class using first the system class loader and then the class's class loader. The normal order is normally the opposite. The order was changed and now the code compiles and the tests pass.

## Testing

Tested on my mac and it works.

## Tickets
* closes #2268
