### PR TITLE
Get Transaction RPC

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
@@ -13,4 +13,6 @@ trait ToplRpc[F[_]] {
   def fetchBlockHeader(blockId: TypedIdentifier): F[Option[BlockHeaderV2]]
 
   def fetchBlockBody(blockId: TypedIdentifier): F[Option[BlockBodyV2]]
+
+  def fetchTransaction(transactionId: TypedIdentifier): F[Option[Transaction]]
 }

--- a/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
@@ -79,6 +79,9 @@ object ToplRpcServer {
         def fetchBlockBody(blockId: TypedIdentifier): F[Option[BlockBodyV2]] =
           bodyStore.get(blockId)
 
+        def fetchTransaction(transactionId: TypedIdentifier): F[Option[Transaction]] =
+          transactionStore.get(transactionId)
+
         private def syntacticValidateOrRaise(transaction: Transaction) =
           EitherT(syntacticValidation.validate(transaction).map(_.toEither))
             .leftSemiflatTap(errors =>

--- a/topl-grpc/src/main/protobuf/topl_grpc.proto
+++ b/topl-grpc/src/main/protobuf/topl_grpc.proto
@@ -4,6 +4,7 @@ package co.topl.grpc.services;
 
 import 'models/common.proto';
 import 'models/block.proto';
+import 'models/transaction.proto';
 
 service ToplGrpc {
   rpc BroadcastTransaction (BroadcastTransactionReq) returns (BroadcastTransactionRes);
@@ -11,14 +12,11 @@ service ToplGrpc {
 
   rpc FetchBlockHeader (FetchBlockHeaderReq) returns (FetchBlockHeaderRes);
   rpc FetchBlockBody (FetchBlockBodyReq) returns (FetchBlockBodyRes);
-
+  rpc FetchTransaction (FetchTransactionReq) returns (FetchTransactionRes);
 }
 
 message BroadcastTransactionReq {
-  // TODO: Use a Transaction structure instead of just its transmittableBytes
-  // But for now, just encode/decode the byte representation.  Re-implementing the full
-  // structure requires re-implementing the full Proposition/Proof structure.
-  bytes transmittableBytes = 1;
+  co.topl.grpc.models.Transaction transaction = 1;
 }
 
 message BroadcastTransactionRes {}
@@ -43,4 +41,12 @@ message FetchBlockBodyReq {
 
 message FetchBlockBodyRes {
   co.topl.grpc.models.BlockBody body = 1;
+}
+
+message FetchTransactionReq {
+  co.topl.grpc.models.TransactionId transactionId = 1;
+}
+
+message FetchTransactionRes {
+  co.topl.grpc.models.Transaction transaction = 1;
 }

--- a/topl-grpc/src/main/scala/co/topl/grpc/BifrostMorphismInstances.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/BifrostMorphismInstances.scala
@@ -1,7 +1,7 @@
 package co.topl.grpc
 
 import cats.{Functor, Monad}
-import cats.data.{Chain, EitherT, NonEmptyChain, OptionT}
+import cats.data.{Chain, EitherT, NonEmptyChain}
 import cats.implicits._
 import co.topl.models.utility.HasLength.instances.{bigIntLength, _}
 import co.topl.models.utility.Lengths._
@@ -1333,3 +1333,4 @@ trait BlockBifrostMorphismInstances {
     )
 
 }
+// Hello :)


### PR DESCRIPTION
## Purpose
- Adds an RPC to read a Transaction by ID from a node
## Approach
- Added new RPC `FetchTransaction` to ToplGrpc service
- Also updated BroadcastTx RPC to accept a full Transaction (instead of Transaction bytes)
## Testing
- Unit test of FetchTransaction RPC
## Tickets
- #2323 
