### PR TITLE
Add block header verifications: mismatch timestamp-slot; block from far future

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ClockAlgebra.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ClockAlgebra.scala
@@ -18,6 +18,8 @@ trait ClockAlgebra[F[_]] {
   def currentEpoch: F[Epoch]
   def globalSlot: F[Slot]
   def currentTimestamp: F[Timestamp]
+  def forwardBiasedSlotWindow: F[Slot]
+  def timestampToSlot(timestamp:       Timestamp): F[Slot]
   def delayedUntilSlot(slot:           Slot): F[Unit]
   def delayedUntilTimestamp(timestamp: Timestamp): F[Unit]
 }

--- a/consensus/src/main/scala/co/topl/consensus/BlockHeaderValidationFailure.scala
+++ b/consensus/src/main/scala/co/topl/consensus/BlockHeaderValidationFailure.scala
@@ -12,6 +12,10 @@ object BlockHeaderValidationFailures {
 
   case class NonForwardHeight(height: Long, parentHeight: Long) extends BlockHeaderValidationFailure
 
+  case class TimestampSlotMismatch(blockSlot: Slot, timestamp: Timestamp) extends BlockHeaderValidationFailure
+
+  case class SlotBeyondForwardBiasedSlotWindow(globalSlot: Slot, blockSlot: Slot) extends BlockHeaderValidationFailure
+
   case class ParentMismatch(expectedParentId: TypedIdentifier, parentId: TypedIdentifier)
       extends BlockHeaderValidationFailure
 

--- a/consensus/src/test/scala/co/topl/consensus/BlockHeaderValidationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/BlockHeaderValidationSpec.scala
@@ -103,7 +103,7 @@ class BlockHeaderValidationSpec
     forAll(genValid(u => u.copy(slot = 0L))) { case (parent, child, _: Operator, _: Eta, _: Ratio) =>
       val etaInterpreter = mock[EtaCalculationAlgebra[F]]
       val consensusValidationState = mock[ConsensusValidationStateAlgebra[F]]
-      val clockAlgebra = createDummyClockAlgebra(child)
+      val clockAlgebra = mock[ClockAlgebra[F]]
       val ed25519VRFResource = mock[UnsafeResource[F, Ed25519VRF]]
       val kesProductResource = mock[UnsafeResource[F, KesProduct]]
       val ed25519Resource = mock[UnsafeResource[F, Ed25519]]
@@ -132,7 +132,7 @@ class BlockHeaderValidationSpec
     forAll(genValid(u => u.copy(timestamp = 0L))) { case (parent, child, _: Operator, _: Eta, _: Ratio) =>
       val etaInterpreter = mock[EtaCalculationAlgebra[F]]
       val consensusValidationState = mock[ConsensusValidationStateAlgebra[F]]
-      val clockAlgebra = createDummyClockAlgebra(child)
+      val clockAlgebra = mock[ClockAlgebra[F]]
       val ed25519VRFResource = mock[UnsafeResource[F, Ed25519VRF]]
       val kesProductResource = mock[UnsafeResource[F, KesProduct]]
       val ed25519Resource = mock[UnsafeResource[F, Ed25519]]
@@ -161,7 +161,7 @@ class BlockHeaderValidationSpec
       case (parent, child, _: Operator, _: Eta, _: Ratio) =>
         val etaInterpreter = mock[EtaCalculationAlgebra[F]]
         val consensusValidationState = mock[ConsensusValidationStateAlgebra[F]]
-        val clockAlgebra = createDummyClockAlgebra(child)
+        val clockAlgebra = mock[ClockAlgebra[F]]
         val ed25519VRFResource = mock[UnsafeResource[F, Ed25519VRF]]
         val kesProductResource = mock[UnsafeResource[F, KesProduct]]
         val ed25519Resource = mock[UnsafeResource[F, Ed25519]]

--- a/demo/src/main/scala/co/topl/demo/DemoUtils.scala
+++ b/demo/src/main/scala/co/topl/demo/DemoUtils.scala
@@ -110,6 +110,7 @@ object DemoConfig {
   val ChainSelectionKLookback: Long = 50
   val SlotDuration: FiniteDuration = 100.milli
   val OperationalPeriodsPerEpoch: Long = 2L
+  val ForwardBiasedSlotWindow: Slot = 50L
 
   val ChainSelectionSWindow: Long =
     (Ratio(ChainSelectionKLookback, 4L) * fEffective.inverse).round.toLong

--- a/demo/src/main/scala/co/topl/demo/TetraSuperDemo.scala
+++ b/demo/src/main/scala/co/topl/demo/TetraSuperDemo.scala
@@ -62,7 +62,7 @@ object TetraSuperDemo extends IOApp {
   type F[A] = IO[A]
 
   private def makeClock(genesisTimestamp: Timestamp): ClockAlgebra[F] =
-    SchedulerClock.Eval.make(SlotDuration, EpochLength, Instant.ofEpochMilli(genesisTimestamp))
+    SchedulerClock.Eval.make(SlotDuration, EpochLength, Instant.ofEpochMilli(genesisTimestamp), ForwardBiasedSlotWindow)
 
   // Program definition
 
@@ -215,6 +215,7 @@ object TetraSuperDemo extends IOApp {
           etaCalculation,
           consensusValidationState,
           leaderElectionThreshold,
+          clock,
           ed25519VRFResource,
           kesProductResource,
           ed25519Resource,

--- a/node-tetra/src/main/resources/application.conf
+++ b/node-tetra/src/main/resources/application.conf
@@ -56,6 +56,7 @@ bifrost {
       vrf-amplitude = "1/2"
       chain-selection-k-lookback = 50
       slot-duration = 100 milli
+      forward-biased-slot-window = 50
       operational-periods-per-epoch = 2
       kes-key-hours = 9
       kes-key-minutes = 9

--- a/node-tetra/src/main/scala/co/topl/node/ApplicationConfig.scala
+++ b/node-tetra/src/main/scala/co/topl/node/ApplicationConfig.scala
@@ -78,6 +78,7 @@ object ApplicationConfig {
       vrfAmplitude:               Ratio,
       chainSelectionKLookback:    Long,
       slotDuration:               FiniteDuration,
+      forwardBiasedSlotWindow:    Slot,
       operationalPeriodsPerEpoch: Long,
       kesKeyHours:                Int,
       kesKeyMinutes:              Int

--- a/node-tetra/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node-tetra/src/main/scala/co/topl/node/NodeApp.scala
@@ -116,7 +116,8 @@ object NodeApp
             clock = SchedulerClock.Eval.make[F](
               bigBangProtocol.slotDuration,
               bigBangProtocol.epochLength,
-              Instant.ofEpochMilli(bigBangBlock.headerV2.timestamp)
+              Instant.ofEpochMilli(bigBangBlock.headerV2.timestamp),
+              bigBangProtocol.forwardBiasedSlotWindow
             )
             _ <- clock.globalSlot.flatMap(globalSlot =>
               Logger[F].info(show"globalSlot=$globalSlot canonicalHeadSlot=${canonicalHeadSlotData.slotId.slot}")
@@ -185,7 +186,8 @@ object NodeApp
               blockIdTree,
               etaCalculation,
               consensusValidationState,
-              leaderElectionThreshold
+              leaderElectionThreshold,
+              clock
             )
             // Finally, run the program
             _ <- Blockchain

--- a/node-tetra/src/main/scala/co/topl/node/Validators.scala
+++ b/node-tetra/src/main/scala/co/topl/node/Validators.scala
@@ -2,6 +2,7 @@ package co.topl.node
 
 import cats.effect.Async
 import cats.implicits._
+import co.topl.algebras.ClockAlgebra
 import co.topl.consensus.BlockHeaderValidation
 import co.topl.consensus.algebras.{
   BlockHeaderValidationAlgebra,
@@ -37,7 +38,8 @@ object Validators {
     blockIdTree:                 ParentChildTree[F, TypedIdentifier],
     etaCalculation:              EtaCalculationAlgebra[F],
     consensusValidationState:    ConsensusValidationStateAlgebra[F],
-    leaderElectionThreshold:     LeaderElectionValidationAlgebra[F]
+    leaderElectionThreshold:     LeaderElectionValidationAlgebra[F],
+    clockAlgebra:                ClockAlgebra[F]
   ): F[Validators[F]] =
     for {
       headerValidation <- BlockHeaderValidation.Eval
@@ -45,6 +47,7 @@ object Validators {
           etaCalculation,
           consensusValidationState,
           leaderElectionThreshold,
+          clockAlgebra,
           cryptoResources.ed25519VRF,
           cryptoResources.kesProduct,
           cryptoResources.ed25519,


### PR DESCRIPTION
Add next block header verifications: 
 - Reject block if block's timestamp is not matched slot for that timestamp
 - Reject block if block's slot is greater than current global slot + forward biased slot window

## Purpose
Do not allow to attack blockchain by propagating blocks from far future (which allow to switch to attacker chain, and stop minting block until attacker last block will be reach)

## Approach
Appropriate verification had been added to the block header validation

## Testing
tested by updated unit tests

## Tickets
[*](https://topl.atlassian.net/browse/BN-673)
