### PR TITLE
GraalVM -> Temurin JDK

### DIFF
--- a/.github/workflows/_postman_integration_tests.yml
+++ b/.github/workflows/_postman_integration_tests.yml
@@ -10,7 +10,7 @@ on:
         type: string
       java-versions:
         description: 'List of Java versions to target.'
-        default: 'graalvm-ce-java11@21.1.0'
+        default: '11'
         required: false
         type: string
       preserve-cache-between-runs:

--- a/.github/workflows/_sbt_build.yml
+++ b/.github/workflows/_sbt_build.yml
@@ -41,7 +41,8 @@ jobs:
 
       - name: Setup SBT
         run: |
-          set -eux && curl --fail --silent --location --retry 3 https://github.com/sbt/sbt/releases/download/v1.7.1/sbt-1.7.1.tgz gunzip | tar x -C $HOME/bin/sbt
+          mkdir -p $HOME/bin/sbt
+          set -eux && curl --fail --silent --location --retry 3 https://github.com/sbt/sbt/releases/download/v1.7.1/sbt-1.7.1.tgz | gunzip | tar x -C $HOME/bin/sbt
           echo "$HOME/bin/sbt" >> $GITHUB_PATH
 
       - name: Cache sbt

--- a/.github/workflows/_sbt_build.yml
+++ b/.github/workflows/_sbt_build.yml
@@ -10,7 +10,7 @@ on:
         type: string
       java-versions:
         description: 'List of Java versions to target.'
-        default: 'graalvm-ce-java11@21.1.0'
+        default: '11'
         required: false
         type: string
       preserve-cache-between-runs:
@@ -34,9 +34,15 @@ jobs:
           fetch-depth: 0 # Need full history to update last modified time.
 
       - name: Setup Java
-        uses: olafurpg/setup-scala@v10
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+
+      - name: Setup SBT
+        run: |
+          set -eux && curl --fail --silent --location --retry 3 https://github.com/sbt/sbt/releases/download/v1.7.1/sbt-1.7.1.tgz gunzip | tar x -C $HOME/bin/sbt
+          echo "$HOME/bin/sbt" >> $GITHUB_PATH
 
       - name: Cache sbt
         uses: actions/cache@v3

--- a/.github/workflows/_scala_integration_tests.yml
+++ b/.github/workflows/_scala_integration_tests.yml
@@ -10,7 +10,7 @@ on:
         type: string
       java-versions:
         description: 'List of Java versions to target.'
-        default: 'graalvm-ce-java11@21.1.0'
+        default: '11'
         required: false
         type: string
       preserve-cache-between-runs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       target-os: >-
         ["ubuntu-latest"]
       java-versions: >-
-        ["graalvm-ce-java11@21.1.0"]
+        ["11"]
 
   sbt-integration-tests:
     uses: ./.github/workflows/_scala_integration_tests.yml
@@ -21,7 +21,7 @@ jobs:
       target-os: >-
         ["ubuntu-latest"]
       java-versions: >-
-        ["graalvm-ce-java11@21.1.0"]
+        ["11"]
 
   post-man-integration-tests:
     uses: ./.github/workflows/_postman_integration_tests.yml
@@ -30,7 +30,7 @@ jobs:
       target-os: >-
         ["ubuntu-latest"]
       java-versions: >-
-        ["graalvm-ce-java11@21.1.0"]
+        ["11"]
 
   publish-test-results:
     uses: ./.github/workflows/_publish_test_results.yml

--- a/.github/workflows/doc_gen.yml
+++ b/.github/workflows/doc_gen.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
         matrix:
           os: [ubuntu-latest]
-          java: [graalvm-ce-java11@21.1.0]
+          java: [11]
     
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
       target-os: >-
         ["ubuntu-latest"]
       java-versions: >-
-        ["graalvm-ce-java11@21.1.0"]
+        ["11"]
       preserve-cache-between-runs: true
 
   post-man-integration-tests:
@@ -21,7 +21,7 @@ jobs:
       target-os: >-
         ["ubuntu-latest"]
       java-versions: >-
