### PR TITLE
Network Delayer Application

### DIFF
--- a/brambl/src/main/scala/co/topl/client/BramblTetra.scala
+++ b/brambl/src/main/scala/co/topl/client/BramblTetra.scala
@@ -10,6 +10,7 @@ import cats.implicits._
 import co.topl.catsakka._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
+import co.topl.common.application.IOAkkaApp
 import co.topl.grpc.ToplGrpc
 import co.topl.models._
 import co.topl.models.utility.HasLength.instances.bytesLength

--- a/brambl/src/main/scala/co/topl/client/BramblTetra.scala
+++ b/brambl/src/main/scala/co/topl/client/BramblTetra.scala
@@ -86,14 +86,14 @@ object BramblTetra
         ),
         outputs = Chain(
           Transaction.Output(
-            address(Propositions.Contextual.HeightLock(20L)),
+            address(Propositions.Contextual.HeightLock(1L)),
             Box.Values.Poly(10000L),
             minting = false
           )
         ),
-        schedule = Transaction.Schedule(System.currentTimeMillis(), 0L, Long.MaxValue),
+        schedule = Transaction.Schedule(System.currentTimeMillis(), 1L, Long.MaxValue),
         data = none
-      ).some.map(transaction => (transaction, Propositions.Contextual.HeightLock(20L), 0: Short) -> transaction)
+      ).some.map(transaction => (transaction, Propositions.Contextual.HeightLock(0L), 0: Short) -> transaction)
     }
 
   private def address(proposition: Proposition) =

--- a/brambl/src/main/scala/co/topl/client/BramblTetraMempoolReader.scala
+++ b/brambl/src/main/scala/co/topl/client/BramblTetraMempoolReader.scala
@@ -5,7 +5,7 @@ import akka.actor.typed.scaladsl.Behaviors
 import cats.effect.{Async, IO, Sync}
 import cats.implicits._
 import co.topl.algebras.ToplRpc
-import co.topl.catsakka._
+import co.topl.common.application.IOAkkaApp
 import co.topl.grpc.ToplGrpc
 import co.topl.typeclasses.implicits._
 import com.typesafe.config.ConfigFactory

--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,11 @@ lazy val dionNodeDockerSettings =
     Docker / packageName := "bifrost-node"
   )
 
+lazy val networkDelayerDockerSettings =
+  dockerSettings ++ Seq(
+    Docker / packageName := "network-delayer"
+  )
+
 def assemblySettings(main: String) = Seq(
   assembly / mainClass := Some(main),
   assembly / test := {},
@@ -232,7 +237,9 @@ lazy val bifrost = project
     tools,
     scripting,
     genus,
-    levelDbStore
+    levelDbStore,
+    commonApplication,
+    networkDelayer
   )
 
 lazy val node = project
@@ -288,10 +295,35 @@ lazy val nodeTetra = project
     catsAkka,
     toplGrpc,
     blockchain,
-    levelDbStore
+    levelDbStore,
+    commonApplication
   )
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, DockerPlugin)
   .settings(scalamacrosParadiseSettings)
+
+lazy val networkDelayer = project
+  .in(file("network-delayer"))
+  .settings(
+    name := "network-delayer",
+    commonSettings,
+    assemblySettings("co.topl.networkdelayer.NetworkDelayer"),
+    assemblyJarName := s"network-delayer-${version.value}.jar",
+    networkDelayerDockerSettings,
+    Defaults.itSettings,
+    crossScalaVersions := Seq(scala213),
+    Compile / mainClass := Some("co.topl.networkdelayer.NetworkDelayer"),
+    publish / skip := true,
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoPackage := "co.topl.buildinfo.networkdelayer",
+    libraryDependencies ++= Dependencies.networkDelayer
+  )
+  .configs(IntegrationTest)
+  .settings(
+    IntegrationTest / parallelExecution := false
+  )
+  .enablePlugins(BuildInfoPlugin, JavaAppPackaging, DockerPlugin)
+  .settings(scalamacrosParadiseSettings)
+  .dependsOn(catsAkka, commonApplication)
 
 lazy val common = project
   .in(file("common"))
@@ -302,6 +334,17 @@ lazy val common = project
     libraryDependencies ++= Dependencies.common
   )
   .dependsOn(crypto, typeclasses, models % "compile->compile;test->test")
