### PR TITLE
Fixed Contributing Guide link in README.md. Fixed Discord invite in CONTRIBUTING.md.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Before you get lost in the repository, here are a few starting points
 for you to check out. You might find that others have had similar
 questions or that your question rather belongs in one place than another.
 
-* Chat: https://discord.gg/CHaG8utU
+* Chat: https://discord.gg/WVPGaG5Cqc
 * Website: https://www.topl.co/
 * Twitter: https://twitter.com/topl_protocol
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ We appreciate your interest in this project and welcome contributions!
 
 If you'd like to contribute to Project Bifrost, please fork, fix, commit and send a pull request so that we can review your code and merge it when it is complete. For more complex changes, please contact us via Gitter or Slack to ensure those changes are reasonable and/or get some early feedback to expedite the review and merge process.
 
-**Please read our [Contributing Guide](https://github.com/Topl/Project-Bifrost/blob/master/CONTRIBUTING.md) for more information before submitting any pull requests, as the submission of any content to Topl's repositories constitutes your understanding of and agreement to our Contributor License Agreement and Code of Conduct.**
+**Please read our [Contributing Guide](https://github.com/Topl/Bifrost/blob/main/.github/CONTRIBUTING.md) for more information before submitting any pull requests, as the submission of any content to Topl's repositories constitutes your understanding of and agreement to our Contributor License Agreement and Code of Conduct.**
 
 To keep up with our development
 


### PR DESCRIPTION
## Purpose
New contributors wouldn't be able to find the contributing guide on the readme. Anyone who wants to join the Discord would be met with a broken invite.
## Approach
Replaced the links with the proper URL.
## Testing
I clicked the links.
## Tickets
* closes #2333 