### PR TITLE
Bn 552 bifrost node definition

### DIFF
--- a/helm/bifrost/.helmignore
+++ b/helm/bifrost/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/bifrost/Chart.yaml
+++ b/helm/bifrost/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: bifrost
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"
+
+#TODO: Find a better icon.
+icon: https://uploads-ssl.webflow.com/60f98f46d44e675abb7e66ea/611c4d83ed3df101fd221875_topl_basew.svg

--- a/helm/bifrost/templates/_helpers.tpl
+++ b/helm/bifrost/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bifrost.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bifrost.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bifrost.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bifrost.labels" -}}
+helm.sh/chart: {{ include "bifrost.chart" . }}
+{{ include "bifrost.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bifrost.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bifrost.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bifrost.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bifrost.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           {{ end }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
-        {{- if (.Values.readinessProbe.enabled) }}
+        {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
             port: {{ .Values.ports.rpc }}

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-deployment
+  labels:
+    app: {{ .Values.bifrost.name }}
+spec:
+  serviceName: {{ .Values.bifrost.name }}-service
+  replicas: {{ .Values.bifrost.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.bifrost.name }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.bifrost.name }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsUser: 1001 # TODO: Update Bifrost Docker container to use high UID. Add CKV_K8S_40 as a check.
+        runAsGroup: 0
+        fsGroup: 0
+        seccompProfile:
+            type: RuntimeDefault
+      containers:
+      - name: {{ .Values.bifrost.name }}
+        image: {{ .Values.bifrost.image }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        command:
+          {{ range .Values.bifrost.command }}
+            - {{ . }}
+          {{ end }}
+        args:
+          {{ range .Values.bifrost.args }}
+            - {{ . }}
+          {{ end }}
+        {{- if or (.Values.bifrost.resources.minCPU) (.Values.bifrost.resources.minMemory) (.Values.bifrost.resources.maxCPU) (.Values.bifrost.resources.maxMemory) }}
+        resources:
+          {{- if or (.Values.bifrost.resources.minCPU) (.Values.bifrost.resources.minMemory) }}
+          requests:
+            {{- if .Values.bifrost.resources.minMemory }}
+            memory: {{ .Values.bifrost.resources.minMemory }}
+            {{- end }}
+            {{- if .Values.bifrost.resources.minCPU }}
+            cpu: {{ .Values.bifrost.resources.minCPU }}
+            {{- end }}
+          {{- end }}
+          {{- if or (.Values.bifrost.resources.maxCPU) (.Values.bifrost.resources.maxMemory) }}
+          limits:
+            {{- if .Values.bifrost.resources.maxMemory }}
+            memory: {{ .Values.bifrost.resources.maxMemory }}
+            {{- end }}
+            {{- if .Values.bifrost.resources.maxCPU }}
+            cpu: {{ .Values.bifrost.resources.maxCPU }}
+            {{- end }}
+          {{- end }}
+        {{- end}}
+        {{- if (.Values.bifrost.readinessProbe.enabled) }}
+        readinessProbe:
+          httpGet:
+            port: {{ .Values.bifrost.ports.rpc }}
+            initialDelaySeconds: {{ .Values.bifrost.readinessProbe.initialDelaySeconds }}
+        {{- end }}
+        {{- if .Values.bifrost.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            port: {{ .Values.bifrost.ports.rpc }}
+            initialDelaySeconds: {{ .Values.bifrost.livenessProbe.initialDelaySeconds }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.bifrost.ports.p2p }}
+        - containerPort: {{ .Values.bifrost.ports.rpc }}
+        volumeMounts:
+        - name: {{ .Values.bifrost.name }}-pv
+          mountPath: {{ .Values.bifrost.volume.mountDirectory }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ .Values.bifrost.name }}-pv
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ .Values.bifrost.volume.storageClass }}
+      resources:
+        requests:
+          storage: {{ .Values.bifrost.volume.storageSize }}

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -1,91 +1,63 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-deployment
+  name: {{ include "bifrost.fullname" . }}
   labels:
-    app: {{ .Values.bifrost.name }}
+    {{- include "bifrost.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ .Values.bifrost.name }}-service
-  replicas: {{ .Values.bifrost.replicas }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: {{ .Values.bifrost.name }}
+      {{- include "bifrost.selectorLabels" . | nindent 6 }}
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app: {{ .Values.bifrost.name }}
+        {{- include "bifrost.selectorLabels" . | nindent 8 }}
     spec:
       automountServiceAccountToken: false
       securityContext:
-        runAsUser: 1001 # TODO: Update Bifrost Docker container to use high UID. Add CKV_K8S_40 as a check.
-        runAsGroup: 0
-        fsGroup: 0
-        seccompProfile:
-            type: RuntimeDefault
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-      - name: {{ .Values.bifrost.name }}
-        image: {{ .Values.bifrost.image }}
+      - name: {{ .Chart.Name }}
+        image: {{ .Values.image }}
         securityContext:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
+          {{- toYaml .Values.securityContext | nindent 10 }}
         command:
-          {{ range .Values.bifrost.command }}
+          {{ range .Values.command }}
             - {{ . }}
           {{ end }}
         args:
-          {{ range .Values.bifrost.args }}
+          {{ range .Values.args }}
             - {{ . }}
           {{ end }}
-        {{- if or (.Values.bifrost.resources.minCPU) (.Values.bifrost.resources.minMemory) (.Values.bifrost.resources.maxCPU) (.Values.bifrost.resources.maxMemory) }}
         resources:
-          {{- if or (.Values.bifrost.resources.minCPU) (.Values.bifrost.resources.minMemory) }}
-          requests:
-            {{- if .Values.bifrost.resources.minMemory }}
-            memory: {{ .Values.bifrost.resources.minMemory }}
-            {{- end }}
-            {{- if .Values.bifrost.resources.minCPU }}
-            cpu: {{ .Values.bifrost.resources.minCPU }}
-            {{- end }}
-          {{- end }}
-          {{- if or (.Values.bifrost.resources.maxCPU) (.Values.bifrost.resources.maxMemory) }}
-          limits:
-            {{- if .Values.bifrost.resources.maxMemory }}
-            memory: {{ .Values.bifrost.resources.maxMemory }}
-            {{- end }}
-            {{- if .Values.bifrost.resources.maxCPU }}
-            cpu: {{ .Values.bifrost.resources.maxCPU }}
-            {{- end }}
-          {{- end }}
-        {{- end}}
-        {{- if (.Values.bifrost.readinessProbe.enabled) }}
+          {{- toYaml .Values.resources | nindent 12 }}
+        {{- if (.Values.readinessProbe.enabled) }}
         readinessProbe:
           httpGet:
-            port: {{ .Values.bifrost.ports.rpc }}
-            initialDelaySeconds: {{ .Values.bifrost.readinessProbe.initialDelaySeconds }}
+            port: {{ .Values.ports.rpc }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
         {{- end }}
-        {{- if .Values.bifrost.livenessProbe.enabled }}
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            port: {{ .Values.bifrost.ports.rpc }}
-            initialDelaySeconds: {{ .Values.bifrost.livenessProbe.initialDelaySeconds }}
+            port: {{ .Values.ports.rpc }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
         {{- end }}
         ports:
-        - containerPort: {{ .Values.bifrost.ports.p2p }}
-        - containerPort: {{ .Values.bifrost.ports.rpc }}
+        - containerPort: {{ .Values.ports.p2p }}
+        - containerPort: {{ .Values.ports.rpc }}
         volumeMounts:
-        - name: {{ .Values.bifrost.name }}-pv
-          mountPath: {{ .Values.bifrost.volume.mountDirectory }}
+        - name: {{ .Values.name }}-pv
+          mountPath: {{ .Values.volume.mountDirectory }}
   volumeClaimTemplates:
   - metadata:
-      name: {{ .Values.bifrost.name }}-pv
+      name: {{ .Values.name }}-pv
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: {{ .Values.bifrost.volume.storageClass }}
+      storageClassName: {{ .Values.volume.storageClass }}
       resources:
         requests:
-          storage: {{ .Values.bifrost.volume.storageSize }}
+          storage: {{ .Values.volume.storageSize }}

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "bifrost.labels" . | nindent 4 }}
 spec:
+  serviceName: {{ include "bifrost.fullname" . }}
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
@@ -38,13 +39,17 @@ spec:
         readinessProbe:
           httpGet:
             port: {{ .Values.ports.rpc }}
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
         {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             port: {{ .Values.ports.rpc }}
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ .Values.ports.p2p }}

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}
-        image: {{ .Values.image }}
+        image: {{ .Values.image.name }}:{{ .Values.image.tag }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
         command:

--- a/helm/bifrost/templates/bifrost/service.yaml
+++ b/helm/bifrost/templates/bifrost/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.bifrost.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.bifrost.name }}-service
+spec:
+  selector:
+    app: {{ .Values.bifrost.name }}
+  ports:
+    - protocol: TCP
+      name: p2p
+      port: {{ .Values.bifrost.service.ports.p2p }}
+      targetPort: {{ .Values.bifrost.ports.p2p }}
+    - protocol: TCP
+      name: rpc
+      port: {{ .Values.bifrost.service.ports.rpc }}
+      targetPort: {{ .Values.bifrost.ports.rpc }}
+  type: {{ .Values.bifrost.service.type }}
+{{- end }}

--- a/helm/bifrost/templates/bifrost/service.yaml
+++ b/helm/bifrost/templates/bifrost/service.yaml
@@ -1,19 +1,21 @@
-{{- if .Values.bifrost.service.enabled }}
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.bifrost.name }}-service
+  name: {{ include "bifrost.fullname" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4}}
 spec:
   selector:
