### PR TITLE
Fixing docker image build for integration tests

### DIFF
--- a/node/src/it/resources/Dockerfile
+++ b/node/src/it/resources/Dockerfile
@@ -22,8 +22,8 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /
 # JDK Install
 RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add - \
     && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
-    && apt update \
-    && apt install temurin-11-jdk
+    && apt -y update \
+    && apt -y install temurin-11-jdk
 
 # SBT Install
 ARG SBT_PKG=https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz


### PR DESCRIPTION
## Purpose
Successfully run integration tests on docker
## Approach
Change appropriate docker building file

## Testing
Docker image had been successfully created on local PC by using updated image file

## Tickets
[*](https://topl.atlassian.net/browse/BN-668)
