### PR TITLE
Added Proto model definitions

### DIFF
--- a/topl-grpc/src/main/protobuf/models/address.proto
+++ b/topl-grpc/src/main/protobuf/models/address.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package co.topl.grpc.models;
+
+import 'models/common.proto';
+import 'models/verification_key.proto';
+import 'models/proof.proto';
+
+message FullAddress {
+  NetworkPrefix networkPrefix = 1;
+  SpendingAddress spendingAddress = 2;
+  StakingAddress stakingAddress = 3;
+  ProofKnowledgeEd25519 commitment = 4;
+}
+
+message SpendingAddress {
+  TypedEvidence typedEvidence = 1;
+}
+
+message StakingAddress {
+  oneof sealed_value {
+    StakingAddressOperator operator = 1;
+    StakingAddressNonStaking nonStaking = 2;
+  }
+}
+
+message StakingAddressOperator {
+  VerificationKeyEd25519 vk = 1;
+}
+
+message StakingAddressNonStaking {}

--- a/topl-grpc/src/main/protobuf/models/block.proto
+++ b/topl-grpc/src/main/protobuf/models/block.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+package co.topl.grpc.models;
+
+import 'models/common.proto';
+import 'models/address.proto';
+import 'models/certificate.proto';
+import 'models/transaction.proto';
+
+message BlockHeader {
+  BlockId parentHeaderId = 1;
+  int64 parentSlot = 2;
+  bytes txRoot = 3;
+  bytes bloomFilter = 4;
+  int64 timestamp = 5;
+  int64 height = 6;
+  int64 slot = 7;
+  EligibilityCertificate eligibilityCertificate = 8;
+  OperationalCertificate operationalCertificate = 9;
+  Metadata metadata = 10;
+  StakingAddressOperator address = 11;
+
+  message Metadata {
+    bytes value = 1;
+  }
+}
+
+message BlockBody {
+  repeated TransactionId transactionIds = 1;
+}
+
+message FullBlockBody {
+  repeated Transaction transaction = 1;
+}
+
+message FullBlock {
+  BlockHeader header = 1;
+  FullBlockBody fullBody = 2;
+}

--- a/topl-grpc/src/main/protobuf/models/box.proto
+++ b/topl-grpc/src/main/protobuf/models/box.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+package co.topl.grpc.models;
+
+import 'models/common.proto';
+
+message Box {
+  message Id {
+    TransactionId transactionId = 1;
+    int32 transactionOutputIndex = 2;
+  }
+}
+
+message BoxValue {
+  oneof sealed_value {
+    EmptyBoxValue empty = 1;
+    PolyBoxValue poly = 2;
+    ArbitBoxValue arbit = 3;
+    DionAssetBoxValue asset = 4;
+    OperatorRegistrationBoxValue operatorRegistration = 5;
+  }
+}
+
+message EmptyBoxValue {}
+message PolyBoxValue {
+  Int128 quantity = 1;
+}
+message ArbitBoxValue {
+  Int128 quantity = 1;
+}
+message DionAssetBoxValue {
+  Int128 quantity = 1;
+  Code assetCode = 2;
+  bytes securityRoot = 3;
+  bytes metadata = 4;
+
+  message Code {
+    int32 version = 1;
+    bytes issuerAddress = 2;
+    bytes shortName = 3;
+  }
+}
+message OperatorRegistrationBoxValue {
+  bytes vrfCommitment = 1;
+}

--- a/topl-grpc/src/main/protobuf/models/certificate.proto
+++ b/topl-grpc/src/main/protobuf/models/certificate.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package co.topl.grpc.models;
+
+import 'models/verification_key.proto';
+import 'models/proof.proto';
+
+message OperationalCertificate {
+  VerificationKeyKesProduct parentVK = 1;
+  ProofKnowledgeKesProduct parentSignature = 2;
+  VerificationKeyEd25519 childVK = 3;
+  ProofKnowledgeEd25519 childSignature = 4;
+}
+
+message EligibilityCertificate {
+  ProofKnowledgeVrfEd25519 vrfSig = 1;
+  VerificationKeyVrfEd25519 vkVRF = 2;
+  bytes thresholdEvidence = 3;
+  bytes eta = 4;
+}

