### PR TITLE
Add Docker publish workflow for CI

### DIFF
--- a/.github/workflows/_docker_publish.yml
+++ b/.github/workflows/_docker_publish.yml
@@ -56,4 +56,4 @@ jobs:
       - name: Tag and push image to remote registry
         run: |
           docker tag $(docker images ${{ inputs.local-docker-repo }}/${{ inputs.local-docker-image }} --format "{{.ID}}" | head -n 1) ${{ inputs.remote-repository }}bifrost-node:$(docker images toplprotocol/bifrost-node --format "{{.Tag}}" | head -n 1)
-          docker push --all-tags ${{ inputs.remote-repository }}bifrost-node
+          docker push --all-tags ${{ inputs.remote-repository }}/bifrost-node

--- a/.github/workflows/_docker_publish.yml
+++ b/.github/workflows/_docker_publish.yml
@@ -55,5 +55,5 @@ jobs:
 
       - name: Tag and push image to remote registry
         run: |
-          docker tag $(docker images ${{ inputs.local-docker-repo }}/${{ inputs.local-docker-image }} --format "{{.ID}}" | head -n 1) ${{ inputs.remote-repository }}bifrost-node:$(docker images toplprotocol/bifrost-node --format "{{.Tag}}" | head -n 1)
-          docker push --all-tags ${{ inputs.remote-repository }}/bifrost-node
+          docker tag $(docker images ${{ inputs.local-docker-repo }}/${{ inputs.local-docker-image }} --format "{{.ID}}" | head -n 1) ${{ inputs.remote-repository }}/${{ inputs.local-docker-image }}:$(docker images ${{ inputs.local-docker-repo }}/${{ inputs.local-docker-image }} --format "{{.Tag}}" | head -n 1)
+          docker push --all-tags ${{ inputs.remote-repository }}/${{ inputs.local-docker-image }}

--- a/.github/workflows/_docker_publish.yml
+++ b/.github/workflows/_docker_publish.yml
@@ -23,6 +23,11 @@ on:
         default: "bifrost-node"
         required: false
         type: string
+      scala-project:
+        description: 'Which Bifrost node project to use (node, node-tetra).'
+        default: "node"
+        required: false
+        type: string
 
 jobs:
   publish_docker_image:
@@ -51,7 +56,7 @@ jobs:
         run: gcloud auth configure-docker ${{ inputs.registry-auth-location }}
 
       - name: Stage Docker Image
-        run: sbt node/docker:publishLocal
+        run: sbt ${{ inputs.scala-project }}/docker:publishLocal
 
       - name: Tag and push image to remote registry
         run: |

