### PR TITLE
Block Packer - Sort Transactions by Timestamp

### DIFF
--- a/minting/src/main/scala/co/topl/minting/BlockPacker.scala
+++ b/minting/src/main/scala/co/topl/minting/BlockPacker.scala
@@ -40,12 +40,12 @@ object BlockPacker {
         _                     <- Logger[F].debug(show"Block packing candidates=${mempoolTransactionIds.toList}")
         // The transactions that come out of the mempool arrive in no particular order
         unsortedTransactions <- mempoolTransactionIds.toList.traverse(fetchTransaction)
-        transactions = orderTransactions(unsortedTransactions)
+        sortedTransactions = orderTransactions(unsortedTransactions)
         iterative <-
           // Enqueue all of the transactions (in no particular order, which is terrible for performance and accuracy)
           Queue
             .unbounded[F, Transaction]
-            .flatTap(queue => transactions.traverse(queue.offer))
+            .flatTap(queue => sortedTransactions.traverse(queue.offer))
             .map(queue =>
               new Iterative[F, BlockBodyV2.Full] {
 

--- a/minting/src/main/scala/co/topl/minting/BlockPacker.scala
+++ b/minting/src/main/scala/co/topl/minting/BlockPacker.scala
@@ -38,8 +38,10 @@ object BlockPacker {
         // Read all transaction IDs from the mempool
         mempoolTransactionIds <- mempool.read(parentBlockId)
         _                     <- Logger[F].debug(show"Block packing candidates=${mempoolTransactionIds.toList}")
-        transactions          <- mempoolTransactionIds.toList.traverse(fetchTransaction)
-        iterative             <-
+        // The transactions that come out of the mempool arrive in no particular order
+        unsortedTransactions <- mempoolTransactionIds.toList.traverse(fetchTransaction)
+        transactions = orderTransactions(unsortedTransactions)
+        iterative <-
           // Enqueue all of the transactions (in no particular order, which is terrible for performance and accuracy)
           Queue
             .unbounded[F, Transaction]
@@ -65,6 +67,14 @@ object BlockPacker {
       } yield iterative
     )
   }
+
+  /**
+   * A naive mechanism to pre-sort the Transactions that are attempted into a block.  The pre-sort attempts to
+   * decrease the odds of wasting an attempt on a double-spend Transaction.
+   */
+  private def orderTransactions(transactions: List[Transaction]): List[Transaction] =
+    // TODO: This may introduce an attack vector in which an adversary may spam 0-timestamp Transactions
+    transactions.sortBy(_.schedule.creation)
 
   def makeBodyValidator[F[_]: Monad: Logger](
     bodySyntaxValidation:        BodySyntaxValidationAlgebra[F],


### PR DESCRIPTION
## Purpose
- The Block Packer selects Transactions to be included in a new Block
- The current implementation randomly selects Transactions, attempts to validate them, and includes them if successful
  - Random selection is very non-performant
## Approach
- Modify the selection slightly by sorting the initial list of Transactions by timestamp
  - NOTE: This introduces an attack vector which we will accept for now (See ticket BN-686)
## Testing
- Ran local node with a modified Transaction Generator that generates worst-case-scenario graphs.  The mempool was properly clearing under 7TPS
## Tickets
- #2565 