### PR TITLE
Rename Transaction.Chronology to Transaction.Schedule

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
@@ -45,7 +45,7 @@ object BigBang {
         Transaction(
           inputs = Chain.empty,
           outputs = config.outputs,
-          chronology = Transaction.Chronology(0L, Slot, Slot), // This transaction is only valid at the BigBang slot
+          schedule = Transaction.Schedule(0L, Slot, Slot), // This transaction is only valid at the BigBang slot
           data = None
         )
       )

--- a/brambl/src/main/scala/co/topl/client/BramblTetra.scala
+++ b/brambl/src/main/scala/co/topl/client/BramblTetra.scala
@@ -91,7 +91,7 @@ object BramblTetra extends IOApp.Simple {
             minting = false
           )
         ),
-        chronology = Transaction.Chronology(System.currentTimeMillis(), 0L, Long.MaxValue),
+        schedule = Transaction.Schedule(System.currentTimeMillis(), 0L, Long.MaxValue),
         data = none
       ).some.map(transaction => (transaction, Propositions.Contextual.HeightLock(20L), 0: Short) -> transaction)
     }

--- a/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundBV.scala
+++ b/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundBV.scala
@@ -100,7 +100,7 @@ object CredentialPlaygroundBV extends App {
         Transaction
           .Output(fullAddress(boardProp.spendingAddress), Box.Values.Poly(Sized.maxUnsafe(BigInt(10))), minting = false)
       ),
-      chronology = Transaction.Chronology(System.currentTimeMillis(), 0, Long.MaxValue),
+      chronology = Transaction.Schedule(System.currentTimeMillis(), 0, Long.MaxValue),
       data = None
     )
 

--- a/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundBV.scala
+++ b/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundBV.scala
@@ -100,7 +100,7 @@ object CredentialPlaygroundBV extends App {
         Transaction
           .Output(fullAddress(boardProp.spendingAddress), Box.Values.Poly(Sized.maxUnsafe(BigInt(10))), minting = false)
       ),
-      chronology = Transaction.Schedule(System.currentTimeMillis(), 0, Long.MaxValue),
+      schedule = Transaction.Schedule(System.currentTimeMillis(), 0, Long.MaxValue),
       data = None
     )
 

--- a/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundJAA.scala
+++ b/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundJAA.scala
@@ -61,7 +61,7 @@ object SetupSandbox {
     Transaction.Unproven(
       inputs.toChain,
       outputs.toChain,
-      chronology = Transaction.Chronology(System.currentTimeMillis(), 0, Long.MaxValue),
+      chronology = Transaction.Schedule(System.currentTimeMillis(), 0, Long.MaxValue),
       data = None
     )
 }

--- a/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundJAA.scala
+++ b/brambl/src/test/scala/co/topl/credential/playground/CredentialPlaygroundJAA.scala
@@ -61,7 +61,7 @@ object SetupSandbox {
     Transaction.Unproven(
       inputs.toChain,
       outputs.toChain,
-      chronology = Transaction.Schedule(System.currentTimeMillis(), 0, Long.MaxValue),
+      schedule = Transaction.Schedule(System.currentTimeMillis(), 0, Long.MaxValue),
       data = None
     )
 }

--- a/common/src/main/scala/co/topl/modifier/ops/TetraTransactionOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/TetraTransactionOps.scala
@@ -63,7 +63,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
           coinOutputs.prepend(getFeeOutput).iterator.toIndexedSeq,
           attestation,
           getFee,
-          transaction.chronology.creation,
+          transaction.schedule.creation,
           getData,
           minting
         )
@@ -85,7 +85,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
           coinOutputs.prepend(getFeeOutput).iterator.toIndexedSeq,
           attestation,
           getFee,
-          transaction.chronology.creation,
+          transaction.schedule.creation,
           getData,
           minting
         )
@@ -107,7 +107,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
           coinOutputs.prepend(getFeeOutput).iterator.toIndexedSeq,
           attestation,
           getFee,
