### PR TITLE
BN-692-scala213FlagUnused

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ClockAlgebra.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ClockAlgebra.scala
@@ -6,7 +6,6 @@ import co.topl.models.{Epoch, Slot, Timestamp}
 
 import scala.collection.immutable.NumericRange
 import scala.concurrent.duration.FiniteDuration
-import scala.language.implicitConversions
 
 /**
  * Provides global slot, epoch, and timing operations

--- a/algebras/src/main/scala/co/topl/algebras/Store.scala
+++ b/algebras/src/main/scala/co/topl/algebras/Store.scala
@@ -1,6 +1,6 @@
 package co.topl.algebras
 
-import cats.{ApplicativeThrow, Functor, MonadThrow, Show}
+import cats.{Functor, MonadThrow, Show}
 import cats.implicits._
 import cats.data.OptionT
 

--- a/brambl/src/main/scala/co/topl/credential/Credentialer.scala
+++ b/brambl/src/main/scala/co/topl/credential/Credentialer.scala
@@ -3,8 +3,6 @@ package co.topl.credential
 import co.topl.crypto.signing.{Ed25519, ExtendedEd25519}
 import co.topl.models.{Propositions, SecretKeys, Transaction}
 
-import scala.language.implicitConversions
-
 /**
  * Reveal inputs to produce a Credential
  */

--- a/brambl/src/test/scala/co/topl/client/rpcExample.scala
+++ b/brambl/src/test/scala/co/topl/client/rpcExample.scala
@@ -9,7 +9,6 @@ import co.topl.attestation.implicits._
 import co.topl.attestation.keyManagement.{KeyRing, KeyfileCurve25519, KeyfileCurve25519Companion, PrivateKeyCurve25519}
 import co.topl.attestation.{Address, PublicKeyPropositionCurve25519}
 import co.topl.client.Provider.PrivateTestNet
-import co.topl.codecs._
 import co.topl.modifier.box.{AssetCode, AssetValue}
 import co.topl.modifier.transaction.builder.BoxSelectionAlgorithms
 import co.topl.rpc.ToplRpc

--- a/brambl/src/test/scala/co/topl/credential/CredentialSpec.scala
+++ b/brambl/src/test/scala/co/topl/credential/CredentialSpec.scala
@@ -85,7 +85,7 @@ class CredentialSpec
         val andProof =
           andCredential.proof
 
-        val transaction = unprovenTransaction.prove(_ => andProof)
+        unprovenTransaction.prove(_ => andProof)
       }
     }
   }
@@ -101,7 +101,7 @@ class CredentialSpec
 
         orCredential.proposition shouldBe orProposition
 
-        val orProof = orCredential.proof
+        orCredential.proof
       }
     }
   }
@@ -127,7 +127,7 @@ class CredentialSpec
 
           val thresholdProof = thresholdCredential.proof
 
-          val transaction = unprovenTransaction.prove(_ => thresholdProof)
+          unprovenTransaction.prove(_ => thresholdProof)
         }
     }
   }
@@ -163,7 +163,7 @@ class CredentialSpec
           val andProof =
             andCredential.proof
 
-          val transaction = unprovenTransaction.prove(_ => andProof)
+          unprovenTransaction.prove(_ => andProof)
         }
     }
   }

--- a/brambl/src/test/scala/co/topl/credential/KeyFileSpec.scala
+++ b/brambl/src/test/scala/co/topl/credential/KeyFileSpec.scala
@@ -1,10 +1,9 @@
 package co.topl.credential
 
-import KeyFile.Encryption.MACMismatch
 import co.topl.credential.KeyFile.Encryption.MACMismatch
 import co.topl.models.utility.HasLength.instances.bytesLength
 import co.topl.models.utility.Sized
-import co.topl.models.{Bytes, Evidence, TypedEvidence}
+import co.topl.models.{Bytes, TypedEvidence}
 import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.flatspec.AnyFlatSpec

--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,8 @@ lazy val scalamacrosParadiseSettings =
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, v)) if v >= 13 =>
           Seq(
-            "-Ymacro-annotations"
+            "-Ymacro-annotations",
+            "-Xlint:unused"
           )
         case _ =>
           Nil
