### PR TITLE
CORE - BN-666 - avoid warning in pattern matching

### DIFF
--- a/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
+++ b/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
@@ -286,10 +286,10 @@ trait ModelsJsonCodecs {
         "args"      -> io.circe.parser.parse(serializedArgs).getOrElse(serializedArgs.asJson)
       )
     case _ =>
-
       /**
        * It would fail on the following inputs: HashLock(_, _), KesProduct(_, _, _), KesSum(_, _, _), Not(_), RequiredBoxState(), VrfEd25519(_)
-       * TODO: ask if raising an error here is fine, never happen, or should we define specific encoders for the above items
+       * It may lead to odd behavior for users who hit this when decoding,
+       * but only Dion users would hit this, and these Propositions aren't supported in Dion anyway.
        */
       Json.Null
   }

--- a/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
+++ b/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
@@ -285,6 +285,13 @@ trait ModelsJsonCodecs {
         "proofType" -> "Script.JS".asJson,
         "args"      -> io.circe.parser.parse(serializedArgs).getOrElse(serializedArgs.asJson)
       )
+    case _ =>
+
+      /**
+       * It would fail on the following inputs: HashLock(_, _), KesProduct(_, _, _), KesSum(_, _, _), Not(_), RequiredBoxState(), VrfEd25519(_)
+       * TODO: ask if raising an error here is fine, never happen, or should we define specific encoders for the above items
+       */
+      Json.Null
   }
 
   implicit val proofsKnowledgeCurve25519Decoder: Decoder[Proofs.Knowledge.Curve25519] = deriveDecoder


### PR DESCRIPTION
## Purpose
Avoid warning
> It would fail on the following inputs: HashLock(_, _), KesProduct(_, _, _), KesSum(_, _, _), Not(_), RequiredBoxState(), VrfEd25519(_)

## Approach
add last branch or pattern matching with Json.null

## Testing

unit test
## Tickets
BN-666 