-          transaction.chronology.creation,
+          transaction.schedule.creation,
           getData,
           minting
         )
@@ -129,7 +129,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
           coinOutputs.prepend(getFeeOutput).iterator.toIndexedSeq,
           attestation,
           getFee,
-          transaction.chronology.creation,
+          transaction.schedule.creation,
           getData,
           minting
         )
@@ -151,7 +151,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
           coinOutputs.prepend(getFeeOutput).iterator.toIndexedSeq,
           attestation,
           getFee,
-          transaction.chronology.creation,
+          transaction.schedule.creation,
           getData,
           minting
         )
@@ -173,7 +173,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
           coinOutputs.prepend(getFeeOutput).iterator.toIndexedSeq,
           attestation,
           getFee,
-          transaction.chronology.creation,
+          transaction.schedule.creation,
           getData,
           minting
         )
@@ -195,7 +195,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
           coinOutputs.prepend(getFeeOutput).iterator.toIndexedSeq,
           attestation,
           getFee,
-          transaction.chronology.creation,
+          transaction.schedule.creation,
           getData,
           minting
         )
@@ -217,7 +217,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
           coinOutputs.prepend(getFeeOutput).iterator.toIndexedSeq,
           attestation,
           getFee,
-          transaction.chronology.creation,
+          transaction.schedule.creation,
           getData,
           minting
         )
@@ -239,7 +239,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
           coinOutputs.prepend(getFeeOutput).iterator.toIndexedSeq,
           attestation,
           getFee,
-          transaction.chronology.creation,
+          transaction.schedule.creation,
           getData,
           minting
         )

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusDataEventSourcedStateSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusDataEventSourcedStateSpec.scala
@@ -35,7 +35,7 @@ class ConsensusDataEventSourcedStateSpec extends CatsEffectSuite with ScalaCheck
           Chain(
             Transaction.Output(address, Box.Values.Arbit(5), minting = true)
           ),
-          Transaction.Chronology(0, 0, Long.MaxValue),
+          Transaction.Schedule(0, 0, Long.MaxValue),
           None
         )
 
@@ -89,7 +89,7 @@ class ConsensusDataEventSourcedStateSpec extends CatsEffectSuite with ScalaCheck
             Transaction.Output(address, Box.Values.Arbit(3), minting = false),
             Transaction.Output(nonStakingFullAddress, Box.Values.Arbit(2), minting = false)
           ),
-          Transaction.Chronology(0, 0, Long.MaxValue),
+          Transaction.Schedule(0, 0, Long.MaxValue),
           None
         )
 
@@ -120,7 +120,7 @@ class ConsensusDataEventSourcedStateSpec extends CatsEffectSuite with ScalaCheck
             Transaction.Output(address, Box.Values.Arbit(1), minting = false),
             Transaction.Output(nonStakingFullAddress, Box.Values.Arbit(1), minting = false)
           ),
-          Transaction.Chronology(0, 0, Long.MaxValue),
+          Transaction.Schedule(0, 0, Long.MaxValue),
           None
         )
 
@@ -169,7 +169,7 @@ class ConsensusDataEventSourcedStateSpec extends CatsEffectSuite with ScalaCheck
               minting = true
             )
           ),
-          Transaction.Chronology(0, 0, Long.MaxValue),
+          Transaction.Schedule(0, 0, Long.MaxValue),
           None
         )
 
@@ -218,7 +218,7 @@ class ConsensusDataEventSourcedStateSpec extends CatsEffectSuite with ScalaCheck
             )
           ),
           Chain.empty,
-          Transaction.Chronology(0, 0, Long.MaxValue),
+          Transaction.Schedule(0, 0, Long.MaxValue),
           None
         )
 

--- a/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
+++ b/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
@@ -480,7 +480,7 @@ trait ModelsJsonCodecs {
         }
       } yield output
 