-    app: {{ .Values.bifrost.name }}
+    {{- include "bifrost.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}
   ports:
     - protocol: TCP
       name: p2p
-      port: {{ .Values.bifrost.service.ports.p2p }}
-      targetPort: {{ .Values.bifrost.ports.p2p }}
+      port: {{ .Values.service.ports.p2p }}
+      targetPort: {{ .Values.ports.p2p }}
     - protocol: TCP
       name: rpc
-      port: {{ .Values.bifrost.service.ports.rpc }}
-      targetPort: {{ .Values.bifrost.ports.rpc }}
-  type: {{ .Values.bifrost.service.type }}
+      port: {{ .Values.service.ports.rpc }}
+      targetPort: {{ .Values.ports.rpc }}
 {{- end }}

--- a/helm/bifrost/values.yaml
+++ b/helm/bifrost/values.yaml
@@ -38,7 +38,7 @@ command:
 # command: ["tail", "-f", "/dev/null"] # Use this to debug Bifrost and exec into the running pod.
 
 service:
-  enabled: false
+  enabled: true
   type: ClusterIP
   ports:
     p2p: 9084

--- a/helm/bifrost/values.yaml
+++ b/helm/bifrost/values.yaml
@@ -4,7 +4,9 @@
 
 name: bifrost-node
 
-image: ghcr.io/topl/bifrost-node:latest
+image:
+  name: ghcr.io/topl/bifrost-node
+  tag: latest
 
 replicas: 1
 

--- a/helm/bifrost/values.yaml
+++ b/helm/bifrost/values.yaml
@@ -56,8 +56,12 @@ volume:
 
 livenessProbe:
   enabled: true
-  initialDelaySeconds: 10
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 60 # Perform check every x seconds.
 
 readinessProbe:
   enabled: true
-  initialDelaySeconds: 5
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 60 # Perform check every x seconds.

--- a/helm/bifrost/values.yaml
+++ b/helm/bifrost/values.yaml
@@ -1,0 +1,38 @@
+# # Default values for bifrost.
+# # This is a YAML-formatted file.
+# # Declare variables to be passed into your templates.
+
+bifrost:
+  name: bifrost-node
+  image: ghcr.io/topl/bifrost-node:latest
+  replicas: 1
+  resources:
+    minCPU: 250m
+    maxCPU: 2.0
+    minMemory: 250Mi
+    maxMemory: 4000Mi
+  args: # Refer to CLI: https://github.com/Topl/Bifrost#command-line-reference
+  # args: ['--seed', 'test', '--forge']
+  # args: ['--network', 'valhalla']
+  command:
+  # command: ["tail", "-f", "/dev/null"] # Use this to debug Bifrost and exec into the running pod.
+  service:
+    enabled: false
+    type: ClusterIP
+    ports:
+      p2p: 9084
+      rpc: 9085
+  ports:
+    p2p: 9084
+    rpc: 9085
+  volume:
+    mountDirectory: /opt/docker/.bifrost
+    # GKE specific storage classes: standard, standard-rwo, premium-rwo
+    storageClass: default
+    storageSize: 10Gi
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5

--- a/helm/bifrost/values.yaml
+++ b/helm/bifrost/values.yaml
@@ -2,37 +2,62 @@
 # # This is a YAML-formatted file.
 # # Declare variables to be passed into your templates.
 
-bifrost:
-  name: bifrost-node
-  image: ghcr.io/topl/bifrost-node:latest
-  replicas: 1
-  resources:
-    minCPU: 250m
-    maxCPU: 2.0
-    minMemory: 250Mi
-    maxMemory: 4000Mi
-  args: # Refer to CLI: https://github.com/Topl/Bifrost#command-line-reference
-  # args: ['--seed', 'test', '--forge']
-  # args: ['--network', 'valhalla']
-  command:
-  # command: ["tail", "-f", "/dev/null"] # Use this to debug Bifrost and exec into the running pod.
-  service:
-    enabled: false
-    type: ClusterIP
-    ports:
-      p2p: 9084
-      rpc: 9085
+name: bifrost-node
+
+image: ghcr.io/topl/bifrost-node:latest
+
+replicas: 1
+
+resources:
+  limits:
+    cpu: 2.0
+    memory: 4000Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+podSecurityContext:
+  runAsUser: 1001 # TODO: Update Bifrost Docker container to use high UID. Add CKV_K8S_40 as a check.
+  runAsGroup: 0
+  fsGroup: 0
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+args: # Refer to CLI: https://github.com/Topl/Bifrost#command-line-reference
+# args: ['--seed', 'test', '--forge']
+# args: ['--network', 'valhalla']
+
+command:
+# command: ["tail", "-f", "/dev/null"] # Use this to debug Bifrost and exec into the running pod.
+
+service:
+  enabled: false
+  type: ClusterIP
   ports:
     p2p: 9084
     rpc: 9085
-  volume:
-    mountDirectory: /opt/docker/.bifrost
-    # GKE specific storage classes: standard, standard-rwo, premium-rwo
-    storageClass: default
-    storageSize: 10Gi
-  livenessProbe:
-    enabled: true
-    initialDelaySeconds: 10
-  readinessProbe:
-    enabled: true
-    initialDelaySeconds: 5
+
+ports:
+  p2p: 9084
+  rpc: 9085
+
+volume:
+  mountDirectory: /opt/docker/.bifrost
+  # GKE specific storage classes: standard, standard-rwo, premium-rwo
+  storageClass: default
+  storageSize: 10Gi
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5


### PR DESCRIPTION
## Purpose
To help with deployment in cloud native environments, create a Helm chart for running a Bifrost node

## Approach
This is the first pass of a simple Bifrost node helm chart. Use [node besu helm chart](https://github.com/hyperledger/bevel/tree/main/platforms/hyperledger-besu/charts/node_besu) for inspiration.

The Helm chart consists of a `StatefulSet` deployment for the `bifrost-node` Docker image, which will also spin up a `PersistentVolume` automatically.

The `Service` routes traffic back to the pods.

### Creation
1. Use `helm create bifrost` to create a template Helm chart.
2. Remove extra files and scope the chart to a `StatefulSet` and a `Service`.

Also ran `checkov` on the chart and fixed any issues that appeared.

## Testing
Deployed basic example in GCP which just attached to the Valhalla network. Verified connection via logs.

## How to use

Locally:
1. Install Docker Desktop, enable Kubernetes.
2. Install Helm
3. In root of Bifrost repo: `helm upgrade --install bifrost-node-deployment-name ./helm/bifrost/ -f values.yaml`
4. `-f values.yaml` is a user specified override for the values. This part is optional.

## Tickets
>_* closes #2264 _