### PR TITLE
BN-620_Extend_TransactionDataLimit

### DIFF
--- a/common/src/main/scala/co/topl/modifier/ops/TetraTransactionOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/TetraTransactionOps.scala
@@ -364,7 +364,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
       }
       .getOrElse(Int128(0))
 
-  private def getData: Option[Latin1Data] = transaction.data.map(d => Latin1Data.fromData(d.data.bytes))
+  private def getData: Option[Latin1Data] = transaction.data.map(d => Latin1Data.fromData(d.toArray))
 
   // TODO
   private def getFeeOutput: (Address, SimpleValue) = ???

--- a/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
+++ b/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
@@ -497,7 +497,7 @@ trait ModelsJsonCodecs {
         "inputs"   -> tx.inputs.asJson,
         "outputs"  -> tx.outputs.asJson,
         "schedule" -> tx.schedule.asJson,
-        "data"     -> tx.data.map(_.data).asJson
+        "data"     -> tx.data.asJson
       )
 
   implicit def transactionJsonDecoder(implicit networkPrefix: NetworkPrefix): Decoder[Transaction] =
@@ -515,7 +515,7 @@ trait ModelsJsonCodecs {
         "inputs"   -> tx.inputs.asJson,
         "outputs"  -> tx.outputs.asJson,
         "schedule" -> tx.schedule.asJson,
-        "data"     -> tx.data.map(_.data).asJson
+        "data"     -> tx.data.asJson
       )
 
   implicit val unprovenTransactionJsonDecoder: Decoder[Transaction.Unproven] =

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSyntaxValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSyntaxValidation.scala
@@ -26,7 +26,8 @@ object TransactionSyntaxValidation {
       scheduleValidation,
       positiveOutputValuesValidation,
       sufficientFundsValidation,
-      proofTypeValidation
+      proofTypeValidation,
+      dataLengthValidation
     )
 
   /**
@@ -250,4 +251,11 @@ object TransactionSyntaxValidation {
           _ => (TransactionSyntaxErrors.InvalidProofType(proposition, proof): TransactionSyntaxError).invalidNec[Unit]
         )
 
+  private[interpreters] def dataLengthValidation(transaction: Transaction): ValidatedNec[TransactionSyntaxError, Unit] =
+    Validated.condNec(
+      transaction.data.isEmpty ||
+      transaction.data.exists(_.length < Transaction.maxDataLength),
+      (),
+      TransactionSyntaxErrors.InvalidDataLength
+    )
 }

--- a/ledger/src/main/scala/co/topl/ledger/models/TransactionSyntaxError.scala
+++ b/ledger/src/main/scala/co/topl/ledger/models/TransactionSyntaxError.scala
@@ -16,4 +16,5 @@ object TransactionSyntaxErrors {
   case class InsufficientInputFunds[V <: Box.Value](inputs: Chain[V], outputs: Chain[V]) extends TransactionSyntaxError
 
   case class InvalidProofType(proposition: Proposition, proof: Proof) extends TransactionSyntaxError
+  case object InvalidDataLength extends TransactionSyntaxError
 }

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSyntaxValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSyntaxValidationSpec.scala
@@ -8,7 +8,7 @@ import co.topl.ledger.models._
 import co.topl.models.ModelGenerators._
 import co.topl.models.utility.HasLength.instances.bigIntLength
 import co.topl.models.utility.Sized
-import co.topl.models.{Box, Proof, Proofs, Proposition, Propositions, SecretKeys, Transaction}
+import co.topl.models.{Box, Bytes, Proof, Proofs, Proposition, Propositions, SecretKeys, Transaction}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.Gen
 import org.scalacheck.effect.PropF
@@ -290,6 +290,21 @@ class TransactionSyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEff
         _ <- testTransaction(transaction4)
         _ <- testTransaction(transaction5)
         _ <- testTransaction(transaction6)
+      } yield ()
+    }
+  }
+
+  test("validate data-length transaction") {
+    val invalidData = Bytes.fill(Transaction.maxDataLength)(1)
+    PropF.forAllF(arbitraryTransaction.arbitrary.map(_.copy(data = Some(invalidData)))) { transaction: Transaction =>
+      for {
+        underTest <- TransactionSyntaxValidation.make[F]
+        result    <- underTest.validate(transaction)
+        _ <- EitherT
+          .fromEither[F](result.toEither)
+          .swap
+          .exists(_.toList.contains(TransactionSyntaxErrors.InvalidDataLength))
+          .assert
       } yield ()
     }
   }

--- a/models/src/main/scala/co/topl/models/Transaction.scala
+++ b/models/src/main/scala/co/topl/models/Transaction.scala
@@ -1,8 +1,6 @@
 package co.topl.models
 
 import cats.data.Chain
-import co.topl.models.utility.StringDataTypes.Latin1Data
-import co.topl.models.utility.{Lengths, Sized}
 
 case class Transaction(
   inputs:   Chain[Transaction.Input],
@@ -13,7 +11,8 @@ case class Transaction(
 
 object Transaction {
 
-  type Data = Sized.Max[Latin1Data, Lengths.`127`.type]
+  type Data = Bytes
+  val maxDataLength = 15360
 
   case class Input(
     boxId:       Box.Id,

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
@@ -139,15 +139,11 @@ trait TransactionRpcParamsEncoders extends SharedCodecs {
   implicit val unprovenPolyTransferParamsEncoder: Encoder[ToplRpc.Transaction.UnprovenPolyTransfer.Params] =
     t =>
       Json.obj(
-        "senders"       -> t.senders.asJson,
-        "recipients"    -> t.recipients.asJson,
-        "fee"           -> t.fee.asJson,
-        "changeAddress" -> t.changeAddress.asJson,
-        "data" -> t.data.asJson(
-          Encoder.encodeOption[TetraTransaction.Data](
-            sizedMaxEncoder[co.topl.models.utility.StringDataTypes.Latin1Data, Lengths.`127`.type]
-          )
-        ),
+        "senders"               -> t.senders.asJson,
+        "recipients"            -> t.recipients.asJson,
+        "fee"                   -> t.fee.asJson,
+        "changeAddress"         -> t.changeAddress.asJson,
+        "data"                  -> t.data.asJson,
         "boxSelectionAlgorithm" -> t.boxSelectionAlgorithm.asJson
       )
 


### PR DESCRIPTION
## Purpose
The Transaction.Data field is currently defined as an Option[Sized.Max[Latin1Data, Lengths.`127`.type]].  Some use-cases may require more data than that, and some use-cases may require non-Latin1Data.  The field should be updated to allow for arbitrary byte data of greater length.

## Approach

we should consider making a Transaction Syntax Validation check to impose the 15kb limit, instead of using the Sized type

## Testing
unit test implemented for syntax validator.

## Tickets
https://topl.atlassian.net/browse/BN-620