### PR TITLE
Enforce Transaction.Schedule

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/BlockchainPeerHandler.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BlockchainPeerHandler.scala
@@ -19,6 +19,7 @@ import co.topl.ledger.models.{
   BodyAuthorizationError,
   BodySemanticError,
   BodySyntaxError,
+  StaticBodyValidationContext,
   TransactionSemanticError,
   TransactionSyntaxError
 }
@@ -270,7 +271,13 @@ object BlockchainPeerHandler {
                       _ <- EitherT.liftF(Logger[F].info(show"Validating semantics of body id=$blockId"))
                       _ <- EitherT(
                         bodySemanticValidation
-                          .validate(block.headerV2.parentHeaderId)(block.blockBodyV2)
+                          .validate(
+                            StaticBodyValidationContext(
+                              block.headerV2.parentHeaderId,
+                              block.headerV2.height,
+                              block.headerV2.slot
+                            )
+                          )(block.blockBodyV2)
                           .map(_.toEither.leftMap(_.show))
                       )
                       _ <- EitherT.liftF(Logger[F].info(show"Validating authorization of body id=$blockId"))

--- a/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
@@ -33,6 +33,8 @@ object ToplRpcServer {
   implicit private val showTransactionSemanticError: Show[TransactionSemanticError] = {
     case TransactionSemanticErrors.InputDataMismatch(input) => show"InputDataMismatch(boxId=${input.boxId})"
     case TransactionSemanticErrors.UnspendableBox(boxId)    => show"UnspendableBox(boxId=$boxId)"
+    case TransactionSemanticErrors.UnsatisfiedSchedule(slot, schedule) =>
+      show"UnsatisfiedSchedule(slot=$slot, minimumSlot=${schedule.minimumSlot}, maximumSlot=${schedule.maximumSlot})"
   }
 
   /**

--- a/demo/src/main/scala/co/topl/demo/TetraSuperDemo.scala
+++ b/demo/src/main/scala/co/topl/demo/TetraSuperDemo.scala
@@ -254,11 +254,8 @@ object TetraSuperDemo extends IOApp {
           slotDataStore.getOrRaise
         )
         bodySyntaxValidation <- BodySyntaxValidation.make[F](transactionStore.getOrRaise, transactionSyntaxValidation)
-        bodySemanticValidation <- BodySemanticValidation.make[F](
-          transactionStore.getOrRaise,
-          boxState,
-          boxState => TransactionSemanticValidation.make[F](transactionStore.getOrRaise, boxState)
-        )
+        bodySemanticValidation <- BodySemanticValidation
+          .make[F](transactionStore.getOrRaise, transactionSemanticValidation)
         bodyAuthorizationValidation <- BodyAuthorizationValidation.make[F](
           transactionStore.getOrRaise,
           transactionAuthorizationValidation

--- a/ledger/src/main/scala/co/topl/ledger/algebras/BodySemanticValidationAlgebra.scala
+++ b/ledger/src/main/scala/co/topl/ledger/algebras/BodySemanticValidationAlgebra.scala
@@ -1,8 +1,8 @@
 package co.topl.ledger.algebras
 
 import co.topl.algebras.ContextualValidationAlgebra
-import co.topl.ledger.models.BodySemanticError
+import co.topl.ledger.models.{BodySemanticError, BodyValidationContext}
 import co.topl.models.{BlockBodyV2, TypedIdentifier}
 
 trait BodySemanticValidationAlgebra[F[_]]
-    extends ContextualValidationAlgebra[F, BodySemanticError, BlockBodyV2, TypedIdentifier]
+    extends ContextualValidationAlgebra[F, BodySemanticError, BlockBodyV2, BodyValidationContext]

--- a/ledger/src/main/scala/co/topl/ledger/algebras/TransactionSemanticValidationAlgebra.scala
+++ b/ledger/src/main/scala/co/topl/ledger/algebras/TransactionSemanticValidationAlgebra.scala
@@ -1,8 +1,8 @@
 package co.topl.ledger.algebras
 
 import co.topl.algebras.ContextualValidationAlgebra
-import co.topl.ledger.models.TransactionSemanticError
-import co.topl.models.{Transaction, TypedIdentifier}
+import co.topl.ledger.models.{TransactionSemanticError, TransactionValidationContext}
+import co.topl.models.Transaction
 
 trait TransactionSemanticValidationAlgebra[F[_]]
-    extends ContextualValidationAlgebra[F, TransactionSemanticError, Transaction, TypedIdentifier]
+    extends ContextualValidationAlgebra[F, TransactionSemanticError, Transaction, TransactionValidationContext]

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BodySemanticValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BodySemanticValidation.scala
@@ -35,7 +35,7 @@ object BodySemanticValidation {
          * Fetch the given transaction ID and (semantically) validate it in the context of the given block ID.
          * Transaction semantic validation uses the given augmented box state during validation.
          *
-         * @return a ValidatedNec containing either errors or a _new_ StateAugmentation
+         * @return a ValidatedNec containing either errors or the original Transaction
          */
         private def validateTransaction(
           context:       BodyValidationContext,

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSemanticValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSemanticValidation.scala
@@ -86,6 +86,9 @@ object TransactionSemanticValidation {
         (TransactionSemanticErrors.UnspendableBox(input.boxId): TransactionSemanticError).invalidNec[Unit].pure[F]
       )
 
+  /**
+   * Is this Transaction valid at the provided Slot?
+   */
   private def scheduleValidation[F[_]: Applicative](
     slot:     Slot
   )(schedule: Transaction.Schedule): F[ValidatedNec[TransactionSemanticError, Unit]] =

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSemanticValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSemanticValidation.scala
@@ -3,7 +3,7 @@ package co.topl.ledger.interpreters
 import cats.data.{EitherT, NonEmptyChain, Validated, ValidatedNec}
 import cats.effect._
 import cats.implicits._
-import cats.{Functor, Monad}
+import cats.{Applicative, Functor, Monad}
 import co.topl.ledger.algebras._
 import co.topl.ledger.models._
 import co.topl.models._
@@ -24,19 +24,26 @@ object TransactionSemanticValidation {
          *  - for each input, the referenced output is still spendable
          */
         def validate(
-          parentBlockId: TypedIdentifier
-        )(transaction:   Transaction): F[ValidatedNec[TransactionSemanticError, Transaction]] =
-          transaction.inputs
-            // Stop validating after the first error
-            .foldM(transaction.validNec[TransactionSemanticError]) {
-              case (Validated.Valid(_), input) =>
-                EitherT(dataValidation(fetchTransaction)(input).map(_.toEither))
-                  .flatMapF(_ => spendableValidation(boxState)(parentBlockId)(input).map(_.toEither))
-                  .toNestedValidatedNec
-                  .value
-                  .map(_.leftMap(_.flatten).as(transaction))
-              case (invalid, _) => invalid.pure[F]
-            }
+          context:     TransactionValidationContext
+        )(transaction: Transaction): F[ValidatedNec[TransactionSemanticError, Transaction]] =
+          AugmentedBoxState
+            .make(boxState)(
+              context.prefix.foldLeft(AugmentedBoxState.StateAugmentation.empty)(_.augment(_))
+            )
+            .flatMap(boxState =>
+              transaction.inputs
+                // Stop validating after the first error
+                .foldM(transaction.validNec[TransactionSemanticError]) {
+                  case (Validated.Valid(_), input) =>
+                    EitherT(dataValidation(fetchTransaction)(input).map(_.toEither))
+                      .flatMapF(_ => spendableValidation(boxState)(context.parentHeaderId)(input).map(_.toEither))
+                      .flatMapF(_ => scheduleValidation[F](context.slot)(transaction.schedule).map(_.toEither))
+                      .toNestedValidatedNec
+                      .value
+                      .map(_.leftMap(_.flatten).as(transaction))
+                  case (invalid, _) => invalid.pure[F]
+                }
+            )
       }
     )
 
@@ -78,4 +85,16 @@ object TransactionSemanticValidation {
         ().validNec[TransactionSemanticError].pure[F],
         (TransactionSemanticErrors.UnspendableBox(input.boxId): TransactionSemanticError).invalidNec[Unit].pure[F]
       )
+
+  private def scheduleValidation[F[_]: Applicative](
+    slot:     Slot
+  )(schedule: Transaction.Schedule): F[ValidatedNec[TransactionSemanticError, Unit]] =
+    Validated
+      .condNec(
+        slot >= schedule.minimumSlot && slot <= schedule.maximumSlot,
+        (),
+        TransactionSemanticErrors.UnsatisfiedSchedule(slot, schedule): TransactionSemanticError
+      )
+      .pure[F]
+
 }

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSyntaxValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSyntaxValidation.scala
@@ -23,6 +23,7 @@ object TransactionSyntaxValidation {
       distinctInputsValidation,
       maximumOutputsCountValidation,
       positiveTimestampValidation,
+      scheduleValidation,
       positiveOutputValuesValidation,
       sufficientFundsValidation,
       proofTypeValidation
@@ -70,6 +71,18 @@ object TransactionSyntaxValidation {
     transaction: Transaction
   ): ValidatedNec[TransactionSyntaxError, Unit] =
     Validated.condNec(transaction.timestamp >= 0, (), TransactionSyntaxErrors.InvalidTimestamp(transaction.timestamp))
+
+  /**
+   * Verify that the schedule of the timestamp contains valid minimum and maximum slot values
+   */
+  private[interpreters] def scheduleValidation(
+    transaction: Transaction
+  ): ValidatedNec[TransactionSyntaxError, Unit] =
+    Validated.condNec(
+      transaction.schedule.maximumSlot >= transaction.schedule.minimumSlot && transaction.schedule.maximumSlot >= 0,
+      (),
+      TransactionSyntaxErrors.InvalidSchedule(transaction.schedule)
+    )
 
   /**
    * Verify that each transaction output contains a positive quantity (where applicable)

--- a/ledger/src/main/scala/co/topl/ledger/models/BodyValidationContext.scala
+++ b/ledger/src/main/scala/co/topl/ledger/models/BodyValidationContext.scala
@@ -1,0 +1,30 @@
+package co.topl.ledger.models
+
+import co.topl.models.{Slot, TypedIdentifier}
+
+/**
+ * The context to use when validating the semantics of a Transaction
+ */
+trait BodyValidationContext {
+
+  /**
+   * The ID of the ancestor of the block being validated (i.e. if validating a transaction in block B, pass in block A)
+   */
+  def parentHeaderId: TypedIdentifier
+
+  /**
+   * The height of the chain for validation purposes
+   */
+  def height: Long
+
+  /**
+   * The slot of the chain for validation purposes
+   */
+  def slot: Long
+}
+
+case class StaticBodyValidationContext(
+  parentHeaderId: TypedIdentifier,
+  height:         Long,
+  slot:           Slot
+) extends BodyValidationContext

--- a/ledger/src/main/scala/co/topl/ledger/models/TransactionSemanticError.scala
+++ b/ledger/src/main/scala/co/topl/ledger/models/TransactionSemanticError.scala
@@ -1,6 +1,7 @@
 package co.topl.ledger.models
 
-import co.topl.models.{Box, Transaction}
+import co.topl.models.Transaction.Schedule
+import co.topl.models.{Box, Slot, Transaction}
 
 sealed abstract class TransactionSemanticError
 
@@ -17,4 +18,11 @@ object TransactionSemanticErrors {
    *   - The box may have been spent already
    */
   case class UnspendableBox(boxId: Box.Id) extends TransactionSemanticError
+
+  /**
+   * The Transaction was included in a block with a Slot that does not satisfy the Transaction's schedule requirements
+   * @param slot the slot of the block containing the transaction
+   * @param schedule the transaction's schedule
+   */
+  case class UnsatisfiedSchedule(slot: Slot, schedule: Schedule) extends TransactionSemanticError
 }

--- a/ledger/src/main/scala/co/topl/ledger/models/TransactionSyntaxError.scala
+++ b/ledger/src/main/scala/co/topl/ledger/models/TransactionSyntaxError.scala
@@ -10,6 +10,8 @@ object TransactionSyntaxErrors {
   case class DuplicateInput(boxId: Box.Id) extends TransactionSyntaxError
   case object ExcessiveOutputsCount extends TransactionSyntaxError
   case class InvalidTimestamp(timestamp: Timestamp) extends TransactionSyntaxError
+
+  case class InvalidSchedule(schedule: Transaction.Schedule) extends TransactionSyntaxError
   case class NonPositiveOutputValue(outputValue: Box.Value) extends TransactionSyntaxError
   case class InsufficientInputFunds[V <: Box.Value](inputs: Chain[V], outputs: Chain[V]) extends TransactionSyntaxError
 

--- a/ledger/src/main/scala/co/topl/ledger/models/TransactionValidationContext.scala
+++ b/ledger/src/main/scala/co/topl/ledger/models/TransactionValidationContext.scala
@@ -1,0 +1,37 @@
+package co.topl.ledger.models
+
+import cats.data.Chain
+import co.topl.models.{Slot, Transaction, TypedIdentifier}
+
+/**
+ * The context to use when validating the semantics of a Transaction
+ */
+trait TransactionValidationContext {
+
+  /**
+   * The ID of the ancestor of the block being validated (i.e. if validating a transaction in block B, pass in block A)
+   */
+  def parentHeaderId: TypedIdentifier
+
+  /**
+   * The sequence of transactions that have already been validated within the current block
+   */
+  def prefix: Chain[Transaction]
+
+  /**
+   * The height of the chain for validation purposes
+   */
+  def height: Long
+
+  /**
+   * The slot of the chain for validation purposes
+   */
+  def slot: Long
+}
+
+case class StaticTransactionValidationContext(
+  parentHeaderId: TypedIdentifier,
+  prefix:         Chain[Transaction],
+  height:         Long,
+  slot:           Slot
+) extends TransactionValidationContext

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BodySemanticValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BodySemanticValidationSpec.scala
@@ -5,10 +5,10 @@ import cats.effect.IO
 import cats.implicits._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
-import co.topl.ledger.algebras.{BoxStateAlgebra, TransactionSemanticValidationAlgebra}
+import co.topl.ledger.algebras.TransactionSemanticValidationAlgebra
 import co.topl.ledger.models._
 import co.topl.models.ModelGenerators._
-import co.topl.models.{Box, Transaction, TypedIdentifier}
+import co.topl.models.{Slot, Transaction, TypedIdentifier}
 import co.topl.typeclasses.implicits._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
@@ -21,29 +21,28 @@ class BodySemanticValidationSpec extends CatsEffectSuite with ScalaCheckEffectSu
   type F[A] = IO[A]
 
   test("validation should fail if any transaction is semantically invalid") {
-    PropF.forAllF { (parentBlockId: TypedIdentifier, _transaction: Transaction, input: Transaction.Input) =>
-      val transaction = _transaction.copy(inputs = Chain(input))
-      withMock {
-        val body = ListSet(transaction.id.asTypedBytes)
-        for {
-          fetchTransaction <- mockFunction[TypedIdentifier, F[Transaction]].pure[F]
-          _ = fetchTransaction.expects(transaction.id.asTypedBytes).once().returning(transaction.pure[F])
-          transactionSemanticValidation = mock[TransactionSemanticValidationAlgebra[F]]
-          _ = (transactionSemanticValidation
-            .validate(_: TypedIdentifier)(_: Transaction))
-            .expects(parentBlockId, transaction)
-            .once()
-            .returning(
-              (TransactionSemanticErrors
-                .InputDataMismatch(input): TransactionSemanticError).invalidNec[Transaction].pure[F]
-            )
-          boxState = mock[BoxStateAlgebra[F]]
-          makeTransactionSemanticValidation = (_: BoxStateAlgebra[F]) => transactionSemanticValidation.pure[F]
-          underTest <- BodySemanticValidation.make[F](fetchTransaction, boxState, makeTransactionSemanticValidation)
-          result    <- underTest.validate(parentBlockId)(body)
-          _         <- IO(result.isInvalid).assert
-        } yield ()
-      }
+    PropF.forAllF {
+      (parentBlockId: TypedIdentifier, _transaction: Transaction, input: Transaction.Input, height: Long, slot: Long) =>
+        val transaction = _transaction.copy(inputs = Chain(input))
+        withMock {
+          val body = ListSet(transaction.id.asTypedBytes)
+          for {
+            fetchTransaction <- mockFunction[TypedIdentifier, F[Transaction]].pure[F]
+            _ = fetchTransaction.expects(transaction.id.asTypedBytes).once().returning(transaction.pure[F])
+            transactionSemanticValidation = mock[TransactionSemanticValidationAlgebra[F]]
+            _ = (transactionSemanticValidation
+              .validate(_: TransactionValidationContext)(_: Transaction))
+              .expects(StaticTransactionValidationContext(parentBlockId, Chain.empty, height, slot), transaction)
+              .once()
+              .returning(
+                (TransactionSemanticErrors
+                  .InputDataMismatch(input): TransactionSemanticError).invalidNec[Transaction].pure[F]
+              )
+            underTest <- BodySemanticValidation.make[F](fetchTransaction, transactionSemanticValidation)
+            result    <- underTest.validate(StaticBodyValidationContext(parentBlockId, height, slot))(body)
+            _         <- IO(result.isInvalid).assert
+          } yield ()
+        }
     }
   }
 
@@ -53,7 +52,9 @@ class BodySemanticValidationSpec extends CatsEffectSuite with ScalaCheckEffectSu
         parentBlockId: TypedIdentifier,
         _transactionA: Transaction,
         _transactionB: Transaction,
-        input:         Transaction.Input
+        input:         Transaction.Input,
+        height:        Long,
+        slot:          Slot
       ) =>
         val transactionA = _transactionA.copy(inputs = Chain(input))
         val transactionB = _transactionB.copy(inputs = Chain(input))
@@ -71,44 +72,21 @@ class BodySemanticValidationSpec extends CatsEffectSuite with ScalaCheckEffectSu
               .returning(transactionB.pure[F])
             transactionSemanticValidation = mock[TransactionSemanticValidationAlgebra[F]]
             _ = (transactionSemanticValidation
-              .validate(_: TypedIdentifier)(_: Transaction))
-              .expects(parentBlockId, transactionA)
+              .validate(_: TransactionValidationContext)(_: Transaction))
+              .expects(StaticTransactionValidationContext(parentBlockId, Chain.empty, height, slot), transactionA)
               .once()
               .returning(
                 (TransactionSemanticErrors
                   .InputDataMismatch(input): TransactionSemanticError).invalidNec[Transaction].pure[F]
               )
             _ = (transactionSemanticValidation
-              .validate(_: TypedIdentifier)(_: Transaction))
-              .expects(parentBlockId, transactionB)
+              .validate(_: TransactionValidationContext)(_: Transaction))
+              .expects(*, *)
               .never() // TransactionB should fail before reaching transaction semantic validation
