### PR TITLE
Update slf4j and logback

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,15 +10,16 @@ object Dependencies {
   val simulacrumVersion = "1.0.1"
   val catsCoreVersion = "2.8.0"
   val catsEffectVersion = "3.3.14"
+  val logback = "1.3.3"
 
   val catsSlf4j =
     "org.typelevel" %% "log4cats-slf4j" % "2.4.0"
 
   val logging = Seq(
     "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.5",
-    "ch.qos.logback"              % "logback-classic" % "1.2.11",
-    "ch.qos.logback"              % "logback-core"    % "1.2.11",
-    "org.slf4j"                   % "slf4j-api"       % "1.7.36",
+    "ch.qos.logback"              % "logback-classic" % logback,
+    "ch.qos.logback"              % "logback-core"    % logback,
+    "org.slf4j"                   % "slf4j-api"       % "2.0.0",
     catsSlf4j
   )
 


### PR DESCRIPTION
## Purpose

scala-steward bot is not able to perform slf4j-api upgrade "1.7.36" -> "2.0.0". 

>  java.lang.IllegalArgumentException: Requires Logback logger for [], it was a [org.slf4j.helpers.NOPLogger] 

details https://github.com/Topl/Bifrost/pull/2439

## Approach

upgrade slf4j, and logback. 

## Testing

local unit test

```
[info] Run completed in 3 minutes, 7 seconds.
[info] Total number of tests run: 363
[info] Suites: completed 63, aborted 0
[info] Tests: succeeded 363, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```


## Tickets
*  TODO