-  implicit val transactionChronologyJsonEncoder: Encoder[Transaction.Schedule] =
+  implicit val transactionScheduleJsonEncoder: Encoder[Transaction.Schedule] =
     t =>
       Json.obj(
         "creation"    -> t.creation.asJson,
@@ -488,43 +488,43 @@ trait ModelsJsonCodecs {
         "maximumSlot" -> t.maximumSlot.asJson
       )
 
-  implicit val transactionChronologyJsonDecoder: Decoder[Transaction.Schedule] =
+  implicit val transactionScheduleJsonDecoder: Decoder[Transaction.Schedule] =
     deriveDecoder
 
   implicit val transactionJsonEncoder: Encoder[Transaction] =
     tx =>
       Json.obj(
-        "inputs"     -> tx.inputs.asJson,
-        "outputs"    -> tx.outputs.asJson,
-        "chronology" -> tx.schedule.asJson,
-        "data"       -> tx.data.map(_.data).asJson
+        "inputs"   -> tx.inputs.asJson,
+        "outputs"  -> tx.outputs.asJson,
+        "schedule" -> tx.schedule.asJson,
+        "data"     -> tx.data.map(_.data).asJson
       )
 
   implicit def transactionJsonDecoder(implicit networkPrefix: NetworkPrefix): Decoder[Transaction] =
     hcursor =>
       for {
-        inputs     <- hcursor.downField("inputs").as[Chain[Transaction.Input]]
-        outputs    <- hcursor.downField("outputs").as[Chain[Transaction.Output]]
-        chronology <- hcursor.downField("chronology").as[Transaction.Schedule]
-        data       <- hcursor.downField("data").as[Option[Transaction.Data]]
-      } yield Transaction(inputs, outputs, chronology, data)
+        inputs   <- hcursor.downField("inputs").as[Chain[Transaction.Input]]
+        outputs  <- hcursor.downField("outputs").as[Chain[Transaction.Output]]
+        schedule <- hcursor.downField("schedule").as[Transaction.Schedule]
+        data     <- hcursor.downField("data").as[Option[Transaction.Data]]
+      } yield Transaction(inputs, outputs, schedule, data)
 
   implicit val unprovenTransactionJsonEncoder: Encoder[Transaction.Unproven] =
     tx =>
       Json.obj(
-        "inputs"     -> tx.inputs.asJson,
-        "outputs"    -> tx.outputs.asJson,
-        "chronology" -> tx.chronology.asJson,
-        "data"       -> tx.data.map(_.data).asJson
+        "inputs"   -> tx.inputs.asJson,
+        "outputs"  -> tx.outputs.asJson,
+        "schedule" -> tx.schedule.asJson,
+        "data"     -> tx.data.map(_.data).asJson
       )
 
   implicit val unprovenTransactionJsonDecoder: Decoder[Transaction.Unproven] =
     hcursor =>
       for {
-        inputs     <- hcursor.downField("inputs").as[Chain[Transaction.Unproven.Input]]
-        outputs    <- hcursor.downField("outputs").as[Chain[Transaction.Output]]
-        chronology <- hcursor.downField("chronology").as[Transaction.Schedule]
-        data       <- hcursor.downField("data").as[Option[Transaction.Data]]
-      } yield Transaction.Unproven(inputs, outputs, chronology, data)
+        inputs   <- hcursor.downField("inputs").as[Chain[Transaction.Unproven.Input]]
+        outputs  <- hcursor.downField("outputs").as[Chain[Transaction.Output]]
+        schedule <- hcursor.downField("schedule").as[Transaction.Schedule]
+        data     <- hcursor.downField("data").as[Option[Transaction.Data]]
+      } yield Transaction.Unproven(inputs, outputs, schedule, data)
 
 }

--- a/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
+++ b/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
@@ -480,7 +480,7 @@ trait ModelsJsonCodecs {
         }
       } yield output
 
