### PR TITLE
BN-690-Re-imlementLocalChainBroadCaster V1 (Do NOT Merge)

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/LocalChainBroadcaster.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/LocalChainBroadcaster.scala
@@ -4,35 +4,50 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import cats.data.Validated
 import cats.effect.kernel.Async
+import cats.effect.std.Queue
 import cats.implicits._
 import co.topl.catsakka._
 import co.topl.consensus.algebras.LocalChainAlgebra
 import co.topl.models.{SlotData, TypedIdentifier}
+import fs2.Stream
 
 object LocalChainBroadcaster {
 
   /**
-   * A LocalChain interpreter which wraps a delegate LocalChain.  Any blocks adopted by
-   * this LocalChain will be announced in the returned Source
+   * A LocalChain interpreter which wraps a delegate LocalChain. Any blocks adopted by this LocalChain will be announced in the returned Source
    * @param localChain a delegate interpreter
-   * @return a tuple (interpreter, adoptionsSource)
+   * @return a tuple (interpreter, adoptionsSource, adoptionsStream)
    */
   def make[F[_]: Async](
-    localChain:            LocalChainAlgebra[F]
-  )(implicit materializer: Materializer): F[(LocalChainAlgebra[F], SourceMatNotUsed[TypedIdentifier])] =
-    Async[F]
-      .delay(Source.backpressuredQueue[F, TypedIdentifier]().preMaterialize())
-      .map { case ((offer, _), source) =>
-        val interpreter = new LocalChainAlgebra[F] {
-          def isWorseThan(newHead: SlotData): F[Boolean] = localChain.isWorseThan(newHead)
+    localChain: LocalChainAlgebra[F]
+  )(implicit
+    materializer: Materializer
+  ): F[
+    (LocalChainAlgebra[F], SourceMatNotUsed[TypedIdentifier], Stream[F, TypedIdentifier], Stream[F, TypedIdentifier])
+  ] =
+    (
+      Async[F].delay(Source.backpressuredQueue[F, TypedIdentifier]().preMaterialize()),
+      Queue.bounded[F, TypedIdentifier](capacity = 16), // ToplRpcServer
+      // TODO unused stream, changes in BN-690-Re-imlementLocalChainBroadCaster_v2
+      Queue.circularBuffer[F, TypedIdentifier](capacity = 1) // BlockchainPeerServer
+    ).mapN { case (((offer, _), source), rpcServerBoundedQueue, p2pServerBoundedQueue) =>
+      val interpreter = new LocalChainAlgebra[F] {
+        def isWorseThan(newHead: SlotData): F[Boolean] = localChain.isWorseThan(newHead)
 
-          def adopt(newHead: Validated.Valid[SlotData]): F[Unit] =
-            localChain.adopt(newHead) >> offer(newHead.a.slotId.blockId)
+        def adopt(newHead: Validated.Valid[SlotData]): F[Unit] =
+          localChain.adopt(newHead) >>
+          offer(newHead.a.slotId.blockId) >>
+          rpcServerBoundedQueue.offer(newHead.a.slotId.blockId) >>
+          p2pServerBoundedQueue.offer(newHead.a.slotId.blockId)
 
-          def head: F[SlotData] = localChain.head
-        }
-
-        (interpreter, source)
+        def head: F[SlotData] = localChain.head
       }
+      (
+        interpreter,
+        source,
+        Stream.fromQueueUnterminated(rpcServerBoundedQueue),
+        Stream.fromQueueUnterminated(p2pServerBoundedQueue)
+      )
+    }
 
 }

--- a/blockchain/src/test/scala/co/topl/blockchain/LocalChainBroadcasterSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/LocalChainBroadcasterSpec.scala
@@ -28,7 +28,7 @@ class LocalChainBroadcasterSpec
         for {
           delegate <- mock[LocalChainAlgebra[F]].pure[F]
           _ = (delegate.adopt _).expects(Validated.Valid(slotData)).once().returning(IO.unit)
-          (underTest, source) <- LocalChainBroadcaster.make(delegate)
+          (underTest, source, _, _) <- LocalChainBroadcaster.make(delegate)
           sub = source.runWith(TestSink.probe)
           _ = sub.request(1)
           _ <- underTest.adopt(Validated.Valid(slotData))


### PR DESCRIPTION
## Purpose
BN-690- Re-implementLocalChainBroadCaster V1

## Approach

LocalChainBroadcaster returns:
- local chain algebra 
-  Akka Source of adaptions

it is used on: Akka source is used on 
 - BlockchainPeerServer,  
 -  mintedBlockStream
 - ToplGrpc (with an FS2 converter)

Changes adds a new Fs2 Stream in LocalChainBroadcaster, returning
- local chain algebra 
-  Akka Source of adaptions
- Fs2 Stream for ToplRpcServer  (replace the converter)
- Fs2 Stream for BlockchainPeerServer  (unused, it will be implemented in other PR)

## Testing

## Tickets
BN-690