--- a/topl-grpc/src/main/protobuf/models/common.proto
+++ b/topl-grpc/src/main/protobuf/models/common.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package co.topl.grpc.models;
+
+message NetworkPrefix {
+  int32 value = 1;
+}
+
+message TypedEvidence {
+  int32 typePrefix = 1;
+  bytes evidence = 2;
+}
+
+message BlockId {
+  bytes value = 1;
+}
+
+message TransactionId {
+  bytes value = 1;
+}
+
+message Int128 {
+  bytes value = 1;
+}

--- a/topl-grpc/src/main/protobuf/models/proof.proto
+++ b/topl-grpc/src/main/protobuf/models/proof.proto
@@ -1,0 +1,72 @@
+syntax = "proto3";
+
+package co.topl.grpc.models;
+
+import 'models/verification_key.proto';
+
+message Proof {
+  oneof sealed_value {
+    ProofUndefined undefined = 1;
+
+    ProofKnowledgeEd25519 knowledgeEd25519 = 2;
+    ProofKnowledgeVrfEd25519 knowledgeVrfEd25519 = 3;
+    ProofKnowledgeKesSum knowledgeKesSum = 4;
+    ProofKnowledgeKesProduct knowledgeKesProduct = 5;
+    ProofKnowledgeHashLock knowledgeHashLock = 6;
+
+    ProofCompositionalThreshold compositionalThreshold = 7;
+    ProofCompositionalAnd compositionalAnd = 8;
+    ProofCompositionalOr compositionalOr = 9;
+    ProofCompositionalNot compositionalNot = 10;
+
+    ProofContextualHeightLock contextualHeightLock = 11;
+    ProofContextualRequiredTransactionIO contextualTransactionIO = 12;
+  }
+}
+
+message ProofUndefined {}
+
+message ProofKnowledgeEd25519 {
+  bytes value = 1;
+}
+
+message ProofKnowledgeVrfEd25519 {
+  bytes value = 1;
+}
+
+message ProofKnowledgeKesSum {
+  VerificationKeyEd25519 verificationKey = 1;
+  ProofKnowledgeEd25519 signature = 2;
+  repeated bytes witness = 3;
+}
+
+message ProofKnowledgeKesProduct {
+  ProofKnowledgeKesSum superSignature = 1;
+  ProofKnowledgeKesSum subSignature = 2;
+  bytes subRoot = 3;
+}
+
+message ProofKnowledgeHashLock {
+  bytes value = 1;
+}
+
+message ProofCompositionalThreshold {
+  repeated Proof proofs = 1;
+}
+
+message ProofCompositionalAnd {
+  Proof a = 1;
+  Proof b = 2;
+}
+
+message ProofCompositionalOr {
+  Proof a = 1;
+  Proof b = 2;
+}
+
+message ProofCompositionalNot {
+  Proof a = 1;
+}
+
+message ProofContextualHeightLock {}
+message ProofContextualRequiredTransactionIO {}

