### PR TITLE
Use Headless Service for Bifrost for direct pod communication (for peer to peer)

### DIFF
--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -20,8 +20,6 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.name }}:{{ .Values.image.tag }}

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         {{- include "bifrost.selectorLabels" . | nindent 8 }}
     spec:
       automountServiceAccountToken: false
+      setHostnameAsFQDN: true
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       subdomain: {{ include "bifrost.fullname" . }}-p2p

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      subdomain: sd        
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.name }}:{{ .Values.image.tag }}

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: {{ .Chart.Name }}

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -58,10 +58,6 @@ spec:
         volumeMounts:
         - name: {{ .Values.name }}-pv
           mountPath: {{ .Values.volume.mountDirectory }}
-        {{- if .Values.config.enabled }}
-        - name: {{ .Values.name }}-custom-config
-          mountpath: 
-        {{- end }}
 
   volumeClaimTemplates:
   - metadata:

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "bifrost.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ include "bifrost.fullname" . }}
+  serviceName: {{ include "bifrost.fullname" . }}-p2p
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -18,10 +18,8 @@ spec:
         {{- include "bifrost.selectorLabels" . | nindent 8 }}
     spec:
       automountServiceAccountToken: false
-      setHostnameAsFQDN: true
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      subdomain: {{ include "bifrost.fullname" . }}-p2p
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.name }}:{{ .Values.image.tag }}

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      subdomain: sd        
+      subdomain: {{ include "bifrost.fullname" . }}-p2p
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.name }}:{{ .Values.image.tag }}

--- a/helm/bifrost/templates/bifrost/deployment.yaml
+++ b/helm/bifrost/templates/bifrost/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.name }}:{{ .Values.image.tag }}
@@ -57,6 +58,11 @@ spec:
         volumeMounts:
         - name: {{ .Values.name }}-pv
           mountPath: {{ .Values.volume.mountDirectory }}
+        {{- if .Values.config.enabled }}
+        - name: {{ .Values.name }}-custom-config
+          mountpath: 
+        {{- end }}
+
   volumeClaimTemplates:
   - metadata:
       name: {{ .Values.name }}-pv

--- a/helm/bifrost/templates/bifrost/service.yaml
+++ b/helm/bifrost/templates/bifrost/service.yaml
@@ -18,13 +18,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "bifrost.fullname" . }}-p2p-headless
+  name: {{ include "bifrost.fullname" . }}-p2p
   labels:
     {{- include "bifrost.labels" . | nindent 4}}
 spec:
   selector:
     {{- include "bifrost.selectorLabels" . | nindent 4 }}
   clusterIP: None
+  type: NodePort
   ports:
     - protocol: TCP
       name: p2p

--- a/helm/bifrost/templates/bifrost/service.yaml
+++ b/helm/bifrost/templates/bifrost/service.yaml
@@ -25,7 +25,6 @@ spec:
   selector:
     {{- include "bifrost.selectorLabels" . | nindent 4 }}
   clusterIP: None
-  type: NodePort
   ports:
     - protocol: TCP
       name: p2p

--- a/helm/bifrost/templates/bifrost/service.yaml
+++ b/helm/bifrost/templates/bifrost/service.yaml
@@ -11,11 +11,23 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - protocol: TCP
-      name: p2p
-      port: {{ .Values.service.ports.p2p }}
-      targetPort: {{ .Values.ports.p2p }}
-    - protocol: TCP
       name: rpc
       port: {{ .Values.service.ports.rpc }}
       targetPort: {{ .Values.ports.rpc }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bifrost.fullname" . }}-p2p-headless
+  labels:
+    {{- include "bifrost.labels" . | nindent 4}}
+spec:
+  selector:
+    {{- include "bifrost.selectorLabels" . | nindent 4 }}
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      name: p2p
+      port: {{ .Values.service.ports.p2p }}
+      targetPort: {{ .Values.ports.p2p }}
 {{- end }}


### PR DESCRIPTION
## Purpose
To enable p2p networking for our Bifrost, also expose the application using a [headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services).

## Approach
Create an additional service in Helm, use that to route p2p traffic, and keep the existing RPC service.

## Testing
Deployed with ArgoCD. Made sure passing `knownPeers` on the CLI worked (logs showed peers communicating).
Ensured RPC traffic worked via Postman.
