### PR TITLE
LevelDB Store Interpreter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -661,6 +661,20 @@ lazy val toplGrpc = project
     munitScalamock % "test->test"
   )
 
+lazy val levelDbStore = project
+  .in(file("level-db-store"))
+  .settings(
+    name := "level-db-store",
+    commonSettings,
+    libraryDependencies ++= Dependencies.levelDb
+  )
+  .dependsOn(
+    byteCodecs,
+    algebras,
+    catsAkka,
+    munitScalamock % "test->test"
+  )
+
 // This module has fallen out of sync with the rest of the codebase and is not currently needed
 //lazy val gjallarhorn = project
 //  .in(file("gjallarhorn"))

--- a/build.sbt
+++ b/build.sbt
@@ -220,7 +220,8 @@ lazy val bifrost = project
     tools,
     scripting,
     eligibilitySimulator,
-    genus
+    genus,
+    levelDbStore
   )
 
 lazy val node = project

--- a/build.sbt
+++ b/build.sbt
@@ -666,13 +666,12 @@ lazy val levelDbStore = project
   .settings(
     name := "level-db-store",
     commonSettings,
-    libraryDependencies ++= Dependencies.levelDb
+    libraryDependencies ++= Dependencies.levelDbStore
   )
   .dependsOn(
     byteCodecs,
     algebras,
-    catsAkka,
-    munitScalamock % "test->test"
+    catsAkka
   )
 
 // This module has fallen out of sync with the rest of the codebase and is not currently needed

--- a/level-db-store/src/main/scala/co/topl/db/leveldb/LevelDbStore.scala
+++ b/level-db-store/src/main/scala/co/topl/db/leveldb/LevelDbStore.scala
@@ -1,0 +1,68 @@
+package co.topl.db.leveldb
+
+import cats.data.OptionT
+import cats.effect.Sync
+import cats.implicits._
+import co.topl.codecs.bytes.typeclasses.implicits._
+import co.topl.algebras.Store
+import co.topl.codecs.bytes.typeclasses.Persistable
+import org.iq80.leveldb.{CompressionType, DB, Options}
+import scodec.bits.ByteVector
+
+import java.nio.file.{Files, Path}
+import java.util.InputMismatchException
+import scala.language.implicitConversions
+
+/**
+ * A `Store` interpreter which is backed by LevelDB.  Keys and Values must have a Persistable typeclass instance available.
+ * The keys and values are encoded to and from their persistable byte representation.
+ */
+object LevelDbStore {
+
+  def make[F[_]: Sync, Key: Persistable, Value: Persistable](db: DB): F[Store[F, Key, Value]] =
+    Sync[F].delay {
+      new Store[F, Key, Value] {
+        def put(id: Key, t: Value): F[Unit] =
+          useDb(_.put(id.persistedBytes.toArray, t.persistedBytes.toArray))
+
+        def remove(id: Key): F[Unit] =
+          useDb(_.delete(id.persistedBytes.toArray))
+
+        def get(id: Key): F[Option[Value]] =
+          OptionT(useDb(db => Option(db.get(id.persistedBytes.toArray))))
+            .semiflatMap(array =>
+              ByteVector(array)
+                .decodePersisted[Value]
+                .leftMap(new InputMismatchException(_))
+                .toEitherT[F]
+                .rethrowT
+            )
+            .value
+
+        def contains(id: Key): F[Boolean] =
+          OptionT(useDb(db => Option(db.get(id.persistedBytes.toArray)))).isDefined
+
+        private def useDb[R](f: DB => R): F[R] =
+          Sync[F].blocking(f(db))
+      }
+    }
+
+  /**
+   * Creates an instance of a DB from the given path
+   */
+  def makeDb[F[_]: Sync](baseDirectory: Path): F[DB] =
+    Sync[F].blocking {
+      Files.createDirectories(baseDirectory)
+      val options = new Options
+      options.createIfMissing(true)
+      options.paranoidChecks(true)
+      options.blockSize(4 * 1024 * 1024)
+      options.cacheSize(0)
+      options.maxOpenFiles(10)
+      options.compressionType(CompressionType.SNAPPY)
+      org.iq80.leveldb.impl.Iq80DBFactory.factory.open(
+        baseDirectory.toFile,
+        options
+      )
+    }
+}