+  .settings(scalamacrosParadiseSettings)
+
+lazy val commonApplication = project
+  .in(file("common-application"))
+  .settings(
+    name := "common-application",
+    commonSettings,
+    publishSettings,
+    libraryDependencies ++= Dependencies.commonApplication
+  )
+  .dependsOn(catsAkka)
   .settings(scalamacrosParadiseSettings)
 
 //lazy val chainProgram = project
@@ -327,7 +370,16 @@ lazy val brambl = project
     buildInfoPackage := "co.topl.buildinfo.brambl"
   )
   .settings(scalamacrosParadiseSettings)
-  .dependsOn(toplRpc, common, typeclasses, models % "compile->compile;test->test", scripting, tetraByteCodecs, toplGrpc)
+  .dependsOn(
+    toplRpc,
+    common,
+    typeclasses,
+    models % "compile->compile;test->test",
+    scripting,
+    tetraByteCodecs,
+    toplGrpc,
+    commonApplication
+  )
 
 lazy val akkaHttpRpc = project
   .in(file("akka-http-rpc"))

--- a/common-application/src/main/scala/co/topl/common/application/IOBaseApp.scala
+++ b/common-application/src/main/scala/co/topl/common/application/IOBaseApp.scala
@@ -1,0 +1,118 @@
+package co.topl.common.application
+
+import cats.data.Chain
+import cats.effect._
+import cats.effect.unsafe.IORuntime
+import cats.implicits._
+import cats.kernel.Monoid
+import com.typesafe.config.{Config, ConfigFactory}
+import pureconfig.{ConfigObjectSource, ConfigSource}
+
+import java.nio.file.Paths
+
+/**
+ * Assists with constructing applications which use both cats-effect and akka.  Constructs an
+ * ActorSystem that will be installed as the cats-effect runtime.  Then runs the defined
+ * IO program before cleaning up.
+ * @param createArgs a function which turns stringified command-line args into a structured type
+ * @param createConfig a function which creates a HOCON config using the parsed command-line args
+ * @param createSystem a function which creates an ActorSystem using the parsed args and config
+ * @tparam CmdArgs a type representing the arguments of your program
+ * @tparam Guardian the actor type of the guardian actor
+ */
+abstract class IOBaseApp[CmdArgs, AppConfig](
+  createArgs:   List[String] => CmdArgs,
+  createConfig: CmdArgs => Config,
+  parseConfig:  (CmdArgs, Config) => AppConfig
+) {
+
+  type F[A] = IO[A]
+
+  protected[application] var _args: CmdArgs = _
+  protected[application] var _config: Config = _
+  protected[application] var _appConfig: AppConfig = _
+  protected[application] var _ioApp: IOApp = _
+  protected[application] var _ioRuntime: IORuntime = _
+
+  implicit def args: CmdArgs = _args
+  implicit def appConfig: AppConfig = _appConfig
+  implicit def config: Config = _config
+
+  def run: IO[Unit]
+
+  protected def initRuntime(): Unit =
+    _ioRuntime = cats.effect.unsafe.IORuntime.global
+
+  final def main(args: Array[String]): Unit = {
+    _args = createArgs(args.toList)
+    _config = createConfig(_args)
+    _appConfig = parseConfig(_args, _config)
+    initRuntime()
+    _ioApp = new IOApp {
+      override protected val runtime: IORuntime = _ioRuntime
+      def run(args: List[String]): IO[ExitCode] =
+        IOBaseApp.this.run.as(ExitCode.Success)
+    }
+    _ioApp.main(Array.empty)
+  }
+}
+
+object IOBaseApp {
+
+  implicit private val monoidConfig: Monoid[Config] =
+    Monoid.instance(ConfigFactory.empty(), _ withFallback _)
+
+  def createTypesafeConfig[Args: ContainsUserConfigs: ContainsDebugFlag](cmdArgs: Args): Config =
+    (
+      argsToDebugConfigs(cmdArgs) ++
+        Chain(ConfigSource.resources("environment.conf")) ++
+        argsToUserConfigs(cmdArgs) ++
+        Chain(
+          ConfigSource.default
+        )
+    ).foldMapM(_.config()) match {
+      case Right(value) => value.resolve()
+      case Left(e)      => throw new IllegalStateException(e.toString)
+    }
+
+  /**
+   * Allow the --debug argument to enable the `CONFIG_FORCE_` environment variable syntax from Typesafe Config
+   */
+  private def argsToDebugConfigs[Args: ContainsDebugFlag](args: Args): Chain[ConfigObjectSource] =
+    Chain.fromOption(
+      Option.when(ContainsDebugFlag[Args].debugFlagOf(args))(
+        ConfigSource.fromConfig(ConfigFactory.systemEnvironmentOverrides())
+      )
+    )
+
+  /**
+   * Load user-defined configuration files from disk/resources
+   */
+  private def argsToUserConfigs[Args: ContainsUserConfigs](args: Args): Chain[ConfigObjectSource] =
+    Chain
+      .fromSeq(ContainsUserConfigs[Args].userConfigsOf(args).reverse)
+      .map(name =>
+        if (name.startsWith("resource://")) {
+          if (name.endsWith(".yaml") || name.endsWith(".yml"))
+            ConfigSource.fromConfig(YamlConfig.loadResource(name))
+          else
+            ConfigSource.resources(name)
+        } else {
+          val path = Paths.get(name)
+          if (name.endsWith(".yaml") || name.endsWith(".yml"))
+            ConfigSource.fromConfig(YamlConfig.load(path))
+          else
+            ConfigSource.file(path)
+        }
+      )
+}
+
+@simulacrum.typeclass
+trait ContainsUserConfigs[Args] {
+  def userConfigsOf(args: Args): List[String]
+}
+
+@simulacrum.typeclass
+trait ContainsDebugFlag[Args] {
+  def debugFlagOf(args: Args): Boolean
+}

