### PR TITLE
Fetch Header RPC

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
@@ -1,9 +1,14 @@
 package co.topl.algebras
 
-import co.topl.models.{Transaction, TypedIdentifier}
+import co.topl.models.{BlockHeaderV2, Transaction, TypedIdentifier}
 
+/**
+ * An interaction layer intended for users/clients of a blockchain node.
+ */
 trait ToplRpc[F[_]] {
   def broadcastTransaction(transaction: Transaction): F[Unit]
 
   def currentMempool(): F[Set[TypedIdentifier]]
+
+  def fetchBlockHeader(blockId: TypedIdentifier): F[Option[BlockHeaderV2]]
 }

--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -118,6 +118,7 @@ object Blockchain {
         )
       mintedBlockStream <- mint.fold(Source.never[BlockV2].pure[F])(_.blocks)
       rpcInterpreter <- ToplRpcServer.make(
+        headerStore,
         transactionStore,
         mempool,
         transactionSyntaxValidation,

--- a/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
@@ -15,7 +15,7 @@ import co.topl.ledger.algebras.{
   TransactionSyntaxValidationAlgebra
 }
 import co.topl.ledger.models._
-import co.topl.models.{Transaction, TypedIdentifier}
+import co.topl.models.{BlockHeaderV2, Transaction, TypedIdentifier}
 import org.typelevel.log4cats.Logger
 import co.topl.typeclasses.implicits._
 
@@ -42,6 +42,7 @@ object ToplRpcServer {
    * Interpreter which serves Topl RPC data using local blockchain interpreters
    */
   def make[F[_]: Async: Logger: FToFuture](
+    headerStore:         Store[F, TypedIdentifier, BlockHeaderV2],
     transactionStore:    Store[F, TypedIdentifier, Transaction],
     mempool:             MempoolAlgebra[F],
     syntacticValidation: TransactionSyntaxValidationAlgebra[F],
@@ -96,6 +97,9 @@ object ToplRpcServer {
               new IllegalArgumentException(show"Semantically invalid transaction id=${transaction.id.asTypedBytes}")
             )
             .rethrowT
+
+        def fetchBlockHeader(blockId: TypedIdentifier): F[Option[BlockHeaderV2]] =
+          headerStore.get(blockId)
       }
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -638,6 +638,7 @@ lazy val toplGrpc = project
     tetraByteCodecs,
     algebras,
     catsAkka,
+    typeclasses,
     munitScalamock % "test->test"
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,15 @@ enablePlugins(ReproducibleBuildsPlugin, ReproducibleBuildsAssemblyPlugin)
 lazy val commonSettings = Seq(
   sonatypeCredentialHost := "s01.oss.sonatype.org",
   scalacOptions ++= commonScalacOptions,
+  // Enable PartialUnification in Scala 2.12.  Scala 2.13 fixes this by default
+  scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, v)) if v <= 12 =>
+      Seq(
+        "-Ypartial-unification"
+      )
+    case _ =>
+      Nil
+  }),
   semanticdbEnabled := true, // enable SemanticDB for Scalafix
   semanticdbVersion := scalafixSemanticdb.revision, // use Scalafix compatible version
 //  wartremoverErrors := Warts.unsafe, // settings for wartremover

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraImmutableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraImmutableCodecs.scala
@@ -9,6 +9,9 @@ import co.topl.models.utility.Ratio
 trait TetraImmutableCodecs {
   import TetraScodecCodecs._
 
+  implicit val typedBytesImmutableCodec: ImmutableCodec[TypedBytes] =
+    ImmutableCodec.fromScodecCodec
+
   implicit val ratioStableCodec: ImmutableCodec[Ratio] =
     ImmutableCodec.fromScodecCodec
 

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraTransmittableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraTransmittableCodecs.scala
@@ -1,8 +1,8 @@
 package co.topl.codecs.bytes.tetra
 
 import co.topl.codecs.bytes.typeclasses.Transmittable
-import co.topl.models.{BlockHeaderV2, SlotData, Transaction, TypedBytes, TypedIdentifier}
 import co.topl.models.utility.Ratio
+import co.topl.models._
 
 import scala.collection.immutable.ListSet
 
@@ -17,6 +17,15 @@ trait TetraTransmittableCodecs {
   implicit val blockHeaderV2Transmittable: Transmittable[BlockHeaderV2] = Transmittable.instanceFromCodec
   implicit val slotDataTransmittable: Transmittable[SlotData] = Transmittable.instanceFromCodec
   implicit val transactionTransmittable: Transmittable[Transaction] = Transmittable.instanceFromCodec
+
+  implicit val eligibilityCertificateTransmittable: Transmittable[EligibilityCertificate] =
+    Transmittable.instanceFromCodec
+
+  implicit val operationalCertificateTransmittable: Transmittable[OperationalCertificate] =
+    Transmittable.instanceFromCodec
+
+  implicit val operatorStakingAddressTransmittable: Transmittable[StakingAddresses.Operator] =
+    Transmittable.instanceFromCodec
 
   implicit val longTypedIdentifierOptTransmittable: Transmittable[(Long, Option[TypedIdentifier])] =
     Transmittable.instanceFromCodec(

--- a/topl-grpc/src/main/protobuf/topl_grpc.proto
+++ b/topl-grpc/src/main/protobuf/topl_grpc.proto
@@ -43,7 +43,10 @@ message BlockHeader {
   int64 slot = 7;
   bytes eligibilityCertificate = 8;
   bytes operationalCertificate = 9;
-  // TODO: Empty/None metadata?
-  bytes metadata = 10;
+  Metadata metadata = 10;
   bytes address = 11;
+
+  message Metadata {
+    bytes value = 1;
+  }
 }

--- a/topl-grpc/src/main/protobuf/topl_grpc.proto
+++ b/topl-grpc/src/main/protobuf/topl_grpc.proto
@@ -5,6 +5,9 @@ package co.topl.grpc.services;
 service ToplGrpc {
   rpc BroadcastTransaction (BroadcastTransactionReq) returns (BroadcastTransactionRes);
   rpc CurrentMempool (CurrentMempoolReq) returns (CurrentMempoolRes);
+
+  rpc FetchBlockHeader (FetchBlockHeaderReq) returns (FetchBlockHeaderRes);
+
 }
 
 message BroadcastTransactionReq {
@@ -20,4 +23,27 @@ message CurrentMempoolReq {}
 
 message CurrentMempoolRes {
   repeated bytes transactionIds = 1;
+}
+
+message FetchBlockHeaderReq {
+  bytes blockId = 1;
+}
+
+message FetchBlockHeaderRes {
+  BlockHeader header = 1;
+}
+
+message BlockHeader {
+  bytes parentHeaderId = 1;
+  int64 parentSlot = 2;
+  bytes txRoot = 3;
+  bytes bloomFilter = 4;
+  int64 timestamp = 5;
+  int64 height = 6;
+  int64 slot = 7;
+  bytes eligibilityCertificate = 8;
+  bytes operationalCertificate = 9;
+  // TODO: Empty/None metadata?
+  bytes metadata = 10;
+  bytes address = 11;
 }

--- a/topl-grpc/src/main/scala/co/topl/grpc/MessageIsomorphism.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/MessageIsomorphism.scala
@@ -1,0 +1,105 @@
+package co.topl.grpc
+
+import cats.Monad
+import cats.implicits._
+import co.topl.codecs.bytes.tetra.instances._
+import co.topl.codecs.bytes.typeclasses.implicits._
+import co.topl.models
+import co.topl.models.utility.HasLength.instances.{bytesLength, latin1DataLength}
+import co.topl.models.utility.StringDataTypes.Latin1Data
+import co.topl.models.utility.{Lengths, Sized}
+
+/**
+ * Represents a fallible isomorphism between two types, A and B.
+ */
+trait MessageIsomorphism[F[_], A, B] {
+  def aToB(a: F[A]): F[Either[String, B]]
+  def bToA(b: F[B]): F[Either[String, A]]
+}
+
+object MessageIsomorphism {
+
+  def create[F[_], A, B](
+    _aToB: F[A] => F[Either[String, B]],
+    _bToA: F[B] => F[Either[String, A]]
+  ): MessageIsomorphism[F, A, B] =
+    new MessageIsomorphism[F, A, B] {
+      def aToB(a: F[A]): F[Either[String, B]] = _aToB(a)
+
+      def bToA(b: F[B]): F[Either[String, A]] = _bToA(b)
+    }
+
+  trait Instances {
+
+    implicit def headerIsomorphism[F[_]: Monad]: MessageIsomorphism[F, models.BlockHeaderV2, services.BlockHeader] =
+      MessageIsomorphism.create(
+        _.map(header =>
+          services
+            .BlockHeader(
+              header.parentHeaderId.transmittableBytes,
+              header.parentSlot,
+              header.txRoot.data,
+              header.bloomFilter.data,
+              header.timestamp,
+              header.height,
+              header.slot,
+              header.eligibilityCertificate.transmittableBytes,
+              header.operationalCertificate.transmittableBytes,
+              header.metadata.map(v => services.BlockHeader.Metadata(models.Bytes(v.data.bytes))),
+              header.address.transmittableBytes
+            )
+            .asRight
+        ),
+        _.map(protoHeader =>
+          for {
+            txRoot <- Sized
+              .strict[models.Bytes, Lengths.`32`.type](protoHeader.txRoot: models.Bytes)
+              .leftMap(_ => "Invalid txRoot")
+            bloomFilter <- Sized
+              .strict[models.Bytes, Lengths.`256`.type](protoHeader.bloomFilter: models.Bytes)
+              .leftMap(_ => "Invalid bloomFilter")
+            eligibilityCertificate <- (protoHeader.eligibilityCertificate: models.Bytes)
+              .decodeTransmitted[models.EligibilityCertificate]
+              .leftMap(_ => "Invalid eligibilityCertificate")
+            operationalCertificate <- (protoHeader.operationalCertificate: models.Bytes)
+              .decodeTransmitted[models.OperationalCertificate]
+              .leftMap(_ => "Invalid operationalCertificate")
+            metadata <- protoHeader.metadata.traverse(metadata =>
+              Sized
+                .max[Latin1Data, Lengths.`32`.type](Latin1Data.fromData(metadata.toByteArray))
+                .leftMap(_ => "Invalid metadata")
+            )
+            address <- (protoHeader.address: models.Bytes)
+              .decodeTransmitted[models.StakingAddresses.Operator]
+              .leftMap(_ => "Invalid address")
+          } yield models.BlockHeaderV2(
+            models.TypedBytes(protoHeader.parentHeaderId),
+            protoHeader.parentSlot,
+            txRoot,
+            bloomFilter,
+            protoHeader.timestamp,
+            protoHeader.height,
+            protoHeader.slot,
+            eligibilityCertificate,
+            operationalCertificate,
+            metadata,
+            address
+          )
+        )
+      )
+  }
+
+  trait Ops {
+
+    implicit class IsomorphicValueOps[F[_], X](x: F[X]) {
+
+      def toB[B](implicit isomorphim: MessageIsomorphism[F, X, B]): F[Either[String, B]] =
+        isomorphim.aToB(x)
+
+      def toA[A](implicit isomorphim: MessageIsomorphism[F, A, X]): F[Either[String, A]] =
+        isomorphim.bToA(x)
+    }
+  }
+
+  object instances extends Instances with Ops
+}

--- a/topl-grpc/src/main/scala/co/topl/grpc/ToplGrpc.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/ToplGrpc.scala
@@ -1,19 +1,23 @@
 package co.topl.grpc
 
 import akka.actor.ClassicActorSystemProvider
-import akka.grpc.GrpcClientSettings
+import akka.grpc.{GrpcClientSettings, GrpcServiceException}
 import akka.http.scaladsl.Http
 import cats.MonadThrow
-import cats.data.ValidatedNec
+import cats.data.{OptionT, ValidatedNec}
 import cats.effect.kernel.{Async, Resource}
 import cats.implicits._
 import co.topl.algebras.ToplRpc
 import co.topl.catsakka._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
-import co.topl.grpc.services.{CurrentMempoolReq, CurrentMempoolRes}
+import co.topl.grpc.services.{CurrentMempoolReq, CurrentMempoolRes, FetchBlockHeaderReq, FetchBlockHeaderRes}
 import co.topl.models._
+import co.topl.models.utility.HasLength.instances.{bytesLength, latin1DataLength}
+import co.topl.models.utility.StringDataTypes.Latin1Data
+import co.topl.models.utility.{Lengths, Sized}
 import com.google.protobuf.ByteString
+import io.grpc.Status
 
 import scala.concurrent.Future
 
@@ -49,16 +53,67 @@ object ToplGrpc {
               .fromFuture(
                 Async[F].delay(client.currentMempool(services.CurrentMempoolReq()))
               )
-              .map(
+              .flatMap(
                 _.transactionIds.toList
                   .traverse[ValidatedNec[String, *], TypedIdentifier](data =>
                     (data: Bytes).decodeTransmitted[TypedIdentifier].toValidatedNec
                   )
                   .map(_.toSet)
                   .leftMap(errors => new IllegalArgumentException(show"Invalid Transaction bytes. reason=$errors"))
-                  .toEither
+                  .liftTo[F]
               )
-              .rethrow
+
+          def fetchBlockHeader(blockId: TypedIdentifier): F[Option[BlockHeaderV2]] =
+            OptionT(
+              Async[F]
+                .fromFuture(
+                  Async[F].delay(
+                    client.fetchBlockHeader(
+                      services.FetchBlockHeaderReq(blockId.allBytes)
+                    )
+                  )
+                )
+                .map(_.header)
+            )
+              .semiflatMap(protoHeader =>
+                (for {
+                  txRoot <- Sized
+                    .strict[Bytes, Lengths.`32`.type](protoHeader.txRoot: Bytes)
+                    .leftMap(_ => new IllegalArgumentException("Invalid txRoot"))
+                  bloomFilter <- Sized
+                    .strict[Bytes, Lengths.`256`.type](protoHeader.bloomFilter: Bytes)
+                    .leftMap(_ => new IllegalArgumentException("Invalid bloomFilter"))
+                  eligibilityCertificate <- (protoHeader.eligibilityCertificate: Bytes)
+                    .decodeImmutable[EligibilityCertificate]
+                    .leftMap(_ => new IllegalArgumentException("Invalid eligibilityCertificate"))
+                  operationalCertificate <- (protoHeader.operationalCertificate: Bytes)
+                    .decodeImmutable[OperationalCertificate]
+                    .leftMap(_ => new IllegalArgumentException("Invalid operationalCertificate"))
+                  metadata <-
+                    if (protoHeader.metadata.isEmpty) Right(None)
+                    else
+                      Sized
+                        .max[Latin1Data, Lengths.`32`.type](Latin1Data.fromData(protoHeader.metadata.toByteArray))
+                        .map(_.some)
+                        .leftMap(_ => new IllegalArgumentException("Invalid metadata"))
+                  address <- (protoHeader.address: Bytes)
+                    .decodeImmutable[StakingAddresses.Operator]
+                    .leftMap(_ => new IllegalArgumentException("Invalid address"))
+                } yield BlockHeaderV2(
+                  TypedBytes(protoHeader.parentHeaderId),
+                  protoHeader.parentSlot,
+                  txRoot,
+                  bloomFilter,
+                  protoHeader.timestamp,
+                  protoHeader.height,
+                  protoHeader.slot,
+                  eligibilityCertificate,
+                  operationalCertificate,
+                  metadata,
+                  address
+                )).liftTo[F]
+              )
+              .value
         }
       }
   }
@@ -90,7 +145,11 @@ object ToplGrpc {
         implicitly[FToFuture[F]].apply(
           (in.transmittableBytes: Bytes)
             .decodeTransmitted[Transaction]
-            .leftMap(err => new IllegalArgumentException(s"Invalid Transaction bytes. reason=$err"))
+            .leftMap(err =>
+              new GrpcServiceException(
+                Status.INVALID_ARGUMENT.withDescription(s"Invalid Transaction bytes. reason=$err")
+              )
+            )
             .liftTo[F]
             .flatMap(interpreter.broadcastTransaction)
             .as(services.BroadcastTransactionRes())
@@ -101,6 +160,34 @@ object ToplGrpc {
           interpreter
             .currentMempool()
             .map(ids => CurrentMempoolRes(ids.toList.map(_.transmittableBytes: ByteString)))
+        )
+
+      def fetchBlockHeader(in: FetchBlockHeaderReq): Future[FetchBlockHeaderRes] =
+        implicitly[FToFuture[F]].apply(
+          (in.blockId: Bytes)
+            .decodeImmutable[TypedIdentifier]
+            .leftMap(_ => new GrpcServiceException(Status.INVALID_ARGUMENT.withDescription("Invalid Block ID")))
+            .liftTo[F]
+            .flatMap(id =>
+              OptionT(interpreter.fetchBlockHeader(id))
+                .map(header =>
+                  services.BlockHeader(
+                    header.parentHeaderId.immutableBytes,
+                    header.parentSlot,
+                    header.txRoot.data,
+                    header.bloomFilter.data,
+                    header.timestamp,
+                    header.height,
+                    header.slot,
+                    header.eligibilityCertificate.immutableBytes,
+                    header.operationalCertificate.immutableBytes,
+                    header.metadata.fold(Bytes.empty)(v => Bytes(v.data.bytes)),
+                    header.address.immutableBytes
+                  )
+                )
+                .value
+                .map(services.FetchBlockHeaderRes(_))
+            )
         )
     }
   }

--- a/topl-grpc/src/main/scala/co/topl/grpc/package.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/package.scala
@@ -9,7 +9,7 @@ import scodec.bits.ByteVector
 
 import scala.language.implicitConversions
 
-package object grpc {
+package object grpc extends MessageIsomorphism.Instances with MessageIsomorphism.Ops {
 
   implicit def byteStringToByteVector(byteString: ByteString): ByteVector =
     ByteVector(byteString.asReadOnlyByteBuffer())

--- a/topl-grpc/src/main/scala/co/topl/grpc/package.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/package.scala
@@ -1,6 +1,10 @@
 package co.topl
 
+import akka.grpc.GrpcServiceException
+import cats.ApplicativeThrow
+import cats.implicits._
 import com.google.protobuf.ByteString
+import io.grpc.Status
 import scodec.bits.ByteVector
 
 import scala.language.implicitConversions
@@ -12,4 +16,30 @@ package object grpc {
 
   implicit def byteVectorToByteString(byteVector: ByteVector): ByteString =
     ByteString.copyFrom(byteVector.toByteBuffer)
+
+  implicit class ThrowableAdapter(throwable: Throwable) {
+
+    def asGrpcException: GrpcServiceException =
+      throwable match {
+        case e: GrpcServiceException => e
+        case i: IllegalArgumentException =>
+          new GrpcServiceException(
+            Status.INVALID_ARGUMENT.withDescription(i.getMessage)
+          )
+        case e: NotImplementedError =>
+          new GrpcServiceException(
+            Status.UNIMPLEMENTED.withDescription(e.getMessage)
+          )
+        case e =>
+          new GrpcServiceException(Status.fromThrowable(e))
+      }
+  }
+
+  implicit class FApplicativeErrorAdapter[F[_]: ApplicativeThrow, A](fa: F[A]) {
+
+    def adaptErrorsToGrpc: F[A] =
+      fa.adaptErr { case e =>
+        e.asGrpcException
+      }
+  }
 }

--- a/topl-grpc/src/test/scala/co/topl/grpc/ToplGrpcSpec.scala
+++ b/topl-grpc/src/test/scala/co/topl/grpc/ToplGrpcSpec.scala
@@ -56,25 +56,25 @@ class ToplGrpcSpec extends CatsEffectSuite with ScalaCheckEffectSuite with Async
         for {
           res <- Async[F]
             .fromFuture(
-              underTest.fetchBlockHeader(FetchBlockHeaderReq(headerId.immutableBytes)).pure[F]
+              underTest.fetchBlockHeader(FetchBlockHeaderReq(headerId.transmittableBytes)).pure[F]
             )
           protoHeader = res.header.get
-          _ = assert((protoHeader.parentHeaderId: Bytes) == header.parentHeaderId.immutableBytes)
+          _ = assert((protoHeader.parentHeaderId: Bytes) == header.parentHeaderId.transmittableBytes)
           _ = assert(protoHeader.parentSlot == header.parentSlot)
           _ = assert((protoHeader.txRoot: Bytes) == header.txRoot.data)
           _ = assert((protoHeader.bloomFilter: Bytes) == header.bloomFilter.data)
           _ = assert(protoHeader.timestamp == header.timestamp)
           _ = assert(protoHeader.height == header.height)
           _ = assert(protoHeader.slot == header.slot)
-          _ = assert((protoHeader.eligibilityCertificate: Bytes) == header.eligibilityCertificate.immutableBytes)
-          _ = assert((protoHeader.operationalCertificate: Bytes) == header.operationalCertificate.immutableBytes)
+          _ = assert((protoHeader.eligibilityCertificate: Bytes) == header.eligibilityCertificate.transmittableBytes)
+          _ = assert((protoHeader.operationalCertificate: Bytes) == header.operationalCertificate.transmittableBytes)
           _ =
             assert(
               protoHeader.metadata.map(_.value.toByteArray).map(Bytes(_)) == header.metadata
                 .map(_.data.bytes)
                 .map(Bytes(_))
             )
-          _ = assert((protoHeader.address: Bytes) == header.address.immutableBytes)
+          _ = assert((protoHeader.address: Bytes) == header.address.transmittableBytes)
         } yield ()
       }
     }

--- a/topl-grpc/src/test/scala/co/topl/grpc/ToplGrpcSpec.scala
+++ b/topl-grpc/src/test/scala/co/topl/grpc/ToplGrpcSpec.scala
@@ -1,5 +1,6 @@
 package co.topl.grpc
 
+import akka.grpc.GrpcServiceException
 import cats.Applicative
 import cats.effect.{Async, IO}
 import cats.implicits._
@@ -7,12 +8,15 @@ import co.topl.algebras.ToplRpc
 import co.topl.catsakka._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
-import co.topl.grpc.services.{BroadcastTransactionReq, BroadcastTransactionRes}
+import co.topl.grpc.services.{BroadcastTransactionReq, BroadcastTransactionRes, FetchBlockHeaderReq}
 import co.topl.models.ModelGenerators._
-import co.topl.models.Transaction
+import co.topl.models.{BlockHeaderV2, Bytes, Transaction}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
+import co.topl.typeclasses.implicits._
+import com.google.protobuf.ByteString
+import io.grpc.Status
 
 class ToplGrpcSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   type F[A] = IO[A]
@@ -34,6 +38,63 @@ class ToplGrpcSpec extends CatsEffectSuite with ScalaCheckEffectSuite with Async
           )
           .assertEquals(BroadcastTransactionRes())
       }
+    }
+  }
+
+  test("A block header can be retrieved") {
+    PropF.forAllF { (header: BlockHeaderV2) =>
+      val headerId = header.id.asTypedBytes
+      withMock {
+        val interpreter = mock[ToplRpc[F]]
+        val underTest = new ToplGrpc.Server.GrpcServerImpl[F](interpreter)
+
+        (interpreter.fetchBlockHeader _)
+          .expects(headerId)
+          .once()
+          .returning(header.some.pure[F])
+
+        for {
+          res <- Async[F]
+            .fromFuture(
+              underTest.fetchBlockHeader(FetchBlockHeaderReq(headerId.immutableBytes)).pure[F]
+            )
+          protoHeader = res.header.get
+          _ = assert((protoHeader.parentHeaderId: Bytes) == header.parentHeaderId.immutableBytes)
+          _ = assert(protoHeader.parentSlot == header.parentSlot)
+          _ = assert((protoHeader.txRoot: Bytes) == header.txRoot.data)
+          _ = assert((protoHeader.bloomFilter: Bytes) == header.bloomFilter.data)
+          _ = assert(protoHeader.timestamp == header.timestamp)
+          _ = assert(protoHeader.height == header.height)
+          _ = assert(protoHeader.slot == header.slot)
+          _ = assert((protoHeader.eligibilityCertificate: Bytes) == header.eligibilityCertificate.immutableBytes)
+          _ = assert((protoHeader.operationalCertificate: Bytes) == header.operationalCertificate.immutableBytes)
+          _ =
+            header.metadata match {
+              case Some(data) =>
+                assert((protoHeader.metadata: Bytes) == Bytes(data.data.bytes))
+              case _ =>
+                assert(protoHeader.metadata.isEmpty)
+            }
+          _ = assert((protoHeader.address: Bytes) == header.address.immutableBytes)
+        } yield ()
+      }
+    }
+  }
+
+  test("An invalid block header ID is rejected") {
+    withMock {
+      val interpreter = mock[ToplRpc[F]]
+      val underTest = new ToplGrpc.Server.GrpcServerImpl[F](interpreter)
+
+      for {
+        e <- interceptIO[GrpcServiceException](
+          Async[F]
+            .fromFuture(
+              underTest.fetchBlockHeader(FetchBlockHeaderReq(ByteString.EMPTY)).pure[F]
+            )
+        )
+        _ = assert(e.status.getCode == Status.Code.INVALID_ARGUMENT)
+      } yield ()
     }
   }
 }