-  implicit val transactionChronologyJsonEncoder: Encoder[Transaction.Chronology] =
+  implicit val transactionChronologyJsonEncoder: Encoder[Transaction.Schedule] =
     t =>
       Json.obj(
         "creation"    -> t.creation.asJson,
@@ -488,7 +488,7 @@ trait ModelsJsonCodecs {
         "maximumSlot" -> t.maximumSlot.asJson
       )
 
-  implicit val transactionChronologyJsonDecoder: Decoder[Transaction.Chronology] =
+  implicit val transactionChronologyJsonDecoder: Decoder[Transaction.Schedule] =
     deriveDecoder
 
   implicit val transactionJsonEncoder: Encoder[Transaction] =
@@ -496,7 +496,7 @@ trait ModelsJsonCodecs {
       Json.obj(
         "inputs"     -> tx.inputs.asJson,
         "outputs"    -> tx.outputs.asJson,
-        "chronology" -> tx.chronology.asJson,
+        "chronology" -> tx.schedule.asJson,
         "data"       -> tx.data.map(_.data).asJson
       )
 
@@ -505,7 +505,7 @@ trait ModelsJsonCodecs {
       for {
         inputs     <- hcursor.downField("inputs").as[Chain[Transaction.Input]]
         outputs    <- hcursor.downField("outputs").as[Chain[Transaction.Output]]
-        chronology <- hcursor.downField("chronology").as[Transaction.Chronology]
+        chronology <- hcursor.downField("chronology").as[Transaction.Schedule]
         data       <- hcursor.downField("data").as[Option[Transaction.Data]]
       } yield Transaction(inputs, outputs, chronology, data)
 
@@ -523,7 +523,7 @@ trait ModelsJsonCodecs {
       for {
         inputs     <- hcursor.downField("inputs").as[Chain[Transaction.Unproven.Input]]
         outputs    <- hcursor.downField("outputs").as[Chain[Transaction.Output]]
-        chronology <- hcursor.downField("chronology").as[Transaction.Chronology]
+        chronology <- hcursor.downField("chronology").as[Transaction.Schedule]
         data       <- hcursor.downField("data").as[Option[Transaction.Data]]
       } yield Transaction.Unproven(inputs, outputs, chronology, data)
 

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/Mempool.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/Mempool.scala
@@ -53,7 +53,7 @@ object Mempool {
       addTransactionWithDefaultExpiration = (transaction: Transaction) =>
         for {
           currentSlot <- clock.globalSlot
-          targetSlot = transaction.chronology.maximumSlot.min(currentSlot + defaultExpirationLimit)
+          targetSlot = transaction.schedule.maximumSlot.min(currentSlot + defaultExpirationLimit)
           _ <- addTransaction(transaction, targetSlot)
         } yield ()
       applyBlock = (state: State[F], blockId: TypedIdentifier) =>

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/MempoolSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/MempoolSpec.scala
@@ -123,7 +123,7 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
     PropF.forAllF { (currentBlockId: TypedIdentifier, transactionWithRandomTime: Transaction) =>
       withMock {
         val transaction =
-          transactionWithRandomTime.copy(chronology = transactionWithRandomTime.chronology.copy(maximumSlot = 2))
+          transactionWithRandomTime.copy(schedule = transactionWithRandomTime.schedule.copy(maximumSlot = 2))
         val fetchTransaction = mockFunction[TypedIdentifier, F[Transaction]]
         fetchTransaction
           .expects(transaction.id: TypedIdentifier)
@@ -140,7 +140,7 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
             (clock
               .delayedUntilSlot(_: Slot))
               // This is the real thing being tested here
-              .expects(transaction.chronology.maximumSlot)
+              .expects(transaction.schedule.maximumSlot)
               .once()
               .returning(deferred.get)
           underTest <-
@@ -169,8 +169,8 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
     PropF.forAllF { (currentBlockId: TypedIdentifier, transactionWithRandomTime: Transaction) =>
       withMock {
         val transaction =
-          transactionWithRandomTime.copy(chronology =
-            transactionWithRandomTime.chronology.copy(maximumSlot = Long.MaxValue)
+          transactionWithRandomTime.copy(schedule =
+            transactionWithRandomTime.schedule.copy(maximumSlot = Long.MaxValue)
           )
         val fetchTransaction = mockFunction[TypedIdentifier, F[Transaction]]
         fetchTransaction
@@ -228,10 +228,10 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
           val transactionWithSingleInput = baseTransaction.copy(inputs = Chain(input))
           // Transaction A and Transaction B are exactly the same, except for the creation timestamp to force a different ID
           val transactionA =
-            transactionWithSingleInput.copy(chronology = transactionWithSingleInput.chronology.copy(creation = 0))
+            transactionWithSingleInput.copy(schedule = transactionWithSingleInput.schedule.copy(creation = 0))
           val transactionAId = transactionA.id.asTypedBytes
           val transactionB =
-            transactionWithSingleInput.copy(chronology = transactionWithSingleInput.chronology.copy(creation = 1))
+            transactionWithSingleInput.copy(schedule = transactionWithSingleInput.schedule.copy(creation = 1))
           val transactionBId = transactionB.id.asTypedBytes
           val bodies =
             Map(
@@ -269,11 +269,11 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
             _ <- underTest.read(blockIdA).assertEquals(Set.empty[TypedIdentifier])
             _ <-
               inSequence {
-                if (transactionA.chronology.maximumSlot != 1L) {
+                if (transactionA.schedule.maximumSlot != 1L) {
                   // The "unapply" operation will schedule a normal expiration
                   (clock
                     .delayedUntilSlot(_: Slot))
-                    .expects(transactionA.chronology.maximumSlot)
+                    .expects(transactionA.schedule.maximumSlot)
                     .once()
                     .returning(MonadCancel[F].never[Unit])
                   // But the "apply" operation will re-schedule the expiration

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/MempoolSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/MempoolSpec.scala
@@ -283,7 +283,7 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
                     .once()
                     .returning(MonadCancel[F].never[Unit])
                 } else {
-                  // This is just an edge-case where the Chronology generator produces a maximum slot of 1L,
+                  // This is just an edge-case where the Schedule generator produces a maximum slot of 1L,
                   // so the scalamock expectation needs to expect the value twice instead of just once
                   (clock
                     .delayedUntilSlot(_: Slot))

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionAuthorizationValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionAuthorizationValidationSpec.scala
@@ -355,7 +355,7 @@ class TransactionAuthorizationValidationSpec extends CatsEffectSuite with ScalaC
     val unprovenTransaction = Transaction.Unproven(
       Chain(input.copy(proposition = proposition)),
       Chain.empty,
-      Transaction.Chronology(0L, 0L, Long.MaxValue),
+      Transaction.Schedule(0L, 0L, Long.MaxValue),
       None
     )
 

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSyntaxValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSyntaxValidationSpec.scala
@@ -63,7 +63,7 @@ class TransactionSyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEff
   }
 
   test("validate positive timestamp") {
-    PropF.forAllF(arbitraryTransaction.arbitrary.map(tx => tx.copy(chronology = tx.chronology.copy(creation = -1)))) {
+    PropF.forAllF(arbitraryTransaction.arbitrary.map(tx => tx.copy(schedule = tx.schedule.copy(creation = -1)))) {
       transaction: Transaction =>
         for {
           underTest <- TransactionSyntaxValidation.make[F]
@@ -232,7 +232,7 @@ class TransactionSyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEff
       Transaction(
         Chain(arbitraryTransactionInput.arbitrary.first.copy(proposition = proposition, proof = proof)),
         Chain.empty,
-        Transaction.Chronology(0L, 0L, Long.MaxValue),
+        Transaction.Schedule(0L, 0L, Long.MaxValue),
         None
       )
     PropF.forAllF { (transaction: Transaction, curveSk: SecretKeys.Curve25519, edSK: SecretKeys.Ed25519) =>

--- a/models/src/main/scala/co/topl/models/Transaction.scala
+++ b/models/src/main/scala/co/topl/models/Transaction.scala
@@ -5,19 +5,16 @@ import co.topl.models.utility.StringDataTypes.Latin1Data
 import co.topl.models.utility.{Lengths, Sized}
 
 case class Transaction(
-  inputs:     Chain[Transaction.Input],
-  outputs:    Chain[Transaction.Output],
-  chronology: Transaction.Chronology,
-  data:       Option[Transaction.Data]
+  inputs:   Chain[Transaction.Input],
+  outputs:  Chain[Transaction.Output],
+  schedule: Transaction.Schedule,
+  data:     Option[Transaction.Data]
 )
 
 object Transaction {
 
   type Data = Sized.Max[Latin1Data, Lengths.`127`.type]
 
-  /**
-   * @param transactionOutputIndex TODO: How does the network behave if we allow a huge number of outputs in a transaction?
-   */
   case class Input(
     boxId:       Box.Id,
     proposition: Proposition,
@@ -32,12 +29,12 @@ object Transaction {
    * @param minimumSlot What is the earliest slot in which this transaction can be included in the blockchain?
    * @param maximumSlot What is the latest slot in which this transaction can be included in the blockchain?
    */
-  case class Chronology(creation: Timestamp, minimumSlot: Slot, maximumSlot: Slot)
+  case class Schedule(creation: Timestamp, minimumSlot: Slot, maximumSlot: Slot)
 
   case class Unproven(
     inputs:     Chain[Transaction.Unproven.Input],
     outputs:    Chain[Transaction.Output],
-    chronology: Chronology,
+    chronology: Schedule,
     data:       Option[Transaction.Data]
   )
 

--- a/models/src/main/scala/co/topl/models/Transaction.scala
+++ b/models/src/main/scala/co/topl/models/Transaction.scala
@@ -32,10 +32,10 @@ object Transaction {
   case class Schedule(creation: Timestamp, minimumSlot: Slot, maximumSlot: Slot)
 
   case class Unproven(
-    inputs:     Chain[Transaction.Unproven.Input],
-    outputs:    Chain[Transaction.Output],
-    chronology: Schedule,
-    data:       Option[Transaction.Data]
+    inputs:   Chain[Transaction.Unproven.Input],
+    outputs:  Chain[Transaction.Output],
+    schedule: Schedule,
+    data:     Option[Transaction.Data]
   )
 
   object Unproven {

--- a/models/src/test/scala/co/topl/models/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/ModelGenerators.scala
@@ -599,7 +599,7 @@ trait ModelGenerators {
       } yield Transaction.Unproven.Input(boxId, proposition, value)
     )
 
-  implicit val arbitraryTransactionChronology: Arbitrary[Transaction.Schedule] =
+  implicit val arbitraryTransactionSchedule: Arbitrary[Transaction.Schedule] =
     Arbitrary(
       for {
         creation    <- Gen.chooseNum[Long](0L, 100000L)
@@ -627,9 +627,9 @@ trait ModelGenerators {
                 .listOfN(count, arbitraryTransactionOutput.arbitrary)
                 .map(Chain.fromSeq)
             )
-        chronology <- arbitraryTransactionChronology.arbitrary
+        schedule <- arbitraryTransactionSchedule.arbitrary
         data = None
-      } yield Transaction.Unproven(inputs, outputs, chronology, data)
+      } yield Transaction.Unproven(inputs, outputs, schedule, data)
     )
 
   implicit val arbitraryTransaction: Arbitrary[Transaction] =
@@ -651,9 +651,9 @@ trait ModelGenerators {
                 .listOfN(count, arbitraryTransactionOutput.arbitrary)
                 .map(Chain.fromSeq)
             )
-        chronology <- arbitraryTransactionChronology.arbitrary
+        schedule <- arbitraryTransactionSchedule.arbitrary
         data = None
-      } yield Transaction(inputs, outputs, chronology, data)
+      } yield Transaction(inputs, outputs, schedule, data)
     )
 
   implicit val arbitrarySlotId: Arbitrary[SlotId] =

--- a/models/src/test/scala/co/topl/models/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/ModelGenerators.scala
@@ -599,13 +599,13 @@ trait ModelGenerators {
       } yield Transaction.Unproven.Input(boxId, proposition, value)
     )
 
-  implicit val arbitraryTransactionChronology: Arbitrary[Transaction.Chronology] =
+  implicit val arbitraryTransactionChronology: Arbitrary[Transaction.Schedule] =
     Arbitrary(
       for {
         creation    <- Gen.chooseNum[Long](0L, 100000L)
         minimumSlot <- Gen.chooseNum[Slot](0L, 100000L)
         maximumSlot <- Gen.chooseNum[Slot](0L, 100000L)
-      } yield Transaction.Chronology(creation, minimumSlot, maximumSlot)
+      } yield Transaction.Schedule(creation, minimumSlot, maximumSlot)
     )
 
   implicit val arbitraryUnprovenTransaction: Arbitrary[Transaction.Unproven] =

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraIdentifiableInstances.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraIdentifiableInstances.scala
@@ -31,7 +31,7 @@ trait TetraIdentifiableInstances {
           .Unproven(
             transaction.inputs.map(i => Transaction.Unproven.Input(i.boxId, i.proposition, i.value)),
             transaction.outputs,
-            transaction.chronology,
+            transaction.schedule,
             transaction.data
           )
           .immutableBytes

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -408,15 +408,15 @@ trait TetraScodecTransactionCodecs {
     (Codec[FullAddress] :: Codec[Box.Value] :: Codec[Boolean])
       .as[Transaction.Output]
 
-  implicit val transactionChronologyCodec: Codec[Transaction.Chronology] =
+  implicit val transactionChronologyCodec: Codec[Transaction.Schedule] =
     (Codec[Timestamp](uLongCodec) :: Codec[Slot](uLongCodec) :: Codec[Slot](uLongCodec))
-      .as[Transaction.Chronology]
+      .as[Transaction.Schedule]
 
   implicit val transactionCodec: Codec[Transaction] =
     (
       Codec[Chain[Transaction.Input]] ::
         Codec[Chain[Transaction.Output]] ::
-        Codec[Transaction.Chronology] ::
+        Codec[Transaction.Schedule] ::
         Codec[Option[Transaction.Data]]
     ).as[Transaction]
 
@@ -424,7 +424,7 @@ trait TetraScodecTransactionCodecs {
     (
       Codec[Chain[Transaction.Unproven.Input]] ::
         Codec[Chain[Transaction.Output]] ::
-        Codec[Transaction.Chronology] ::
+        Codec[Transaction.Schedule] ::
         Codec[Option[Transaction.Data]]
     ).as[Transaction.Unproven]
 }

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -408,7 +408,7 @@ trait TetraScodecTransactionCodecs {
     (Codec[FullAddress] :: Codec[Box.Value] :: Codec[Boolean])
       .as[Transaction.Output]
 
-  implicit val transactionChronologyCodec: Codec[Transaction.Schedule] =
+  implicit val transactionScheduleCodec: Codec[Transaction.Schedule] =
     (Codec[Timestamp](uLongCodec) :: Codec[Slot](uLongCodec) :: Codec[Slot](uLongCodec))
       .as[Transaction.Schedule]
 

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraSignableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraSignableCodecs.scala
@@ -42,7 +42,7 @@ trait TetraSignableCodecs {
         .Unproven(
           t.inputs.map(i => Transaction.Unproven.Input(i.boxId, i.proposition, i.value)),
           t.outputs,
-          t.chronology,
+          t.schedule,
           t.data
         )
         .signableBytes

--- a/topl-grpc/src/main/scala/co/topl/grpc/BifrostMorphismInstances.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/BifrostMorphismInstances.scala
@@ -1102,12 +1102,12 @@ trait TransactionBifrostMorphismInstances {
     )
 
   implicit def transactionScheduleIsomorphism[F[_]: Monad]
-    : Isomorphism[F, bifrostModels.Transaction.Chronology, models.Transaction.Schedule] =
+    : Isomorphism[F, bifrostModels.Transaction.Schedule, models.Transaction.Schedule] =
     Isomorphism(
       _.map(input => models.Transaction.Schedule(input.creation, input.minimumSlot, input.maximumSlot).asRight[String]),
       _.map(protoInput =>
         bifrostModels.Transaction
-          .Chronology(protoInput.creation, protoInput.minimumSlot, protoInput.maximumSlot)
+          .Schedule(protoInput.creation, protoInput.minimumSlot, protoInput.maximumSlot)
           .asRight[String]
       )
     )
@@ -1127,7 +1127,7 @@ trait TransactionBifrostMorphismInstances {
               .map(_.sequence)
           )
           schedule <- EitherT(
-            transaction.chronology.toF[F, models.Transaction.Schedule]
+            transaction.schedule.toF[F, models.Transaction.Schedule]
           )
           data <- transaction.data.traverse(v => EitherT(v.toF[F, ByteString]))
         } yield models.Transaction(inputs, outputs, schedule.some, data)
@@ -1149,7 +1149,7 @@ trait TransactionBifrostMorphismInstances {
           )
           chronology <- EitherT
             .fromOption[F](protoTransaction.schedule, "Missing schedule")
-            .flatMapF(_.toF[F, bifrostModels.Transaction.Chronology])
+            .flatMapF(_.toF[F, bifrostModels.Transaction.Schedule])
           data <- protoTransaction.data.traverse(v => EitherT(v.toF[F, bifrostModels.Transaction.Data]))
         } yield bifrostModels.Transaction(inputs, outputs, chronology, data)
       )

--- a/topl-grpc/src/main/scala/co/topl/grpc/BifrostMorphismInstances.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/BifrostMorphismInstances.scala
@@ -1147,11 +1147,11 @@ trait TransactionBifrostMorphismInstances {
               .traverse(_.toF[F, bifrostModels.Transaction.Output])
               .map(_.sequence)
           )
-          chronology <- EitherT
+          schedule <- EitherT
             .fromOption[F](protoTransaction.schedule, "Missing schedule")
             .flatMapF(_.toF[F, bifrostModels.Transaction.Schedule])
           data <- protoTransaction.data.traverse(v => EitherT(v.toF[F, bifrostModels.Transaction.Data]))
-        } yield bifrostModels.Transaction(inputs, outputs, chronology, data)
+        } yield bifrostModels.Transaction(inputs, outputs, schedule, data)
       )
         .flatMap(_.value)
     )

--- a/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTimestamp.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTimestamp.scala
@@ -15,7 +15,7 @@ object ContainsTimestamp {
   trait Instances {
     implicit val blockHeaderV2ContainsTimestamp: ContainsTimestamp[BlockHeaderV2] = _.timestamp
     implicit val blockV1ContainsTimestamp: ContainsTimestamp[BlockV1] = _.timestamp
-    implicit val transactionContainsTimestamp: ContainsTimestamp[Transaction] = _.chronology.creation
+    implicit val transactionContainsTimestamp: ContainsTimestamp[Transaction] = _.schedule.creation
   }
 
   object instances extends Instances

--- a/typeclasses/src/main/scala/co/topl/typeclasses/TransactionOps.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/TransactionOps.scala
@@ -17,7 +17,7 @@ object TransactionOps {
           .Unproven(
             transaction.inputs.map(i => Transaction.Unproven.Input(i.boxId, i.proposition, i.value)),
             transaction.outputs,
-            transaction.chronology,
+            transaction.schedule,
             transaction.data
           )
 

--- a/typeclasses/src/main/scala/co/topl/typeclasses/TransactionOps.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/TransactionOps.scala
@@ -45,7 +45,7 @@ object TransactionOps {
         Transaction(
           unproven.inputs.map(i => Transaction.Input(i.boxId, i.proposition, prove(i.proposition), i.value)),
           unproven.outputs,
-          unproven.chronology,
+          unproven.schedule,
           unproven.data
         )
     }


### PR DESCRIPTION
## Purpose
- Transaction.Chronology is not descriptive enough for the field's purpose
## Approach
- Rename Transaction.Chronology to Transaction.Schedule
## Testing
- N/A
## Tickets
- #2374 