--- a/common-application/src/main/scala/co/topl/common/application/YamlConfig.scala
+++ b/common-application/src/main/scala/co/topl/common/application/YamlConfig.scala
@@ -1,4 +1,4 @@
-package co.topl.node
+package co.topl.common.application
 
 import com.typesafe.config.{Config, ConfigFactory}
 

--- a/consensus/src/main/scala/co/topl/consensus/algebras/LocalChainAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/LocalChainAlgebra.scala
@@ -9,7 +9,7 @@ import co.topl.models.SlotData
 trait LocalChainAlgebra[F[_]] {
 
   /**
-   * Indicates if the provided "head" results in a better chain than the current local chain.
+   * Indicates if the provided "newHead" results in a better chain than the current local chain.
    *
    * The `newHead` _can_ be invalid.  (For example, the block needs to have the proper syntax,
    * but it may not necessarily need to be validated for consensus and ledger purposes)

--- a/network-delayer/src/main/resources/example.conf
+++ b/network-delayer/src/main/resources/example.conf
@@ -1,0 +1,29 @@
+// Define a list of routes/pipes.  Each defined route will bind to a local port and forward incoming
+// connections to the destination.
+routes = [
+  {
+    // The local host which receives inbound connections
+    bindHost = 0.0.0.0
+    // The local port which receives inbound connections
+    bindPort = 9001
+    // The destination host to which all traffic will be forwarded
+    destinationHost = 192.168.1.5
+    // The destination port to which all traffic will be forwarded
+    destinationPort = 9005
+    // An _optional_ throttling configuration to impose on this route
+    throttle = {
+      // The number of milliseconds to delay each byte
+      latency = 30 milli
+      // The maximum number of bytes that can be downloaded within a second
+      downloadBytesPerSecond = 500000
+      // The maximum number of bytes that can be uploaded within a second
+      uploadBytesPerSecond = 100000
+    }
+  },
+  {
+    bindHost = 0.0.0.0
+    bindPort = 9002
+    destinationHost = localhost
+    destinationPort = 9005
+  }
+]

--- a/network-delayer/src/main/scala/co/topl/networkdelayer/ApplicationConfig.scala
+++ b/network-delayer/src/main/scala/co/topl/networkdelayer/ApplicationConfig.scala
@@ -1,0 +1,33 @@
+package co.topl.networkdelayer
+
+import cats.Show
+import com.typesafe.config.Config
+import pureconfig.ConfigSource
+import pureconfig.generic.auto._
+
+import scala.concurrent.duration.FiniteDuration
+
+case class ApplicationConfig(
+  routes: List[ApplicationConfig.Route]
+)
+
+object ApplicationConfig {
+
+  case class Route(
+    bindHost:        String,
+    bindPort:        Int,
+    destinationHost: String,
+    destinationPort: Int,
+    throttle:        Option[Route.Throttle]
+  )
+
+  object Route {
+    case class Throttle(latency: FiniteDuration, downloadBytesPerSecond: Long, uploadBytesPerSecond: Long)
+  }
+
+  def unsafe(args: Args, config: Config): ApplicationConfig =
+    ConfigSource.fromConfig(config).loadOrThrow[ApplicationConfig]
+
+  implicit val showApplicationConfig: Show[ApplicationConfig] =
+    Show.fromToString
+}

--- a/network-delayer/src/main/scala/co/topl/networkdelayer/Args.scala
+++ b/network-delayer/src/main/scala/co/topl/networkdelayer/Args.scala
@@ -1,0 +1,40 @@
+package co.topl.networkdelayer
+
+import cats.Show
+import co.topl.common.application.{ContainsDebugFlag, ContainsUserConfigs}
+import mainargs._
+
+@main
+case class Args(startup: Args.Startup)
+
+object Args {
+
+  @main
+  case class Startup(
+    @arg(
+      doc = "Zero or more config files (.conf, .json, .yaml) to apply to the node." +
+        "  Config files stack such that the last config file takes precedence." +
+        "  To specify an internal resource, prefix the value with \"resource://\"."
+    )
+    config: List[String] = Nil,
+    @arg(
+      doc = "An optional flag to enable debug mode on this node."
+    )
+    debug: Flag
+  )
+
+  implicit val parserStartupArgs: ParserForClass[Args.Startup] =
+    ParserForClass[Args.Startup]
+
+  implicit val parserArgs: ParserForClass[Args] =
+    ParserForClass[Args]
+
+  implicit val argsContainsUserConfigs: ContainsUserConfigs[Args] =
+    _.startup.config
+
+  implicit val argsContainsDebugFlag: ContainsDebugFlag[Args] =
+    _.startup.debug.value
+
+  implicit val showArgs: Show[Args] =
+    Show.fromToString
+}

--- a/network-delayer/src/main/scala/co/topl/networkdelayer/NetworkDelayer.scala
+++ b/network-delayer/src/main/scala/co/topl/networkdelayer/NetworkDelayer.scala
@@ -1,0 +1,128 @@
+package co.topl.networkdelayer
+
+import cats.data.OptionT
+import cats.effect.kernel.Resource
+import cats.effect.{Async, IO}
+import cats.implicits._
+import co.topl.common.application.IOBaseApp
+import com.comcast.ip4s._
+import fs2._
+import fs2.io.net.{Network, Socket}
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import scala.concurrent.duration._
+
+object NetworkDelayer
+    extends IOBaseApp[Args, ApplicationConfig](
+      createArgs = args => Args.parserArgs.constructOrThrow(args),
+      createConfig = IOBaseApp.createTypesafeConfig,
+      parseConfig = (args, conf) => ApplicationConfig.unsafe(args, conf)
+    ) {
+
+  implicit private val logger: Logger[F] =
+    Slf4jLogger.getLoggerFromClass[F](this.getClass)
+
+  def run: IO[Unit] =
+    for {
+      _ <- Logger[F].info("Launching NetworkDelayer")
+      _ <- Logger[F].info(show"args=$args")
+      _ <- Logger[F].info(show"config=$appConfig")
+      _ <- appConfig.routes.parTraverse(serverForRoute).void
+    } yield ()
+
+  /**
+   * Handle the given route configuration by binding the local host/port and forwarding any incoming request payloads
+   * to the route configuration's destination.  The configuration's throttle is also applied to the connection.
+   */
+  private def serverForRoute(route: ApplicationConfig.Route): F[Unit] =
+    for {
+      serverStream   <- buildServerStream(route)
+      clientResource <- buildClientResource(route)
+      _ <- Logger[F].info(s"Serving at binding=${route.bindHost}:${route.bindPort} with throttle=${route.throttle}")
+      _ <- serverStream
+        .mapAsync(1)(handleSocket(route)(clientResource))
+        .compile
+        .drain
+    } yield ()
+
+  /**
+   * Validate the route settings for the local binding, and bind the port to return a stream of inbound connections
+   */
+  private def buildServerStream(route: ApplicationConfig.Route): F[Stream[F, Socket[F]]] =
+    for {
+      bindHost <- OptionT
+        .fromOption[F](Host.fromString(route.bindHost))
+        .getOrRaise(new IllegalArgumentException("Invalid bindHost"))
+      bindPort <- OptionT
+        .fromOption[F](Port.fromInt(route.bindPort))
+        .getOrRaise(new IllegalArgumentException("Invalid bindPort"))
+    } yield Network[F].server(bindHost.some, bindPort.some)
+
+  /**
+   * Validate the route's destination and construct a reusable destination connection resource.
+   */
+  private def buildClientResource(route: ApplicationConfig.Route): F[Resource[F, Socket[F]]] =
+    for {
+      destinationHost <- OptionT
+        .fromOption[F](Host.fromString(route.destinationHost))
+        .getOrRaise(new IllegalArgumentException("Invalid destinationHost"))
+      destinationPort <- OptionT
+        .fromOption[F](Port.fromInt(route.destinationPort))
+        .getOrRaise(new IllegalArgumentException("Invalid destinationPort"))
+    } yield Network[F].client(SocketAddress(destinationHost, destinationPort))
+
+  /**
+   * Forward inbound data from the local socket to the destination.  Forward inbound data from the destination
+   * to the local socket.  Apply throttling if configured.
+   */
+  private def handleSocket(route: ApplicationConfig.Route)(clientResource: Resource[F, Socket[F]])(
+    localSocket:                  Socket[F]
+  ): F[Unit] =
+    Logger[F].info(s"Accepted inbound connection at binding=${route.bindHost}:${route.bindPort}") >>
+    clientResource
+      .use(clientSocket =>
+        Logger[F].info(
+          s"Forwarding from binding=${route.bindHost}:${route.bindPort}" +
+          s" to remote=${route.destinationHost}:${route.destinationPort}"
+        ) >>
+        (
+          download(route)(clientSocket.reads)(localSocket.writes),
+          upload(route)(localSocket.reads)(clientSocket.writes)
+        ).parTupled.void
+      )
+      .handleErrorWith(Logger[F].error(_)("Connection failed"))
+
+  /**
+   * Handle the "download" side of the socket, and impose throttling
+   */
+  private def download(route: ApplicationConfig.Route)(in: Stream[F, Byte])(out: Pipe[F, Byte, Nothing]): F[Unit] =
+    route.throttle
+      .foldLeft(in)(_ through downloadThrottler(_))
+      .through(out)
+      .compile
+      .drain
+
+  /**
+   * Handle the "upload" side of the socket, and impose throttling
+   */
+  private def upload(route: ApplicationConfig.Route)(in: Stream[F, Byte])(out: Pipe[F, Byte, Nothing]): F[Unit] =
+    route.throttle
+      .foldLeft(in)(_ through uploadThrottler(_))
+      .through(out)
+      .compile
+      .drain
+
+  private def downloadThrottler(throttle: ApplicationConfig.Route.Throttle): Pipe[F, Byte, Byte] =
+    _.through(latencyThrottler(throttle.latency)).through(bandwidthThrottler(throttle.downloadBytesPerSecond))
+
+  private def uploadThrottler(throttle: ApplicationConfig.Route.Throttle): Pipe[F, Byte, Byte] =
+    _.through(latencyThrottler(throttle.latency)).through(bandwidthThrottler(throttle.uploadBytesPerSecond))
+
+  private def bandwidthThrottler(bytesPerSecond: Long): Pipe[F, Byte, Byte] =
+    _.metered(1.seconds / bytesPerSecond)
+
+  private def latencyThrottler(latency: FiniteDuration): Pipe[F, Byte, Byte] =
+    _.chunks.parEvalMapUnbounded(v => Async[F].delayBy(Async[F].pure(v), latency)).unchunks
+
+}

