### PR TITLE
Fetch Block Body RPC

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
@@ -1,6 +1,6 @@
 package co.topl.algebras
 
-import co.topl.models.{BlockHeaderV2, Transaction, TypedIdentifier}
+import co.topl.models.{BlockBodyV2, BlockHeaderV2, Transaction, TypedIdentifier}
 
 /**
  * An interaction layer intended for users/clients of a blockchain node.
@@ -11,4 +11,6 @@ trait ToplRpc[F[_]] {
   def currentMempool(): F[Set[TypedIdentifier]]
 
   def fetchBlockHeader(blockId: TypedIdentifier): F[Option[BlockHeaderV2]]
+
+  def fetchBlockBody(blockId: TypedIdentifier): F[Option[BlockBodyV2]]
 }

--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -119,6 +119,7 @@ object Blockchain {
       mintedBlockStream <- mint.fold(Source.never[BlockV2].pure[F])(_.blocks)
       rpcInterpreter <- ToplRpcServer.make(
         headerStore,
+        bodyStore,
         transactionStore,
         mempool,
         transactionSyntaxValidation,

--- a/topl-grpc/src/main/protobuf/topl_grpc.proto
+++ b/topl-grpc/src/main/protobuf/topl_grpc.proto
@@ -7,6 +7,7 @@ service ToplGrpc {
   rpc CurrentMempool (CurrentMempoolReq) returns (CurrentMempoolRes);
 
   rpc FetchBlockHeader (FetchBlockHeaderReq) returns (FetchBlockHeaderRes);
+  rpc FetchBlockBody (FetchBlockBodyReq) returns (FetchBlockBodyRes);
 
 }
 
@@ -49,4 +50,16 @@ message BlockHeader {
   message Metadata {
     bytes value = 1;
   }
+}
+
+message FetchBlockBodyReq {
+  bytes blockId = 1;
+}
+
+message FetchBlockBodyRes {
+  BlockBody body = 1;
+}
+
+message BlockBody {
+  repeated bytes transactionIds = 1;
 }


### PR DESCRIPTION
## Purpose
- RPC Clients need the ability to fetch the transaction IDs associated with a block ID
## Approach
- Added FetchBlockBody RPC to topl_grpc.proto
- Interpreted using Block Body Store
## Testing
- Added unit tests for FetchBlockBody
## Tickets
* #2322 
