### PR TITLE
Update Scalacache Dependency (Tetra) 

### DIFF
--- a/.github/workflows/_docker_publish.yml
+++ b/.github/workflows/_docker_publish.yml
@@ -1,0 +1,64 @@
+name: Publish Docker Image
+
+on:
+  workflow_call:
+    inputs:
+      remote-repository:
+        description: 'Name of the GCP managed Artifact Registry.'
+        default: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev/"
+        required: false
+        type: string
+      registry-auth-location:
+        description: 'Name of the GCP managed Artifact Registry.'
+        default: "us-central1-docker.pkg.dev"
+        required: false
+        type: string
+      local-docker-repo:
+        description: 'Name of the locally staged Docker image.'
+        default: "toplprotocol"
+        required: false
+        type: string
+      local-docker-image:
+        description: 'Name of the locally staged Docker image.'
+        default: "bifrost-node"
+        required: false
+        type: string
+      scala-project:
+        description: 'Which Bifrost node project to use (node, node-tetra).'
+        default: "node"
+        required: false
+        type: string
+
+jobs:
+  publish_docker_image:
+    name: Publish Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - id: 'auth'
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: ${{ secrets.GCP_OIDC_PROVIDER_NAME }}
+          service_account: ${{ secrets.GCP_OIDC_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Set up gcloud
+        uses: 'google-github-actions/setup-gcloud@v0'
+
+      - name: Auth Artifact Registry
+        run: gcloud auth configure-docker ${{ inputs.registry-auth-location }}
+
+      - name: Stage Docker Image
+        run: sbt ${{ inputs.scala-project }}/docker:publishLocal
+
+      - name: Tag and push image to remote registry
+        run: |
+          docker tag $(docker images ${{ inputs.local-docker-repo }}/${{ inputs.local-docker-image }} --format "{{.ID}}" | head -n 1) ${{ inputs.remote-repository }}/${{ inputs.local-docker-image }}:$(docker images ${{ inputs.local-docker-repo }}/${{ inputs.local-docker-image }} --format "{{.Tag}}" | head -n 1)
+          docker push --all-tags ${{ inputs.remote-repository }}/${{ inputs.local-docker-image }}

--- a/.github/workflows/_docker_publish_official.yml
+++ b/.github/workflows/_docker_publish_official.yml
@@ -1,7 +1,7 @@
-name: Docker Release
+name: Publish Docker Image
+
 on:
-  push:
-    tags: ["*"]
+  workflow_call:
 
 jobs:
   docker_release:

--- a/.github/workflows/_validate_helm.yml
+++ b/.github/workflows/_validate_helm.yml
@@ -1,0 +1,25 @@
+name: Validate Helm Chart
+
+on:
+  workflow_call:
+    inputs:
+      target-os:
+        description: 'List of operating systems to build on.'
+        default: 'ubuntu-latest'
+        required: false
+        type: string
+
+jobs:
+  validate_helm:
+    name: Validate Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v2
+
+      - name: Run Checkov action
+        id: checkov
+        uses: bridgecrewio/checkov-action@master
+        with:
+          directory: helm/
+          config_file: helm/.checkov.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,13 @@ name: Bifrost_CI
 on:
   push:
     branches: [dev, main, release-*, rc-*, tetra]
+    tags: ['*']
   workflow_dispatch:
 
 jobs:
+  validate-helm:
+    uses: ./.github/workflows/_validate_helm.yml
+
   sbt-build:
     uses: ./.github/workflows/_sbt_build.yml
     with:
@@ -13,6 +17,47 @@ jobs:
         ["ubuntu-latest"]
       java-versions: >-
         ["11"]
+
+  publish-docker-image-dev:
+    if: ${{ github.ref_name == 'dev' }}
+    uses: ./.github/workflows/_docker_publish.yml
+    needs: sbt-build
+    with:
+      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
+      registry-auth-location: "us-central1-docker.pkg.dev"
+      local-docker-repo: "toplprotocol"
+      local-docker-image: "bifrost-node"
+    secrets: inherit
+
+  publish-docker-image-dev-tetra:
+    if: ${{ github.ref_name == 'tetra' }}
+    uses: ./.github/workflows/_docker_publish.yml
+    needs: sbt-build
+    with:
+      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
+      registry-auth-location: "us-central1-docker.pkg.dev"
+      local-docker-repo: "toplprotocol"
+      local-docker-image: "bifrost-node-tetra"
+      scala-project: "node-tetra"
+    secrets: inherit
+
+  publish-docker-image-qa:
+    if: ${{ startsWith(github.ref_name, 'release-') }}
+    uses: ./.github/workflows/_docker_publish.yml
+    needs: sbt-build
+    with:
+      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-qa/topl-artifacts-qa"
+      registry-auth-location: "us-central1-docker.pkg.dev"
+      local-docker-repo: "toplprotocol"
+      local-docker-image: "bifrost-node"
+    secrets: inherit
+
+  publish-docker-image-main:
+    # Execute if ref is a tag, and the format starts with v like v1.2.1.
+    if: ${{ startsWith(github.ref_name, 'v') && github.ref_type == 'tag' }}
+    uses: ./.github/workflows/_docker_publish_official.yml
+    needs: sbt-build
+    secrets: inherit
 
   sbt-integration-tests:
     uses: ./.github/workflows/_scala_integration_tests.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,9 @@ on:
     branches: [dev, main, release-*, rc-*, tetra]
 
 jobs:
+  validate-helm:
+    uses: ./.github/workflows/_validate_helm.yml
+
   sbt-build:
     uses: ./.github/workflows/_sbt_build.yml
     with:

--- a/consensus/src/main/scala/co/topl/consensus/EtaCalculation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/EtaCalculation.scala
@@ -1,6 +1,5 @@
 package co.topl.consensus
 
-import cats.MonadError
 import cats.data.NonEmptyChain
 import cats.effect.{Clock, Sync}
 import cats.implicits._
@@ -12,16 +11,13 @@ import co.topl.crypto.signing.Ed25519VRF
 import co.topl.models._
 import co.topl.typeclasses.implicits._
 import org.typelevel.log4cats.Logger
-import scalacache._
 import scalacache.caffeine.CaffeineCache
 
 object EtaCalculation {
 
   object Eval {
 
-    implicit private val cacheConfig: CacheConfig = CacheConfig(cacheKeyBuilder[TypedIdentifier])
-
-    def make[F[_]: Clock: Sync: MonadError[*[_], Throwable]: Logger](
+    def make[F[_]: Clock: Sync: Logger](
       fetchSlotData:      TypedIdentifier => F[SlotData],
       clock:              ClockAlgebra[F],
       genesisEta:         Eta,
@@ -29,19 +25,19 @@ object EtaCalculation {
       blake2b512Resource: UnsafeResource[F, Blake2b512]
     ): F[EtaCalculationAlgebra[F]] =
       for {
-        implicit0(cache: CaffeineCache[F, Eta]) <- CaffeineCache[F, Eta]
-        slotsPerEpoch                           <- clock.slotsPerEpoch
+        implicit0(cache: CaffeineCache[F, Bytes, Eta]) <- CaffeineCache[F, Bytes, Eta]
+        slotsPerEpoch                                  <- clock.slotsPerEpoch
         impl = new Impl[F](fetchSlotData, clock, genesisEta, slotsPerEpoch, blake2b256Resource, blake2b512Resource)
       } yield impl
 
-    private class Impl[F[_]: Clock: Sync: MonadError[*[_], Throwable]: Logger](
+    private class Impl[F[_]: Clock: Sync: Logger](
       fetchSlotData:      TypedIdentifier => F[SlotData],
       clock:              ClockAlgebra[F],
       genesisEta:         Eta,
       slotsPerEpoch:      Long,
       blake2b256Resource: UnsafeResource[F, Blake2b256],
       blake2b512Resource: UnsafeResource[F, Blake2b512]
-    )(implicit cache:     CaffeineCache[F, Eta])
+    )(implicit cache:     CaffeineCache[F, Bytes, Eta])
         extends EtaCalculationAlgebra[F] {
 
       private val twoThirdsLength = slotsPerEpoch * 2 / 3
@@ -60,7 +56,7 @@ object EtaCalculation {
               // TODO: If childEpoch - parentEpoch > 1, destroy the node
               // OR: childSlot - parentSlot > slotsPerEpoch
               case (_, _, parentSlotData) =>
-                cache.cachingF(parentSlotId.blockId)(ttl = None)(
+                cache.cachingF(parentSlotId.blockId.allBytes)(ttl = None)(
                   locateTwoThirdsBest(parentSlotData)
                     .flatMap(calculate)
                     .flatTap(nextEta =>
@@ -91,7 +87,7 @@ object EtaCalculation {
        * @param twoThirdsBest The latest block header in some tine, but within the first 2/3 of the epoch
        */
       private def calculate(twoThirdsBest: SlotData): F[Eta] =
-        cache.cachingF(twoThirdsBest.slotId.blockId)(ttl = None)(
+        cache.cachingF(twoThirdsBest.slotId.blockId.allBytes)(ttl = None)(
           for {
             epoch      <- clock.epochOf(twoThirdsBest.slotId.slot)
             epochRange <- clock.epochRange(epoch)

--- a/consensus/src/main/scala/co/topl/consensus/LeaderElectionValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/LeaderElectionValidation.scala
@@ -68,7 +68,7 @@ object LeaderElectionValidation {
       }
 
     def makeCached[F[_]: Sync: Clock](alg: LeaderElectionValidationAlgebra[F]): F[LeaderElectionValidationAlgebra[F]] =
-      CaffeineCache[F, Ratio].map(cache =>
+      CaffeineCache[F, (Ratio, Slot), Ratio].map(cache =>
         new LeaderElectionValidationAlgebra[F] {
 
           override def getThreshold(relativeStake: Ratio, slotDiff: Slot): F[Ratio] =

--- a/consensus/src/main/scala/co/topl/consensus/package.scala
+++ b/consensus/src/main/scala/co/topl/consensus/package.scala
@@ -1,10 +1,8 @@
 package co.topl
 
-import cats.implicits._
-import cats.{Order, Show}
+import cats.Order
 import co.topl.crypto.signing.Ed25519VRF
 import co.topl.models.{BlockHeaderV2, SlotData}
-import scalacache.CacheKeyBuilder
 
 package object consensus {
 
@@ -12,17 +10,6 @@ package object consensus {
 
     def tiebreakWith(other: Order[T]): Order[T] =
       Order.whenEqual(order, other)
-  }
-
-  def cacheKeyBuilder[T: Show]: CacheKeyBuilder = new CacheKeyBuilder {
-
-    def toCacheKey(parts: Seq[Any]): String =
-      parts.map {
-        case s: T @unchecked => s.show
-        case s               => throw new MatchError(s)
-      }.mkString
-
-    def stringToCacheKey(key: String): String = key
   }
 
   implicit class BlockHeaderV2Ops(blockHeaderV2: BlockHeaderV2) {

--- a/helm/.checkov.yaml
+++ b/helm/.checkov.yaml
@@ -1,0 +1,9 @@
+skip-check:
+  - CKV_K8S_14 # Ignore since default should just pull latest tag, users will override specific version: https://docs.bridgecrew.io/docs/bc_k8s_13.
+  - CKV_K8S_43 # Ignore since users will override the default Docker image: https://docs.bridgecrew.io/docs/bc_k8s_39.
+  - CKV_K8S_21 # Ignore since users will override the namespace when deploying with Helm: https://docs.bridgecrew.io/docs/bc_k8s_20.
+  - CKV_K8S_40 # TODO: Remove this once the Bifrost Docker image is using a high UID.
+evaluate-variables: true
+framework: all
+output: cli
+quiet: true

--- a/helm/bifrost/.helmignore
+++ b/helm/bifrost/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/bifrost/Chart.yaml
+++ b/helm/bifrost/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: bifrost
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"
+
+#TODO: Find a better icon.
+icon: https://uploads-ssl.webflow.com/60f98f46d44e675abb7e66ea/611c4d83ed3df101fd221875_topl_basew.svg

--- a/helm/bifrost/templates/_helpers.tpl
+++ b/helm/bifrost/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bifrost.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bifrost.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bifrost.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bifrost.labels" -}}
+helm.sh/chart: {{ include "bifrost.chart" . }}
+{{ include "bifrost.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bifrost.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bifrost.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bifrost.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bifrost.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "bifrost.fullname" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "bifrost.fullname" . }}
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "bifrost.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        {{- include "bifrost.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ .Values.image.name }}:{{ .Values.image.tag }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        command:
+          {{ range .Values.command }}
+            - {{ . }}
+          {{ end }}
+        args:
+          {{ range .Values.args }}
+            - {{ . }}
+          {{ end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            port: {{ .Values.ports.rpc }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+        {{- end }}
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            port: {{ .Values.ports.rpc }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.ports.p2p }}
+        - containerPort: {{ .Values.ports.rpc }}
+        volumeMounts:
+        - name: {{ .Values.name }}-pv
+          mountPath: {{ .Values.volume.mountDirectory }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ .Values.name }}-pv
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ .Values.volume.storageClass }}
+      resources:
+        requests:
+          storage: {{ .Values.volume.storageSize }}

--- a/helm/bifrost/templates/bifrost/service.yaml
+++ b/helm/bifrost/templates/bifrost/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bifrost.fullname" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4}}
+spec:
+  selector:
+    {{- include "bifrost.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}
+  ports:
+    - protocol: TCP
+      name: p2p
+      port: {{ .Values.service.ports.p2p }}
+      targetPort: {{ .Values.ports.p2p }}
+    - protocol: TCP
+      name: rpc
+      port: {{ .Values.service.ports.rpc }}
+      targetPort: {{ .Values.ports.rpc }}
+{{- end }}

--- a/helm/bifrost/values.yaml
+++ b/helm/bifrost/values.yaml
@@ -1,0 +1,69 @@
+# # Default values for bifrost.
+# # This is a YAML-formatted file.
+# # Declare variables to be passed into your templates.
+
+name: bifrost-node
+
+image:
+  name: ghcr.io/topl/bifrost-node
+  tag: latest
+
+replicas: 1
+
+resources:
+  limits:
+    cpu: 2.0
+    memory: 4000Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+podSecurityContext:
+  runAsUser: 1001 # TODO: Update Bifrost Docker container to use high UID. Add CKV_K8S_40 as a check.
+  runAsGroup: 0
+  fsGroup: 0
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+args: # Refer to CLI: https://github.com/Topl/Bifrost#command-line-reference
+# args: ['--seed', 'test', '--forge']
+# args: ['--network', 'valhalla']
+
+command:
+# command: ["tail", "-f", "/dev/null"] # Use this to debug Bifrost and exec into the running pod.
+
+service:
+  enabled: true
+  type: ClusterIP
+  ports:
+    p2p: 9084
+    rpc: 9085
+
+ports:
+  p2p: 9084
+  rpc: 9085
+
+volume:
+  mountDirectory: /opt/docker/.bifrost
+  # GKE specific storage classes: standard, standard-rwo, premium-rwo
+  storageClass: default
+  storageSize: 10Gi
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 60 # Perform check every x seconds.
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 60 # Perform check every x seconds.

--- a/json-codecs/src/test/scala/co/topl/codecs/json/tetra/DionAddressJsonCodecSpec.scala
+++ b/json-codecs/src/test/scala/co/topl/codecs/json/tetra/DionAddressJsonCodecSpec.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 import co.topl.codecs.json.tetra.instances._
 import co.topl.models.utility.HasLength.instances.bytesLength
 import co.topl.models.utility.Sized
-import co.topl.models.{DionAddress, NetworkPrefix, TypedEvidence}
+import co.topl.models.{NetworkPrefix, SpendingAddress, TypedEvidence}
 import io.circe.DecodingFailure
 import io.circe.syntax._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -22,12 +22,11 @@ class DionAddressJsonCodecSpec extends AnyFlatSpec with Matchers {
 
     val evidenceBytes =
       ByteVector.fromHex("0x0183ebe813408a46e2be7bd20e401944824690a741553710133124bf5d3855fb82").get
-    val privateTestnetPrefix = NetworkPrefix(64.toByte)
 
-    val dionAddress =
-      DionAddress(privateTestnetPrefix, TypedEvidence(evidenceBytes.head, Sized.strictUnsafe(evidenceBytes.tail)))
+    val spendingAddress =
+      SpendingAddress(TypedEvidence(evidenceBytes.head, Sized.strictUnsafe(evidenceBytes.tail)))
 
-    val encodedAddress = dionAddressEncoder(dionAddress)
+    val encodedAddress = spendingAddressEncoder(spendingAddress)
 
     encodedAddress.noSpaces shouldBe expectedAddressString
   }
@@ -38,7 +37,7 @@ class DionAddressJsonCodecSpec extends AnyFlatSpec with Matchers {
     val addressJson = "AUAJSGFeLjJuE2ThYdXxXvRaJecRzPjmHzegvEgtoyURQ2zmUQav"
 
     val decodedAddressResult =
-      dionAddressDecoder
+      spendingAddressDecoder
         .decodeJson(addressJson.asJson)
 
     val decodedAddressValue = decodedAddressResult.valueOr(error => throw new Exception(error))
@@ -53,8 +52,7 @@ class DionAddressJsonCodecSpec extends AnyFlatSpec with Matchers {
     val addressJson = "AUAJSGFeLjJuE2ThYdXxXvRaJecRzPjmHzegvEgtoyURQ2zmUQav"
 
     val decodedAddressResult =
-      dionAddressDecoder(NetworkPrefix(100))
-        .decodeJson(addressJson.asJson)
+      spendingAddressDecoder.decodeJson(addressJson.asJson)
 
     decodedAddressResult shouldBe Left(
       DecodingFailure("incorrect network prefix", Nil)

--- a/numerics/src/main/scala/co/topl/numerics/Log1pInterpreter.scala
+++ b/numerics/src/main/scala/co/topl/numerics/Log1pInterpreter.scala
@@ -15,7 +15,9 @@ object Log1pInterpreter extends LentzMethod {
   }.pure[F]
 
   def makeCached[F[_]: Sync: Clock](log1p: Log1p[F]): F[Log1p[F]] =
-    CaffeineCache[F, Ratio].map(cache => (x: Ratio) => cache.cachingF(x)(ttl = None)(Sync[F].defer(log1p.evaluate(x))))
+    CaffeineCache[F, Ratio, Ratio].map(cache =>
+      (x: Ratio) => cache.cachingF(x)(ttl = None)(Sync[F].defer(log1p.evaluate(x)))
+    )
 
   /**
    * Returns the natural logarithm of the argument plus one

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -127,7 +127,7 @@ object Dependencies {
   )
 
   val scalacache = Seq(
-    "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M4"
+    "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M6"
   )
 
   val simulacrum = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ Seq(
   "org.scalameta"           % "sbt-scalafmt"              % "2.4.6",
   "ch.epfl.scala"           % "sbt-scalafix"              % "0.10.1",
   "org.wartremover"         % "sbt-wartremover"           % "3.0.5",
-  "com.github.sbt"          % "sbt-native-packager"       % "1.9.10",
+  "com.github.sbt"          % "sbt-native-packager"       % "1.9.11",
   "com.eed3si9n"            % "sbt-buildinfo"             % "0.11.0",
   "com.github.sbt"          % "sbt-ci-release"            % "1.5.10",
   "net.bzzt"                % "sbt-reproducible-builds"   % "0.30",

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
@@ -519,7 +519,26 @@ trait TransactionRpcParamsDecoders extends SharedCodecs {
   implicit def transactionRawPolyTransferParamsDecoder(implicit
     networkPrefix: NetworkPrefix
   ): Decoder[ToplRpc.Transaction.RawPolyTransfer.Params] =
-    deriveDecoder
+    cursor =>
+      for {
+        propositionType <- cursor.downField("propositionType").as[String]
+        sender          <- cursor.downField("sender").as[NonEmptyChain[Address]]
+        recipients      <- cursor.downField("recipients").as[NonEmptyChain[(Address, Int128)]]
+        fee             <- cursor.downField("fee").as[Int128]
+        changeAddress   <- cursor.downField("changeAddress").as[Address]
+        data            <- cursor.downField("data").as[Option[Latin1Data]]
+        boxSelectionAlgorithm <- cursor.getOrElse("boxSelectionAlgorithm")(
+          BoxSelectionAlgorithms.All: BoxSelectionAlgorithm // default to BoxSelectionAlgorithms.All
+        )
+      } yield ToplRpc.Transaction.RawPolyTransfer.Params(
+        propositionType,
+        sender,
+        recipients,
+        fee,
+        changeAddress,
+        data,
+        boxSelectionAlgorithm
+      )
 
   implicit def transactionUnprovenPolyTransferParamsDecoder(implicit
     networkPrefix: NetworkPrefix


### PR DESCRIPTION
## Purpose
- Merges `dev` + https://github.com/Topl/Bifrost/pull/2481 into `tetra`
- scalacache is a library for caching within an effect context
- scalacache 1.0.0-M6 introduces a backwards incompatible change which allows CaffeineCache to specify a Key type
  - (This is a really helpful change because previously, the keys needed to be converted to strings which is inefficient)
## Approach
- Update scalacache dependency
- Update usages of CaffeineCache.apply to specify a key type
- In cases which used TypedIdentifier as the key type, the type was changed to just `Bytes` due to an issue with TypedBytes being an `@newtype` which does not work as a key
## Testing
- N/A
## Tickets
#2419 