### PR TITLE
BlockIdAtDepth RPC

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
@@ -17,4 +17,6 @@ trait ToplRpc[F[_]] {
   def fetchTransaction(transactionId: TypedIdentifier): F[Option[Transaction]]
 
   def blockIdAtHeight(height: Long): F[Option[TypedIdentifier]]
+
+  def blockIdAtDepth(depth: Long): F[Option[TypedIdentifier]]
 }

--- a/blockchain/src/test/scala/co/topl/blockchain/ToplRpcServerSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/ToplRpcServerSpec.scala
@@ -1,0 +1,166 @@
+package co.topl.blockchain
+
+import cats.effect.IO
+import cats.implicits._
+import co.topl.algebras.Store
+import co.topl.catsakka._
+import co.topl.consensus.algebras.LocalChainAlgebra
+import co.topl.eventtree.EventSourcedState
+import co.topl.ledger.algebras.{MempoolAlgebra, TransactionSyntaxValidationAlgebra}
+import co.topl.models.ModelGenerators._
+import co.topl.models.{BlockBodyV2, BlockHeaderV2, SlotData, Transaction, TypedIdentifier}
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF
+import org.scalamock.munit.AsyncMockFactory
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+class ToplRpcServerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+
+  implicit private val logger: Logger[F] =
+    Slf4jLogger.getLoggerFromClass[F](this.getClass)
+
+  type F[A] = IO[A]
+
+  test("Fetch Block ID At Height") {
+    PropF.forAllF { (_canonicalHead: SlotData, targetBlockId: TypedIdentifier) =>
+      val canonicalHead = _canonicalHead.copy(height = 10)
+      // Test where requested height is less than canonical head height
+      withMock {
+        for {
+          localChain <- mock[LocalChainAlgebra[F]].pure[F]
+          _ = (() => localChain.head).expects().once().returning(canonicalHead.pure[F])
+          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]]]]
+          _ = (blockHeights
+            .useStateAt[Option[TypedIdentifier]](_: TypedIdentifier)(
+              _: (Long => F[Option[TypedIdentifier]]) => F[Option[TypedIdentifier]]
+            ))
+            .expects(canonicalHead.slotId.blockId, *)
+            .once()
+            .onCall { case (_, _) =>
+              targetBlockId.some.pure[F]
+            }
+          underTest <- createServer(localChain = localChain, blockHeights = blockHeights)
+          _         <- underTest.blockIdAtHeight(canonicalHead.height - 1).assertEquals(targetBlockId.some)
+        } yield ()
+      } >>
+      // Test where requested height equals canonical head height
+      withMock {
+        for {
+          localChain <- mock[LocalChainAlgebra[F]].pure[F]
+          _ = (() => localChain.head).expects().once().returning(canonicalHead.pure[F])
+          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]]]]
+          underTest <- ToplRpcServer.make[F](
+            mock[Store[F, TypedIdentifier, BlockHeaderV2]],
+            mock[Store[F, TypedIdentifier, BlockBodyV2]],
+            mock[Store[F, TypedIdentifier, Transaction]],
+            mock[MempoolAlgebra[F]],
+            mock[TransactionSyntaxValidationAlgebra[F]],
+            localChain,
+            blockHeights
+          )
+          _ <- underTest.blockIdAtHeight(canonicalHead.height).assertEquals(canonicalHead.slotId.blockId.some)
+        } yield ()
+      } >>
+      // Test where requested height is greater than canonical head height
+      withMock {
+        for {
+          localChain <- mock[LocalChainAlgebra[F]].pure[F]
+          _ = (() => localChain.head).expects().once().returning(canonicalHead.pure[F])
+          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]]]]
+          underTest <- ToplRpcServer.make[F](
+            mock[Store[F, TypedIdentifier, BlockHeaderV2]],
+            mock[Store[F, TypedIdentifier, BlockBodyV2]],
+            mock[Store[F, TypedIdentifier, Transaction]],
+            mock[MempoolAlgebra[F]],
+            mock[TransactionSyntaxValidationAlgebra[F]],
+            localChain,
+            blockHeights
+          )
+          _ <- underTest.blockIdAtHeight(canonicalHead.height + 1).assertEquals(None)
+        } yield ()
+      } >>
+      // Test where requested height is invalid
+      withMock {
+        for {
+          localChain <- mock[LocalChainAlgebra[F]].pure[F]
+          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]]]]
+          underTest <- ToplRpcServer.make[F](
+            mock[Store[F, TypedIdentifier, BlockHeaderV2]],
+            mock[Store[F, TypedIdentifier, BlockBodyV2]],
+            mock[Store[F, TypedIdentifier, Transaction]],
+            mock[MempoolAlgebra[F]],
+            mock[TransactionSyntaxValidationAlgebra[F]],
+            localChain,
+            blockHeights
+          )
+          _ <- interceptIO[IllegalArgumentException](underTest.blockIdAtHeight(0))
+          _ <- interceptIO[IllegalArgumentException](underTest.blockIdAtHeight(-1))
+        } yield ()
+      }
+    }
+  }
+
+  test("Fetch Block ID At Depth") {
+    PropF.forAllF { (_canonicalHead: SlotData, targetBlockId: TypedIdentifier) =>
+      val canonicalHead = _canonicalHead.copy(height = 10)
+      // Test where requested depth is greater than 0 but less than chain height
+      withMock {
+        for {
+          localChain <- mock[LocalChainAlgebra[F]].pure[F]
+          _ = (() => localChain.head).expects().once().returning(canonicalHead.pure[F])
+          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]]]]
+          _ = (blockHeights
+            .useStateAt[Option[TypedIdentifier]](_: TypedIdentifier)(
+              _: (Long => F[Option[TypedIdentifier]]) => F[Option[TypedIdentifier]]
+            ))
+            .expects(canonicalHead.slotId.blockId, *)
+            .once()
+            .onCall { case (_, _) =>
+              targetBlockId.some.pure[F]
+            }
+          underTest <- createServer(localChain = localChain, blockHeights = blockHeights)
+          _         <- underTest.blockIdAtDepth(1).assertEquals(targetBlockId.some)
+        } yield ()
+      } >>
+      // Test where requested depth is 0
+      withMock {
+        for {
+          localChain <- mock[LocalChainAlgebra[F]].pure[F]
+          _ = (() => localChain.head).expects().once().returning(canonicalHead.pure[F])
+          underTest <- createServer(localChain = localChain)
+          _         <- underTest.blockIdAtDepth(0).assertEquals(canonicalHead.slotId.blockId.some)
+        } yield ()
+      } >>
+      // Test where requested depth is greater than chain height
+      withMock {
+        for {
+          localChain <- mock[LocalChainAlgebra[F]].pure[F]
+          _ = (() => localChain.head).expects().once().returning(canonicalHead.pure[F])
+          underTest <- createServer(localChain = localChain)
+          _         <- underTest.blockIdAtDepth(canonicalHead.height + 1).assertEquals(None)
+        } yield ()
+      } >>
+      // Test where requested depth is invalid
+      withMock {
+        for {
+          underTest <- createServer()
+          _         <- interceptIO[IllegalArgumentException](underTest.blockIdAtDepth(-1))
+        } yield ()
+      }
+    }
+  }
+
+  private def createServer(
+    headerStore:         Store[F, TypedIdentifier, BlockHeaderV2] = mock[Store[F, TypedIdentifier, BlockHeaderV2]],
+    bodyStore:           Store[F, TypedIdentifier, BlockBodyV2] = mock[Store[F, TypedIdentifier, BlockBodyV2]],
+    transactionStore:    Store[F, TypedIdentifier, Transaction] = mock[Store[F, TypedIdentifier, Transaction]],
+    mempool:             MempoolAlgebra[F] = mock[MempoolAlgebra[F]],
+    syntacticValidation: TransactionSyntaxValidationAlgebra[F] = mock[TransactionSyntaxValidationAlgebra[F]],
+    localChain:          LocalChainAlgebra[F] = mock[LocalChainAlgebra[F]],
+    blockHeights: EventSourcedState[F, Long => F[Option[TypedIdentifier]]] =
+      mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]]]]
+  ) =
+    ToplRpcServer
+      .make[F](headerStore, bodyStore, transactionStore, mempool, syntacticValidation, localChain, blockHeights)
+}

