### PR TITLE
Tetra Main Use LevelDB

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -287,7 +287,8 @@ lazy val nodeTetra = project
     networking,
     catsAkka,
     toplGrpc,
-    blockchain
+    blockchain,
+    levelDbStore
   )
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, DockerPlugin)
 

--- a/level-db-store/src/test/scala/co/topl/db/leveldb/LevelDbStoreSpec.scala
+++ b/level-db-store/src/test/scala/co/topl/db/leveldb/LevelDbStoreSpec.scala
@@ -19,7 +19,7 @@ class LevelDbStoreSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
   ResourceFixture[Path](Resource.make(Files[F].createTempDirectory)(Files[F].deleteRecursively))
     .test("Save, Contains, Read, Delete") { testPath =>
       for {
-        dbUnderTest <- LevelDbStore.makeDb[F](testPath.toNioPath)
+        dbUnderTest <- LevelDbStore.makeDb[F](testPath)
         underTest   <- LevelDbStore.make[F, SpecKey, SpecValue](dbUnderTest)
         key = SpecKey("test1")
         keyArray = key.persistedBytes.toArray
@@ -49,7 +49,7 @@ class LevelDbStoreSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
   ResourceFixture[Path](Resource.make(Files[F].createTempDirectory)(Files[F].deleteRecursively))
     .test("Malformed data throws exceptions") { testPath =>
       for {
-        dbUnderTest <- LevelDbStore.makeDb[F](testPath.toNioPath)
+        dbUnderTest <- LevelDbStore.makeDb[F](testPath)
         underTest   <- LevelDbStore.make[F, SpecKey, SpecValue](dbUnderTest)
         key = SpecKey("test1")
         keyArray = key.persistedBytes.toArray

--- a/node-tetra/src/main/scala/co/topl/node/DataStores.scala
+++ b/node-tetra/src/main/scala/co/topl/node/DataStores.scala
@@ -1,0 +1,84 @@
+package co.topl.node
+
+import cats.Applicative
+import cats.data.NonEmptySet
+import cats.effect.Async
+import cats.implicits._
+import co.topl.algebras.Store
+import co.topl.codecs.bytes.typeclasses.Persistable
+import co.topl.codecs.bytes.typeclasses.implicits._
+import co.topl.codecs.bytes.tetra.instances._
+import co.topl.consensus.BlockHeaderV2Ops
+import co.topl.crypto.signing.Ed25519VRF
+import co.topl.db.leveldb.LevelDbStore
+import co.topl.models._
+import co.topl.typeclasses.implicits._
+import fs2.io.file.Path
+
+import scala.collection.immutable.ListSet
+
+case class DataStores[F[_]](
+  slotData:               Store[F, TypedIdentifier, SlotData],
+  headers:                Store[F, TypedIdentifier, BlockHeaderV2],
+  bodies:                 Store[F, TypedIdentifier, BlockBodyV2],
+  transactions:           Store[F, TypedIdentifier, Transaction],
+  spendableBoxIds:        Store[F, TypedIdentifier, NonEmptySet[Short]],
+  epochBoundaries:        Store[F, Long, TypedIdentifier],
+  operatorStakes:         Store[F, StakingAddresses.Operator, Int128],
+  activeStake:            Store[F, Unit, Int128],
+  registrations:          Store[F, StakingAddresses.Operator, Box.Values.Registrations.Operator],
+  blockHeightTree:        Store[F, Long, TypedIdentifier],
+  blockHeightTreeUnapply: Store[F, TypedIdentifier, Long]
+)
+
+object DataStores {
+
+  def init[F[_]: Async](dataDir: Path)(bigBangBlock: BlockV2.Full): F[DataStores[F]] =
+    for {
+      slotDataStore        <- makeDb[F, TypedIdentifier, SlotData](dataDir)("slot-data")
+      blockHeaderStore     <- makeDb[F, TypedIdentifier, BlockHeaderV2](dataDir)("block-headers")
+      blockBodyStore       <- makeDb[F, TypedIdentifier, BlockBodyV2](dataDir)("block-bodies")
+      transactionStore     <- makeDb[F, TypedIdentifier, Transaction](dataDir)("transactions")
+      spendableBoxIdsStore <- makeDb[F, TypedIdentifier, NonEmptySet[Short]](dataDir)("spendable-box-ids")
+      epochBoundariesStore <- makeDb[F, Long, TypedIdentifier](dataDir)("epoch-boundaries")
+      operatorStakesStore  <- makeDb[F, StakingAddresses.Operator, Int128](dataDir)("operator-stakes")
+      activeStakeStore     <- makeDb[F, Unit, Int128](dataDir)("active-stake")
+      registrationsStore <- makeDb[F, StakingAddresses.Operator, Box.Values.Registrations.Operator](dataDir)(
+        "registrations"
+      )
+      blockHeightTreeStore        <- makeDb[F, Long, TypedIdentifier](dataDir)("block-heights")
+      blockHeightTreeUnapplyStore <- makeDb[F, TypedIdentifier, Long](dataDir)("block-heights-unapply")
+
+      // Store the big bang data
+      _ <- slotDataStore.put(bigBangBlock.headerV2.id, bigBangBlock.headerV2.slotData(Ed25519VRF.precomputed()))
+      _ <- blockHeaderStore.put(bigBangBlock.headerV2.id, bigBangBlock.headerV2)
+      _ <- blockBodyStore.put(
+        bigBangBlock.headerV2.id,
+        ListSet.empty ++ bigBangBlock.transactions.map(_.id.asTypedBytes).toList
+      )
+      _ <- bigBangBlock.transactions.traverseTap(transaction => transactionStore.put(transaction.id, transaction))
+      _ <- blockHeightTreeStore.put(0, bigBangBlock.headerV2.parentHeaderId)
+      _ <- activeStakeStore.contains(()).ifM(Applicative[F].unit, activeStakeStore.put((), 0))
+
+      dataStores = DataStores(
+        slotDataStore,
+        blockHeaderStore,
+        blockBodyStore,
+        transactionStore,
+        spendableBoxIdsStore,
+        epochBoundariesStore,
+        operatorStakesStore,
+        activeStakeStore,
+        registrationsStore,
+        blockHeightTreeStore,
+        blockHeightTreeUnapplyStore
+      )
+
+    } yield dataStores
+
+  private def makeDb[F[_]: Async, Key: Persistable, Value: Persistable](dataDir: Path)(
+    name:                                                                        String
+  ): F[Store[F, Key, Value]] =
+    LevelDbStore.makeDb[F](dataDir / name) >>= LevelDbStore.make[F, Key, Value]
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -197,7 +197,9 @@ object Dependencies {
   val nodeTetra: Seq[ModuleID] =
     cats ++ catsEffect ++ mainargs ++ logging ++ Seq(
       catsSlf4j,
-      akka("actor-typed")
+      akka("actor-typed"),
+      fs2Core,
+      fs2IO
     )
 
   lazy val algebras =
@@ -344,7 +346,7 @@ object Dependencies {
     cats ++
     catsEffect ++
     mUnitTest ++
-    Seq(fs2Core % Test, fs2IO % Test)
+    Seq(fs2Core, fs2IO)
 
   lazy val genus: Seq[ModuleID] =
     Seq(

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraPersistableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraPersistableCodecs.scala
@@ -1,7 +1,10 @@
 package co.topl.codecs.bytes.tetra
 
-import co.topl.codecs.bytes.typeclasses.{Persistable, Transmittable}
-import co.topl.models.SecretKeys
+import cats.data.{NonEmptyChain, NonEmptySet}
+import co.topl.codecs.bytes.scodecs._
+import co.topl.codecs.bytes.typeclasses.Persistable
+import co.topl.models._
+import scodec.bits.ByteVector
 
 trait TetraPersistableCodecs {
   import TetraScodecCodecs._
@@ -13,6 +16,46 @@ trait TetraPersistableCodecs {
     Persistable.instanceFromCodec
 
   implicit val persistableKesProductSecretKey: Persistable[SecretKeys.KesProduct] =
+    Persistable.instanceFromCodec
+
+  implicit val persistableTypedIdentifier: Persistable[TypedIdentifier] =
+    Persistable.instanceFromCodec
+
+  implicit val persistableSlotData: Persistable[SlotData] =
+    Persistable.instanceFromCodec
+
+  implicit val persistableBlockHeader: Persistable[BlockHeaderV2] =
+    Persistable.instanceFromCodec
+
+  implicit val persistableBlockBody: Persistable[BlockBodyV2] =
+    Persistable.instanceFromCodec
+
+  implicit val persistableTransaction: Persistable[Transaction] =
+    Persistable.instanceFromCodec
+
+  implicit val persistableTransactionOutputIndices: Persistable[NonEmptySet[Short]] =
+    Persistable.instanceFromCodec(
+      nonEmptyChainCodec[Short].xmap(_.toNes, s => NonEmptyChain.fromNonEmptyList(s.toNonEmptyList))
+    )
+
+  implicit val persistableLong: Persistable[Long] =
+    Persistable.instanceFromCodec(longCodec)
+
+  implicit val persistableStakingAddressesOperator: Persistable[StakingAddresses.Operator] =
+    Persistable.instanceFromCodec
+
+  implicit val persistableInt128: Persistable[Int128] =
+    Persistable.instanceFromCodec
+
+  implicit val persistableUnit: Persistable[Unit] =
+    new Persistable[Unit] {
+      def persistedBytes(value: Unit): Bytes = ByteVector.fromByte(0)
+
+      def fromPersistedBytes(bytes: Bytes): Either[String, Unit] =
+        Either.cond(bytes.length == 1 && bytes.head == (0: Byte), (), "Invalid Unit")
+    }
+
+  implicit val persistableBoxValueOperatorRegistration: Persistable[Box.Values.Registrations.Operator] =
     Persistable.instanceFromCodec
 }
 

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -237,7 +237,7 @@ trait TetraScodecBoxCodecs {
   implicit val boxIdCodec: Codec[Box.Id] =
     (Codec[TypedIdentifier] :: Codec[Short]).as[Box.Id]
 
-  implicit val boxValueCode: Codec[Box.Value] =
+  implicit val boxValueCodec: Codec[Box.Value] =
     discriminated[Box.Value]
       .by(byteCodec)
       .typecase(0: Byte, boxValuesEmptyCodec)


### PR DESCRIPTION
## Purpose
- The Tetra "main" currently launches in-memory Store interpreters
- This PR incorporates LevelDB Store interpreters
## Approach
- Change DB type in `DataStores`
- Create temp directories to store the data
## Testing
- Manual testing, verifying data is stored locally
## Tickets
- #2384 