@@ -166,11 +167,11 @@ lazy val scalamacrosParadiseSettings =
   )
 
 lazy val commonScalacOptions = Seq(
-  "-deprecation",
-  "-feature",
-  "-language:higherKinds",
+  "-deprecation", // Emit warning and location for usages of deprecated APIs.
+  "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+  "-language:higherKinds", // Allow higher-kinded types
   "-language:postfixOps",
-  "-unchecked",
+  "-unchecked", // Enable additional warnings where generated code depends on assumptions.
   "-Xlint:",
   "-Ywarn-unused:-implicits,-privates",
   "-Yrangepos"

--- a/byte-codecs/src/main/scala/co/topl/codecs/bytes/typeclasses/Signable.scala
+++ b/byte-codecs/src/main/scala/co/topl/codecs/bytes/typeclasses/Signable.scala
@@ -4,8 +4,6 @@ import scodec.{Attempt, Encoder}
 import scodec.bits.ByteVector
 import simulacrum.typeclass
 
-import scala.language.implicitConversions
-
 /**
  * Typeclass for encoding a value into its byte representation for signing routines.
  *

--- a/cats-akka/src/main/scala/co/topl/catsakka/AbandonerFlow.scala
+++ b/cats-akka/src/main/scala/co/topl/catsakka/AbandonerFlow.scala
@@ -5,7 +5,6 @@ import akka.stream.{Attributes, FlowShape, Inlet, Materializer, Outlet}
 import akka.stream.scaladsl.Flow
 import akka.stream.stage.{AsyncCallback, GraphStage, GraphStageLogic, GraphStageLogicWithLogging, InHandler, OutHandler}
 import cats.effect.{Async, Fiber}
-import cats.implicits._
 
 import scala.concurrent.ExecutionContext
 

--- a/common/src/main/scala/co/topl/attestation/Evidence.scala
+++ b/common/src/main/scala/co/topl/attestation/Evidence.scala
@@ -4,11 +4,6 @@ import co.topl.codecs.binary.legacy.attestation.EvidenceSerializer
 import co.topl.codecs.binary.legacy.{BifrostSerializer, BytesSerializable}
 import co.topl.crypto.hash.digest.Digest
 import co.topl.crypto.implicits._
-import co.topl.utils.IdiomaticScalaTransition.implicits.toEitherOps
-import co.topl.utils.StringDataTypes.Base58Data
-import co.topl.codecs._
-import co.topl.codecs.binary.legacy.attestation.EvidenceSerializer
-import co.topl.codecs.binary.legacy.{BifrostSerializer, BytesSerializable}
 import co.topl.utils.encode.Base58
 import com.google.common.primitives.Ints
 import io.estatico.newtype.macros.newtype

--- a/common/src/main/scala/co/topl/attestation/Proposition.scala
+++ b/common/src/main/scala/co/topl/attestation/Proposition.scala
@@ -12,7 +12,7 @@ import co.topl.crypto.PublicKey
 import co.topl.crypto.hash.blake2b256
 import co.topl.crypto.signing.{Curve25519, Ed25519}
 import co.topl.utils.NetworkType.NetworkPrefix
-import co.topl.utils.StringDataTypes.{Base16Data, DataEncodingValidationFailure}
+import co.topl.utils.StringDataTypes.DataEncodingValidationFailure
 import co.topl.utils.encode.Base16
 import co.topl.utils.{Identifiable, Identifier}
 import com.google.common.primitives.Ints

--- a/common/src/main/scala/co/topl/attestation/ops/AddressOps.scala
+++ b/common/src/main/scala/co/topl/attestation/ops/AddressOps.scala
@@ -3,7 +3,7 @@ package co.topl.attestation.ops
 import cats.implicits._
 import co.topl.attestation.Address
 import co.topl.attestation.ops.EvidenceOps.ToTypedEvidenceFailure
-import co.topl.models.{NetworkPrefix, SpendingAddress}
+import co.topl.models.SpendingAddress
 import co.topl.attestation.ops.EvidenceOps.implicits._
 
 import scala.language.implicitConversions

--- a/common/src/main/scala/co/topl/codecs/binary/scodecs/modifier/block/BlockCodecs.scala
+++ b/common/src/main/scala/co/topl/codecs/binary/scodecs/modifier/block/BlockCodecs.scala
@@ -7,7 +7,6 @@ import co.topl.codecs.binary.scodecs.modifier.transaction.transactionCodec
 import co.topl.codecs.binary.scodecs.valuetypes._
 import co.topl.modifier.ModifierId
 import co.topl.modifier.block.{Block, BlockBody, BlockHeader, BloomFilter}
-import co.topl.modifier.transaction.Transaction
 import scodec.{Codec, Err}
 import shapeless.{::, HList, HNil}
 import co.topl.codecs.binary.scodecs.ops.implicits._

--- a/common/src/main/scala/co/topl/codecs/binary/scodecs/modifier/transaction/TransactionCodecs.scala
+++ b/common/src/main/scala/co/topl/codecs/binary/scodecs/modifier/transaction/TransactionCodecs.scala
@@ -4,8 +4,7 @@ import co.topl.attestation._
 import co.topl.codecs.binary.scodecs.attestation._
 import co.topl.codecs.binary.scodecs.modifier.box._
 import co.topl.codecs.binary.scodecs.valuetypes._
-import co.topl.modifier.box.Box.Nonce
-import co.topl.modifier.box.{SimpleValue, TokenValueHolder}
+import co.topl.modifier.box.SimpleValue
 import co.topl.modifier.transaction.{ArbitTransfer, AssetTransfer, PolyTransfer, Transaction}
 import co.topl.utils.Identifiable
 import scodec.codecs.{byte, discriminated}

--- a/common/src/main/scala/co/topl/codecs/binary/typeclasses/SignableInstances.scala
+++ b/common/src/main/scala/co/topl/codecs/binary/typeclasses/SignableInstances.scala
@@ -4,7 +4,7 @@ import co.topl.codecs.bytes.tetra.TetraSignableCodecs
 import co.topl.codecs.bytes.typeclasses.Signable
 import co.topl.crypto.hash.Blake2b256
 import co.topl.models._
-import scodec.{Attempt, Codec, Encoder}
+import scodec.{Attempt, Encoder}
 
 import scala.util.Try
 

--- a/common/src/main/scala/co/topl/codecs/json/attestation/keyManagement/KeyManagementJsonCodecs.scala
+++ b/common/src/main/scala/co/topl/codecs/json/attestation/keyManagement/KeyManagementJsonCodecs.scala
@@ -34,16 +34,13 @@ trait KeyManagementJsonCodecs {
         mac        <- c.downField("crypto").downField("mac").as[Base58Data]
         salt       <- c.downField("crypto").downField("kdfSalt").as[Base58Data]
         iv         <- c.downField("crypto").downField("cipherParams").downField("iv").as[Base58Data]
-      } yield {
-        implicit val netPrefix: NetworkPrefix = address.networkPrefix
-        KeyfileCurve25519(
-          address,
-          cipherText.encodeAsBytes,
-          mac.encodeAsBytes,
-          salt.encodeAsBytes,
-          iv.encodeAsBytes
-        )
-      }
+      } yield KeyfileCurve25519(
+        address,
+        cipherText.encodeAsBytes,
+        mac.encodeAsBytes,
+        salt.encodeAsBytes,
+        iv.encodeAsBytes
+      )
 
   implicit val keyfileEd25519JsonEncoder: Encoder[KeyfileEd25519] = { kf: KeyfileEd25519 =>
     Map(
@@ -67,10 +64,7 @@ trait KeyManagementJsonCodecs {
         mac        <- c.downField("crypto").downField("mac").as[Base58Data]
         salt       <- c.downField("crypto").downField("kdfSalt").as[Base58Data]
         iv         <- c.downField("crypto").downField("cipherParams").downField("iv").as[Base58Data]
-      } yield {
-        implicit val netPrefix: NetworkPrefix = address.networkPrefix
-        KeyfileEd25519(address, cipherText.encodeAsBytes, mac.encodeAsBytes, salt.encodeAsBytes, iv.encodeAsBytes)
-      }
+      } yield KeyfileEd25519(address, cipherText.encodeAsBytes, mac.encodeAsBytes, salt.encodeAsBytes, iv.encodeAsBytes)
 
   implicit def keyfileJsonEncoder[KF <: Keyfile[_]]: Encoder[KF] = {
     case kfc: KeyfileCurve25519 => keyfileCurve25519JsonEncoder(kfc)

--- a/common/src/main/scala/co/topl/modifier/ops/AssetValueOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/AssetValueOps.scala
@@ -2,7 +2,7 @@ package co.topl.modifier.ops
 
 import cats.implicits._
 import co.topl.attestation.Address
-import co.topl.models.{Box, Bytes, FullAddress, SpendingAddress, Transaction}
+import co.topl.models.{Box, Bytes, FullAddress, Transaction}
 import co.topl.models.utility.HasLength.instances.{bigIntLength, bytesLength, latin1DataLength}
 import co.topl.models.utility.{Lengths, Sized}
 import co.topl.modifier.box.AssetValue
@@ -33,16 +33,11 @@ class AssetValueOps(private val assetValue: AssetValue) extends AnyVal {
           .leftMap(error => ToAssetOutputFailures.InvalidQuantity(assetValue.quantity, error))
       issuer <-
         assetValue.assetCode.issuer.toSpendingAddress
-          .leftMap[ToAssetOutputFailure](error =>
-            ToAssetOutputFailures.InvalidIssuerAddress(assetValue.assetCode.issuer)
-          )
+          .leftMap[ToAssetOutputFailure](_ => ToAssetOutputFailures.InvalidIssuerAddress(assetValue.assetCode.issuer))
       shortName <-
         Sized
           .max[Latin1Data, Lengths.`8`.type](Latin1Data.fromData(assetValue.assetCode.shortName.value))
-          .leftMap[ToAssetOutputFailure](error =>
-            ToAssetOutputFailures.InvalidShortName(assetValue.assetCode.shortName)
-          )
-      assetCode = Box.Values.AssetV1.Code(assetValue.assetCode.version, issuer, shortName)
+          .leftMap[ToAssetOutputFailure](_ => ToAssetOutputFailures.InvalidShortName(assetValue.assetCode.shortName))
       assetCode <-
         assetValue.assetCode.toTetraAssetCode
           .leftMap {

--- a/common/src/main/scala/co/topl/modifier/ops/SimpleValueOps.scala
+++ b/common/src/main/scala/co/topl/modifier/ops/SimpleValueOps.scala
@@ -3,7 +3,7 @@ package co.topl.modifier.ops
 import cats.implicits._
 import co.topl.models.utility.HasLength.instances.bigIntLength
 import co.topl.models.utility.{Lengths, Sized}
-import co.topl.models.{Box => TetraBox, FullAddress, SpendingAddress, Transaction}
+import co.topl.models.{Box => TetraBox, FullAddress, Transaction}
 import co.topl.modifier.box.SimpleValue
 
 import scala.language.implicitConversions

--- a/common/src/main/scala/co/topl/modifier/transaction/builder/TransferBuilder.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/builder/TransferBuilder.scala
@@ -9,7 +9,6 @@ import co.topl.modifier.box._
 import co.topl.modifier.implicits._
 import co.topl.modifier.ops.AssetCodeOps.ToTetraAssetCodeFailures
 import co.topl.modifier.transaction.builder.Validation._
-import co.topl.modifier.transaction.builder.ops.BoxSetOps.ToBoxReferencesFailures
 import co.topl.modifier.transaction.builder.ops.implicits._
 import co.topl.modifier.transaction.{ArbitTransfer, AssetTransfer, PolyTransfer}
 import co.topl.modifier.{BoxReader, ProgramId}

--- a/common/src/main/scala/co/topl/modifier/transaction/builder/Validation.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/builder/Validation.scala
@@ -1,6 +1,5 @@
 package co.topl.modifier.transaction.builder
 
-import cats.{Foldable, Traverse}
 import cats.implicits._
 import co.topl.attestation.Address
 import co.topl.modifier.box.{AssetBox, AssetCode, Box}

--- a/common/src/main/scala/co/topl/modifier/transaction/builder/ops/BoxSetOps.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/builder/ops/BoxSetOps.scala
@@ -9,8 +9,6 @@ import scala.language.implicitConversions
 
 class BoxSetOps(private val value: BoxSet) extends AnyVal {
 
-  import BoxSetOps._
-
   def polySum: Int128 = value.polys.map(_._2.value.quantity).sum
 
   def arbitSum: Int128 = value.arbits.map(_._2.value.quantity).sum

--- a/common/src/main/scala/co/topl/modifier/transaction/validation/SemanticallyValidatable.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/validation/SemanticallyValidatable.scala
@@ -11,7 +11,7 @@ import co.topl.utils.NetworkType.NetworkPrefix
 import simulacrum._
 
 import scala.collection.compat.immutable.LazyList
-import scala.language.implicitConversions
+
 import scala.util.{Failure, Success, Try}
 
 @typeclass trait SemanticallyValidatable[T] {

--- a/common/src/main/scala/co/topl/modifier/transaction/validation/SyntacticallyValidatable.scala
+++ b/common/src/main/scala/co/topl/modifier/transaction/validation/SyntacticallyValidatable.scala
@@ -10,8 +10,6 @@ import co.topl.modifier.transaction._
 import co.topl.utils.NetworkType.NetworkPrefix
 import simulacrum._
 
-import scala.language.implicitConversions
-
 @typeclass trait SyntacticallyValidatable[T] {
 
   /**

--- a/common/src/main/scala/co/topl/utils/Extensions.scala
+++ b/common/src/main/scala/co/topl/utils/Extensions.scala
@@ -1,7 +1,5 @@
 package co.topl.utils
 
-import co.topl.utils.StringDataTypes.{Base16Data, Base58Data}
-
 import java.nio.charset.{Charset, StandardCharsets}
 import scala.collection.compat.BuildFrom
 import scala.collection.immutable.Iterable

--- a/common/src/main/scala/co/topl/utils/catsinstances/EqInstances.scala
+++ b/common/src/main/scala/co/topl/utils/catsinstances/EqInstances.scala
@@ -14,7 +14,6 @@ import co.topl.modifier.transaction.{ArbitTransfer, AssetTransfer, PolyTransfer,
 import co.topl.utils.Int128
 import co.topl.utils.StringDataTypes.{Base16Data, Base58Data, Latin1Data}
 import co.topl.crypto.implicits._
-import co.topl.typeclasses.implicits._
 
 import scala.collection.immutable.ListMap
 

--- a/common/src/test/scala/co/topl/modifier/transaction/builder/BoxSelectionAlgorithmSpec.scala
+++ b/common/src/test/scala/co/topl/modifier/transaction/builder/BoxSelectionAlgorithmSpec.scala
@@ -1,6 +1,6 @@
 package co.topl.modifier.transaction.builder
 
-import co.topl.modifier.transaction.builder.TransferRequests.{ArbitTransferRequest, PolyTransferRequest}
+import co.topl.modifier.transaction.builder.TransferRequests.ArbitTransferRequest
 import co.topl.utils.CommonGenerators
 import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
@@ -48,7 +48,7 @@ class BoxSelectionAlgorithmSpec
         val polyBoxes = (firstPolyBox :: otherPolyBoxes).map(address -> _)
         val arbitBoxes = (firstArbitBox :: otherArbitBoxes).map(address -> _)
         val tokenBoxes = BoxSet(arbitBoxes.toSet, polyBoxes.toSet, Set.empty)
-        val request = ArbitTransferRequest(List(address), List(address -> 100), address, address, 0, None)
+        ArbitTransferRequest(List(address), List(address -> 100), address, address, 0, None)
         val algorithm = BoxSelectionAlgorithms.Specific(List(firstPolyBox.id, firstArbitBox.id))
 
         val result = BoxSelectionAlgorithm.pickBoxes(algorithm, tokenBoxes, 0, 0, Map.empty)

--- a/common/src/test/scala/co/topl/modifier/transaction/builder/BuildUnsignedAssetTransferSpec.scala
+++ b/common/src/test/scala/co/topl/modifier/transaction/builder/BuildUnsignedAssetTransferSpec.scala
@@ -1,9 +1,7 @@
 package co.topl.modifier.transaction.builder
 
-import cats.data.Chain
-import co.topl.attestation.{Address, PublicKeyPropositionCurve25519}
+import co.topl.attestation.PublicKeyPropositionCurve25519
 import co.topl.modifier.box.{AssetBox, AssetCode, AssetValue}
-import co.topl.modifier.{BoxReader, ProgramId}
 import co.topl.utils.CommonGenerators
 import co.topl.utils.StringDataTypes.Latin1Data
 import org.scalacheck.Gen

--- a/common/src/test/scala/co/topl/modifier/transaction/builder/BuildUnsignedPolyTransferSpec.scala
+++ b/common/src/test/scala/co/topl/modifier/transaction/builder/BuildUnsignedPolyTransferSpec.scala
@@ -1,12 +1,7 @@
 package co.topl.modifier.transaction.builder
 
-import cats.implicits._
-import cats.data.NonEmptyChain
-import co.topl.attestation.{Address, PublicKeyPropositionCurve25519}
-import co.topl.modifier.box.{PolyBox, SimpleValue}
-import co.topl.modifier.{BoxReader, ProgramId}
+import co.topl.attestation.PublicKeyPropositionCurve25519
 import co.topl.utils.{CommonGenerators, Int128}
-import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec

--- a/common/src/test/scala/co/topl/modifier/transaction/ops/SimpleValueOpsSpec.scala
+++ b/common/src/test/scala/co/topl/modifier/transaction/ops/SimpleValueOpsSpec.scala
@@ -1,6 +1,6 @@
 package co.topl.modifier.transaction.ops
 
-import co.topl.models.{Box => TetraBox, FullAddress, ModelGenerators, SpendingAddress, Transaction}
+import co.topl.models.{Box => TetraBox, FullAddress, ModelGenerators, Transaction}
 import co.topl.modifier.box.SimpleValue
 import co.topl.modifier.implicits._
 import co.topl.utils.{CommonGenerators, Int128}

--- a/common/src/test/scala/co/topl/serialization/JsonTests.scala
+++ b/common/src/test/scala/co/topl/serialization/JsonTests.scala
@@ -9,7 +9,7 @@ import co.topl.attestation.keyManagement.{
   KeyfileEd25519Companion
 }
 import co.topl.codecs._
-import co.topl.modifier.{ModifierId, ProgramId}
+import co.topl.modifier.ModifierId
 import co.topl.modifier.block.{Block, BlockBody, BlockHeader, BloomFilter}
 import co.topl.modifier.box._
 import co.topl.modifier.transaction.Transaction

--- a/common/src/test/scala/co/topl/utils/CommonGenerators.scala
+++ b/common/src/test/scala/co/topl/utils/CommonGenerators.scala
@@ -14,7 +14,6 @@ import co.topl.models.utility.HasLength.instances.bytesLength
 import co.topl.models.utility.{Lengths, Sized}
 import co.topl.modifier.{ModifierId, ProgramId}
 import co.topl.modifier.block.{Block, BloomFilter}
-import co.topl.modifier.block.PersistentNodeViewModifier.PNVMVersion
 import co.topl.modifier.box.Box.Nonce
 import co.topl.modifier.box._
 import co.topl.modifier.transaction._
@@ -23,7 +22,6 @@ import io.circe.Json
 import io.circe.syntax._
 import org.scalacheck.rng.Seed
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.Suite
 
 import java.nio.charset.StandardCharsets
 import scala.collection.SortedSet

--- a/consensus/src/main/scala/co/topl/consensus/BlockHeaderValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/BlockHeaderValidation.scala
@@ -16,8 +16,6 @@ import scalacache.caffeine.CaffeineCache
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
 
-import scala.language.implicitConversions
-
 /**
  * Interpreters for the ConsensusValidationAlgebra
  */

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusValidationStateSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusValidationStateSpec.scala
@@ -7,7 +7,7 @@ import co.topl.algebras.testInterpreters.TestStore
 import co.topl.consensus.interpreters.EpochBoundariesEventSourcedState.EpochBoundaries
 import co.topl.eventtree.EventSourcedState
 import co.topl.models.utility.Ratio
-import co.topl.models.{Box, Epoch, Int128, StakingAddress, StakingAddresses, TypedIdentifier}
+import co.topl.models.{Box, Epoch, Int128, StakingAddresses, TypedIdentifier}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory

--- a/crypto/src/main/scala/co/topl/crypto/accumulators/merkle/MerkleTree.scala
+++ b/crypto/src/main/scala/co/topl/crypto/accumulators/merkle/MerkleTree.scala
@@ -7,7 +7,6 @@ import co.topl.crypto.hash.digest.implicits._
 import co.topl.models.Bytes
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
 /* Forked from https://github.com/input-output-hk/scrypto */
 

--- a/crypto/src/main/scala/co/topl/crypto/generation/KeyInitializer.scala
+++ b/crypto/src/main/scala/co/topl/crypto/generation/KeyInitializer.scala
@@ -6,7 +6,7 @@ import co.topl.crypto.generation.mnemonic.{Entropy, EntropyFailure, Language}
 import co.topl.crypto.signing._
 import co.topl.models._
 import co.topl.models.utility.HasLength.instances._
-import co.topl.models.utility.{Lengths, Sized}
+import co.topl.models.utility.Sized
 import scodec.bits.BitVector
 import simulacrum.typeclass
 

--- a/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/Phrase.scala
+++ b/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/Phrase.scala
@@ -2,7 +2,6 @@ package co.topl.crypto.generation.mnemonic
 
 import cats.implicits._
 import co.topl.crypto.generation.mnemonic.Language.LanguageWordList
-import co.topl.crypto.generation.mnemonic.PhraseFailures.InvalidWordLength
 import co.topl.crypto.hash.sha256
 
 /**

--- a/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/mnemonic.scala
+++ b/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/mnemonic.scala
@@ -1,8 +1,5 @@
 package co.topl.crypto.generation
 
-import scala.language.implicitConversions
-import scala.math.BigInt
-
 /**
  * A mnemonic represents a set of random entropy that can be used to derive a private key or other type of value.
  * This implementation follows a combination of BIP-0039 and SLIP-0023.

--- a/crypto/src/main/scala/co/topl/crypto/hash/digest/digest.scala
+++ b/crypto/src/main/scala/co/topl/crypto/hash/digest/digest.scala
@@ -1,7 +1,6 @@
 package co.topl.crypto.hash
 
 import cats.data.{Validated, ValidatedNec}
-import cats.{Eq, Show}
 import io.estatico.newtype.macros.newtype
 import io.estatico.newtype.ops._
 import simulacrum.typeclass

--- a/crypto/src/main/scala/co/topl/crypto/hash/hash.scala
+++ b/crypto/src/main/scala/co/topl/crypto/hash/hash.scala
@@ -2,8 +2,6 @@ package co.topl.crypto
 
 import co.topl.crypto.hash.digest._
 
-import scala.language.implicitConversions
-
 /* Forked from https://github.com/input-output-hk/scrypto */
 
 package object hash {

--- a/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala
@@ -1,8 +1,6 @@
 package co.topl.crypto.signing
 
-import co.topl.crypto.generation.{Bip32Index, Bip32Indexes, EntropyToSeed, Pbkdf2Sha512}
-import co.topl.crypto.generation.mnemonic.Entropy
-import co.topl.models.SecretKeys.ExtendedEd25519.Length
+import co.topl.crypto.generation.{Bip32Index, Bip32Indexes}
 import co.topl.models._
 import co.topl.models.utility.HasLength.instances._
 import co.topl.models.utility.{Lengths, Sized}
@@ -10,7 +8,6 @@ import org.bouncycastle.crypto.digests.SHA512Digest
 import org.bouncycastle.crypto.macs.HMac
 import org.bouncycastle.crypto.params.KeyParameter
 
-import java.nio.charset.StandardCharsets
 import java.nio.{ByteBuffer, ByteOrder}
 
 class ExtendedEd25519

--- a/crypto/src/main/scala/co/topl/crypto/signing/package.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signing/package.scala
@@ -2,7 +2,6 @@ package co.topl.crypto
 
 import io.estatico.newtype.macros.newtype
 
-import java.security.SecureRandom
 import scala.language.implicitConversions
 
 package object signing {

--- a/crypto/src/test/scala/co/topl/crypto/accumulators/MerkleTreeSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/accumulators/MerkleTreeSpec.scala
@@ -4,7 +4,6 @@ import co.topl.crypto.accumulators.merkle.{Leaf, MerkleTree}
 import co.topl.crypto.hash.digest.{Digest, Digest32}
 import co.topl.crypto.hash.implicits._
 import co.topl.crypto.hash.{Blake2b, Hash}
-import co.topl.crypto.utils.Generators._
 import co.topl.crypto.utils.randomBytes
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers

--- a/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/LanguageSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/LanguageSpec.scala
@@ -3,8 +3,6 @@ package co.topl.crypto.generation.mnemonic
 import cats.implicits._
 import co.topl.crypto.generation.mnemonic.Language._
 import co.topl.crypto.utils.Generators
-import org.scalacheck.Gen
-import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}

--- a/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala
@@ -1,9 +1,6 @@
 package co.topl.crypto.generation.mnemonic
 
-import co.topl.crypto.generation.mnemonic.Language.LanguageWordList
-import co.topl.crypto.generation.mnemonic.MnemonicSizes.{`12`, `18`, `24`}
 import co.topl.crypto.utils.Generators
-import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}

--- a/crypto/src/test/scala/co/topl/crypto/utils/EntropySupport.scala
+++ b/crypto/src/test/scala/co/topl/crypto/utils/EntropySupport.scala
@@ -2,7 +2,6 @@ package co.topl.crypto.utils
 
 import cats.Eq
 import co.topl.crypto.generation.mnemonic.Entropy
-import co.topl.models.Bytes
 import org.scalacheck.Arbitrary
 
 trait EntropySupport {

--- a/genus-library/src/main/scala/co/topl/genusLibrary/GenusException.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/GenusException.scala
@@ -1,7 +1,5 @@
 package co.topl.genusLibrary
 
-import co.topl.typeclasses.Log
-
 /**
  * Base exception class for the Genus library.
  *

--- a/genus-library/src/main/scala/co/topl/genusLibrary/Txo.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/Txo.scala
@@ -22,7 +22,6 @@ import co.topl.genusLibrary.TxoState._
  * @param state The status of the box
  */
 case class Txo(box: Box, state: TxoState, id: Box.Id, address: Option[SpendingAddress]) {
-  import Txo._
 
   private def unsupported[T](v: Box.Value): T = throw GenusException(s"Encountered unsupported type of box value: $v")
 

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/VertexSchema.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/VertexSchema.scala
@@ -1,9 +1,7 @@
 package co.topl.genusLibrary.orientDb
 
-import co.topl.models.TypedIdentifier
 import com.orientechnologies.orient.core.metadata.schema.OClass.INDEX_TYPE
 import com.orientechnologies.orient.core.metadata.schema.{OClass, OPropertyAbstractDelegate, OType}
-import scodec.bits.ByteVector
 
 /**
  * Describe how data from a scala class will be stored in an OrientDB vertex.

--- a/genus/src/main/scala/co/topl/genus/GenusApp.scala
+++ b/genus/src/main/scala/co/topl/genus/GenusApp.scala
@@ -13,11 +13,11 @@ import co.topl.genus.interpreters.services._
 import co.topl.genus.programs.GenusProgram
 import co.topl.genus.settings._
 import co.topl.genus.typeclasses.implicits._
-import co.topl.genus.ops.implicits._
+
 import co.topl.utils.StringDataTypes.Base58Data
 import com.typesafe.config.ConfigFactory
 import mainargs.ParserForClass
-import org.mongodb.scala.{Document, MongoClient}
+import org.mongodb.scala.MongoClient
 
 import java.io.File
 import scala.concurrent.ExecutionContext

--- a/genus/src/main/scala/co/topl/genus/interpreters/MongoChainHeight.scala
+++ b/genus/src/main/scala/co/topl/genus/interpreters/MongoChainHeight.scala
@@ -15,7 +15,6 @@ import co.topl.utils.mongodb.DocumentDecoder
 import co.topl.utils.mongodb.codecs._
 import co.topl.utils.mongodb.models.BlockDataModel
 import org.mongodb.scala.bson.conversions.Bson
-import org.mongodb.scala.{Document, MongoCollection}
 import co.topl.genus.ops.implicits._
 
 import scala.concurrent.duration.DurationInt

--- a/genus/src/main/scala/co/topl/genus/ops/protobufops/QueryBlocksReqOps.scala
+++ b/genus/src/main/scala/co/topl/genus/ops/protobufops/QueryBlocksReqOps.scala
@@ -3,7 +3,6 @@ package co.topl.genus.ops.protobufops
 import co.topl.genus.algebras.QueryService.QueryRequest
 import co.topl.genus.filters.BlockFilter
 import co.topl.genus.services.blocks_query.{BlockSorting, QueryBlocksReq}
-import org.mongodb.scala.bson.conversions.Bson
 
 import scala.language.implicitConversions
 

--- a/genus/src/main/scala/co/topl/genus/ops/protobufops/TxsQueryStreamReqOps.scala
+++ b/genus/src/main/scala/co/topl/genus/ops/protobufops/TxsQueryStreamReqOps.scala
@@ -3,7 +3,6 @@ package co.topl.genus.ops.protobufops
 import co.topl.genus.algebras.QueryService.QueryRequest
 import co.topl.genus.filters.TransactionFilter
 import co.topl.genus.services.transactions_query.{TransactionSorting, TxsQueryStreamReq}
-import org.mongodb.scala.bson.conversions.Bson
 
 import scala.language.implicitConversions
 

--- a/genus/src/main/scala/co/topl/genus/ops/protobufops/TxsSubscriptionResCompanionOps.scala
+++ b/genus/src/main/scala/co/topl/genus/ops/protobufops/TxsSubscriptionResCompanionOps.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 import cats.Functor
 import co.topl.genus.algebras.SubscriptionService.{CreateSubscriptionFailure, CreateSubscriptionFailures}
 import co.topl.genus.services.transactions_subscription.TxsSubscriptionRes
-import co.topl.genus.services.transactions_subscription.TxsSubscriptionRes.Failure.{messageCompanion, Reason}
+import co.topl.genus.services.transactions_subscription.TxsSubscriptionRes.Failure.Reason
 import co.topl.genus.types.Transaction
 
 import scala.language.implicitConversions

--- a/genus/src/main/scala/co/topl/genus/typeclasses/MongoFilterInstances.scala
+++ b/genus/src/main/scala/co/topl/genus/typeclasses/MongoFilterInstances.scala
@@ -1,8 +1,6 @@
 package co.topl.genus.typeclasses
 
 import co.topl.genus.filters._
-import co.topl.genus.types.BlockHeight
-import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.Filters
 
 trait MongoFilterInstances {

--- a/genus/src/test/scala/co/topl/genus/interpreters/mongo/BatchedMongoSubscriptionSpec.scala
+++ b/genus/src/test/scala/co/topl/genus/interpreters/mongo/BatchedMongoSubscriptionSpec.scala
@@ -20,7 +20,6 @@ import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import co.topl.genus.ops.implicits._
 import co.topl.genus.types.BlockHeight
 
 import scala.concurrent.duration.DurationInt

--- a/genus/src/test/scala/co/topl/genus/interpreters/services/TransactionsQueryServiceSpec.scala
+++ b/genus/src/test/scala/co/topl/genus/interpreters/services/TransactionsQueryServiceSpec.scala
@@ -10,7 +10,7 @@ import co.topl.genus.interpreters.{MockChainHeight, MockMongoStore}
 import co.topl.genus.ops.EitherTSourceOps.implicits._
 import co.topl.genus.services.transactions_query.TransactionSorting
 import co.topl.genus.typeclasses.implicits._
-import co.topl.genus.types.{BlockHeight, Transaction}
+import co.topl.genus.types.Transaction
 import co.topl.utils.mongodb.codecs._
 import co.topl.utils.mongodb.implicits._
 import co.topl.utils.mongodb.models.{BlockSummaryDataModel, ConfirmedTransactionDataModel}

--- a/genus/src/test/scala/co/topl/genus/typeclasses/mongofilter/MongoFilterBehavior.scala
+++ b/genus/src/test/scala/co/topl/genus/typeclasses/mongofilter/MongoFilterBehavior.scala
@@ -1,7 +1,7 @@
 package co.topl.genus.typeclasses.mongofilter
 
 import co.topl.genus.typeclasses.MongoFilter
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks

--- a/ledger/src/main/scala/co/topl/ledger/algebras/BodySemanticValidationAlgebra.scala
+++ b/ledger/src/main/scala/co/topl/ledger/algebras/BodySemanticValidationAlgebra.scala
@@ -2,7 +2,7 @@ package co.topl.ledger.algebras
 
 import co.topl.algebras.ContextualValidationAlgebra
 import co.topl.ledger.models.{BodySemanticError, BodyValidationContext}
-import co.topl.models.{BlockBodyV2, TypedIdentifier}
+import co.topl.models.BlockBodyV2
 
 trait BodySemanticValidationAlgebra[F[_]]
     extends ContextualValidationAlgebra[F, BodySemanticError, BlockBodyV2, BodyValidationContext]

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
@@ -1,7 +1,7 @@
 package co.topl.ledger.interpreters
 
 import cats.data.{NonEmptySet, OptionT}
-import cats.effect.{Async, Sync}
+import cats.effect.Async
 import cats.implicits._
 import cats.{Applicative, MonadThrow}
 import co.topl.algebras.Store

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
@@ -1,6 +1,5 @@
 package co.topl.ledger.interpreters
 
-import cats.Applicative
 import cats.data.{Chain, NonEmptySet}
 import cats.effect.IO
 import co.topl.models.{Box, Transaction, TypedIdentifier}

--- a/minting/src/main/scala/co/topl/minting/BlockPacker.scala
+++ b/minting/src/main/scala/co/topl/minting/BlockPacker.scala
@@ -55,7 +55,6 @@ object BlockPacker {
                     .flatMap { transaction =>
                       // Attempt to stuff that transaction into our current block
                       val fullBody = current.append(transaction)
-                      val body = ListSet.empty[TypedIdentifier] ++ fullBody.toList.map(_.id.asTypedBytes)
                       // If it's valid, hooray.  If not, return the previous value
                       val transactionValidationContext =
                         StaticTransactionValidationContext(parentBlockId, fullBody, height, slot)

--- a/minting/src/main/scala/co/topl/minting/algebras/OperationalKeysAlgebra.scala
+++ b/minting/src/main/scala/co/topl/minting/algebras/OperationalKeysAlgebra.scala
@@ -1,6 +1,6 @@
 package co.topl.minting.algebras
 
-import co.topl.models.{Eta, Proofs, SecretKeys, Slot, SlotId, VerificationKeys}
+import co.topl.models.{Proofs, SecretKeys, Slot, SlotId, VerificationKeys}
 
 /**
  * A KeyEvolverAlgebra is responsible for encapsulating a key locally and emitting an evolved version of

--- a/models/src/main/scala/co/topl/models/Proposition.scala
+++ b/models/src/main/scala/co/topl/models/Proposition.scala
@@ -3,7 +3,6 @@ package co.topl.models
 import cats.data.NonEmptyChain
 
 import scala.collection.immutable.ListSet
-import scala.language.implicitConversions
 
 /**
  * Encodes the "spending logic" of a Box.  Roughly translates to a function `(Proof, Blockchain Context) => Boolean`

--- a/models/src/main/scala/co/topl/models/utility/BinaryTree.scala
+++ b/models/src/main/scala/co/topl/models/utility/BinaryTree.scala
@@ -2,8 +2,6 @@ package co.topl.models.utility
 
 import co.topl.models.utility.BinaryTree.{Empty, Leaf, Node}
 
-import scala.language.postfixOps
-
 /**
  * AMS 2021: Modified for use with MMM construction, ported from: https://gist.github.com/dholbrook/2967371
  * All credit and praise goes to: https://gist.github.com/dholbrook

--- a/networking/src/main/scala/co/topl/networking/multiplexer/SubHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/multiplexer/SubHandler.scala
@@ -1,6 +1,6 @@
 package co.topl.networking.multiplexer
 
-import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 
 /**

--- a/networking/src/main/scala/co/topl/networking/p2p/AkkaP2PServer.scala
+++ b/networking/src/main/scala/co/topl/networking/p2p/AkkaP2PServer.scala
@@ -2,7 +2,7 @@ package co.topl.networking.p2p
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream._
+
 import akka.stream.scaladsl._
 import akka.util.ByteString
 import cats._
@@ -13,9 +13,8 @@ import co.topl.catsakka._
 import org.typelevel.log4cats.Logger
 
 import java.net.InetSocketAddress
-import scala.concurrent.duration._
+
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Random
 
 /**
  * Interprets P2PServer[F, Client] using akka-stream. Binds to the requested host/port to accept incoming connections,

--- a/networking/src/main/scala/co/topl/networking/p2p/ConnectedPeer.scala
+++ b/networking/src/main/scala/co/topl/networking/p2p/ConnectedPeer.scala
@@ -1,7 +1,6 @@
 package co.topl.networking.p2p
 
 import java.net.InetSocketAddress
-import scala.concurrent.duration.FiniteDuration
 
 case class ConnectedPeer(remoteAddress: InetSocketAddress, coordinate: (Double, Double))
 

--- a/networking/src/test/scala/co/topl/networking/multiplexer/DynamicMultiplexerSpec.scala
+++ b/networking/src/test/scala/co/topl/networking/multiplexer/DynamicMultiplexerSpec.scala
@@ -1,7 +1,7 @@
 package co.topl.networking.multiplexer
 
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.testkit.TestKitBase
 import akka.util.ByteString

--- a/node-tetra/src/main/scala/co/topl/node/ApplicationConfig.scala
+++ b/node-tetra/src/main/scala/co/topl/node/ApplicationConfig.scala
@@ -8,7 +8,6 @@ import co.topl.networking.p2p.DisconnectedPeer
 import com.typesafe.config.Config
 import monocle._
 import monocle.macros._
-import monocle.macros.syntax.lens._
 import pureconfig._
 import pureconfig.generic.ProductHint
 import pureconfig.generic.auto._

--- a/node-tetra/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node-tetra/src/main/scala/co/topl/node/NodeApp.scala
@@ -16,7 +16,6 @@ import co.topl.crypto.hash.Blake2b512
 import co.topl.crypto.signing._
 import co.topl.interpreters._
 import co.topl.codecs.bytes.typeclasses.implicits._
-import co.topl.codecs.bytes.tetra.instances._
 import co.topl.models._
 import co.topl.typeclasses.implicits._
 import co.topl.codecs.bytes.tetra.instances._

--- a/node-tetra/src/main/scala/co/topl/node/Validators.scala
+++ b/node-tetra/src/main/scala/co/topl/node/Validators.scala
@@ -18,7 +18,7 @@ import co.topl.ledger.algebras.{
   TransactionSyntaxValidationAlgebra
 }
 import co.topl.ledger.interpreters._
-import co.topl.models.{BlockHeaderV2, TypedIdentifier}
+import co.topl.models.TypedIdentifier
 import co.topl.typeclasses.implicits._
 
 case class Validators[F[_]](

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraBinaryShowCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraBinaryShowCodecs.scala
@@ -1,7 +1,3 @@
 package co.topl.codecs.bytes.tetra
 
-import co.topl.codecs.bytes.typeclasses._
-import co.topl.models.{BlockHeaderV2, Bytes, StakingAddress, Transaction, TypedIdentifier}
-import com.google.common.primitives.{Ints, Longs}
-
 trait TetraBinaryShowCodecs {}

--- a/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
+++ b/topl-rpc/src/main/scala/co/topl/rpc/ToplRpcCodecs.scala
@@ -119,7 +119,6 @@ trait NodeViewRpcParamsEncoders {
 }
 
 trait TransactionRpcParamsEncoders extends SharedCodecs {
-  import co.topl.codecs.json.tetra.instances._
 
   implicit val transactionRawAssetTransferParamsEncoder: Encoder[ToplRpc.Transaction.RawAssetTransfer.Params] =
     deriveEncoder
@@ -543,6 +542,7 @@ trait TransactionRpcParamsDecoders extends SharedCodecs {
   implicit def transactionUnprovenPolyTransferParamsDecoder(implicit
     networkPrefix: NetworkPrefix
   ): Decoder[ToplRpc.Transaction.UnprovenPolyTransfer.Params] = {
+    // compiler warning is never used? TODO
     implicit val tetraNetworkPrefix: TetraNetworkPrefix = TetraNetworkPrefix(networkPrefix)
     deriveDecoder
   }
@@ -550,6 +550,7 @@ trait TransactionRpcParamsDecoders extends SharedCodecs {
   implicit def transactionUnprovenArbitTransferParamsDecoder(implicit
     networkPrefix: NetworkPrefix
   ): Decoder[ToplRpc.Transaction.UnprovenArbitTransfer.Params] = {
+    // compiler warning is never used? TODO
     implicit val tetraNetworkPrefix: TetraNetworkPrefix = TetraNetworkPrefix(networkPrefix)
     deriveDecoder
   }
@@ -557,6 +558,7 @@ trait TransactionRpcParamsDecoders extends SharedCodecs {
   implicit def transactionUnprovenAssetTransferParamsDecoder(implicit
     networkPrefix: NetworkPrefix
   ): Decoder[ToplRpc.Transaction.UnprovenAssetTransfer.Params] = {
+    // compiler warning is never used? TODO
     implicit val tetraNetworkPrefix: TetraNetworkPrefix = TetraNetworkPrefix(networkPrefix)
     deriveDecoder
   }
@@ -569,6 +571,7 @@ trait TransactionRpcParamsDecoders extends SharedCodecs {
   implicit def transactionBroadcastTetraTransferParamsDecoder(implicit
     networkPrefix: NetworkPrefix
   ): Decoder[ToplRpc.Transaction.BroadcastTetraTransfer.Params] = {
+    // compiler warning is never used? TODO
     implicit val tetraNetworkPrefix: TetraNetworkPrefix = TetraNetworkPrefix(networkPrefix)
     deriveDecoder
   }

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/TransactionGeneratorApp.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/TransactionGeneratorApp.scala
@@ -14,12 +14,10 @@ import co.topl.interpreters._
 import co.topl.models._
 import co.topl.transactiongenerator.interpreters._
 import co.topl.typeclasses.implicits._
-import com.typesafe.config.ConfigFactory
 import fs2._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-import scala.collection.immutable.ListSet
 import scala.concurrent.duration._
 
 object TransactionGeneratorApp

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/ToplRpcWalletInitializer.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/ToplRpcWalletInitializer.scala
@@ -8,9 +8,6 @@ import co.topl.models._
 import co.topl.transactiongenerator.algebras.WalletInitializer
 import co.topl.transactiongenerator.models.Wallet
 import fs2._
-import co.topl.typeclasses.implicits._
-import co.topl.codecs.bytes.tetra.instances._
-import co.topl.codecs.bytes.typeclasses.implicits._
 
 object ToplRpcWalletInitializer {
 

--- a/typeclasses/src/main/scala/co/topl/typeclasses/ContainsSlotId.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ContainsSlotId.scala
@@ -2,8 +2,7 @@ package co.topl.typeclasses
 
 import co.topl.codecs.bytes.typeclasses.Identifiable
 import co.topl.codecs.bytes.typeclasses.implicits._
-import co.topl.codecs.bytes.tetra.instances._
-import co.topl.models.{SlotId, TypedBytes}
+import co.topl.models.SlotId
 import simulacrum._
 import IdentityOps._
 

--- a/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTransactions.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTransactions.scala
@@ -1,12 +1,12 @@
 package co.topl.typeclasses
 
+import cats.Foldable
+import cats.implicits._
+import co.topl.models.utility.HasLength.instances._
+import co.topl.models.utility.Lengths._
 import co.topl.models.utility.{Lengths, Sized}
 import co.topl.models.{BlockV1, BloomFilter, Bytes, Transaction}
 import simulacrum.{op, typeclass}
-import co.topl.models.utility.HasLength.instances._
-import Lengths._
-import cats.{Foldable, Traverse}
-import cats.implicits._
 
 /**
  * Satisfies that T contains transactions

--- a/typeclasses/src/main/scala/co/topl/typeclasses/Proposer.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/Proposer.scala
@@ -3,7 +3,6 @@ package co.topl.typeclasses
 import co.topl.models.{Proposition, Propositions, VerificationKey, VerificationKeys}
 
 import scala.collection.immutable.ListSet
-import scala.language.implicitConversions
 
 /**
  * Reveal inputs to produce a Proposition

--- a/typeclasses/src/main/scala/co/topl/typeclasses/Prover.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/Prover.scala
@@ -5,8 +5,6 @@ import co.topl.codecs.bytes.typeclasses.implicits._
 import co.topl.crypto.signing.{Curve25519, Ed25519, ExtendedEd25519}
 import co.topl.models._
 
-import scala.language.implicitConversions
-
 @simulacrum.typeclass
 trait Prover[ProofInput] {
 

--- a/typeclasses/src/main/scala/co/topl/typeclasses/RatioOps.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/RatioOps.scala
@@ -2,9 +2,6 @@ package co.topl.typeclasses
 
 import co.topl.models.utility.Ratio
 
-import scala.language.implicitConversions
-import scala.math.BigInt
-
 object RatioOps {
 
   trait Implicits {


### PR DESCRIPTION
## Purpose
Node is being cross compiled with 2 scala versions

- 2.12.16  **(which is currently no compiling)**
- 2.13.18

There are a lot of warnings in the code and we should add a flag in the compiler to avoid them

## Approach
add a flag to 2.13 compiler, 

**TODO: remoce specs Warnings**

## Testing
unit test

## Tickets
https://topl.atlassian.net/browse/BN-692
closes #2574 

