### PR TITLE
Transaction Schedule Non-Negative Minimum Slot

### DIFF
--- a/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSyntaxValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSyntaxValidation.scala
@@ -79,7 +79,8 @@ object TransactionSyntaxValidation {
     transaction: Transaction
   ): ValidatedNec[TransactionSyntaxError, Unit] =
     Validated.condNec(
-      transaction.schedule.maximumSlot >= transaction.schedule.minimumSlot && transaction.schedule.maximumSlot >= 0,
+      transaction.schedule.maximumSlot >= transaction.schedule.minimumSlot &&
+      transaction.schedule.minimumSlot >= 0,
       (),
       TransactionSyntaxErrors.InvalidSchedule(transaction.schedule)
     )

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSyntaxValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSyntaxValidationSpec.scala
@@ -82,12 +82,17 @@ class TransactionSyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEff
       val invalidTransaction1 = transaction.copy(schedule = transaction.schedule.copy(minimumSlot = 5, maximumSlot = 4))
       val invalidTransaction2 =
         transaction.copy(schedule = transaction.schedule.copy(minimumSlot = -5, maximumSlot = -1))
+      val invalidTransaction3 =
+        transaction.copy(schedule = transaction.schedule.copy(minimumSlot = -1, maximumSlot = 0))
+      val invalidTransaction4 =
+        transaction.copy(schedule = transaction.schedule.copy(minimumSlot = -1, maximumSlot = 1))
       for {
         underTest <- TransactionSyntaxValidation.make[F]
-        _ <- List(invalidTransaction1, invalidTransaction2).traverse(transaction =>
-          EitherT(underTest.validate(transaction).map(_.toEither)).swap
-            .exists(_.toList.contains(TransactionSyntaxErrors.InvalidSchedule(transaction.schedule)))
-            .assert
+        _ <- List(invalidTransaction1, invalidTransaction2, invalidTransaction3, invalidTransaction4).traverse(
+          transaction =>
+            EitherT(underTest.validate(transaction).map(_.toEither)).swap
+              .exists(_.toList.contains(TransactionSyntaxErrors.InvalidSchedule(transaction.schedule)))
+              .assert
         )
       } yield ()
     }

--- a/node/src/it/resources/Dockerfile
+++ b/node/src/it/resources/Dockerfile
@@ -20,8 +20,8 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /
       apt -y update && DEBIAN_FRONTEND=noninteractive apt -y install docker-ce docker-ce-cli containerd.io
 
 # JDK Install
-RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add - \
-    && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list \
+RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add - \
+    && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
     && apt update \
     && apt install temurin-11-jdk
 


### PR DESCRIPTION
## Purpose
- Slots can never practically be non-negative in the protocol
- Users should not use negative slots when declaring transaction schedule bounds
## Approach
- Verify Transaction.schedule.minimumSlot >= 0
## Testing
- Update unit test to verify non-negative schedules
## Tickets
#2473 