### PR TITLE
Disable Scala 2.12.  Disable Dion modules.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,16 +68,7 @@ jobs:
       java-versions: >-
         ["11"]
 
-  post-man-integration-tests:
-    uses: ./.github/workflows/_postman_integration_tests.yml
-    needs: sbt-build
-    with:
-      target-os: >-
-        ["ubuntu-latest"]
-      java-versions: >-
-        ["11"]
-
   publish-test-results:
     uses: ./.github/workflows/_publish_test_results.yml
     if: always()
-    needs: [sbt-integration-tests, post-man-integration-tests]
+    needs: [sbt-integration-tests]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,8 +17,8 @@ jobs:
         ["11"]
       preserve-cache-between-runs: true
 
-  post-man-integration-tests:
-    uses: ./.github/workflows/_postman_integration_tests.yml
+  sbt-integration-tests:
+    uses: ./.github/workflows/_scala_integration_tests.yml
     needs: sbt-build
     with:
       target-os: >-
@@ -30,4 +30,4 @@ jobs:
   publish-test-results:
     uses: ./.github/workflows/_publish_test_results.yml
     if: always()
-    needs: [post-man-integration-tests]
+    needs: [sbt-integration-tests]

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import sbt.Keys.{homepage, organization, test}
 import sbtassembly.MergeStrategy
 
-val scala212 = "2.12.16"
 val scala213 = "2.13.8"
 
 inThisBuild(
@@ -26,15 +25,6 @@ enablePlugins(ReproducibleBuildsPlugin, ReproducibleBuildsAssemblyPlugin)
 lazy val commonSettings = Seq(
   sonatypeCredentialHost := "s01.oss.sonatype.org",
   scalacOptions ++= commonScalacOptions,
-  // Enable PartialUnification in Scala 2.12.  Scala 2.13 fixes this by default
-  scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, v)) if v <= 12 =>
-      Seq(
-        "-Ypartial-unification"
-      )
-    case _ =>
-      Nil
-  }),
   semanticdbEnabled := true, // enable SemanticDB for Scalafix
   semanticdbVersion := scalafixSemanticdb.revision, // use Scalafix compatible version
 //  wartremoverErrors := Warts.unsafe, // settings for wartremover
@@ -45,7 +35,7 @@ lazy val commonSettings = Seq(
       case _                       => sourceDir / "scala-2.12-"
     }
   },
-  crossScalaVersions := Seq(scala212, scala213),
+  crossScalaVersions := Seq(scala213),
   Test / testOptions ++= Seq(
     Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "2"),
     Tests.Argument(TestFrameworks.ScalaTest, "-f", "sbttest.log", "-oDGG", "-u", "target/test-reports")
@@ -143,16 +133,6 @@ def assemblySettings(main: String) = Seq(
 
 lazy val scalamacrosParadiseSettings =
   Seq(
-    libraryDependencies ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, v)) if v <= 12 =>
-          Seq(
-            compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
-          )
-        case _ =>
-          Nil
-      }
-    },
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, v)) if v >= 13 =>
@@ -171,7 +151,6 @@ lazy val commonScalacOptions = Seq(
   "-language:higherKinds",
   "-language:postfixOps",
   "-unchecked",
-  "-Xlint:",
   "-Ywarn-unused:-implicits,-privates",
   "-Yrangepos"
 )
@@ -213,16 +192,16 @@ lazy val bifrost = project
   )
   .configs(IntegrationTest)
   .aggregate(
-    node,
+//    node,
     nodeTetra,
-    common,
-    akkaHttpRpc,
+//    common,
+//    akkaHttpRpc,
     typeclasses,
-    toplRpc,
+//    toplRpc,
     toplGrpc,
     crypto,
     catsAkka,
-    brambl,
+//    brambl,
     models,
     numerics,
     eventTree,
@@ -236,9 +215,8 @@ lazy val bifrost = project
     ledger,
     blockchain,
     demo,
-    tools,
-    scripting,
-    genus,
+//    tools,
+//    genus,
     levelDbStore,
     commonApplication,
     networkDelayer,
@@ -255,7 +233,7 @@ lazy val node = project
     assemblySettings("co.topl.BifrostApp"),
     dionNodeDockerSettings,
     Defaults.itSettings,
-    crossScalaVersions := Seq(scala213), // The `monocle` library does not support Scala 2.12
+    crossScalaVersions := Seq(scala213),
     Compile / mainClass := Some("co.topl.BifrostApp"),
     publish / skip := true,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
@@ -294,7 +272,6 @@ lazy val nodeTetra = project
     typeclasses,
     consensus,
     minting,
-    scripting,
     commonInterpreters,
     networking,
     catsAkka,
@@ -381,7 +358,6 @@ lazy val brambl = project
     common,
     typeclasses,
     models % "compile->compile;test->test",
-    scripting,
     tetraByteCodecs,
     toplGrpc
   )
@@ -689,7 +665,6 @@ lazy val blockchain = project
     munitScalamock % "test->test",
     consensus,
     minting,
-    scripting,
     commonInterpreters,
     networking,
     catsAkka,
@@ -714,7 +689,6 @@ lazy val demo = project
     typeclasses,
     consensus,
     minting,
-    scripting,
     commonInterpreters,
     networking,
     catsAkka,
@@ -722,22 +696,6 @@ lazy val demo = project
     blockchain
   )
   .enablePlugins(BuildInfoPlugin)
-
-lazy val scripting: Project = project
-  .in(file("scripting"))
-  .enablePlugins(BuildInfoPlugin)
-  .settings(
-    name := "scripting",
-    commonSettings,
-    publishSettings,
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
-    buildInfoPackage := "co.topl.buildinfo.scripting"
-  )
-  .settings(
-    libraryDependencies ++= Dependencies.graal ++ Dependencies.catsEffect ++ Dependencies.circe ++ Dependencies.simulacrum
-  )
-  .settings(libraryDependencies ++= Dependencies.test)
-  .settings(scalamacrosParadiseSettings)
 
 lazy val toplRpc = project
   .in(file("topl-rpc"))


### PR DESCRIPTION
## Purpose
- This repository will (eventually) only include server-code.  Servers/applications can target a single Scala version, which simplifies the build/compile/test loop.
- Dion-specific code is not needed, and the unit tests consume significant time
## Approach
- Remove 2.12 references in the build.sbt
- Comment out dion-specific SBT modules in the `.aggregate`
- Also comment out the `scripting` module
- Also disable "postman integration tests", but enable "integration tests"
  - We can remove this once integration tests take too long
- NOTE: Dion code will be removed at a later date
## Testing
- `preparePR` locally executes significantly faster
## Tickets
- #2576 