--- a/node-tetra/src/main/scala/co/topl/node/Args.scala
+++ b/node-tetra/src/main/scala/co/topl/node/Args.scala
@@ -1,6 +1,7 @@
 package co.topl.node
 
 import cats.Show
+import co.topl.common.application.{ContainsDebugFlag, ContainsUserConfigs}
 import mainargs._
 
 @main
@@ -89,4 +90,10 @@ object Args {
 
   implicit val parserArgs: ParserForClass[Args] =
     ParserForClass[Args]
+
+  implicit val argsContainsUserConfigs: ContainsUserConfigs[Args] =
+    _.startup.config.toList
+
+  implicit val argsContainsDebugFlag: ContainsDebugFlag[Args] =
+    _.startup.debug.value
 }

--- a/node-tetra/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node-tetra/src/main/scala/co/topl/node/NodeApp.scala
@@ -20,7 +20,7 @@ import co.topl.codecs.bytes.tetra.instances._
 import co.topl.models._
 import co.topl.typeclasses.implicits._
 import co.topl.codecs.bytes.tetra.instances._
-import co.topl.common.application.IOAkkaApp
+import co.topl.common.application.{IOAkkaApp, IOBaseApp}
 import co.topl.consensus.LeaderElectionValidation.VrfConfig
 import co.topl.consensus._
 import co.topl.consensus.algebras._
