### PR TITLE
Consensus Testnet Helm Chart

### DIFF
--- a/helm/bifrost-consensus-testnet/.helmignore
+++ b/helm/bifrost-consensus-testnet/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/bifrost-consensus-testnet/Chart.yaml
+++ b/helm/bifrost-consensus-testnet/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: bifrost-consensus-testnet
+description: A Helm chart for Kubernetes
+
+type: application
+
+version: 0.1.0
+
+appVersion: "1.16.0"
+
+#TODO: Find a better icon.
+icon: https://uploads-ssl.webflow.com/60f98f46d44e675abb7e66ea/611c4d83ed3df101fd221875_topl_basew.svg

--- a/helm/bifrost-consensus-testnet/Chart.yaml
+++ b/helm/bifrost-consensus-testnet/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bifrost-consensus-testnet
-description: A Helm chart for Kubernetes
+description: Launches a private testnet using configurable nodes and artificial throttling.
 
 type: application
 

--- a/helm/bifrost-consensus-testnet/README.md
+++ b/helm/bifrost-consensus-testnet/README.md
@@ -1,0 +1,3 @@
+# Usage
+1. Copy file `override-example.yaml` into `override.yaml`.  Update values accordingly.
+1. Install the helm chart: `helm install -f /path/to/override.yaml --create-namespace --namespace scenario1 scenario1 ./bifrost-consensus-testnet`

--- a/helm/bifrost-consensus-testnet/README.md
+++ b/helm/bifrost-consensus-testnet/README.md
@@ -1,3 +1,5 @@
 # Usage
 1. Copy file `override-example.yaml` into `override.yaml`.  Update values accordingly.
 1. Install the helm chart: `helm install -f /path/to/override.yaml --create-namespace --namespace scenario1 scenario1 ./bifrost-consensus-testnet`
+1. Observe the logs of each node the Kubernetes cluster in the `scenario1` namespace
+1. Terminate the scenario using  `helm delete -n scenario1 scenario1`

--- a/helm/bifrost-consensus-testnet/override-example.yaml
+++ b/helm/bifrost-consensus-testnet/override-example.yaml
@@ -1,4 +1,6 @@
+# These settings will apply to the configurations of all nodes.
 shared-config:
+  # Define custom application.conf overrides
   bifrost:
     big-bang:
       staker-count: 2
@@ -6,31 +8,54 @@ shared-config:
       0:
         slot-duration: 250 milli
 
+# Define an entry for each node you wish to launch in the cluster
 configs:
+  # Name the node
   producer0:
+    # Define custom application.conf overrides
     bifrost:
       big-bang:
         local-staker-index: 0
-    throttle:
-      latency: 20 milli
-      downloadBytesPerSecond: 500000
-      uploadBytesPerSecond: 500000
+    # Define the network topology of this node
+    topology:
+      # Applies to all connections received by this node
+      ingress:
+        # The amount of throttling to impose on the local node's portion of the connection
+        throttle:
+          latency: 10 milli
+          downloadBytesPerSecond: 500000
+          uploadBytesPerSecond: 500000
   producer1:
     bifrost:
       big-bang:
         local-staker-index: 1
-    throttle:
-      latency: 20 milli
-      downloadBytesPerSecond: 500000
-      uploadBytesPerSecond: 500000
+    topology:
+      ingress:
+        throttle:
+          latency: 10 milli
+          downloadBytesPerSecond: 500000
+          uploadBytesPerSecond: 500000
   relay0:
     bifrost:
       big-bang:
         local-staker-index: -1
-    peers:
-      - producer0
-      - producer1
-    throttle:
-      latency: 20 milli
-      downloadBytesPerSecond: 500000
-      uploadBytesPerSecond: 500000
+    topology:
+      ingress:
+        throttle:
+          latency: 10 milli
+          downloadBytesPerSecond: 500000
+          uploadBytesPerSecond: 500000
+      # Outbound connections are defined here
+      egress:
+          # The name of the peer
+        - peer: producer0
+          # The amount of throttling to impose on the local node's portion of the connection
+          throttle:
+            latency: 10 milli
+            downloadBytesPerSecond: 500000
+            uploadBytesPerSecond: 500000
+        - peer: producer1
+          throttle:
+            latency: 10 milli
+            downloadBytesPerSecond: 500000
+            uploadBytesPerSecond: 500000

