### PR TITLE
txRoot now correctly build transaction root by using Merkle Tree

### DIFF
--- a/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTransactions.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTransactions.scala
@@ -1,7 +1,6 @@
 package co.topl.typeclasses
 
 import cats.Foldable
-import cats.data.Chain
 import cats.implicits._
 import co.topl.codecs.bytes.tetra.TetraIdentifiableInstances._
 import co.topl.codecs.bytes.typeclasses.Identifiable.ops._
@@ -14,8 +13,8 @@ import co.topl.models.utility.HasLength.instances._
 import co.topl.models.utility.Lengths._
 import co.topl.models.utility.{Lengths, Sized}
 import co.topl.models.{BlockV1, BloomFilter, Bytes, Transaction}
+import co.topl.typeclasses.IdentityOps._
 import simulacrum.{op, typeclass}
-import co.topl.typeclasses.implicits._
 
 /**
  * Satisfies that T contains transactions
@@ -24,8 +23,8 @@ import co.topl.typeclasses.implicits._
   @op("transactions") def transactionsOf(t: T): Seq[Transaction]
 
   @op("merkleTree") def merkleTreeOf(t: T): Sized.Strict[Bytes, Lengths.`32`.type] = {
-    val rootHash =
-      MerkleTree[Blake2b, Digest32](transactionsOf(t).map(tx => LeafData(tx.id.asTypedBytes.allBytes.toArray))).rootHash.bytes
+    val leafs = transactionsOf(t).map(tx => LeafData(tx.id.asTypedBytes.allBytes.toArray))
+    val rootHash = MerkleTree[Blake2b, Digest32](leafs).rootHash.bytes
     Sized.strictUnsafe[Bytes, Lengths.`32`.type](Bytes(rootHash))
   }
 

--- a/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTransactions.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTransactions.scala
@@ -1,12 +1,21 @@
 package co.topl.typeclasses
 
+import cats.Foldable
+import cats.data.Chain
+import cats.implicits._
+import co.topl.codecs.bytes.tetra.TetraIdentifiableInstances._
+import co.topl.codecs.bytes.typeclasses.Identifiable.ops._
+import co.topl.crypto.accumulators.LeafData
+import co.topl.crypto.accumulators.merkle.MerkleTree
+import co.topl.crypto.hash.Blake2b
+import co.topl.crypto.hash.digest.Digest32
+import co.topl.crypto.hash.implicits._
+import co.topl.models.utility.HasLength.instances._
+import co.topl.models.utility.Lengths._
 import co.topl.models.utility.{Lengths, Sized}
 import co.topl.models.{BlockV1, BloomFilter, Bytes, Transaction}
 import simulacrum.{op, typeclass}
-import co.topl.models.utility.HasLength.instances._
-import Lengths._
-import cats.{Foldable, Traverse}
-import cats.implicits._
+import co.topl.typeclasses.implicits._
 
 /**
  * Satisfies that T contains transactions
@@ -14,9 +23,11 @@ import cats.implicits._
 @typeclass trait ContainsTransactions[T] {
   @op("transactions") def transactionsOf(t: T): Seq[Transaction]
 
-  @op("merkleTree") def merkleTreeOf(t: T): Sized.Strict[Bytes, Lengths.`32`.type] =
-    // TODO
-    Sized.strictUnsafe[Bytes, Lengths.`32`.type](Bytes(Array.fill[Byte](32)(1)))
+  @op("merkleTree") def merkleTreeOf(t: T): Sized.Strict[Bytes, Lengths.`32`.type] = {
+    val rootHash =
+      MerkleTree[Blake2b, Digest32](transactionsOf(t).map(tx => LeafData(tx.id.asTypedBytes.allBytes.toArray))).rootHash.bytes
+    Sized.strictUnsafe[Bytes, Lengths.`32`.type](Bytes(rootHash))
+  }
 
   @op("bloomFilter") def bloomFilterOf(t: T): BloomFilter =
     // TODO
@@ -34,5 +45,6 @@ object ContainsTransactions {
 
     implicit val blockV1ContainsTransactions: ContainsTransactions[BlockV1] = _.transactions
   }
+
   object Instances extends Instances
 }


### PR DESCRIPTION
## Purpose
Using correct accumulator for transaction root in block header

## Approach
Importing existing implementation from Dion

## Testing
Manually tested that blocks header get correct Merkel tree root hash, additional tests will be added during implementation ticket BN-694

## Tickets
* closes https://topl.atlassian.net/browse/BN-596