### PR TITLE
Akka-Stream to FS2 Adapter Delay

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -147,7 +147,6 @@ object Blockchain {
           )
           .flatMap(_.blocks)
       )
-      localBlockAdoptionsStream <- localBlockAdoptionsSource.asFS2Stream[F]
       rpcInterpreter <- ToplRpcServer.make(
         headerStore,
         bodyStore,
@@ -157,7 +156,7 @@ object Blockchain {
         localChain,
         blockHeights,
         blockIdTree,
-        localBlockAdoptionsStream
+        localBlockAdoptionsSource.asFS2Stream[F]
       )
       rpcServer = ToplGrpc.Server.serve(rpcHost, rpcPort, rpcInterpreter)
       mintedBlockStreamCompletionFuture =


### PR DESCRIPTION
## Purpose
- The adapter from an akka-stream Source to an FS2 Stream materializes the Akka stream only once, even if the Stream is consumed multiple times
## Approach
- Delay the adaption from akka to FS2 until the Stream is consumed (instead of pre-adapting it and then consuming)
## Testing
- Verified manually when testing the testnet-simulation-orchestrator
## Tickets
N/A