--- a/helm/bifrost-consensus-testnet/override-example.yaml
+++ b/helm/bifrost-consensus-testnet/override-example.yaml
@@ -1,0 +1,36 @@
+shared-config:
+  bifrost:
+    big-bang:
+      staker-count: 2
+    protocols:
+      0:
+        slot-duration: 250 milli
+
+configs:
+  producer0:
+    bifrost:
+      big-bang:
+        local-staker-index: 0
+    throttle:
+      latency: 20 milli
+      downloadBytesPerSecond: 500000
+      uploadBytesPerSecond: 500000
+  producer1:
+    bifrost:
+      big-bang:
+        local-staker-index: 1
+    throttle:
+      latency: 20 milli
+      downloadBytesPerSecond: 500000
+      uploadBytesPerSecond: 500000
+  relay0:
+    bifrost:
+      big-bang:
+        local-staker-index: -1
+    peers:
+      - producer0
+      - producer1
+    throttle:
+      latency: 20 milli
+      downloadBytesPerSecond: 500000
+      uploadBytesPerSecond: 500000

--- a/helm/bifrost-consensus-testnet/templates/_helpers.tpl
+++ b/helm/bifrost-consensus-testnet/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bifrost.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bifrost.fullname" -}}
+{{- if $.Values.fullnameOverride }}
+{{- $.Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name $.Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bifrost.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bifrost.labels" -}}
+helm.sh/chart: {{ include "bifrost.chart" . }}
+{{ include "bifrost.selectorLabels" . }}
+{{- if $.Chart.AppVersion }}
+app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ $.Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bifrost.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bifrost.name" . }}
+app.kubernetes.io/instance: {{ $.Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bifrost.serviceAccountName" -}}
+{{- if $.Values.serviceAccount.create }}
+{{- default (include "bifrost.fullname" .) $.Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" $.Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/bifrost-consensus-testnet/templates/bifrost/nodes.yaml
+++ b/helm/bifrost-consensus-testnet/templates/bifrost/nodes.yaml
@@ -32,7 +32,7 @@ data:
     {{- toYaml $value | nindent 4 }}
   peers.yaml: |
     {{- $knownPeersString := "" -}}
-    {{ range $index, $peer := $value.peers }}
+    {{ range $index, $peer := $value.topology.egress }}
         {{- if $index }}{{ $knownPeersString = print $knownPeersString "," }}{{ end -}}
     {{ $knownPeersString = print $knownPeersString "localhost:"}}
     {{ $knownPeersString = print $knownPeersString (add 9100 $index)}}
@@ -47,22 +47,22 @@ data:
         bind-port: {{ $Values.service.ports.p2p }}
         destination-host: localhost
         destination-port: 9083
-        {{ if $value.throttle }}
+        {{ if $value.topology.ingress.throttle }}
         throttle:
-          latency: {{ $value.throttle.latency }}
-          download-bytes-per-second: {{ $value.throttle.downloadBytesPerSecond }}
-          upload-bytes-per-second: {{ $value.throttle.uploadBytesPerSecond }}
+          latency: {{ $value.topology.ingress.throttle.latency }}
+          download-bytes-per-second: {{ $value.topology.ingress.throttle.downloadBytesPerSecond }}
+          upload-bytes-per-second: {{ $value.topology.ingress.throttle.uploadBytesPerSecond }}
         {{ end }}
-    {{ range $index, $peer := $value.peers }}
+    {{ range $index, $egress := $value.topology.egress }}
       - bind-host: localhost
         bind-port: {{ add 9100 $index }}
-        destination-host: {{ $fullname }}-p2p-{{ $peer }}.{{ $Release.Name }}.svc.cluster.local
+        destination-host: {{ $fullname }}-p2p-{{ $egress.peer }}.{{ $Release.Name }}.svc.cluster.local
         destination-port: {{ $Values.service.ports.p2p }}
-        {{ if $value.throttle }}
+        {{ if $egress.throttle }}
         throttle:
-          latency: {{ $value.throttle.latency }}
-          download-bytes-per-second: {{ $value.throttle.downloadBytesPerSecond }}
-          upload-bytes-per-second: {{ $value.throttle.uploadBytesPerSecond }}
+          latency: {{ $egress.throttle.latency }}
+          download-bytes-per-second: {{ $egress.throttle.downloadBytesPerSecond }}
+          upload-bytes-per-second: {{ $egress.throttle.uploadBytesPerSecond }}
         {{ end }}
     {{ end }}
 

--- a/helm/bifrost-consensus-testnet/templates/bifrost/nodes.yaml
+++ b/helm/bifrost-consensus-testnet/templates/bifrost/nodes.yaml
@@ -1,0 +1,207 @@
+{{ $bigBangTimestamp := default (now | unixEpoch  | mul 1000 | add (default (len $.Values.configs | mul 15000) .Values.bigBang.delayMs)) .Values.bigBang.timestamp }}
+{{ $fullname := include "bifrost.fullname" . }}
+{{ $labels := include "bifrost.labels" . }}
+{{ $selectorLabels := include "bifrost.selectorLabels" . }}
+{{ $Values := .Values }}
+{{ $Release := .Release }}
+{{ range $nodeName, $value :=  $.Values.configs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullname }}-config-{{ $nodeName }}
+  labels:
+    {{ $labels | nindent 4 }}
+data:
+  shared.yaml: |
+    bifrost:
+      big-bang:
+        timestamp: {{ $bigBangTimestamp }}
+      data:
+        directory: /opt/docker/.bifrost/data
+      staking:
+        directory: /opt/docker/.bifrost/staking
+      p2p:
+        bind-host: localhost
+        bind-port: 9083
+      rpc:
+        bind-host: 0.0.0.0
+        bind-port: {{ $Values.service.ports.rpc }}
+  shared-user.yaml: |
+    {{- index $Values "shared-config" | toYaml | nindent 4}}
+  node.yaml: |
+    {{- toYaml $value | nindent 4 }}
+  peers.yaml: |
+    {{- $knownPeersString := "" -}}
+    {{ range $index, $peer := $value.peers }}
+        {{- if $index }}{{ $knownPeersString = print $knownPeersString "," }}{{ end -}}
+    {{ $knownPeersString = print $knownPeersString "localhost:"}}
+    {{ $knownPeersString = print $knownPeersString (add 9100 $index)}}
+    {{ end }}
+    {{ $knownPeersString = nospace $knownPeersString }}
+    bifrost:
+      p2p:
+        known-peers: "{{ $knownPeersString }}"
+  delayer.yaml: |
+    routes:
+      - bind-host: 0.0.0.0
+        bind-port: {{ $Values.service.ports.p2p }}
+        destination-host: localhost
+        destination-port: 9083
+        {{ if $value.throttle }}
+        throttle:
+          latency: {{ $value.throttle.latency }}
+          download-bytes-per-second: {{ $value.throttle.downloadBytesPerSecond }}
+          upload-bytes-per-second: {{ $value.throttle.uploadBytesPerSecond }}
+        {{ end }}
+    {{ range $index, $peer := $value.peers }}
+      - bind-host: localhost
+        bind-port: {{ add 9100 $index }}
+        destination-host: {{ $fullname }}-p2p-{{ $peer }}.{{ $Release.Name }}.svc.cluster.local
+        destination-port: {{ $Values.service.ports.p2p }}
+        {{ if $value.throttle }}
+        throttle:
+          latency: {{ $value.throttle.latency }}
+          download-bytes-per-second: {{ $value.throttle.downloadBytesPerSecond }}
+          upload-bytes-per-second: {{ $value.throttle.uploadBytesPerSecond }}
+        {{ end }}
+    {{ end }}
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $fullname }}-{{ $nodeName }}
+  labels:
+    {{ $labels | nindent 4 }}
+spec:
+  serviceName: {{ $fullname }}-{{ $nodeName }}
+  replicas: 1
+  selector:
+    matchLabels:
+      node-name: {{ $nodeName }}
+      {{- $selectorLabels | nindent 6 }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        node-name: {{ $nodeName }}
+        {{- $selectorLabels | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml $Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: node
+          image: {{ $Values.image.name }}:{{ $Values.image.tag }}
+          securityContext:
+            {{- toYaml $Values.securityContext | nindent 12 }}
+          command:
+          {{ range $Values.command }}
+            - {{ . }}
+          {{ end }}
+          args:
+            - --config
+            - /etc/config/shared.yaml
+            - --config
+            - /etc/config/shared-user.yaml
+            - --config
+            - /etc/config/node.yaml
+            - --config
+            - /etc/config/peers.yaml
+          resources:
+          {{- toYaml $Values.resources | nindent 12 }}
+        {{- if $Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              port: {{ $Values.service.ports.rpc }}
+            initialDelaySeconds: {{ $Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ $Values.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ $Values.readinessProbe.periodSeconds }}
+        {{- end }}
+        {{- if $Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              port: {{ $Values.service.ports.rpc }}
+            initialDelaySeconds: {{ $Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ $Values.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ $Values.livenessProbe.periodSeconds }}
+        {{- end }}
+          ports:
+            - containerPort: {{ $Values.service.ports.rpc }}
+          volumeMounts:
+            - name: {{ $Values.name }}-pv-{{$nodeName}}
+              mountPath: {{ $Values.volume.mountDirectory }}
+            - name: config-map
+              mountPath: /etc/config
+        - name: network-delayer
+          image: {{ $Values.delayerImage.name }}:{{ $Values.delayerImage.tag }}
+          securityContext:
+            {{- toYaml $Values.securityContext | nindent 12 }}
+          args:
+            - --config
+            - /etc/config/delayer.yaml
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          ports:
+            - containerPort: {{ $Values.service.ports.p2p }}
+            {{- range $index, $peer := $value.peers }}
+            - containerPort: {{ add 9100 $index }}
+            {{ end }}
+          volumeMounts:
+            - name: config-map
+              mountPath: /etc/config
+      volumes:
+        - name: config-map
+          configMap:
+            name: {{ $fullname }}-config-{{ $nodeName }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ $Values.name }}-pv-{{$nodeName}}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ $Values.volume.storageClass }}
+        resources:
+          requests:
+            storage: {{ $Values.volume.storageSize }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullname }}-{{ $nodeName }}
+  labels:
+    {{- $labels | nindent 4}}
+spec:
+  selector:
+    node-name: {{ $nodeName }}
+    {{- $selectorLabels | nindent 4 }}
+  type: {{ $Values.service.type }}
+  ports:
+    - protocol: TCP
+      name: rpc
+      port: {{ $Values.service.ports.rpc }}
+      targetPort: {{ $Values.service.ports.rpc }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullname }}-p2p-{{ $nodeName }}
+  labels:
+    {{- $labels | nindent 4}}
+spec:
+  selector:
+    node-name: {{ $nodeName }}
+    {{- $selectorLabels | nindent 4 }}
+  type: {{ $Values.service.type }}
+  ports:
+    - protocol: TCP
+      name: p2p
+      port: {{ $Values.service.ports.p2p }}
+      targetPort: {{ $Values.service.ports.p2p }}
+---
+{{ end }}

--- a/helm/bifrost-consensus-testnet/values.yaml
+++ b/helm/bifrost-consensus-testnet/values.yaml
@@ -1,0 +1,67 @@
+name: bifrost-consensus-testnet
+
+image:
+#  name: bifrost-node-tetra
+#  name: ghcr.io/topl/bifrost-node-tetra
+  name: localhost:32000/topl/bifrost-node-tetra
+  tag: latest
+
+delayerImage:
+  name: localhost:32000/topl/network-delayer
+  tag: latest
+
+bigBang:
+  timestamp:
+  delayMs:
+
+shared-config: {}
+configs: {}
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 1000Mi
+  requests:
+    cpu: 100m
+    memory: 1000Mi
+
+podSecurityContext:
+  runAsUser: 1001 # TODO: Update Bifrost Docker container to use high UID. Add CKV_K8S_40 as a check.
+  runAsGroup: 0
+  fsGroup: 0
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+args: []
+
+command:
+
+service:
+  type: ClusterIP
+  ports:
+    p2p: 9085
+    rpc: 9084
+
+volume:
+  mountDirectory: /opt/docker/.bifrost
+  storageClass:
+  storageSize: 1Gi
+
+livenessProbe:
+  enabled: false
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 60
+
+readinessProbe:
+  enabled: false
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 60


### PR DESCRIPTION
## Purpose
- To test various consensus configurations, we need a way to easily launch a multi-node setup
## Approach
- Added a new helm chart (copied from the existing one)
- Modified for Tetra
- Modified to generate separate resources for each instance of the setup (versus a StatefulSet like the other helm chart)
- Launches one pod per node, with each pod including a node container and a network-delayer container
- Enable node-level configuration, including throttling
## Testing
- Manual testing using local k8s cluster, and "remote" k8s cluster on a separate machine
- Have not tested on GCP k8s yet
## Tickets
- BN-651