### PR TITLE
Incorporate Proto Definition and Models Feedback

### DIFF
--- a/common/src/main/scala/co/topl/modifier/ops/AssetCodeOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/AssetCodeOps.scala
@@ -2,7 +2,7 @@ package co.topl.modifier.ops
 
 import cats.implicits._
 import co.topl.attestation.Address
-import co.topl.models.Box.Values.Asset
+import co.topl.models.Box.Values.AssetV1
 import co.topl.models.utility.{Lengths, Sized}
 import co.topl.modifier.box.AssetCode
 import co.topl.utils.StringDataTypes.Latin1Data
@@ -16,7 +16,7 @@ class AssetCodeOps(private val value: AssetCode) extends AnyVal {
 
   import AssetCodeOps._
 
-  def toTetraAssetCode: Either[ToTetraAssetCodeFailure, Asset.Code] =
+  def toTetraAssetCode: Either[ToTetraAssetCodeFailure, AssetV1.Code] =
     for {
       issuer <-
         value.issuer.toSpendingAddress.leftMap(_ => ToTetraAssetCodeFailures.InvalidAddress(value.issuer))
@@ -27,7 +27,7 @@ class AssetCodeOps(private val value: AssetCode) extends AnyVal {
           )
           .leftMap(_ => ToTetraAssetCodeFailures.InvalidShortName(value.shortName))
       assetCode =
-        Asset.Code(
+        AssetV1.Code(
           value.version,
           issuer,
           shortName

--- a/common/src/main/scala/co/topl/modifier/ops/AssetOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/AssetOps.scala
@@ -9,7 +9,7 @@ import co.topl.utils.StringDataTypes.Latin1Data
 
 import scala.language.implicitConversions
 
-class AssetOps(private val asset: Box.Values.Asset) extends AnyVal {
+class AssetOps(private val asset: Box.Values.AssetV1) extends AnyVal {
 
   def toAssetValue(implicit networkPrefix: NetworkPrefix): AssetValue =
     AssetValue(
@@ -27,7 +27,7 @@ class AssetOps(private val asset: Box.Values.Asset) extends AnyVal {
 object AssetOps {
 
   trait ToAssetOps {
-    implicit def assetOpsFromAsset(asset: Box.Values.Asset): AssetOps = new AssetOps(asset)
+    implicit def assetOpsFromAsset(asset: Box.Values.AssetV1): AssetOps = new AssetOps(asset)
   }
 
   trait Implicits extends ToAssetOps

--- a/common/src/main/scala/co/topl/modifier/ops/AssetValueOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/AssetValueOps.scala
@@ -42,7 +42,7 @@ class AssetValueOps(private val assetValue: AssetValue) extends AnyVal {
           .leftMap[ToAssetOutputFailure](error =>
             ToAssetOutputFailures.InvalidShortName(assetValue.assetCode.shortName)
           )
-      assetCode = Box.Values.Asset.Code(assetValue.assetCode.version, issuer, shortName)
+      assetCode = Box.Values.AssetV1.Code(assetValue.assetCode.version, issuer, shortName)
       assetCode <-
         assetValue.assetCode.toTetraAssetCode
           .leftMap {
@@ -57,7 +57,7 @@ class AssetValueOps(private val assetValue: AssetValue) extends AnyVal {
             .max[Latin1Data, Lengths.`127`.type](Latin1Data.fromData(data.value))
             .leftMap[ToAssetOutputFailure](error => ToAssetOutputFailures.InvalidMetadata(data, error))
         )
-      asset = Box.Values.Asset(quantity, assetCode, securityRoot, metadata)
+      asset = Box.Values.AssetV1(quantity, assetCode, securityRoot, metadata)
     } yield Transaction.Output(address, asset, minting)
 }
 

--- a/common/src/main/scala/co/topl/modifier/ops/TetraTransactionOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/TetraTransactionOps.scala
@@ -33,15 +33,15 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
       tx                  <-
         // use the first proposition type and first coin output type to derive what the Dion transfer type will be
         (expectedProposition, headOutput.value) match {
-          case (_: Propositions.Knowledge.Curve25519, _: TetraBox.Values.Poly)     => asPolyTransferCurve
-          case (_: Propositions.Knowledge.Curve25519, _: TetraBox.Values.Arbit)    => asArbitTransferCurve
-          case (_: Propositions.Knowledge.Curve25519, _: TetraBox.Values.Asset)    => asAssetTransferCurve
-          case (_: Propositions.Knowledge.Ed25519, _: TetraBox.Values.Poly)        => asPolyTransferEd
-          case (_: Propositions.Knowledge.Ed25519, _: TetraBox.Values.Arbit)       => asArbitTransferEd
-          case (_: Propositions.Knowledge.Ed25519, _: TetraBox.Values.Asset)       => asAssetTransferEd
-          case (_: Propositions.Compositional.Threshold, _: TetraBox.Values.Poly)  => asPolyTransferThreshold
-          case (_: Propositions.Compositional.Threshold, _: TetraBox.Values.Arbit) => asArbitTransferThreshold
-          case (_: Propositions.Compositional.Threshold, _: TetraBox.Values.Asset) => asAssetTransferThreshold
+          case (_: Propositions.Knowledge.Curve25519, _: TetraBox.Values.Poly)       => asPolyTransferCurve
+          case (_: Propositions.Knowledge.Curve25519, _: TetraBox.Values.Arbit)      => asArbitTransferCurve
+          case (_: Propositions.Knowledge.Curve25519, _: TetraBox.Values.AssetV1)    => asAssetTransferCurve
+          case (_: Propositions.Knowledge.Ed25519, _: TetraBox.Values.Poly)          => asPolyTransferEd
+          case (_: Propositions.Knowledge.Ed25519, _: TetraBox.Values.Arbit)         => asArbitTransferEd
+          case (_: Propositions.Knowledge.Ed25519, _: TetraBox.Values.AssetV1)       => asAssetTransferEd
+          case (_: Propositions.Compositional.Threshold, _: TetraBox.Values.Poly)    => asPolyTransferThreshold
+          case (_: Propositions.Compositional.Threshold, _: TetraBox.Values.Arbit)   => asArbitTransferThreshold
+          case (_: Propositions.Compositional.Threshold, _: TetraBox.Values.AssetV1) => asAssetTransferThreshold
           case (prop, output) =>
             ToDionTxFailures.InvalidTransferType(prop, headOutput).asLeft[DionTransaction.TX]
         }
@@ -335,7 +335,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
   private def assetOutputs: Either[ToDionTxFailure, Chain[(Address, TokenValueHolder)]] =
     transaction.outputs
       .traverse[ToDionTxResult, (Address, TokenValueHolder)] {
-        case Transaction.Output(address, asset: TetraBox.Values.Asset, _) =>
+        case Transaction.Output(address, asset: TetraBox.Values.AssetV1, _) =>
           (
             toAddress(address),
             AssetValue(

--- a/common/src/main/scala/co/topl/modifier/transaction/builder/TransferBuilder.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/builder/TransferBuilder.scala
@@ -384,7 +384,7 @@ object TransferBuilder {
           .map(assetCode =>
             Transaction.Output(
               consolidationAddress,
-              TetraBox.Values.Asset(asset._2.toSized, assetCode, Sized.strictUnsafe(Bytes.fill(32)(0: Byte)), None),
+              TetraBox.Values.AssetV1(asset._2.toSized, assetCode, Sized.strictUnsafe(Bytes.fill(32)(0: Byte)), None),
               minting
             )
           )

--- a/common/src/main/scala/co/topl/modifier/transaction/builder/TransferRequests.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/builder/TransferRequests.scala
@@ -1,7 +1,7 @@
 package co.topl.modifier.transaction.builder
 
 import co.topl.attestation.Address
-import co.topl.models.{Int128 => TetraInt128, SpendingAddress, Transaction, TransactionData}
+import co.topl.models.{Int128 => TetraInt128, SpendingAddress, Transaction}
 import co.topl.modifier.box.AssetValue
 import co.topl.utils.Int128
 import co.topl.utils.StringDataTypes.Latin1Data
@@ -41,7 +41,7 @@ object TransferRequests {
     feeChangeAddress:     SpendingAddress,
     consolidationAddress: SpendingAddress,
     fee:                  TetraInt128,
-    data:                 Option[TransactionData],
+    data:                 Option[Transaction.Data],
     minting:              Boolean
   )
 }

--- a/common/src/main/scala/co/topl/modifier/transaction/builder/ops/CoinOutputsOps.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/builder/ops/CoinOutputsOps.scala
@@ -16,7 +16,7 @@ class CoinOutputsOps(private val value: List[Transaction.Output]) {
         (polys :+ poly, arbits, assets)
       case ((polys, arbits, assets), arbit @ Transaction.Output(_, _: Box.Values.Arbit, _)) =>
         (polys, arbits :+ arbit, assets)
-      case ((polys, arbits, assets), asset @ Transaction.Output(_, _: Box.Values.Asset, _)) =>
+      case ((polys, arbits, assets), asset @ Transaction.Output(_, _: Box.Values.AssetV1, _)) =>
         (polys, arbits, assets :+ asset)
     }
 }

--- a/common/src/test/scala/co/topl/modifier/transaction/ops/AssetValueOpsSpec.scala
+++ b/common/src/test/scala/co/topl/modifier/transaction/ops/AssetValueOpsSpec.scala
@@ -22,7 +22,7 @@ class AssetValueOpsSpec
     describe("toAssetValue") {
       it("should convert an Asset Value and Dion Address to an Asset Output with the same quantity") {
         forAll(assetValueGen, ModelGen.arbitraryFullAddress.arbitrary) { (assetValue, address) =>
-          val Transaction.Output(_, v: TetraBox.Values.Asset, _) =
+          val Transaction.Output(_, v: TetraBox.Values.AssetV1, _) =
             assetValue.toAssetOutput(address, minting = true).value
 
           v.quantity.data shouldBe BigInt(assetValue.quantity.toByteArray)
@@ -31,7 +31,7 @@ class AssetValueOpsSpec
 
       it("should convert an Asset Value and Dion Address to an Asset Output with the same address") {
         forAll(assetValueGen, ModelGen.arbitraryFullAddress.arbitrary) { (assetValue, address) =>
-          val Transaction.Output(dionAddress, _: TetraBox.Values.Asset, _) =
+          val Transaction.Output(dionAddress, _: TetraBox.Values.AssetV1, _) =
             assetValue.toAssetOutput(address, minting = true).value
 
           dionAddress shouldBe address
@@ -40,7 +40,7 @@ class AssetValueOpsSpec
 
       it("should convert an Asset Value and Dion Address to an Asset Output with the same version") {
         forAll(assetValueGen, ModelGen.arbitraryFullAddress.arbitrary) { (assetValue, address) =>
-          val Transaction.Output(_, v: TetraBox.Values.Asset, _) =
+          val Transaction.Output(_, v: TetraBox.Values.AssetV1, _) =
             assetValue.toAssetOutput(address, minting = true).value
 
           v.assetCode.version shouldBe assetValue.assetCode.version
@@ -49,7 +49,7 @@ class AssetValueOpsSpec
 
       it("should convert an Asset Value and Dion Address to an Asset Output with the same asset code short name") {
         forAll(assetValueGen, ModelGen.arbitraryFullAddress.arbitrary) { (assetValue, address) =>
-          val Transaction.Output(_, v: TetraBox.Values.Asset, _) =
+          val Transaction.Output(_, v: TetraBox.Values.AssetV1, _) =
             assetValue.toAssetOutput(address, minting = true).value
 
           v.assetCode.shortName.data.bytes shouldBe assetValue.assetCode.shortName.value
@@ -61,7 +61,7 @@ class AssetValueOpsSpec
           val expectedAddressBytes =
             assetValue.assetCode.issuer.evidence.evBytes
 
-          val Transaction.Output(_, v: TetraBox.Values.Asset, _) =
+          val Transaction.Output(_, v: TetraBox.Values.AssetV1, _) =
             assetValue.toAssetOutput(address, minting = true).value
 
           v.assetCode.issuer.typedEvidence.allBytes.toArray shouldBe expectedAddressBytes
@@ -70,7 +70,7 @@ class AssetValueOpsSpec
 
       it("should convert an Asset Value and Dion Address to an Asset Output with the same security root") {
         forAll(assetValueGen, ModelGen.arbitraryFullAddress.arbitrary) { (assetValue, address) =>
-          val Transaction.Output(_, v: TetraBox.Values.Asset, _) =
+          val Transaction.Output(_, v: TetraBox.Values.AssetV1, _) =
             assetValue.toAssetOutput(address, minting = true).value
 
           v.securityRoot.data.toArray shouldBe assetValue.securityRoot.root
@@ -81,7 +81,7 @@ class AssetValueOpsSpec
         forAll(assetValueGen, ModelGen.arbitraryFullAddress.arbitrary) { (assetValue, address) =>
           val expectedMetadataBytes = assetValue.metadata.map(_.value).getOrElse(Array.empty)
 
-          val Transaction.Output(_, v: TetraBox.Values.Asset, _) =
+          val Transaction.Output(_, v: TetraBox.Values.AssetV1, _) =
             assetValue.toAssetOutput(address, minting = true).value
 
           val outputMetadataBytes = v.metadata.map(_.data.bytes).getOrElse(Array.empty)

--- a/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
+++ b/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
@@ -320,7 +320,7 @@ trait ModelsJsonCodecs {
   implicit val arbitBoxValueDecoder: Decoder[Box.Values.Arbit] =
     hcursor => hcursor.downField("value").as[Int128].map(Box.Values.Arbit)
 
-  implicit val assetCodeEncoder: Encoder[Box.Values.Asset.Code] =
+  implicit val assetCodeEncoder: Encoder[Box.Values.AssetV1.Code] =
     t =>
       Json.obj(
         "version"   -> t.version.asJson,
@@ -328,7 +328,7 @@ trait ModelsJsonCodecs {
         "shortName" -> t.shortName.data.value.asJson
       )
 
-  implicit val assetCodeDecoder: Decoder[Box.Values.Asset.Code] =
+  implicit val assetCodeDecoder: Decoder[Box.Values.AssetV1.Code] =
     hcursor =>
       for {
         version   <- hcursor.downField("version").as[Byte]
@@ -337,9 +337,9 @@ trait ModelsJsonCodecs {
         validLengthShortName <- Sized
           .max[Latin1Data, Lengths.`8`.type](shortName)
           .leftMap(failure => DecodingFailure(failure.toString, hcursor.history :+ CursorOp.Field("shortName")))
-      } yield Box.Values.Asset.Code(version, issuer, validLengthShortName)
+      } yield Box.Values.AssetV1.Code(version, issuer, validLengthShortName)
 
-  implicit val assetBoxValueEncoder: Encoder[Box.Values.Asset] =
+  implicit val assetBoxValueEncoder: Encoder[Box.Values.AssetV1] =
     t =>
       Json.obj(
         "quantity"     -> t.quantity.asJson,
@@ -348,7 +348,7 @@ trait ModelsJsonCodecs {
         "metadata"     -> t.metadata.map(_.data).asJson
       )
 
-  implicit val assetBoxValueDecoder: Decoder[Box.Values.Asset] =
+  implicit val assetBoxValueDecoder: Decoder[Box.Values.AssetV1] =
     deriveDecoder
 
   implicit val baseRegistrationBoxValueEncoder: Encoder[Box.Values.Registrations.Operator] =
@@ -366,7 +366,7 @@ trait ModelsJsonCodecs {
       case Box.Values.Empty                     => "Empty"
       case _: Box.Values.Poly                   => "Poly"
       case _: Box.Values.Arbit                  => "Arbit"
-      case _: Box.Values.Asset                  => "Asset"
+      case _: Box.Values.AssetV1                => "Asset"
       case _: Box.Values.Registrations.Operator => "Registrations.Operator"
     }
 
@@ -374,7 +374,7 @@ trait ModelsJsonCodecs {
     case Box.Values.Empty                     => Json.Null
     case v: Box.Values.Poly                   => v.asJson
     case v: Box.Values.Arbit                  => v.asJson
-    case v: Box.Values.Asset                  => v.asJson
+    case v: Box.Values.AssetV1                => v.asJson
     case v: Box.Values.Registrations.Operator => v.asJson
   }
 
@@ -421,7 +421,7 @@ trait ModelsJsonCodecs {
         value <- valueType match {
           case "Poly"                  => valueJson.as[Box.Values.Poly]
           case "Arbit"                 => valueJson.as[Box.Values.Arbit]
-          case "Asset"                 => valueJson.as[Box.Values.Asset]
+          case "Asset"                 => valueJson.as[Box.Values.AssetV1]
           case "Registration.Operator" => valueJson.as[Box.Values.Registrations.Operator]
         }
       } yield Transaction.Input(boxId, proposition, proof, value)
@@ -445,7 +445,7 @@ trait ModelsJsonCodecs {
         value <- valueType match {
           case "Poly"              => valueJson.as[Box.Values.Poly]
           case "Arbit"             => valueJson.as[Box.Values.Arbit]
-          case "Asset"             => valueJson.as[Box.Values.Asset]
+          case "Asset"             => valueJson.as[Box.Values.AssetV1]
           case "Registration.Pool" => valueJson.as[Box.Values.Registrations.Operator]
         }
       } yield Transaction.Unproven.Input(boxId, proposition, value)
@@ -472,7 +472,7 @@ trait ModelsJsonCodecs {
           case "Arbit" =>
             valueJson.as[Box.Values.Arbit].map(value => Transaction.Output(address, value, minting))
           case "Asset" =>
-            valueJson.as[Box.Values.Asset].map(value => Transaction.Output(address, value, minting))
+            valueJson.as[Box.Values.AssetV1].map(value => Transaction.Output(address, value, minting))
           case "Registration.Pool" =>
             valueJson.as[Box.Values.Registrations.Operator].map(value => Transaction.Output(address, value, minting))
           case _ =>
@@ -506,7 +506,7 @@ trait ModelsJsonCodecs {
         inputs     <- hcursor.downField("inputs").as[Chain[Transaction.Input]]
         outputs    <- hcursor.downField("outputs").as[Chain[Transaction.Output]]
         chronology <- hcursor.downField("chronology").as[Transaction.Chronology]
-        data       <- hcursor.downField("data").as[Option[TransactionData]]
+        data       <- hcursor.downField("data").as[Option[Transaction.Data]]
       } yield Transaction(inputs, outputs, chronology, data)
 
   implicit val unprovenTransactionJsonEncoder: Encoder[Transaction.Unproven] =
@@ -524,7 +524,7 @@ trait ModelsJsonCodecs {
         inputs     <- hcursor.downField("inputs").as[Chain[Transaction.Unproven.Input]]
         outputs    <- hcursor.downField("outputs").as[Chain[Transaction.Output]]
         chronology <- hcursor.downField("chronology").as[Transaction.Chronology]
-        data       <- hcursor.downField("data").as[Option[TransactionData]]
+        data       <- hcursor.downField("data").as[Option[Transaction.Data]]
       } yield Transaction.Unproven(inputs, outputs, chronology, data)
 
 }

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSyntaxValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSyntaxValidation.scala
@@ -80,10 +80,10 @@ object TransactionSyntaxValidation {
     transaction.outputs
       .foldMap(output =>
         (output.value match {
-          case t: Box.Values.Poly  => t.quantity.data.some
-          case t: Box.Values.Arbit => t.quantity.data.some
-          case t: Box.Values.Asset => t.quantity.data.some
-          case _                   => none
+          case t: Box.Values.Poly    => t.quantity.data.some
+          case t: Box.Values.Arbit   => t.quantity.data.some
+          case t: Box.Values.AssetV1 => t.quantity.data.some
+          case _                     => none
         }).foldMap(quantity =>
           Validated
             .condNec(
@@ -140,12 +140,12 @@ object TransactionSyntaxValidation {
       // Extract all Asset values (grouped by asset code) and their quantities
       Chain.fromSeq(
         (transaction.inputs.map(_.value) ++ transaction.outputs.map(_.value))
-          .collect { case a: Box.Values.Asset =>
+          .collect { case a: Box.Values.AssetV1 =>
             a.assetCode
           }
           .toList
           .distinct
-          .map(code => f { case a: Box.Values.Asset if a.assetCode === code => a.quantity.data })
+          .map(code => f { case a: Box.Values.AssetV1 if a.assetCode === code => a.quantity.data })
       )
     ).combineAll
 

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSyntaxValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSyntaxValidationSpec.scala
@@ -80,10 +80,10 @@ class TransactionSyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEff
   test("validate positive output quantities") {
     val boxValueGen =
       arbitraryBoxValue.arbitrary.flatMap {
-        case Box.Values.Poly(_)  => arbitraryInt128.arbitrary.map(Box.Values.Poly)
-        case Box.Values.Arbit(_) => arbitraryInt128.arbitrary.map(Box.Values.Arbit)
-        case a: Box.Values.Asset => arbitraryInt128.arbitrary.map(q => a.copy(quantity = q))
-        case v                   => Gen.const(v)
+        case Box.Values.Poly(_)    => arbitraryInt128.arbitrary.map(Box.Values.Poly)
+        case Box.Values.Arbit(_)   => arbitraryInt128.arbitrary.map(Box.Values.Arbit)
+        case a: Box.Values.AssetV1 => arbitraryInt128.arbitrary.map(q => a.copy(quantity = q))
+        case v                     => Gen.const(v)
       }
     val outputGen =
       for {
@@ -97,10 +97,10 @@ class TransactionSyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEff
       } yield tx.copy(outputs = Chain.fromSeq(outputs))).filter(transaction =>
         transaction.outputs.exists(o =>
           o.value match {
-            case v: Box.Values.Poly  => v.quantity.data <= 0
-            case v: Box.Values.Arbit => v.quantity.data <= 0
-            case v: Box.Values.Asset => v.quantity.data <= 0
-            case _                   => false
+            case v: Box.Values.Poly    => v.quantity.data <= 0
+            case v: Box.Values.Arbit   => v.quantity.data <= 0
+            case v: Box.Values.AssetV1 => v.quantity.data <= 0
+            case _                     => false
           }
         )
       )
@@ -201,11 +201,11 @@ class TransactionSyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEff
         }.sumAll
 
       val assetInSum =
-        transaction.inputs.collect { case Transaction.Input(_, _, _, v: Box.Values.Asset) =>
+        transaction.inputs.collect { case Transaction.Input(_, _, _, v: Box.Values.AssetV1) =>
           v.quantity.data
         }.sumAll
       val assetOutSum =
-        transaction.outputs.collect { case Transaction.Output(_, v: Box.Values.Asset, false) =>
+        transaction.outputs.collect { case Transaction.Output(_, v: Box.Values.AssetV1, false) =>
           v.quantity.data
         }.sumAll
       def existsInsufficientInputFunds(result: Either[NonEmptyChain[TransactionSyntaxError], Transaction]) =

--- a/models/src/main/scala/co/topl/models/Block.scala
+++ b/models/src/main/scala/co/topl/models/Block.scala
@@ -30,13 +30,15 @@ case class BlockHeaderV2(
   eligibilityCertificate: EligibilityCertificate,
   operationalCertificate: OperationalCertificate,
   // TODO: Discussion on mint signatures
-  metadata: Option[Sized.Max[Latin1Data, Lengths.`32`.type]],
+  metadata: Option[BlockHeaderV2.Metadata],
   address:  StakingAddresses.Operator
 ) {
   def parentSlotId: SlotId = SlotId(parentSlot, parentHeaderId)
 }
 
 object BlockHeaderV2 {
+
+  type Metadata = Sized.Max[Latin1Data, Lengths.`32`.type]
 
   case class Unsigned(
     parentHeaderId:                TypedIdentifier,

--- a/models/src/main/scala/co/topl/models/Box.scala
+++ b/models/src/main/scala/co/topl/models/Box.scala
@@ -16,16 +16,22 @@ object Box {
     case class Poly(quantity: Int128) extends Value
     case class Arbit(quantity: Int128) extends Value
 
-    // TODO: AssetV1
-    case class Asset(
+    case class AssetV1(
       quantity:     Int128,
-      assetCode:    Asset.Code,
-      securityRoot: Sized.Strict[Bytes, Lengths.`32`.type],
-      metadata:     Option[Sized.Max[Latin1Data, Lengths.`127`.type]]
+      assetCode:    AssetV1.Code,
+      securityRoot: AssetV1.SecurityRoot,
+      metadata:     Option[AssetV1.Metadata]
     ) extends Value
 
-    object Asset {
-      case class Code(version: Byte, issuer: SpendingAddress, shortName: Sized.Max[Latin1Data, Lengths.`8`.type])
+    object AssetV1 {
+      case class Code(version: Byte, issuer: SpendingAddress, shortName: Code.ShortName)
+
+      object Code {
+        type ShortName = Sized.Max[Latin1Data, Lengths.`8`.type]
+      }
+
+      type SecurityRoot = Sized.Strict[Bytes, Lengths.`32`.type]
+      type Metadata = Sized.Max[Latin1Data, Lengths.`127`.type]
     }
 
     sealed abstract class Registration extends Value

--- a/models/src/main/scala/co/topl/models/Transaction.scala
+++ b/models/src/main/scala/co/topl/models/Transaction.scala
@@ -1,15 +1,19 @@
 package co.topl.models
 
 import cats.data.Chain
+import co.topl.models.utility.StringDataTypes.Latin1Data
+import co.topl.models.utility.{Lengths, Sized}
 
 case class Transaction(
   inputs:     Chain[Transaction.Input],
   outputs:    Chain[Transaction.Output],
   chronology: Transaction.Chronology,
-  data:       Option[TransactionData]
+  data:       Option[Transaction.Data]
 )
 
 object Transaction {
+
+  type Data = Sized.Max[Latin1Data, Lengths.`127`.type]
 
   /**
    * @param transactionOutputIndex TODO: How does the network behave if we allow a huge number of outputs in a transaction?
@@ -34,7 +38,7 @@ object Transaction {
     inputs:     Chain[Transaction.Unproven.Input],
     outputs:    Chain[Transaction.Output],
     chronology: Chronology,
-    data:       Option[TransactionData]
+    data:       Option[Transaction.Data]
   )
 
   object Unproven {

--- a/models/src/main/scala/co/topl/models/package.scala
+++ b/models/src/main/scala/co/topl/models/package.scala
@@ -13,7 +13,6 @@ import scala.language.implicitConversions
 package object models {
   type Bytes = ByteVector
   val Bytes = ByteVector
-  type BoxNonce = Long
   type Eta = Sized.Strict[Bytes, Lengths.`32`.type]
   type Evidence = Sized.Strict[Bytes, Lengths.`32`.type]
 
@@ -39,9 +38,7 @@ package object models {
   @newtype case class Rho(sizedBytes: Sized.Strict[Bytes, Lengths.`64`.type])
   @newtype case class RhoTestHash(sizedBytes: Sized.Strict[Bytes, Lengths.`64`.type])
   @newtype case class RhoNonceHash(sizedBytes: Sized.Strict[Bytes, Lengths.`64`.type])
-  type StakeAddress = Propositions.Knowledge.Ed25519
   type Digest32 = Sized.Strict[Bytes, Lengths.`32`.type]
-  type TransactionData = Sized.Max[Latin1Data, Lengths.`127`.type]
 
   case class SlotId(slot: Slot, blockId: TypedIdentifier)
 

--- a/models/src/test/scala/co/topl/models/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/ModelGenerators.scala
@@ -332,17 +332,17 @@ trait ModelGenerators {
   val arbitraryPositiveInt128: Arbitrary[Int128] =
     Arbitrary(Gen.posNum[Long].map(BigInt(_)).map(Sized.maxUnsafe[BigInt, Lengths.`128`.type](_)))
 
-  implicit val arbitraryAssetCode: Arbitrary[Box.Values.Asset.Code] =
+  implicit val arbitraryAssetCode: Arbitrary[Box.Values.AssetV1.Code] =
     Arbitrary(
       for {
         version   <- byteGen
         issuer    <- arbitrarySpendingAddress.arbitrary
         shortName <- latin1DataGen.map(data => Latin1Data.unsafe(data.value.take(8)))
-        code = Box.Values.Asset.Code(version, issuer, Sized.maxUnsafe(shortName))
+        code = Box.Values.AssetV1.Code(version, issuer, Sized.maxUnsafe(shortName))
       } yield code
     )
 
-  implicit val arbitraryAssetBox: Arbitrary[Box.Values.Asset] =
+  implicit val arbitraryAssetBox: Arbitrary[Box.Values.AssetV1] =
     Arbitrary(
       for {
         quantity <- arbitraryPositiveInt128.arbitrary
@@ -354,7 +354,7 @@ trait ModelGenerators {
               .map(data => Latin1Data.unsafe(data.value.take(127)))
               .map(data => Sized.maxUnsafe[Latin1Data, Lengths.`127`.type](data))
           )
-        box = Box.Values.Asset(quantity, code, root, metadata)
+        box = Box.Values.AssetV1(quantity, code, root, metadata)
       } yield box
     )
 

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -226,10 +226,10 @@ trait TetraScodecBoxCodecs {
   implicit val boxValuesArbitCodec: Codec[Box.Values.Arbit] =
     int128Codec.as[Box.Values.Arbit]
 
-  implicit val boxValuesAssetCodec: Codec[Box.Values.Asset] =
-    (Codec[Int128] :: Codec[Box.Values.Asset.Code] :: Codec[Sized.Strict[Bytes, Lengths.`32`.type]] :: Codec[Option[
+  implicit val boxValuesAssetCodec: Codec[Box.Values.AssetV1] =
+    (Codec[Int128] :: Codec[Box.Values.AssetV1.Code] :: Codec[Sized.Strict[Bytes, Lengths.`32`.type]] :: Codec[Option[
       Sized.Max[Latin1Data, Lengths.`127`.type]
-    ]]).as[Box.Values.Asset]
+    ]]).as[Box.Values.AssetV1]
 
   implicit val boxValuesPoolRegistrationCodec: Codec[Box.Values.Registrations.Operator] =
     Codec[Proofs.Knowledge.KesProduct].as[Box.Values.Registrations.Operator]
@@ -417,7 +417,7 @@ trait TetraScodecTransactionCodecs {
       Codec[Chain[Transaction.Input]] ::
         Codec[Chain[Transaction.Output]] ::
         Codec[Transaction.Chronology] ::
-        Codec[Option[TransactionData]]
+        Codec[Option[Transaction.Data]]
     ).as[Transaction]
 
   implicit val unprovenTransactionCodec: Codec[Transaction.Unproven] =
@@ -425,7 +425,7 @@ trait TetraScodecTransactionCodecs {
       Codec[Chain[Transaction.Unproven.Input]] ::
         Codec[Chain[Transaction.Output]] ::
         Codec[Transaction.Chronology] ::
-        Codec[Option[TransactionData]]
+        Codec[Option[Transaction.Data]]
     ).as[Transaction.Unproven]
 }
 

--- a/topl-grpc/src/main/protobuf/models/address.proto
+++ b/topl-grpc/src/main/protobuf/models/address.proto
@@ -10,6 +10,7 @@ message FullAddress {
   NetworkPrefix networkPrefix = 1;
   SpendingAddress spendingAddress = 2;
   StakingAddress stakingAddress = 3;
+  // TODO: What do we name this?
   ProofKnowledgeEd25519 commitment = 4;
 }
 

--- a/topl-grpc/src/main/protobuf/models/block.proto
+++ b/topl-grpc/src/main/protobuf/models/block.proto
@@ -9,20 +9,16 @@ import 'models/transaction.proto';
 
 message BlockHeader {
   BlockId parentHeaderId = 1;
-  int64 parentSlot = 2;
+  uint64 parentSlot = 2;
   bytes txRoot = 3;
   bytes bloomFilter = 4;
-  int64 timestamp = 5;
-  int64 height = 6;
-  int64 slot = 7;
+  uint64 timestamp = 5;
+  uint64 height = 6;
+  uint64 slot = 7;
   EligibilityCertificate eligibilityCertificate = 8;
   OperationalCertificate operationalCertificate = 9;
-  Metadata metadata = 10;
+  optional bytes metadata = 10;
   StakingAddressOperator address = 11;
-
-  message Metadata {
-    bytes value = 1;
-  }
 }
 
 message BlockBody {

--- a/topl-grpc/src/main/protobuf/models/box.proto
+++ b/topl-grpc/src/main/protobuf/models/box.proto
@@ -21,7 +21,7 @@ message BoxValue {
     EmptyBoxValue empty = 1;
     PolyBoxValue poly = 2;
     ArbitBoxValue arbit = 3;
-    DionAssetBoxValue asset = 4;
+    AssetV1BoxValue assetV1 = 4;
     OperatorRegistrationBoxValue operatorRegistration = 5;
   }
 }
@@ -33,19 +33,18 @@ message PolyBoxValue {
 message ArbitBoxValue {
   Int128 quantity = 1;
 }
-message DionAssetBoxValue {
+message AssetV1BoxValue {
   Int128 quantity = 1;
   Code assetCode = 2;
   bytes securityRoot = 3;
-  Metadata metadata = 4;
+  optional bytes metadata = 4;
 
   message Code {
-    int32 version = 1;
+    // See #ProtoByteComment
+    // TODO: Can we delete this because we know it's a V1 Asset?
+    uint32 version = 1;
     SpendingAddress issuerAddress = 2;
     bytes shortName = 3;
-  }
-  message Metadata {
-    bytes metadata = 1;
   }
 }
 message OperatorRegistrationBoxValue {

--- a/topl-grpc/src/main/protobuf/models/common.proto
+++ b/topl-grpc/src/main/protobuf/models/common.proto
@@ -2,12 +2,17 @@ syntax = "proto3";
 
 package co.topl.grpc.models;
 
+// #ProtoByteComment
+// Protobuf does not support `byte` types, so we use uint32 instead
+
 message NetworkPrefix {
-  int32 value = 1;
+  // See #ProtoByteComment
+  uint32 value = 1;
 }
 
 message TypedEvidence {
-  int32 typePrefix = 1;
+  // See #ProtoByteComment
+  uint32 typePrefix = 1;
   bytes evidence = 2;
 }
 
@@ -19,6 +24,8 @@ message TransactionId {
   bytes value = 1;
 }
 
+// TODO: Does this representation need to change?
 message Int128 {
+  // BigInt Representation
   bytes value = 1;
 }

--- a/topl-grpc/src/main/protobuf/models/proposition.proto
+++ b/topl-grpc/src/main/protobuf/models/proposition.proto
@@ -74,7 +74,7 @@ message PropositionContextualRequiredTransactionIO {
 }
 
 message BoxLocation {
-  int32 index = 1;
+  uint32 index = 1;
   IO location = 2;
   enum IO {
     INPUT = 0;

--- a/topl-grpc/src/main/protobuf/models/transaction.proto
+++ b/topl-grpc/src/main/protobuf/models/transaction.proto
@@ -11,7 +11,7 @@ message Transaction {
   repeated Input inputs = 1;
   repeated Output outputs = 2;
   Schedule schedule = 3;
-  Data data = 4;
+  optional bytes data = 4;
 
   message Input {
     Box.Id boxId = 1;
@@ -25,11 +25,8 @@ message Transaction {
     bool minting = 3;
   }
   message Schedule {
-    int64 creation = 1;
-    int64 minimumSlot = 2;
-    int64 maximumSlot = 3;
-  }
-  message Data {
-    bytes value = 1;
+    uint64 creation = 1;
+    uint64 minimumSlot = 2;
+    uint64 maximumSlot = 3;
   }
 }

--- a/topl-grpc/src/main/scala/co/topl/grpc/ToplGrpc.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/ToplGrpc.scala
@@ -46,6 +46,8 @@ object ToplGrpc {
               )
               .void
 
+          client.fetchBlockHeader().addHeader("key", "value").invoke(services.FetchBlockHeaderReq())
+
           def currentMempool(): F[Set[bifrostModels.TypedIdentifier]] =
             Async[F]
               .fromFuture(

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpc.scala
@@ -3,13 +3,7 @@ package co.topl.rpc
 import cats.data.NonEmptyChain
 import co.topl.akkahttprpc.Rpc
 import co.topl.attestation.{Address, Proposition}
-import co.topl.models.{
-  FullAddress,
-  Int128 => TetraInt128,
-  SpendingAddress,
-  Transaction => TetraTransaction,
-  TransactionData
-}
+import co.topl.models.{FullAddress, Int128 => TetraInt128, SpendingAddress, Transaction => TetraTransaction}
 import co.topl.modifier.ModifierId
 import co.topl.modifier.block.{Block, GenesisBlob}
 import co.topl.modifier.box.AssetCode.AssetCodeVersion
@@ -529,7 +523,7 @@ object ToplRpc {
         recipients:            NonEmptyChain[TetraTransaction.Output],
         fee:                   TetraInt128,
         changeAddress:         FullAddress,
-        data:                  Option[TransactionData],
+        data:                  Option[TetraTransaction.Data],
         boxSelectionAlgorithm: BoxSelectionAlgorithm
       )
 
@@ -545,7 +539,7 @@ object ToplRpc {
         recipients:            NonEmptyChain[TetraTransaction.Output],
         fee:                   TetraInt128,
         changeAddress:         FullAddress,
-        data:                  Option[TransactionData],
+        data:                  Option[TetraTransaction.Data],
         boxSelectionAlgorithm: BoxSelectionAlgorithm
       )
 
@@ -562,7 +556,7 @@ object ToplRpc {
         fee:                   TetraInt128,
         feeChangeAddress:      FullAddress,
         assetChangeAddress:    FullAddress,
-        data:                  Option[TransactionData],
+        data:                  Option[TetraTransaction.Data],
         minting:               Boolean,
         boxSelectionAlgorithm: BoxSelectionAlgorithm
       )

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
@@ -8,7 +8,7 @@ import co.topl.codecs.json.tetra.ModelsJsonCodecs
 import co.topl.models.utility.Lengths
 import co.topl.models.utility.Lengths._
 import co.topl.models.utility.HasLength.instances._
-import co.topl.models.{NetworkPrefix => TetraNetworkPrefix, TransactionData}
+import co.topl.models.{NetworkPrefix => TetraNetworkPrefix, Transaction => TetraTransaction}
 import co.topl.modifier.ModifierId
 import co.topl.modifier.box._
 import co.topl.modifier.transaction.builder.{BoxSelectionAlgorithm, BoxSelectionAlgorithms}
@@ -144,7 +144,7 @@ trait TransactionRpcParamsEncoders extends SharedCodecs {
         "fee"           -> t.fee.asJson,
         "changeAddress" -> t.changeAddress.asJson,
         "data" -> t.data.asJson(
-          Encoder.encodeOption[TransactionData](
+          Encoder.encodeOption[TetraTransaction.Data](
             sizedMaxEncoder[co.topl.models.utility.StringDataTypes.Latin1Data, Lengths.`127`.type]
           )
         ),

--- a/typeclasses/src/main/scala/co/topl/typeclasses/EqInstances.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/EqInstances.scala
@@ -62,7 +62,7 @@ trait EqInstances {
       a.eta === b.eta &&
       a.height === b.height
 
-  implicit val assetCodeEq: Eq[Box.Values.Asset.Code] =
+  implicit val assetCodeEq: Eq[Box.Values.AssetV1.Code] =
     (a, b) =>
       a.version === b.version &&
       a.issuer === b.issuer &&
@@ -92,7 +92,7 @@ trait EqInstances {
   implicit val arbitBoxValueEq: Eq[Box.Values.Arbit] =
     (a, b) => a.quantity === b.quantity
 
-  implicit val assetBoxValueEq: Eq[Box.Values.Asset] =
+  implicit val assetBoxValueEq: Eq[Box.Values.AssetV1] =
     (a, b) =>
       a.quantity === b.quantity &&
       a.assetCode === b.assetCode &&
@@ -106,7 +106,7 @@ trait EqInstances {
     case (a: Box.Values.Empty.type, b: Box.Values.Empty.type) => emptyBoxValueEq.eqv(a, b)
     case (a: Box.Values.Poly, b: Box.Values.Poly)             => polyBoxValueEq.eqv(a, b)
     case (a: Box.Values.Arbit, b: Box.Values.Arbit)           => arbitBoxValueEq.eqv(a, b)
-    case (a: Box.Values.Asset, b: Box.Values.Asset)           => assetBoxValueEq.eqv(a, b)
+    case (a: Box.Values.AssetV1, b: Box.Values.AssetV1)       => assetBoxValueEq.eqv(a, b)
     case (a: Box.Values.Registrations.Operator, b: Box.Values.Registrations.Operator) =>
       operatorRegistrationBoxValueEq.eqv(a, b)
     case _ => false


### PR DESCRIPTION
## Purpose
- Proto v3.15.0 added support for the `optional` syntax in proto3 specs.  This avoids the need to use a pattern of implementing new message types to allow optionality of scalar types
- Some proto definitions specified int64 where uint64 would be better
- Rename Box.Values.Asset to Box.Values.AssetV1
- More type aliases in the `models` package
- Note: There may be future changes/PRs to the proto definitions.  I'm hoping to incorporate the feedback as it comes so that we can make sure it holds together on the server-side
## Approach
- Incorporate `optional bytes` into proto definitions that defined separate Data/Metadata message types (header, transaction, asset box)
- Update timestamp and slot fields to be uint64 type
- Renaming of classes and type aliases
## Testing
- Unit tests still pass
## Tickets
N/A