### PR TITLE
gRPC Proof Morphisms

### DIFF
--- a/topl-grpc/src/main/protobuf/models/proof.proto
+++ b/topl-grpc/src/main/protobuf/models/proof.proto
@@ -8,23 +8,28 @@ message Proof {
   oneof sealed_value {
     ProofUndefined undefined = 1;
 
-    ProofKnowledgeEd25519 knowledgeEd25519 = 2;
-    ProofKnowledgeVrfEd25519 knowledgeVrfEd25519 = 3;
-    ProofKnowledgeKesSum knowledgeKesSum = 4;
-    ProofKnowledgeKesProduct knowledgeKesProduct = 5;
-    ProofKnowledgeHashLock knowledgeHashLock = 6;
+    ProofKnowledgeCurve25519 knowledgeCurve25519 = 2;
+    ProofKnowledgeEd25519 knowledgeEd25519 = 3;
+    ProofKnowledgeVrfEd25519 knowledgeVrfEd25519 = 4;
+    ProofKnowledgeKesSum knowledgeKesSum = 5;
+    ProofKnowledgeKesProduct knowledgeKesProduct = 6;
+    ProofKnowledgeHashLock knowledgeHashLock = 7;
 
-    ProofCompositionalThreshold compositionalThreshold = 7;
-    ProofCompositionalAnd compositionalAnd = 8;
-    ProofCompositionalOr compositionalOr = 9;
-    ProofCompositionalNot compositionalNot = 10;
+    ProofCompositionalThreshold compositionalThreshold = 8;
+    ProofCompositionalAnd compositionalAnd = 9;
+    ProofCompositionalOr compositionalOr = 10;
+    ProofCompositionalNot compositionalNot = 11;
 
-    ProofContextualHeightLock contextualHeightLock = 11;
-    ProofContextualRequiredTransactionIO contextualTransactionIO = 12;
+    ProofContextualHeightLock contextualHeightLock = 12;
+    ProofContextualRequiredTransactionIO contextualTransactionIO = 13;
   }
 }
 
 message ProofUndefined {}
