### PR TITLE
Fix Transaction.RawAssetTransfer.Params Decoder

### DIFF
--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
@@ -510,7 +510,27 @@ trait TransactionRpcParamsDecoders extends SharedCodecs {
 
   implicit def transactionRawPolyTransferParamsDecoder(implicit
     networkPrefix: NetworkPrefix
-  ): Decoder[ToplRpc.Transaction.RawPolyTransfer.Params] = deriveDecoder
+  ): Decoder[ToplRpc.Transaction.RawPolyTransfer.Params] =
+    cursor =>
+      for {
+        propositionType <- cursor.downField("propositionType").as[String]
+        sender          <- cursor.downField("sender").as[NonEmptyChain[Address]]
+        recipients      <- cursor.downField("recipients").as[NonEmptyChain[(Address, Int128)]]
+        fee             <- cursor.downField("fee").as[Int128]
+        changeAddress   <- cursor.downField("changeAddress").as[Address]
+        data            <- cursor.downField("data").as[Option[Latin1Data]]
+        boxSelectionAlgorithm <- cursor.getOrElse("boxSelectionAlgorithm")(
+          BoxSelectionAlgorithms.All: BoxSelectionAlgorithm // default to BoxSelectionAlgorithms.All
+        )
+      } yield ToplRpc.Transaction.RawPolyTransfer.Params(
+        propositionType,
+        sender,
+        recipients,
+        fee,
+        changeAddress,
+        data,
+        boxSelectionAlgorithm
+      )
 
   implicit def transactionUnprovenPolyTransferParamsDecoder(implicit
     networkPrefix: NetworkPrefix


### PR DESCRIPTION
## Purpose
- A previous merge regressed the decoder for `Transaction.RawAssetTransfer.Params` in a way that _requires_ a boxSelectionAlgorithm to be provided (but should otherwise be optional)
## Approach
- Incorporate the correct code for `co.topl.rpc.TransactionRpcParamsDecoders#transactionRawPolyTransferParamsDecoder`
## Testing
- `preparePR`
## Tickets
N/A