### PR TITLE
LevelDbStorage now correctly closed after effect ahd been ended

### DIFF
--- a/level-db-store/src/test/scala/co/topl/db/leveldb/LevelDbStoreSpec.scala
+++ b/level-db-store/src/test/scala/co/topl/db/leveldb/LevelDbStoreSpec.scala
@@ -19,47 +19,49 @@ class LevelDbStoreSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   ResourceFixture[Path](Resource.make(Files[F].createTempDirectory)(Files[F].deleteRecursively))
     .test("Save, Contains, Read, Delete") { testPath =>
-      for {
-        dbUnderTest <- LevelDbStore.makeDb[F](testPath)
-        underTest   <- LevelDbStore.make[F, SpecKey, SpecValue](dbUnderTest)
-        key = SpecKey("test1")
-        keyArray = key.persistedBytes.toArray
-        value = SpecValue("foo", 6458)
-        valueArray = value.persistedBytes.toArray
-        // The entry should not yet exist
-        _ <- underTest.contains(key).assertEquals(false)
-        // The entry should still be null
-        _ <- IO.blocking(dbUnderTest.get(keyArray)).assertEquals(null)
-        // Now write a value
-        _ <- underTest.put(key, value)
-        // Verify that the written value's byte array matches what we expect
-        _ <- IO.blocking(dbUnderTest.get(keyArray)).map(_ sameElements valueArray).assert
-        // The entry should exist
-        _ <- underTest.contains(key).assertEquals(true)
-        // The entry deserialized value should equal the input value
-        _ <- underTest.get(key).assertEquals(Some(value))
-        // Now delete the entry
-        _ <- underTest.remove(key)
-        // Verify that it no longer exists
-        _ <- underTest.contains(key).assertEquals(false)
-        // Verify directly that it no longer exists
-        _ <- IO.blocking(dbUnderTest.get(keyArray)).assertEquals(null)
-        _ = dbUnderTest.close()
-      } yield ()
+      LevelDbStore.makeDb[F](testPath).use { dbUnderTest =>
+        for {
+          underTest <- LevelDbStore.make[F, SpecKey, SpecValue](dbUnderTest)
+          key = SpecKey("test1")
+          keyArray = key.persistedBytes.toArray
+          value = SpecValue("foo", 6458)
+          valueArray = value.persistedBytes.toArray
+          // The entry should not yet exist
+          _ <- underTest.contains(key).assertEquals(false)
+          // The entry should still be null
+          _ <- IO.blocking(dbUnderTest.get(keyArray)).assertEquals(null)
+          // Now write a value
+          _ <- underTest.put(key, value)
+          // Verify that the written value's byte array matches what we expect
+          _ <- IO.blocking(dbUnderTest.get(keyArray)).map(_ sameElements valueArray).assert
+          // The entry should exist
+          _ <- underTest.contains(key).assertEquals(true)
+          // The entry deserialized value should equal the input value
+          _ <- underTest.get(key).assertEquals(Some(value))
+          // Now delete the entry
+          _ <- underTest.remove(key)
+          // Verify that it no longer exists
+          _ <- underTest.contains(key).assertEquals(false)
+          // Verify directly that it no longer exists
+          _ <- IO.blocking(dbUnderTest.get(keyArray)).assertEquals(null)
+          _ = dbUnderTest.close()
+        } yield ()
+      }
     }
 
   ResourceFixture[Path](Resource.make(Files[F].createTempDirectory)(Files[F].deleteRecursively))
     .test("Malformed data throws exceptions") { testPath =>
-      for {
-        dbUnderTest <- LevelDbStore.makeDb[F](testPath)
-        underTest   <- LevelDbStore.make[F, SpecKey, SpecValue](dbUnderTest)
-        key = SpecKey("test1")
-        keyArray = key.persistedBytes.toArray
-        _ <- IO.blocking(dbUnderTest.put(keyArray, Array[Byte](1, 2, 3, 4)))
-        _ <- underTest.contains(key).assertEquals(true)
-        _ <- interceptIO[InputMismatchException](underTest.get(key))
-        _ = dbUnderTest.close()
-      } yield ()
+      LevelDbStore.makeDb[F](testPath).use { dbUnderTest =>
+        for {
+          underTest <- LevelDbStore.make[F, SpecKey, SpecValue](dbUnderTest)
+          key = SpecKey("test1")
+          keyArray = key.persistedBytes.toArray
+          _ <- IO.blocking(dbUnderTest.put(keyArray, Array[Byte](1, 2, 3, 4)))
+          _ <- underTest.contains(key).assertEquals(true)
+          _ <- interceptIO[InputMismatchException](underTest.get(key))
+          _ = dbUnderTest.close()
+        } yield ()
+      }
     }
 
 }

--- a/node-tetra/src/main/scala/co/topl/node/DataStores.scala
+++ b/node-tetra/src/main/scala/co/topl/node/DataStores.scala
@@ -144,7 +144,7 @@ object DataStores {
   private def makeDb[F[_]: Async, Key: Persistable, Value: Persistable](dataDir: Path)(
     name:                                                                        String
   ): F[Store[F, Key, Value]] =
-    LevelDbStore.makeDb[F](dataDir / name) >>= LevelDbStore.make[F, Key, Value]
+    LevelDbStore.makeDb[F](dataDir / name).use(LevelDbStore.make[F, Key, Value])
 
   private def makeCachedDb[F[_]: Async, Key: Persistable, CacheKey <: AnyRef, Value: Persistable](dataDir: Path)(
     name:                                                                                                  String,


### PR DESCRIPTION
## Purpose
Properly close levelDb storage

## Approach
Using cats resource which correctly closes db storage at end of the effect

## Testing
all unit tests are passed correctly

## Tickets
[*](https://topl.atlassian.net/browse/BN-663)