### PR TITLE
Block Producer Valid Timestamps

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ClockAlgebra.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ClockAlgebra.scala
@@ -20,6 +20,7 @@ trait ClockAlgebra[F[_]] {
   def currentTimestamp: F[Timestamp]
   def forwardBiasedSlotWindow: F[Slot]
   def timestampToSlot(timestamp:       Timestamp): F[Slot]
+  def slotToTimestamps(slot:           Slot): F[NumericRange.Inclusive[Timestamp]]
   def delayedUntilSlot(slot:           Slot): F[Unit]
   def delayedUntilTimestamp(timestamp: Timestamp): F[Unit]
 }

--- a/common-interpreters/src/main/scala/co/topl/interpreters/SchedulerClock.scala
+++ b/common-interpreters/src/main/scala/co/topl/interpreters/SchedulerClock.scala
@@ -8,6 +8,7 @@ import co.topl.algebras.ClockAlgebra
 import co.topl.models.{Epoch, Slot, Timestamp}
 
 import java.time.Instant
+import scala.collection.immutable.NumericRange
 import scala.concurrent.duration._
 
 object SchedulerClock {
@@ -31,6 +32,13 @@ object SchedulerClock {
 
         override def timestampToSlot(timestamp: Timestamp): F[Slot] =
           ((timestamp - startTime) / _slotLength.toMillis).pure[F]
+
+        override def slotToTimestamps(slot: Slot): F[NumericRange.Inclusive[Long]] =
+          Sync[F].delay {
+            val startTimestamp = startTime + (slot * _slotLength.toMillis)
+            val endTimestamp = startTimestamp + (_slotLength.toMillis - 1)
+            NumericRange.inclusive(startTimestamp, endTimestamp, 1L)
+          }
 
         override val forwardBiasedSlotWindow: F[Slot] = _forwardBiasedSlotWindow.pure[F]
 

--- a/minting/src/main/scala/co/topl/minting/BlockProducer.scala
+++ b/minting/src/main/scala/co/topl/minting/BlockProducer.scala
@@ -64,7 +64,7 @@ object BlockProducer {
             )
             // Assemble the transactions to be placed in our new block
             body      <- packBlock(parentSlotData.slotId.blockId, parentSlotData.height + 1, nextHit.slot)
-            timestamp <- clock.currentTimestamp
+            timestamp <- clock.slotToTimestamps(nextHit.slot).map(_.last)
             blockMaker = prepareUnsignedBlock(parentSlotData, body, timestamp, nextHit)
             // Despite being eligible, there may not have a corresponding linear KES key if, for example, the node
             // restarts in the middle of an operational period.  The node must wait until the next operational period

--- a/node-tetra/src/it/scala/co/topl/tetra/it/util/NodeRpcApi.scala
+++ b/node-tetra/src/it/scala/co/topl/tetra/it/util/NodeRpcApi.scala
@@ -45,7 +45,7 @@ case class NodeRpcApi(host: String, rpcPort: Int) {
 }
 
 object NodeRpcApi {
-  val rpcWaitAttempts = 15
+  val rpcWaitAttempts = 30
   val rpcWaitSleepMs = 1000
 
   def apply(node: BifrostDockerTetraNode)(implicit dockerClient: DockerClient): NodeRpcApi = {


### PR DESCRIPTION
## Purpose
- A recent change to Block Header Validation correctly enforces that a header's timestamp is valid for the header's slot
- The Block Producer delays creating the timestamp until _after_ the slot has elapsed.  For short slot-duration configurations (i.e. 100 milli), sometimes the timestamp gets generated outside the valid bounds of the slot
## Approach
- Modify the ClockAlgebra to return a range of valid Timestamps for a given Slot
- Update BlockProducer to always specify the last valid timestamp of the Slot
## Testing
- Verified manually when testing testnet-simulation-orchestrator
## Tickets
- N/A