--- a/topl-grpc/src/main/protobuf/topl_grpc.proto
+++ b/topl-grpc/src/main/protobuf/topl_grpc.proto
@@ -7,57 +7,101 @@ import 'models/block.proto';
 import 'models/transaction.proto';
 
 service ToplGrpc {
+  // Submit a proven Transaction to the node
   rpc BroadcastTransaction (BroadcastTransactionReq) returns (BroadcastTransactionRes);
+  // Read the contents of the node's mempool
   rpc CurrentMempool (CurrentMempoolReq) returns (CurrentMempoolRes);
 
+  // retrieve a Block Header by its ID
   rpc FetchBlockHeader (FetchBlockHeaderReq) returns (FetchBlockHeaderRes);
+
+  // retrieve a Block Body by its ID
   rpc FetchBlockBody (FetchBlockBodyReq) returns (FetchBlockBodyRes);
+
+  // retrieve a Transaction by its ID
   rpc FetchTransaction (FetchTransactionReq) returns (FetchTransactionRes);
 
+  // retrieve the Block ID associated with a height, according to the node's canonical chain
   rpc FetchBlockIdAtHeight (FetchBlockIdAtHeightReq) returns (FetchBlockIdAtHeightRes);
+
+  // retrieve the Block ID associated with a depth, according to the node's canonical chain
+  rpc FetchBlockIdAtDepth (FetchBlockIdAtDepthReq) returns (FetchBlockIdAtDepthRes);
 
 }
 