-            boxState = mock[BoxStateAlgebra[F]]
-            makeTransactionSemanticValidation = mockFunction[BoxStateAlgebra[F], F[
-              TransactionSemanticValidationAlgebra[F]
-            ]]
-            _ <- inSequence {
-              var firstTransactionValidated = false
-              makeTransactionSemanticValidation.expects(*).once().onCall { boxState1: BoxStateAlgebra[F] =>
-                (if (!firstTransactionValidated)
-                   boxState1.boxExistsAt(parentBlockId)(input.boxId).assert
-                 else {
-                   firstTransactionValidated = true
-                   boxState1.boxExistsAt(parentBlockId)(input.boxId).map(!_).assert
-                 }) >>
-                transactionSemanticValidation.pure[F]
-              }
-              (boxState
-                .boxExistsAt(_: TypedIdentifier)(_: Box.Id))
-                .expects(parentBlockId, input.boxId)
-                .once()
-                .returning(true.pure[F])
-              for {
-                underTest <- BodySemanticValidation
-                  .make[F](fetchTransaction, boxState, makeTransactionSemanticValidation)
-                result <- underTest.validate(parentBlockId)(body)
-                _      <- IO(result.isInvalid).assert
-              } yield ()
-            }
+            underTest <- BodySemanticValidation
+              .make[F](fetchTransaction, transactionSemanticValidation)
+            result <- underTest.validate(StaticBodyValidationContext(parentBlockId, height, slot))(body)
+            _      <- IO(result.isInvalid).assert
           } yield ()
         }
     }

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSemanticValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSemanticValidationSpec.scala
@@ -39,7 +39,7 @@ class TransactionSemanticValidationSpec extends CatsEffectSuite with ScalaCheckE
               .returning(true.pure[F])
             underTest <- TransactionSemanticValidation.make[F](fetchTransaction, boxState)
             _ <- underTest