+
+message ProofKnowledgeCurve25519 {
+  bytes value = 1;
+}
 
 message ProofKnowledgeEd25519 {
   bytes value = 1;

--- a/topl-grpc/src/main/protobuf/models/proposition.proto
+++ b/topl-grpc/src/main/protobuf/models/proposition.proto
@@ -9,21 +9,26 @@ message Proposition {
   oneof sealed_value {
     PropositionPermanentlyLocked permanentlyLocked = 1;
 
-    PropositionKnowledgeEd25519 knowledgeEd25519 = 2;
-    PropositionKnowledgeExtendedEd25519 knowledgeExtendedEd25519 = 3;
-    PropositionKnowledgeHashLock knowledgeHashLock = 4;
+    PropositionKnowledgeCurve25519 knowledgeCurve25519 = 3;
+    PropositionKnowledgeEd25519 knowledgeEd25519 = 4;
+    PropositionKnowledgeExtendedEd25519 knowledgeExtendedEd25519 = 5;
+    PropositionKnowledgeHashLock knowledgeHashLock = 6;
 
-    PropositionCompositionalThreshold compositionalThreshold = 5;
-    PropositionCompositionalAnd compositionalAnd = 6;
-    PropositionCompositionalOr compositionalOr = 7;
-    PropositionCompositionalNot compositionalNot = 8;
+    PropositionCompositionalThreshold compositionalThreshold = 7;
+    PropositionCompositionalAnd compositionalAnd = 8;
+    PropositionCompositionalOr compositionalOr = 9;
+    PropositionCompositionalNot compositionalNot = 10;
 
-    PropositionContextualHeightLock contextualHeightLock = 9;
-    PropositionContextualRequiredTransactionIO contextualTransactionIO = 10;
+    PropositionContextualHeightLock contextualHeightLock = 11;
+    PropositionContextualRequiredTransactionIO contextualTransactionIO = 12;
   }
 }
 
 message PropositionPermanentlyLocked {}
+
+message PropositionKnowledgeCurve25519 {
+  VerificationKeyCurve25519 key = 1;
+}
 
 message PropositionKnowledgeEd25519 {
   VerificationKeyEd25519 key = 1;

--- a/topl-grpc/src/main/protobuf/models/verification_key.proto
+++ b/topl-grpc/src/main/protobuf/models/verification_key.proto
@@ -4,11 +4,16 @@ package co.topl.grpc.models;
 
 message VerificationKey {
   oneof sealed_value {
-    VerificationKeyEd25519 ed25519 = 1;
-    VerificationKeyExtendedEd25519 extendedEd25519 = 2;
-    VerificationKeyVrfEd25519 vrfEd25519 = 3;
-    VerificationKeyKesProduct kesProduct = 4;
+    VerificationKeyCurve25519 curve25519 = 1;
+    VerificationKeyEd25519 ed25519 = 2;
+    VerificationKeyExtendedEd25519 extendedEd25519 = 3;
+    VerificationKeyVrfEd25519 vrfEd25519 = 4;
+    VerificationKeyKesProduct kesProduct = 5;
   }
+}
+
+message VerificationKeyCurve25519 {
+  bytes value = 1;
 }
 
 message VerificationKeyEd25519 {

--- a/topl-grpc/src/test/scala/co/topl/grpc/BifrostMorphismInstancesSpec.scala
+++ b/topl-grpc/src/test/scala/co/topl/grpc/BifrostMorphismInstancesSpec.scala
@@ -1,0 +1,37 @@
+package co.topl.grpc
+
+import cats.data.EitherT
+import cats.effect.IO
+import co.topl.models.ModelGenerators._
+import co.topl.models.Proof
+import co.topl.{models => bifrostModels}
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.Arbitrary
+import org.scalacheck.effect.PropF
+import org.scalamock.munit.AsyncMockFactory
+
+class BifrostMorphismInstancesSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+  type F[A] = IO[A]
+
+  test("BlockHeader Morphism") {
+    testIsomorphism[bifrostModels.BlockHeaderV2, models.BlockHeader]
+  }
+
+  test("BlockBody Morphism") {
+    testIsomorphism[bifrostModels.BlockBodyV2, models.BlockBody]
+  }
+
+  test("Proof Morphism") {
+    // TODO: ModelGenerators makes Curve proofs which fails here
+    testIsomorphism[bifrostModels.Proof, models.Proof]
+  }
+
+  private def testIsomorphism[A, B](implicit isomorphism: Isomorphism[F, A, B], arbitraryA: Arbitrary[A]) =
+    PropF.forAllF { (a: A) =>
+      for {
+        protoA <- EitherT(a.toF[F, B]).leftMap(new IllegalArgumentException(_)).rethrowT
+        _a     <- EitherT(protoA.toF[F, A]).leftMap(new IllegalArgumentException(_)).rethrowT
+        _ = assert(a == _a)
+      } yield ()
+    }
+}

--- a/topl-grpc/src/test/scala/co/topl/grpc/BifrostMorphismInstancesSpec.scala
+++ b/topl-grpc/src/test/scala/co/topl/grpc/BifrostMorphismInstancesSpec.scala
@@ -22,7 +22,6 @@ class BifrostMorphismInstancesSpec extends CatsEffectSuite with ScalaCheckEffect
   }
 
   test("Proof Morphism") {
-    // TODO: ModelGenerators makes Curve proofs which fails here
     testIsomorphism[bifrostModels.Proof, models.Proof]
   }
 


### PR DESCRIPTION
## Purpose
- Introduces Isomorphic relationships between Bifrost Proof models and Protobuf/gRPC Proof models

## Approach
- Added isomorphism definitions for all Proof types
- Re-introduced Curve25519 to proto specifications
  - Curve25519 is used heavily in the codebase (including Dion) which would drastically bloat this PR to remove

## Testing
- Added BifrostMorphismInstancesSpec

## Tickets
- #2323 (partially)
  - More work to follow 