--- a/.github/workflows/_docker_publish.yml
+++ b/.github/workflows/_docker_publish.yml
@@ -1,0 +1,54 @@
+name: Publish Docker Image
+
+on:
+  workflow_call:
+    inputs:
+      remote-repository:
+        description: 'Name of the GCP managed Artifact Registry.'
+        default: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev/"
+        required: false
+        type: string
+      local-docker-repo:
+        description: 'Name of the locally staged Docker image.'
+        default: "toplprotocol"
+        required: false
+        type: string
+      local-docker-image:
+        description: 'Name of the locally staged Docker image.'
+        default: "bifrost-node"
+        required: false
+        type: string
+
+jobs:
+  publish_docker_image:
+    name: Publish Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - id: 'auth'
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: ${{ secrets.GCP_OIDC_PROVIDER_NAME }}
+          service_account: ${{ secrets.GCP_OIDC_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Set up gcloud
+        uses: 'google-github-actions/setup-gcloud@v0'
+
+      - name: Auth Artifact Registry
+        run: gcloud auth configure-docker ${{ inputs.remote-repository }}
+
+      - name: Stage Docker Image
+        run: sbt node/docker:publishLocal
+
+      - name: Tag and push image to remote registry
+        run: |
+          docker tag $(docker images ${{ inputs.local-docker-repo }}/${{ inputs.local-docker-image }} --format "{{.ID}}" | head -n 1) ${{ inputs.remote-repository }}bifrost-node:$(docker images toplprotocol/bifrost-node --format "{{.Tag}}" | head -n 1)
+          docker push --all-tags ${{ inputs.remote-repository }}bifrost-node

--- a/.github/workflows/_docker_publish.yml
+++ b/.github/workflows/_docker_publish.yml
@@ -8,6 +8,11 @@ on:
         default: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev/"
         required: false
         type: string
+      registry-auth-location:
+        description: 'Name of the GCP managed Artifact Registry.'
+        default: "us-central1-docker.pkg.dev"
+        required: false
+        type: string
       local-docker-repo:
         description: 'Name of the locally staged Docker image.'
         default: "toplprotocol"
@@ -43,7 +48,7 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v0'
 
       - name: Auth Artifact Registry
-        run: gcloud auth configure-docker ${{ inputs.remote-repository }}
+        run: gcloud auth configure-docker ${{ inputs.registry-auth-location }}
 
       - name: Stage Docker Image
         run: sbt node/docker:publishLocal

--- a/.github/workflows/_docker_publish_official.yml
+++ b/.github/workflows/_docker_publish_official.yml
@@ -1,7 +1,7 @@
-name: Docker Release
+name: Publish Docker Image
+
 on:
-  push:
-    tags: ["*"]
+  workflow_call:
 
 jobs:
   docker_release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   publish-docker-image-dev:
     if: ${{ github.ref_name == 'dev' }}
     uses: ./.github/workflows/_docker_publish.yml
-    # needs: sbt-build
+    needs: sbt-build
     with:
       remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
       registry-auth-location: "us-central1-docker.pkg.dev"
@@ -32,7 +32,7 @@ jobs:
   publish-docker-image-dev-tetra:
     if: ${{ github.ref_name == 'tetra' }}
     uses: ./.github/workflows/_docker_publish.yml
-    # needs: sbt-build
+    needs: sbt-build
     with:
       remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
       registry-auth-location: "us-central1-docker.pkg.dev"
@@ -44,7 +44,7 @@ jobs:
   publish-docker-image-qa:
     if: ${{ startsWith(github.ref_name, 'release-') }}
     uses: ./.github/workflows/_docker_publish.yml
-    # needs: sbt-build
+    needs: sbt-build
     with:
       remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-qa/topl-artifacts-qa"
       registry-auth-location: "us-central1-docker.pkg.dev"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,33 @@ jobs:
       java-versions: >-
         ["graalvm-ce-java11@21.1.0"]
 
+  publish-docker-image-dev:
+    if: ${{ github.ref_name == 'dev' }}
+    uses: ./.github/workflows/_docker_publish.yml
+    needs: sbt-build
+    with:
+      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev/"
+      local-docker-repo: "toplprotocol"
+      local-docker-image: "bifrost-node"
+    secrets: inherit
+
+  publish-docker-image-qa:
+    if: ${{ startsWith(github.ref_name, 'release-') }}
+    uses: ./.github/workflows/_docker_publish.yml
+    needs: sbt-build
+    with:
+      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-qa/topl-artifacts-qa/"
+      local-docker-repo: "toplprotocol"
+      local-docker-image: "bifrost-node"
+    secrets: inherit
+
+  publish-docker-image-main:
+    # Execute if ref is a tag, and the format starts with v like v1.2.1.
+    if: ${{ startsWith(github.ref_name, 'v') && github.ref_type == 'tag' }}
+    uses: ./.github/workflows/_docker_publish_official.yml
+    needs: sbt-build
+    secrets: inherit
+
   sbt-integration-tests:
     uses: ./.github/workflows/_scala_integration_tests.yml
     needs: sbt-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/_docker_publish.yml
     needs: sbt-build
     with:
-      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev/"
+      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
       local-docker-repo: "toplprotocol"
       local-docker-image: "bifrost-node"
     secrets: inherit
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/_docker_publish.yml
     needs: sbt-build
     with:
-      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-qa/topl-artifacts-qa/"
+      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-qa/topl-artifacts-qa"
       local-docker-repo: "toplprotocol"
       local-docker-image: "bifrost-node"
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     needs: sbt-build
     with:
       remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
+      registry-auth-location: "us-central1-docker.pkg.dev"
       local-docker-repo: "toplprotocol"
       local-docker-image: "bifrost-node"
     secrets: inherit
@@ -34,6 +35,7 @@ jobs:
     needs: sbt-build
     with:
       remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-qa/topl-artifacts-qa"
+      registry-auth-location: "us-central1-docker.pkg.dev"
       local-docker-repo: "toplprotocol"
       local-docker-image: "bifrost-node"
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: Bifrost_CI
 
 on:
   push:
-    branches: [dev, main, release-*, rc-*]
+    # branches: [dev, main, release-*, rc-*]
+    branches: [BN-634-docker-publishing-workflow-to-gcp-artifact-registry]
   workflow_dispatch:
 
 jobs:
@@ -18,7 +19,7 @@ jobs:
         ["graalvm-ce-java11@21.1.0"]
 
   publish-docker-image-dev:
-    if: ${{ github.ref_name == 'dev' }}
+    if: ${{ github.ref_name == 'BN-634-docker-publishing-workflow-to-gcp-artifact-registry' }}
     uses: ./.github/workflows/_docker_publish.yml
     needs: sbt-build
     with:
@@ -44,25 +45,25 @@ jobs:
     needs: sbt-build
     secrets: inherit
 
-  sbt-integration-tests:
-    uses: ./.github/workflows/_scala_integration_tests.yml
-    needs: sbt-build
-    with:
-      target-os: >-
-        ["ubuntu-latest"]
-      java-versions: >-
-        ["graalvm-ce-java11@21.1.0"]
+  # sbt-integration-tests:
+  #   uses: ./.github/workflows/_scala_integration_tests.yml
+  #   needs: sbt-build
+  #   with:
+  #     target-os: >-
+  #       ["ubuntu-latest"]
+  #     java-versions: >-
+  #       ["graalvm-ce-java11@21.1.0"]
 
-  post-man-integration-tests:
-    uses: ./.github/workflows/_postman_integration_tests.yml
-    needs: sbt-build
-    with:
-      target-os: >-
-        ["ubuntu-latest"]
-      java-versions: >-
-        ["graalvm-ce-java11@21.1.0"]
+  # post-man-integration-tests:
+  #   uses: ./.github/workflows/_postman_integration_tests.yml
+  #   needs: sbt-build
+  #   with:
+  #     target-os: >-
+  #       ["ubuntu-latest"]
+  #     java-versions: >-
+  #       ["graalvm-ce-java11@21.1.0"]
 
-  publish-test-results:
-    uses: ./.github/workflows/_publish_test_results.yml
-    if: always()
-    needs: [sbt-integration-tests, post-man-integration-tests]
+  # publish-test-results:
+  #   uses: ./.github/workflows/_publish_test_results.yml
+  #   if: always()
+  #   needs: [sbt-integration-tests, post-man-integration-tests]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: Bifrost_CI
 
 on:
   push:
-    # branches: [dev, main, release-*, rc-*]
-    branches: [BN-634-docker-publishing-workflow-to-gcp-artifact-registry]
+    branches: [dev, main, release-*, rc-*]
+    tags: ['*']
   workflow_dispatch:
 
 jobs:
@@ -19,9 +19,9 @@ jobs:
         ["graalvm-ce-java11@21.1.0"]
 
   publish-docker-image-dev:
-    if: ${{ github.ref_name == 'BN-634-docker-publishing-workflow-to-gcp-artifact-registry' }}
+    if: ${{ github.ref_name == 'dev' }}
     uses: ./.github/workflows/_docker_publish.yml
-    needs: sbt-build
+    # needs: sbt-build
     with:
       remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
       registry-auth-location: "us-central1-docker.pkg.dev"
@@ -29,10 +29,22 @@ jobs:
       local-docker-image: "bifrost-node"
     secrets: inherit
 
+  publish-docker-image-dev-tetra:
+    if: ${{ github.ref_name == 'tetra' }}
+    uses: ./.github/workflows/_docker_publish.yml
+    # needs: sbt-build
+    with:
+      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
+      registry-auth-location: "us-central1-docker.pkg.dev"
+      local-docker-repo: "toplprotocol"
+      local-docker-image: "bifrost-node-tetra"
+      scala-project: "node-tetra"
+    secrets: inherit
+
   publish-docker-image-qa:
     if: ${{ startsWith(github.ref_name, 'release-') }}
     uses: ./.github/workflows/_docker_publish.yml
-    needs: sbt-build
+    # needs: sbt-build
     with:
       remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-qa/topl-artifacts-qa"
       registry-auth-location: "us-central1-docker.pkg.dev"
@@ -47,25 +59,25 @@ jobs:
     needs: sbt-build
     secrets: inherit
 
-  # sbt-integration-tests:
-  #   uses: ./.github/workflows/_scala_integration_tests.yml
-  #   needs: sbt-build
-  #   with:
-  #     target-os: >-
-  #       ["ubuntu-latest"]
-  #     java-versions: >-
-  #       ["graalvm-ce-java11@21.1.0"]
+  sbt-integration-tests:
+    uses: ./.github/workflows/_scala_integration_tests.yml
+    needs: sbt-build
+    with:
+      target-os: >-
+        ["ubuntu-latest"]
+      java-versions: >-
+        ["graalvm-ce-java11@21.1.0"]
 
-  # post-man-integration-tests:
-  #   uses: ./.github/workflows/_postman_integration_tests.yml
-  #   needs: sbt-build
-  #   with:
-  #     target-os: >-
-  #       ["ubuntu-latest"]
-  #     java-versions: >-
-  #       ["graalvm-ce-java11@21.1.0"]
+  post-man-integration-tests:
+    uses: ./.github/workflows/_postman_integration_tests.yml
+    needs: sbt-build
+    with:
+      target-os: >-
+        ["ubuntu-latest"]
+      java-versions: >-
+        ["graalvm-ce-java11@21.1.0"]
 
-  # publish-test-results:
-  #   uses: ./.github/workflows/_publish_test_results.yml
-  #   if: always()
-  #   needs: [sbt-integration-tests, post-man-integration-tests]
+  publish-test-results:
+    uses: ./.github/workflows/_publish_test_results.yml
+    if: always()
+    needs: [sbt-integration-tests, post-man-integration-tests]


### PR DESCRIPTION
## Purpose
Support publishing Docker images to GCP Artifact Registry.

## Approach
* Remove docker_release workflow.
* Now release Docker images after validation from the CI.
* Support branch dependent image publishing

Branch publishing strategy:
* dev -> us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev
* release- -> us-central1-docker.pkg.dev/topl-shared-project-qa/topl-artifacts-qa
* main -> dockerhub/ghcr

## Testing
https://github.com/Topl/Bifrost/actions/runs/3054913404/jobs/4927574611
Tetra: https://github.com/Topl/Bifrost/actions/runs/3056502189/jobs/4930732381

## Considerations
I don't like the repetition too much for conditional branch parameters (unfortunately, GitHub doesn't have top level variables like a dictionary I could use to query params by branch name key).

I might be able to do some fancy json parsing, but decided not to over complicate things for now.

## Tickets
* https://topl.atlassian.net/jira/software/c/projects/BN/boards/17?modal=detail&selectedIssue=BN-634&assignee=625dcba7d7f1b80069bd1791