### PR TITLE
BN-620_Extend_TransactionDataLimit_v2

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
@@ -27,7 +27,9 @@ object ToplRpcServer {
       show"NonPositiveOutputValue(value=${outputValue.toString})"
     case TransactionSyntaxErrors.InsufficientInputFunds(_, _) => "InsufficientInputFunds"
     case TransactionSyntaxErrors.InvalidProofType(_, _)       => "InvalidProofType"
-
+    case TransactionSyntaxErrors.InvalidSchedule(s) =>
+      show"InvalidSchedule(creation=${s.creation},maximumSlot=${s.maximumSlot},minimumSlot=${s.minimumSlot})"
+    case TransactionSyntaxErrors.InvalidDataLength => "InvalidDataLength"
   }
 
   /**

--- a/common/src/main/scala/co/topl/modifier/ops/TetraTransactionOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/TetraTransactionOps.scala
@@ -364,7 +364,7 @@ class TetraTransactionOps(private val transaction: Transaction) extends AnyVal {
       }
       .getOrElse(Int128(0))
 
-  private def getData: Option[Latin1Data] = transaction.data.map(d => Latin1Data.fromData(d.data.bytes))
+  private def getData: Option[Latin1Data] = transaction.data.map(d => Latin1Data.fromData(d.toArray))
 
   // TODO
   private def getFeeOutput: (Address, SimpleValue) = ???

--- a/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
+++ b/json-codecs/src/main/scala/co/topl/codecs/json/tetra/ModelsJsonCodecs.scala
@@ -497,7 +497,7 @@ trait ModelsJsonCodecs {
         "inputs"   -> tx.inputs.asJson,
         "outputs"  -> tx.outputs.asJson,
         "schedule" -> tx.schedule.asJson,
-        "data"     -> tx.data.map(_.data).asJson
+        "data"     -> tx.data.asJson
       )
 
   implicit def transactionJsonDecoder(implicit networkPrefix: NetworkPrefix): Decoder[Transaction] =
@@ -506,7 +506,7 @@ trait ModelsJsonCodecs {
         inputs   <- hcursor.downField("inputs").as[Chain[Transaction.Input]]
         outputs  <- hcursor.downField("outputs").as[Chain[Transaction.Output]]
         schedule <- hcursor.downField("schedule").as[Transaction.Schedule]
-        data     <- hcursor.downField("data").as[Option[Transaction.Data]]
+        data     <- hcursor.downField("data").as[Option[Transaction.DataTetra]]
       } yield Transaction(inputs, outputs, schedule, data)
 
   implicit val unprovenTransactionJsonEncoder: Encoder[Transaction.Unproven] =
@@ -515,7 +515,7 @@ trait ModelsJsonCodecs {
         "inputs"   -> tx.inputs.asJson,
         "outputs"  -> tx.outputs.asJson,
         "schedule" -> tx.schedule.asJson,
-        "data"     -> tx.data.map(_.data).asJson
+        "data"     -> tx.data.asJson
       )
 
   implicit val unprovenTransactionJsonDecoder: Decoder[Transaction.Unproven] =
@@ -524,7 +524,7 @@ trait ModelsJsonCodecs {
         inputs   <- hcursor.downField("inputs").as[Chain[Transaction.Unproven.Input]]
         outputs  <- hcursor.downField("outputs").as[Chain[Transaction.Output]]
         schedule <- hcursor.downField("schedule").as[Transaction.Schedule]
-        data     <- hcursor.downField("data").as[Option[Transaction.Data]]
+        data     <- hcursor.downField("data").as[Option[Transaction.DataTetra]]
       } yield Transaction.Unproven(inputs, outputs, schedule, data)
 
 }

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSyntaxValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSyntaxValidation.scala
@@ -26,7 +26,8 @@ object TransactionSyntaxValidation {
       scheduleValidation,
       positiveOutputValuesValidation,
       sufficientFundsValidation,
-      proofTypeValidation
+      proofTypeValidation,
+      dataLengthValidation
     )
 
   /**
@@ -249,5 +250,12 @@ object TransactionSyntaxValidation {
           proof,
           _ => (TransactionSyntaxErrors.InvalidProofType(proposition, proof): TransactionSyntaxError).invalidNec[Unit]
         )
+
+  private[interpreters] def dataLengthValidation(transaction: Transaction): ValidatedNec[TransactionSyntaxError, Unit] =
+    Validated.condNec(
+      transaction.data.forall(_.length <= Transaction.MaxDataLength),
+      (),
+      TransactionSyntaxErrors.InvalidDataLength
+    )
 
 }

--- a/ledger/src/main/scala/co/topl/ledger/models/TransactionSyntaxError.scala
+++ b/ledger/src/main/scala/co/topl/ledger/models/TransactionSyntaxError.scala
@@ -16,4 +16,5 @@ object TransactionSyntaxErrors {
   case class InsufficientInputFunds[V <: Box.Value](inputs: Chain[V], outputs: Chain[V]) extends TransactionSyntaxError
 
   case class InvalidProofType(proposition: Proposition, proof: Proof) extends TransactionSyntaxError
+  case object InvalidDataLength extends TransactionSyntaxError
 }

--- a/models/src/main/scala/co/topl/models/Transaction.scala
+++ b/models/src/main/scala/co/topl/models/Transaction.scala
@@ -8,12 +8,16 @@ case class Transaction(
   inputs:   Chain[Transaction.Input],
   outputs:  Chain[Transaction.Output],
   schedule: Transaction.Schedule,
-  data:     Option[Transaction.Data]
+  data:     Option[Transaction.DataTetra]
 )
 
 object Transaction {
 
+  // Used by Dion protocol
   type Data = Sized.Max[Latin1Data, Lengths.`127`.type]
+  // Used by Tetra Protocol
+  type DataTetra = Bytes
+  val MaxDataLength = 15360
 
   case class Input(
     boxId:       Box.Id,
@@ -35,7 +39,7 @@ object Transaction {
     inputs:   Chain[Transaction.Unproven.Input],
     outputs:  Chain[Transaction.Output],
     schedule: Schedule,
-    data:     Option[Transaction.Data]
+    data:     Option[Transaction.DataTetra]
   )
 
   object Unproven {

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -423,7 +423,7 @@ trait TetraScodecTransactionCodecs {
       Codec[Chain[Transaction.Input]] ::
         Codec[Chain[Transaction.Output]] ::
         Codec[Transaction.Schedule] ::
-        Codec[Option[Transaction.Data]]
+        Codec[Option[Transaction.DataTetra]]
     ).as[Transaction]
 
   implicit val unprovenTransactionCodec: Codec[Transaction.Unproven] =
@@ -431,7 +431,7 @@ trait TetraScodecTransactionCodecs {
       Codec[Chain[Transaction.Unproven.Input]] ::
         Codec[Chain[Transaction.Output]] ::
         Codec[Transaction.Schedule] ::
-        Codec[Option[Transaction.Data]]
+        Codec[Option[Transaction.DataTetra]]
     ).as[Transaction.Unproven]
 }
 

--- a/topl-grpc/src/main/scala/co/topl/grpc/BifrostMorphismInstances.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/BifrostMorphismInstances.scala
@@ -1150,7 +1150,7 @@ trait TransactionBifrostMorphismInstances {
           schedule <- EitherT
             .fromOption[F](protoTransaction.schedule, "Missing schedule")
             .flatMapF(_.toF[F, bifrostModels.Transaction.Schedule])
-          data <- protoTransaction.data.traverse(v => EitherT(v.toF[F, bifrostModels.Transaction.Data]))
+          data <- protoTransaction.data.traverse(v => EitherT(v.toF[F, bifrostModels.Transaction.DataTetra]))
         } yield bifrostModels.Transaction(inputs, outputs, schedule, data)
       )
         .flatMap(_.value)


### PR DESCRIPTION
## Purpose
The Transaction.Data field is currently defined as an Option[Sized.Max[Latin1Data, Lengths.`127`.type]].  Some use-cases may require more data than that, and some use-cases may require non-Latin1Data.  The field should be updated to allow for arbitrary byte data of greater length.

## Approach

we should consider making a Transaction Syntax Validation check to impose the 15kb limit, instead of using the Sized type

## Testing
unit test implemented for syntax validator.

## Tickets
https://topl.atlassian.net/browse/BN-620

Fixes #2436 