### PR TITLE
Tsdk 46 create orient db database 4

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/EdgeSchema.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/EdgeSchema.scala
@@ -3,4 +3,4 @@ package co.topl.genusLibrary.orientDb
 /**
  * Describe a type of edge. Currently does not allow for data to be associated with edges, but this may change.
  */
-case class EdgeSchema (name: String)
+case class EdgeSchema(name: String)

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/EdgeSchema.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/EdgeSchema.scala
@@ -1,0 +1,6 @@
+package co.topl.genusLibrary.orientDb
+
+/**
+ * Describe a type of edge. Currently does not allow for data to be associated with edges, but this may change.
+ */
+case class EdgeSchema (name: String)

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/GenusGraphMetadata.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/GenusGraphMetadata.scala
@@ -29,11 +29,20 @@ package co.topl.genusLibrary.orientDb {
     val txoVertexType: OrientVertexType = ensureVertexSchemaInitialized(txoSchema)
     val transactionVertexType: OrientVertexType = ensureVertexSchemaInitialized(transactionSchema)
 
-    val currentAddressStateEdgeType: OrientEdgeType = graphNoTx.createEdgeType("CurrentAddressState")
-    val prevToNextAddressStateEdgeType: OrientEdgeType = graphNoTx.createEdgeType("PrevToNextAddressState")
-    val addressStateToTxoStateEdgeType: OrientEdgeType = graphNoTx.createEdgeType("AddressStateToTxoState")
-    val inputEdgeType: OrientEdgeType = graphNoTx.createEdgeType("Input")
-    val outputEdgeType: OrientEdgeType = graphNoTx.createEdgeType("Output")
+    val currentAddressStateEdgeType: OrientEdgeType = ensureEdgeSchemaInitialized(EdgeSchema("CurrentAddressState"))
+    val prevToNextAddressStateEdgeType: OrientEdgeType = ensureEdgeSchemaInitialized(
+      EdgeSchema("PrevToNextAddressState")
+    )
+    val addressStateToTxoStateEdgeType: OrientEdgeType = ensureEdgeSchemaInitialized(
+      EdgeSchema("AddressStateToTxoState")
+    )
+    val inputEdgeType: OrientEdgeType = ensureEdgeSchemaInitialized(EdgeSchema("Input"))
+    val outputEdgeType: OrientEdgeType = ensureEdgeSchemaInitialized(EdgeSchema("Output"))
+
+    def ensureEdgeSchemaInitialized(edgeSchema: EdgeSchema): OrientEdgeType =
+      Option(graphNoTx.getEdgeType(edgeSchema.name)).getOrElse {
+        graphNoTx.createEdgeType(edgeSchema.name)
+      }
 
     def ensureVertexSchemaInitialized(vertexSchema: VertexSchema[_]): OrientVertexType =
       Option(graphNoTx.getVertexType(vertexSchema.name)).getOrElse {

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/GenusGraphMetadata.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/GenusGraphMetadata.scala
@@ -30,9 +30,11 @@ package co.topl.genusLibrary.orientDb {
     val transactionVertexType: OrientVertexType = ensureVertexSchemaInitialized(transactionSchema)
 
     val currentAddressStateEdgeType: OrientEdgeType = ensureEdgeSchemaInitialized(EdgeSchema("CurrentAddressState"))
+
     val prevToNextAddressStateEdgeType: OrientEdgeType = ensureEdgeSchemaInitialized(
       EdgeSchema("PrevToNextAddressState")
     )
+
     val addressStateToTxoStateEdgeType: OrientEdgeType = ensureEdgeSchemaInitialized(
       EdgeSchema("AddressStateToTxoState")
     )


### PR DESCRIPTION
## Purpose
Fix  a bug that Fernando noticed after the code had been merged. Edge types were being created even if they already existed.

## Approach
Handle edge type create like vertex types. Create a schema object for each edge and pass it to a method that uses the schema to create the edge only after checking that the edge types does not already exist.

## Testing
No additional testing was done for this. It will be tested in the next Jira ticket when we actually start storing things in the database.

## Tickets
* TSDK-46