-              .validate(blockId)(transactionB)
+              .validate(StaticTransactionValidationContext(blockId, Chain.empty, 1, 1))(transactionB)
               .map(_.toEither.swap.getOrElse(???).exists(_.isInstanceOf[TransactionSemanticErrors.UnspendableBox]))
               .assert
           } yield ()
@@ -82,7 +82,7 @@ class TransactionSemanticValidationSpec extends CatsEffectSuite with ScalaCheckE
               .returning(true.pure[F])
             underTest <- TransactionSemanticValidation.make[F](fetchTransaction, boxState)
             result <- underTest
-              .validate(blockId)(transactionB)
+              .validate(StaticTransactionValidationContext(blockId, Chain.empty, 1, 1))(transactionB)
             _ <- IO(
               if (transactionA.outputs.headOption.get.value =!= transactionB.inputs.headOption.get.value)
                 result.toEither.swap.getOrElse(???).exists(_.isInstanceOf[TransactionSemanticErrors.InputDataMismatch])
@@ -127,7 +127,7 @@ class TransactionSemanticValidationSpec extends CatsEffectSuite with ScalaCheckE
               .anyNumberOfTimes()
               .returning(true.pure[F])
             underTest <- TransactionSemanticValidation.make[F](fetchTransaction, boxState)
-            result    <- underTest.validate(blockId)(transactionB)
+            result <- underTest.validate(StaticTransactionValidationContext(blockId, Chain.empty, 1, 1))(transactionB)
             _ <- IO(
               result.toEither.swap.getOrElse(???).exists(_.isInstanceOf[TransactionSemanticErrors.InputDataMismatch])
             ).assert
@@ -172,7 +172,7 @@ class TransactionSemanticValidationSpec extends CatsEffectSuite with ScalaCheckE
               .once()
               .returning(false.pure[F])
             underTest <- TransactionSemanticValidation.make[F](fetchTransaction, boxState)
-            result    <- underTest.validate(blockId)(transactionB)
+            result <- underTest.validate(StaticTransactionValidationContext(blockId, Chain.empty, 1, 1))(transactionB)
             _ <- IO(
               result.toEither.swap.getOrElse(???).exists(_.isInstanceOf[TransactionSemanticErrors.UnspendableBox])
             ).assert

--- a/minting/src/main/scala/co/topl/minting/algebras/BlockPackerAlgebra.scala
+++ b/minting/src/main/scala/co/topl/minting/algebras/BlockPackerAlgebra.scala
@@ -11,5 +11,5 @@ trait BlockPackerAlgebra[F[_]] {
   /**
    * Constructs an `Iterative` which improves a given Block Body
    */
-  def improvePackedBlock(parentBlockId: TypedIdentifier): F[Iterative[F, BlockBodyV2.Full]]
+  def improvePackedBlock(parentBlockId: TypedIdentifier, height: Long, slot: Long): F[Iterative[F, BlockBodyV2.Full]]
 }

--- a/models/src/test/scala/co/topl/models/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/ModelGenerators.scala
@@ -603,8 +603,8 @@ trait ModelGenerators {
     Arbitrary(
       for {
         creation    <- Gen.chooseNum[Long](0L, 100000L)
-        minimumSlot <- Gen.chooseNum[Slot](0L, 100000L)
-        maximumSlot <- Gen.chooseNum[Slot](0L, 100000L)
+        minimumSlot <- Gen.chooseNum[Slot](0L, 50000L)
+        maximumSlot <- Gen.chooseNum[Slot](minimumSlot, 100000L)
       } yield Transaction.Schedule(creation, minimumSlot, maximumSlot)
     )
 

--- a/node-tetra/src/main/scala/co/topl/node/Validators.scala
+++ b/node-tetra/src/main/scala/co/topl/node/Validators.scala
@@ -59,6 +59,8 @@ object Validators {
         dataStores.spendableBoxIds.pure[F]
       )
       transactionSyntaxValidation <- TransactionSyntaxValidation.make[F]
+      transactionSemanticValidation <- TransactionSemanticValidation
+        .make[F](dataStores.transactions.getOrRaise, boxState)
       transactionAuthorizationValidation <- TransactionAuthorizationValidation.make[F](
         cryptoResources.blake2b256,
         cryptoResources.curve25519,
@@ -70,8 +72,7 @@ object Validators {
         .make[F](dataStores.transactions.getOrRaise, transactionSyntaxValidation)
       bodySemanticValidation <- BodySemanticValidation.make[F](
         dataStores.transactions.getOrRaise,
-        boxState,
-        boxState => TransactionSemanticValidation.make[F](dataStores.transactions.getOrRaise, boxState)
+        transactionSemanticValidation
       )
       bodyAuthorizationValidation <- BodyAuthorizationValidation.make[F](
         dataStores.transactions.getOrRaise,


### PR DESCRIPTION
## Purpose
- A Transaction can define constraints on _when_ it can be included in the blockchain.
- These constraints need to be enforced during minting and validation
## Approach
- Modify Transaction and Body Semantic Validations to use additional context information in its validation
- Enforce Transaction.Schedule constraints in TransactionSemanticValidation
- Also validate Transaction.Schedule values in TransactionSyntaxValidation
## Testing
- New Transaction Semantic and Syntax unit tests for schedule
## Tickets
#2435 