--- a/topl-grpc/src/test/scala/co/topl/grpc/ToplGrpcSpec.scala
+++ b/topl-grpc/src/test/scala/co/topl/grpc/ToplGrpcSpec.scala
@@ -69,12 +69,11 @@ class ToplGrpcSpec extends CatsEffectSuite with ScalaCheckEffectSuite with Async
           _ = assert((protoHeader.eligibilityCertificate: Bytes) == header.eligibilityCertificate.immutableBytes)
           _ = assert((protoHeader.operationalCertificate: Bytes) == header.operationalCertificate.immutableBytes)
           _ =
-            header.metadata match {
-              case Some(data) =>
-                assert((protoHeader.metadata: Bytes) == Bytes(data.data.bytes))
-              case _ =>
-                assert(protoHeader.metadata.isEmpty)
-            }
+            assert(
+              protoHeader.metadata.map(_.value.toByteArray).map(Bytes(_)) == header.metadata
+                .map(_.data.bytes)
+                .map(Bytes(_))
+            )
           _ = assert((protoHeader.address: Bytes) == header.address.immutableBytes)
         } yield ()
       }


### PR DESCRIPTION
## Purpose
- Clients need access to block headers stored on the blockchain
## Approach
- Added a new RPC to the topl_grpc.proto specification
- Added new `fetchHeader` method to ToplRpc algebra
- Interpreted `fetchHeader` method using a provided Store algebra
- Added MessageIsomorphism trait to assist with converting between Models <-> Proto Definitions
## Testing
- Added unit tests for `fetchHeader` RPC
## Tickets
* #2321 
