### PR TITLE
Get Block ID at Height RPC

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
@@ -15,4 +15,6 @@ trait ToplRpc[F[_]] {
   def fetchBlockBody(blockId: TypedIdentifier): F[Option[BlockBodyV2]]
 
   def fetchTransaction(transactionId: TypedIdentifier): F[Option[Transaction]]
+
+  def blockIdAtHeight(height: Long): F[Option[TypedIdentifier]]
 }

--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -124,7 +124,8 @@ object Blockchain {
         mempool,
         transactionSyntaxValidation,
         transactionSemanticValidation,
-        localChain
+        localChain,
+        blockHeights
       )
       rpcServer = ToplGrpc.Server.serve(rpcHost, rpcPort, rpcInterpreter)
       mintedBlockStreamCompletionFuture =

--- a/topl-grpc/src/main/protobuf/topl_grpc.proto
+++ b/topl-grpc/src/main/protobuf/topl_grpc.proto
@@ -13,6 +13,8 @@ service ToplGrpc {
   rpc FetchBlockHeader (FetchBlockHeaderReq) returns (FetchBlockHeaderRes);
   rpc FetchBlockBody (FetchBlockBodyReq) returns (FetchBlockBodyRes);
   rpc FetchTransaction (FetchTransactionReq) returns (FetchTransactionRes);
+
+  rpc FetchBlockIdAtHeight (FetchBlockIdAtHeightReq) returns (FetchBlockIdAtHeightRes);
 }
 
 message BroadcastTransactionReq {
@@ -49,4 +51,12 @@ message FetchTransactionReq {
 
 message FetchTransactionRes {
   co.topl.grpc.models.Transaction transaction = 1;
+}
+
+message FetchBlockIdAtHeightReq {
+  int64 height = 1;
+}
+
+message FetchBlockIdAtHeightRes {
+  co.topl.grpc.models.BlockId blockId = 1;
 }


### PR DESCRIPTION
## Purpose
- Implements a new RPC which retrieves the block ID associated with the requested height
## Approach
- Added new .proto RPC
- Implemented using LocalChain + BlockHeights
- Also updated BramblTetra to use new RPCs to determine genesis block+transactions
## Testing
- Unit test for new RPC
## Tickets
- #2324 