--- a/level-db-store/src/test/scala/co/topl/db/leveldb/LevelDbStoreSpec.scala
+++ b/level-db-store/src/test/scala/co/topl/db/leveldb/LevelDbStoreSpec.scala
@@ -1,0 +1,76 @@
+package co.topl.db.leveldb
+
+import cats.effect.IO
+import cats.implicits._
+import co.topl.codecs.bytes.typeclasses.Persistable
+import co.topl.codecs.bytes.typeclasses.implicits._
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalamock.munit.AsyncMockFactory
+import scodec.{codecs, Codec}
+
+import java.nio.file.Files
+import java.util.InputMismatchException
+
+class LevelDbStoreSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+
+  type F[A] = IO[A]
+
+  import SpecKey._
+  import SpecValue._
+
+  test("Save, Contains, Read, Delete") {
+    for {
+      testPath    <- Files.createTempDirectory("LevelDbStoreSpec").pure[F]
+      dbUnderTest <- LevelDbStore.makeDb[F](testPath)
+      underTest   <- LevelDbStore.make[F, SpecKey, SpecValue](dbUnderTest)
+      key = SpecKey("test1")
+      keyArray = key.persistedBytes.toArray
+      value = SpecValue("foo", 6458)
+      valueArray = value.persistedBytes.toArray
+      _ <- underTest.contains(key).assertEquals(false)
+      _ <- IO.blocking(dbUnderTest.get(keyArray)).assertEquals(null)
+      _ <- underTest.put(key, value)
+      _ <- IO.blocking(dbUnderTest.get(keyArray)).map(_ sameElements valueArray).assert
+      _ <- underTest.contains(key).assertEquals(true)
+      _ <- underTest.get(key).assertEquals(Some(value))
+      _ <- underTest.remove(key)
+      _ <- underTest.contains(key).assertEquals(false)
+      _ <- IO.blocking(dbUnderTest.get(keyArray)).assertEquals(null)
+    } yield ()
+  }
+
+  test("Malformed data throws exceptions") {
+    for {
+      testPath    <- Files.createTempDirectory("LevelDbStoreSpec").pure[F]
+      dbUnderTest <- LevelDbStore.makeDb[F](testPath)
+      underTest   <- LevelDbStore.make[F, SpecKey, SpecValue](dbUnderTest)
+      key = SpecKey("test1")
+      keyArray = key.persistedBytes.toArray
+      _ <- IO.blocking(dbUnderTest.put(keyArray, Array[Byte](1, 2, 3, 4)))
+      _ <- underTest.contains(key).assertEquals(true)
+      _ <- interceptIO[InputMismatchException](underTest.get(key))
+    } yield ()
+  }
+
+}
+
+case class SpecKey(id: String)
+
+object SpecKey {
+
+  implicit val testKeyCodec: Codec[SpecKey] =
+    codecs.utf8_32.as[SpecKey]
+
+  implicit val testKeyPersistable: Persistable[SpecKey] =
+    Persistable.instanceFromCodec
+}
+case class SpecValue(value1: String, value2: Long)
+
+object SpecValue {
+
+  implicit val specValueCodec: Codec[SpecValue] =
+    (codecs.utf8_32 :: codecs.vlongL).as[SpecValue]
+
+  implicit val specValuePersistable: Persistable[SpecValue] =
+    Persistable.instanceFromCodec
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -329,6 +329,12 @@ object Dependencies {
     catsEffect ++
     mUnitTest
 
+  lazy val levelDbStore: Seq[ModuleID] =
+    levelDb ++
+    cats ++
+    catsEffect ++
+    mUnitTest
+
   lazy val genus: Seq[ModuleID] =
     Seq(
       "com.lightbend.akka" %% "akka-stream-alpakka-mongodb" % "3.0.4",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,6 +10,7 @@ object Dependencies {
   val simulacrumVersion = "1.0.1"
   val catsCoreVersion = "2.8.0"
   val catsEffectVersion = "3.3.14"
+  val fs2Version = "3.2.12"
 
   val catsSlf4j =
     "org.typelevel" %% "log4cats-slf4j" % "2.4.0"
@@ -165,6 +166,9 @@ object Dependencies {
   val mainargs = Seq(
     "com.lihaoyi" %% "mainargs" % "0.2.3"
   )
+
+  val fs2Core = "co.fs2" %% "fs2-core" % fs2Version
+  val fs2IO = "co.fs2"   %% "fs2-io"   % fs2Version
 
   val node: Seq[ModuleID] =
     Seq(
@@ -333,7 +337,8 @@ object Dependencies {
     levelDb ++
     cats ++
     catsEffect ++
-    mUnitTest
+    mUnitTest ++
+    Seq(fs2Core % Test, fs2IO % Test)
 
   lazy val genus: Seq[ModuleID] =
     Seq(


### PR DESCRIPTION
## Purpose
- Currently, the only interpreter for `Store` is in-memory and non-persistent
- This PR introduces a `Store` interpreter that persists data to disk
## Approach
- Created new separate LevelDB SBT module which interprets the `Store` algebra
  - Separate SBT module allows us to isolate the unit tests, allowing us to disable _just_ that module when unit testing on machines that don't support LevelDB very well
## Testing
- Added LevelDbStoreSpec
  - Incorporated FS2 to help with the File IO (because deleting a directory with java NIO is rather clunky)
## Tickets
- #2383 