### PR TITLE
Update Scalacache Dependency (Dev)

### DIFF
--- a/consensus/src/main/scala/co/topl/consensus/BlockHeaderValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/BlockHeaderValidation.scala
@@ -13,7 +13,6 @@ import co.topl.models.utility.Ratio
 import co.topl.typeclasses.BlockGenesis
 import co.topl.typeclasses.implicits._
 import com.google.common.primitives.Longs
-import scalacache.CacheConfig
 import scalacache.caffeine.CaffeineCache
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
@@ -276,25 +275,23 @@ object BlockHeaderValidation {
 
   object WithCache {
 
-    implicit private val cacheConfig: CacheConfig = CacheConfig(cacheKeyBuilder[TypedIdentifier])
-
     def make[F[_]: MonadError[*[_], Throwable]: Sync](
       underlying:       BlockHeaderValidationAlgebra[F],
       blockHeaderStore: Store[F, TypedIdentifier, BlockHeaderV2]
     ): F[BlockHeaderValidationAlgebra[F]] =
-      CaffeineCache[F, TypedIdentifier].map(implicit cache =>
+      CaffeineCache[F, Bytes, TypedIdentifier].map(implicit cache =>
         new BlockHeaderValidationAlgebra[F] {
 
           def validate(
             child:  BlockHeaderV2,
             parent: BlockHeaderV2
           ): F[Either[BlockHeaderValidationFailure, BlockHeaderV2]] =
-            OptionT(scalacache.get[F, TypedIdentifier](child.id.asTypedBytes))
+            OptionT(cache.get(child.id.asTypedBytes.allBytes))
               .map(_ => child.asRight[BlockHeaderValidationFailure])
               .getOrElseF(
                 validateParent(parent)
                   .flatMapF(_ => underlying.validate(child, parent))
-                  .semiflatTap(h => scalacache.put(h.id.asTypedBytes)(h.id.asTypedBytes))
+                  .semiflatTap(h => cache.put(h.id.asTypedBytes.allBytes)(h.id.asTypedBytes))
                   .value
               )
 

--- a/consensus/src/main/scala/co/topl/consensus/LeaderElectionValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/LeaderElectionValidation.scala
@@ -68,7 +68,7 @@ object LeaderElectionValidation {
       }
 
     def makeCached[F[_]: Sync: Clock](alg: LeaderElectionValidationAlgebra[F]): F[LeaderElectionValidationAlgebra[F]] =
-      CaffeineCache[F, Ratio].map(cache =>
+      CaffeineCache[F, (Ratio, Slot), Ratio].map(cache =>
         new LeaderElectionValidationAlgebra[F] {
 
           override def getThreshold(relativeStake: Ratio, slotDiff: Slot): F[Ratio] =

--- a/consensus/src/main/scala/co/topl/consensus/SlotDataCache.scala
+++ b/consensus/src/main/scala/co/topl/consensus/SlotDataCache.scala
@@ -6,9 +6,9 @@ import cats.effect._
 import cats.implicits._
 import co.topl.algebras.{Store, UnsafeResource}
 import co.topl.crypto.signing.Ed25519VRF
-import co.topl.models.{BlockHeaderV2, SlotData, TypedIdentifier}
+import co.topl.models.{BlockHeaderV2, Bytes, SlotData, TypedIdentifier}
 import co.topl.typeclasses.implicits._
-import scalacache.{cachingF, CacheConfig}
+import scalacache.cachingF
 import scalacache.caffeine.CaffeineCache
 
 import scala.concurrent.duration._
@@ -21,16 +21,14 @@ object SlotDataCache {
 
   object Eval {
 
-    implicit private val cacheConfig: CacheConfig = CacheConfig(cacheKeyBuilder[TypedIdentifier])
-
     // TODO: Use Epoch thirds for storage
     def make[F[_]: MonadError[*[_], Throwable]: Clock: Sync](
       blockHeaderLookup:  Store[F, TypedIdentifier, BlockHeaderV2],
       ed25519VRFResource: UnsafeResource[F, Ed25519VRF]
     ): F[SlotDataCache[F]] =
-      CaffeineCache[F, SlotData].map(implicit cache =>
+      CaffeineCache[F, Bytes, SlotData].map(implicit cache =>
         (blockId: TypedIdentifier) =>
-          cachingF(blockId)(ttl = Some(1.day))(
+          cachingF(blockId.allBytes)(ttl = Some(1.day))(
             OptionT(blockHeaderLookup.get(blockId))
               .getOrElseF(new IllegalStateException(blockId.show).raiseError[F, BlockHeaderV2])
               .flatMap(header => ed25519VRFResource.use(implicit ed25519Vrf => header.slotData.pure[F]))

--- a/consensus/src/main/scala/co/topl/consensus/package.scala
+++ b/consensus/src/main/scala/co/topl/consensus/package.scala
@@ -1,10 +1,8 @@
 package co.topl
 
-import cats.implicits._
-import cats.{Order, Show}
+import cats.Order
 import co.topl.crypto.signing.Ed25519VRF
 import co.topl.models.{BlockHeaderV2, SlotData}
-import scalacache.CacheKeyBuilder
 
 package object consensus {
 
@@ -12,17 +10,6 @@ package object consensus {
 
     def tiebreakWith(other: Order[T]): Order[T] =
       Order.whenEqual(order, other)
-  }
-
-  def cacheKeyBuilder[T: Show]: CacheKeyBuilder = new CacheKeyBuilder {
-
-    def toCacheKey(parts: Seq[Any]): String =
-      parts.map {
-        case s: T @unchecked => s.show
-        case s               => throw new MatchError(s)
-      }.mkString
-
-    def stringToCacheKey(key: String): String = key
   }
 
   implicit class BlockHeaderV2Ops(blockHeaderV2: BlockHeaderV2) {

--- a/numerics/src/main/scala/co/topl/numerics/Log1pInterpreter.scala
+++ b/numerics/src/main/scala/co/topl/numerics/Log1pInterpreter.scala
@@ -15,7 +15,9 @@ object Log1pInterpreter extends LentzMethod {
   }.pure[F]
 
   def makeCached[F[_]: Sync: Clock](log1p: Log1p[F]): F[Log1p[F]] =
-    CaffeineCache[F, Ratio].map(cache => (x: Ratio) => cache.cachingF(x)(ttl = None)(Sync[F].defer(log1p.evaluate(x))))
+    CaffeineCache[F, Ratio, Ratio].map(cache =>
+      (x: Ratio) => cache.cachingF(x)(ttl = None)(Sync[F].defer(log1p.evaluate(x)))
+    )
 
   /**
    * Returns the natural logarithm of the argument plus one

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -113,7 +113,7 @@ object Dependencies {
   )
 
   val scalacache = Seq(
-    "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M4"
+    "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M6"
   )
 
   val simulacrum = Seq(


### PR DESCRIPTION
## Purpose
- scalacache is a library for caching within an effect context
- scalacache 1.0.0-M6 introduces a backwards incompatible change which allows CaffeineCache to specify a Key type
  - (This is a really helpful change because previously, the keys needed to be converted to strings which is inefficient)
## Approach
- Update scalacache dependency
- Update usages of CaffeineCache.apply to specify a key type
- In cases which used TypedIdentifier as the key type, the type was changed to just `Bytes` due to an issue with TypedBytes being an `@newtype` which does not work as a key
## Testing
- N/A
## Tickets
#2419 