--- a/topl-grpc/src/main/protobuf/models/proposition.proto
+++ b/topl-grpc/src/main/protobuf/models/proposition.proto
@@ -1,0 +1,78 @@
+syntax = "proto3";
+
+package co.topl.grpc.models;
+
+import 'models/verification_key.proto';
+import 'models/box.proto';
+
+message Proposition {
+  oneof sealed_value {
+    PropositionPermanentlyLocked permanentlyLocked = 1;
+
+    PropositionKnowledgeEd25519 knowledgeEd25519 = 2;
+    PropositionKnowledgeExtendedEd25519 knowledgeExtendedEd25519 = 3;
+    PropositionKnowledgeHashLock knowledgeHashLock = 4;
+
+    PropositionCompositionalThreshold compositionalThreshold = 5;
+    PropositionCompositionalAnd compositionalAnd = 6;
+    PropositionCompositionalOr compositionalOr = 7;
+    PropositionCompositionalNot compositionalNot = 8;
+
+    PropositionContextualHeightLock contextualHeightLock = 9;
+    PropositionContextualRequiredTransactionIO contextualTransactionIO = 10;
+  }
+}
+
+message PropositionPermanentlyLocked {}
+
+message PropositionKnowledgeEd25519 {
+  VerificationKeyEd25519 key = 1;
+}
+
+message PropositionKnowledgeExtendedEd25519 {
+  VerificationKeyExtendedEd25519 key = 1;
+}
+
+message PropositionKnowledgeHashLock {
+  bytes valueDigest = 1;
+}
+
+message PropositionCompositionalThreshold {
+  int32 threshold = 1;
+  repeated Proposition propositions = 2;
+}
+
+message PropositionCompositionalAnd {
+  Proposition a = 1;
+  Proposition b = 2;
+}
+
+message PropositionCompositionalOr {
+  Proposition a = 1;
+  Proposition b = 2;
+}
+
+message PropositionCompositionalNot {
+  Proposition a = 1;
+}
+
+message PropositionContextualHeightLock {
+  int64 height = 1;
+}
+message PropositionContextualRequiredTransactionIO {
+  repeated Requirement boxes = 1;
+
+  message Requirement {
+    Box box = 1;
+    BoxLocation location = 2;
+  }
+}
+
+message BoxLocation {
+  int32 index = 1;
+  IO location = 2;
+  enum IO {
+    INPUT = 0;
+    OUTPUT = 1;
+  }
+}

--- a/topl-grpc/src/main/protobuf/models/transaction.proto
+++ b/topl-grpc/src/main/protobuf/models/transaction.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package co.topl.grpc.models;
+
+import 'models/address.proto';
+import 'models/box.proto';
+import 'models/proof.proto';
+import 'models/proposition.proto';
+
+message Transaction {
+  repeated Input inputs = 1;
+  repeated Output outputs = 2;
+  Schedule schedule = 3;
+  Data data = 4;
+
+  message Input {
+    Box.Id boxId = 1;
+    Proposition proposition = 2;
+    Proof proof = 3;
+    BoxValue value = 4;
+  }
+  message Output {
+    FullAddress address = 1;
+    BoxValue value = 2;
+    bool minting = 3;
+  }
+  message Schedule {
+    int64 creation = 1;
+    int64 minimumSlot = 2;
+    int64 maximumSlot = 3;
+  }
+  message Data {
+    bytes value = 1;
+  }
+}

--- a/topl-grpc/src/main/protobuf/models/verification_key.proto
+++ b/topl-grpc/src/main/protobuf/models/verification_key.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package co.topl.grpc.models;
+
+message VerificationKey {
+  oneof sealed_value {
+    VerificationKeyEd25519 ed25519 = 1;
+    VerificationKeyExtendedEd25519 extendedEd25519 = 2;
+    VerificationKeyVrfEd25519 vrfEd25519 = 3;
+    VerificationKeyKesProduct kesProduct = 4;
+  }
+}
+
+message VerificationKeyEd25519 {
+  bytes value = 1;
+}
+
+message VerificationKeyExtendedEd25519 {
+  VerificationKeyEd25519 vk = 1;
+  bytes chainCode = 2;
+}
+
+message VerificationKeyVrfEd25519 {
+  bytes value = 1;
+}
+
+message VerificationKeyKesProduct {
+  bytes value = 1;
+  int32 step = 2;
+}


### PR DESCRIPTION
## Purpose
- To support a "Fetch Transaction" RPC, there must be a `Transaction` message defined in the protobuf descriptor
  - A Transaction message necessarily involves defining messages for Boxes, Proofs, and Propositions

## Approach
- Created separate grpc sub-package which roughly reflects the co.top.models package

## Testing
- N/A
## Tickets
- #2323 (partially)
  - There will be follow-up PRs which _use_ these proto descriptor messages