### PR TITLE
BN 692 - add flag for unused imports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -151,7 +151,7 @@ lazy val commonScalacOptions = Seq(
   "-language:higherKinds",
   "-language:postfixOps",
   "-unchecked",
-  "-Ywarn-unused:-implicits,-privates",
+  "-Ywarn-unused:-implicits,-privates,_",
   "-Yrangepos"
 )
 


### PR DESCRIPTION
## Purpose
avoid unused imports

## Approach
Added a new flag in Scalac options raising warnings, without fixing them, which will be addressed on several minor following PRs.

## Testing
No additional testing, the compiler will show:

```
/home/fernando/topl/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/LanguageSpec.scala:6:23: Unused import
[warn] import org.scalacheck.Gen
[warn]                       ^
[warn] /home/fernando/topl/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/LanguageSpec.scala:7:30: Unused import
[warn] import org.scalatest.funspec.AnyFunSpec
[warn]                              ^
[warn] /home/fernando/topl/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala:3:52: Unused import
[warn] import co.topl.crypto.generation.mnemonic.Language.LanguageWordList
[warn]                                                    ^
[warn] /home/fernando/topl/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala:4:58: Unused import
[warn] import co.topl.crypto.generation.mnemonic.MnemonicSizes.{`12`, `18`, `24`}
[warn]                                                          ^
[warn] /home/fernando/topl/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala:4:64: Unused import
[warn] import co.topl.crypto.generation.mnemonic.MnemonicSizes.{`12`, `18`, `24`}
[warn]                                                                ^
[warn] /home/fernando/topl/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala:4:70: Unused import
[warn] import co.topl.crypto.generation.mnemonic.MnemonicSizes.{`12`, `18`, `24`}
[warn]                                                                      ^
[warn] /home/fernando/topl/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala:6:23: Unused import
[warn] import org.scalacheck.Gen
```




## Tickets
closes BN-692