+// Request type for BroadcastTransaction
 message BroadcastTransactionReq {
+  // A "proven" Transaction that is meant to be included in the blockchain
   co.topl.grpc.models.Transaction transaction = 1;
 }
 
+// Response type for BroadcastTransaction
 message BroadcastTransactionRes {}
 
+// Request type for CurrentMempool
 message CurrentMempoolReq {}
 
+// Response type for CurrentMempool
 message CurrentMempoolRes {
+  // A list of Transaction IDs that are currently in the node's mempool
   repeated co.topl.grpc.models.TransactionId transactionIds = 1;
 }
 
+// Request type for FetchBlockHeader
 message FetchBlockHeaderReq {
+  // The ID of the block to retrieve
   co.topl.grpc.models.BlockId blockId = 1;
 }
 
+// Response type for FetchBlockHeader
 message FetchBlockHeaderRes {
-  co.topl.grpc.models.BlockHeader header = 1;
+  // The Block Header associated with the requested ID.  None/null if not found.
+  optional co.topl.grpc.models.BlockHeader header = 1;
 }
 
+// Request type for FetchBlockBody
 message FetchBlockBodyReq {
+  // The ID of the block to retrieve
   co.topl.grpc.models.BlockId blockId = 1;
 }
 
+// Response type for FetchBlockBody
 message FetchBlockBodyRes {
-  co.topl.grpc.models.BlockBody body = 1;
+  // The Block Body associated with the requested ID.  None/null if not found.
+  optional co.topl.grpc.models.BlockBody body = 1;
 }
 
+// Request type for FetchTransaction
 message FetchTransactionReq {
   co.topl.grpc.models.TransactionId transactionId = 1;
 }
 
+// Response type for FetchTransaction
 message FetchTransactionRes {
-  co.topl.grpc.models.Transaction transaction = 1;
+  // The Transaction associated with the requested ID.  None/null if not found.
+  optional co.topl.grpc.models.Transaction transaction = 1;
 }
 
+// Request type for FetchBlockIdAtHeight
 message FetchBlockIdAtHeightReq {
-  int64 height = 1;
+  // The height of interest
+  uint64 height = 1;
 }
 
+// Response type for FetchBlockIdAtHeight
 message FetchBlockIdAtHeightRes {
-  co.topl.grpc.models.BlockId blockId = 1;
+  // The Block ID associated with the requested height.  None/null if not found.
+  optional co.topl.grpc.models.BlockId blockId = 1;
+}
+
+// Request type for FetchBlockIdAtDepth
+message FetchBlockIdAtDepthReq {
+  // The depth of interest.  When depth=0, the canonical head is retrieved.
+  uint64 depth = 1;
+}
+
+// Response type for FetchBlockIdAtDepth
+message FetchBlockIdAtDepthRes {
+  // The Block ID associated with the requested depth.  None/null if not found.
+  optional co.topl.grpc.models.BlockId blockId = 1;
 }


### PR DESCRIPTION
## Purpose
- Introduces an RPC which retrieves the block ID associated with a requested depth along the node's canonical chain
  - When depth is 0, the RPC acts as a "FetchCanonicalHead" RPC
## Approach
- Add new RPC to proto definition
- Add new method to ToplRpc algebra
- Interpret the RPC in ToplRpcServer and ToplGrpc
## Testing
- Unit tests for ToplRpcServer
## Tickets
- #2325 