@@ -44,7 +44,7 @@ import scala.util.Random
 object NodeApp
     extends IOAkkaApp[Args, ApplicationConfig, Nothing](
       createArgs = args => Args.parserArgs.constructOrThrow(args),
-      createConfig = ApplicationConfig.createTypesafeConfig,
+      createConfig = IOBaseApp.createTypesafeConfig,
       parseConfig = (args, conf) => ApplicationConfig.unsafe(args, conf),
       createSystem = (_, _, conf) => ActorSystem[Nothing](Behaviors.empty, "BifrostTetra", conf)
     ) {

--- a/node-tetra/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node-tetra/src/main/scala/co/topl/node/NodeApp.scala
@@ -11,9 +11,7 @@ import co.topl.algebras._
 import ClockAlgebra.implicits._
 import cats.Applicative
 import cats.data.OptionT
-import ch.qos.logback.classic.joran.JoranConfigurator
 import co.topl.blockchain._
-import co.topl.catsakka.IOAkkaApp
 import co.topl.crypto.hash.Blake2b512
 import co.topl.crypto.signing._
 import co.topl.interpreters._
@@ -22,6 +20,7 @@ import co.topl.codecs.bytes.tetra.instances._
 import co.topl.models._
 import co.topl.typeclasses.implicits._
 import co.topl.codecs.bytes.tetra.instances._
+import co.topl.common.application.IOAkkaApp
 import co.topl.consensus.LeaderElectionValidation.VrfConfig
 import co.topl.consensus._
 import co.topl.consensus.algebras._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val catsSlf4j: ModuleID =
     "org.typelevel" %% "log4cats-slf4j" % "2.4.0"
 
-  val  logging: Seq[ModuleID] = Seq(
+  val logging: Seq[ModuleID] = Seq(
     "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.5",
     "ch.qos.logback"              % "logback-classic" % "1.2.11",
     "ch.qos.logback"              % "logback-core"    % "1.2.11",
@@ -210,6 +210,15 @@ object Dependencies {
       circeYaml
     )
 
+  val networkDelayer: Seq[ModuleID] =
+    cats ++ catsEffect ++ mainargs ++ logging ++ Seq(
+      catsSlf4j,
+      fs2Core,
+      fs2IO,
+      pureConfig,
+      circeYaml
+    )
+
   lazy val algebras: Seq[sbt.ModuleID] =
     test ++
     catsEffect.map(_ % Test) ++
@@ -227,6 +236,15 @@ object Dependencies {
     test ++
     mongoDb ++
     Seq(akka("actor-typed"))
+
+  val commonApplication: Seq[ModuleID] =
+    cats ++ catsEffect ++ mainargs ++ logging ++ monocle ++
+    simulacrum ++ Seq(
+      catsSlf4j,
+      akka("actor-typed"),
+      pureConfig,
+      circeYaml
+    )
 
   lazy val chainProgram: Seq[ModuleID] =
     scalaCollectionCompat ++
@@ -380,11 +398,11 @@ object Dependencies {
     cats ++ catsEffect ++ mainargs ++ logging ++ monocle ++ Seq(
       catsSlf4j
     ) ++
-      mUnitTest
+    mUnitTest
 
   lazy val genusLibrary: Seq[ModuleID] =
     logging ++
-      mUnitTest
+    mUnitTest
 
   lazy val munitScalamock: Seq[sbt.ModuleID] =
     mUnitTest


### PR DESCRIPTION
## Purpose
- Taktikos was designed to behave under real-world network constraints, such as limited latency or bandwidth
- Testing real-world network constraints in a global manner is difficult and expensive
- Simulating network constraints is relatively cheap, and allows for nodes running within the same data center to act as-if they were connected at long distances
- This PR introduces an application which intercepts TCP traffic and throttles the data to configurable amounts
## Approach
- Add new `commonApplication` library module which provides helpers for running cats-effect applications with config and argument parsing.  Split IOAkkaApp into IOBaseApp
- A new SBT Module + Application + Docker image for network-delayer
- Uses fs2-io to handle the TCP communications
- Uses fs2 to impose throttling
## Testing
- Unit testing of timing-related functionality is difficult
- This feature was manually tested in a local kubernetes cluster
## Tickets
- BN-652