-        ["graalvm-ce-java11@21.1.0"]
+        ["11"]
       preserve-cache-between-runs: true
 
   publish-test-results:

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val publishSettings = Seq(
 
 lazy val dockerSettings = Seq(
   Docker / packageName := "bifrost-node",
-  dockerBaseImage := "ghcr.io/graalvm/graalvm-ce:java11-21.3.0",
+  dockerBaseImage := "eclipse-temurin:11-jre",
   dockerUpdateLatest := true,
   dockerExposedPorts := Seq(9084, 9085),
   dockerExposedVolumes += "/opt/docker/.bifrost",

--- a/docker/testImage/Dockerfile
+++ b/docker/testImage/Dockerfile
@@ -1,9 +1,0 @@
-FROM ghcr.io/graalvm/graalvm-ce:java11-21.1.0
-
-ENV SCALA_VERSION 2.13.5
-ENV SBT_VERSION 1.5.0
-
-RUN microdnf update -y \
- && microdnf install -y wget git \
- && curl https://bintray.com/sbt/rpm/rpm | tee /etc/yum.repos.d/bintray-sbt-rpm.repo \
- && microdnf install -y sbt

--- a/node/src/it/resources/Dockerfile
+++ b/node/src/it/resources/Dockerfile
@@ -1,8 +1,6 @@
 FROM ubuntu:22.04
 
-ARG GRAALVM_VERSION=21.1.0
-ARG JAVA_VERSION=java11
-ARG SBT_VERSION=1.5.0
+ARG SBT_VERSION=1.7.1
 
 RUN apt -y update && apt -y upgrade
 RUN apt -y install \
@@ -20,17 +18,11 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /
       $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
       apt -y update && DEBIAN_FRONTEND=noninteractive apt -y install docker-ce docker-ce-cli containerd.io
 
-# GraalVM install
-# See: https://github.com/graalvm/container/blob/master/community/Dockerfile
-ARG GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAALVM_VERSION/graalvm-ce-$JAVA_VERSION-linux-amd64-$GRAALVM_VERSION.tar.gz
-
-ENV LANG=en_US.UTF-8 \
-    JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION/ \
-    PATH=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION/bin:$PATH
-
-RUN set -eux \
-    && curl --fail --silent --location --retry 3 ${GRAALVM_PKG} \
-    | gunzip | tar x -C /opt/
+# JDK Install
+RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add - \
+    && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list \
+    && apt update \
+    && apt install temurin-11-jdk
 
 # SBT Install
 ARG SBT_PKG=https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz

--- a/node/src/main/scala/co/topl/BifrostApp.scala
+++ b/node/src/main/scala/co/topl/BifrostApp.scala
@@ -6,12 +6,10 @@ import co.topl.network.utils.UPnPGateway
 import co.topl.settings._
 import co.topl.tool.Exporter
 import co.topl.utils.Logging
-import com.sun.management.{HotSpotDiagnosticMXBean, VMOption}
 import com.typesafe.config.{Config, ConfigFactory}
 import kamon.Kamon
 import mainargs.ParserForClass
 
-import java.lang.management.ManagementFactory
 import scala.concurrent.Await
 
 class BifrostApp(startupOpts: StartupOpts) extends NodeLogging {
@@ -49,31 +47,6 @@ class BifrostApp(startupOpts: StartupOpts) extends NodeLogging {
   log.debug(s"RPC is allowed at: ${settings.rpcApi.bindAddress}")
   /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ---------------- */
   /** Setup the execution environment for running the application */
-
-  /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ----------------- */ /* ---------------- */
-  /** Am I running on a JDK that supports JVMCI? */
-  val vm_version: String = System.getProperty("java.vm.version")
-  System.out.printf("java.vm.version = %s%n", vm_version)
-
-  val bean: HotSpotDiagnosticMXBean = ManagementFactory.getPlatformMXBean(classOf[HotSpotDiagnosticMXBean])
-
-  // Is JVMCI enabled?
-  try {
-    val enableJVMCI: VMOption = bean.getVMOption("EnableJVMCI")
-    log.debug(s"$enableJVMCI")
-  } catch {
-    case e: Throwable =>
-      log.error(s"${Console.RED}Unexpected error when checking for JVMCI: $e ${Console.RESET}")
-      throw e
-  }
-
-  /** Is the system using the JVMCI compiler for normal compilations? */
-  val useJVMCICompiler: VMOption = bean.getVMOption("UseJVMCICompiler")
-  log.debug(s"$useJVMCICompiler")
-
-  /** What compiler is selected? */
-  val compiler: String = System.getProperty("jvmci.Compiler")
-  System.out.printf("jvmci.Compiler = %s%n", compiler)
 
   implicit val actorSystem: ActorSystem[Heimdall.ReceivableMessage] =
     ActorSystem(Heimdall(settings, appContext), settings.network.agentName, config)

--- a/topl-grpc/src/main/protobuf/topl_grpc.proto
+++ b/topl-grpc/src/main/protobuf/topl_grpc.proto
@@ -15,6 +15,7 @@ service ToplGrpc {
   rpc FetchTransaction (FetchTransactionReq) returns (FetchTransactionRes);
 
   rpc FetchBlockIdAtHeight (FetchBlockIdAtHeightReq) returns (FetchBlockIdAtHeightRes);
+
 }
 
 message BroadcastTransactionReq {


### PR DESCRIPTION
## Purpose
- We currently do not leverage GraalVM for its main benefits
- GraalVM has a very heavy installation footprint which slows down builds/CI
- Until we _need_ GraalVM, a standard JDK distribution will suffice
## Approach
- Switch to Eclipse's Temurin JDK (successor to AdoptOpenJDK)
- Update GitHub workflows to specify Java 11 as the target version
- Update SBT Build workflow to install Temurin Java as a separate step
  - SBT Install is now a separate manual workflow step
  - (setup-scala uses jabba which has not been updated with Temurin support)
## Testing
- preparePR locally
- GitHub Workflow Checks
## Tickets
* #2423 