### PR TITLE
fix 4 warnings

### DIFF
--- a/byte-codecs/src/main/scala/co/topl/codecs/bytes/typeclasses/Signable.scala
+++ b/byte-codecs/src/main/scala/co/topl/codecs/bytes/typeclasses/Signable.scala
@@ -4,8 +4,6 @@ import scodec.{Attempt, Encoder}
 import scodec.bits.ByteVector
 import simulacrum.typeclass
 
-import scala.language.implicitConversions
-
 /**
  * Typeclass for encoding a value into its byte representation for signing routines.
  *

--- a/cats-akka/src/main/scala/co/topl/catsakka/AbandonerFlow.scala
+++ b/cats-akka/src/main/scala/co/topl/catsakka/AbandonerFlow.scala
@@ -5,7 +5,6 @@ import akka.stream.{Attributes, FlowShape, Inlet, Materializer, Outlet}
 import akka.stream.scaladsl.Flow
 import akka.stream.stage.{AsyncCallback, GraphStage, GraphStageLogic, GraphStageLogicWithLogging, InHandler, OutHandler}
 import cats.effect.{Async, Fiber}
-import cats.implicits._
 
 import scala.concurrent.ExecutionContext
 

--- a/models/src/main/scala/co/topl/models/Proposition.scala
+++ b/models/src/main/scala/co/topl/models/Proposition.scala
@@ -3,7 +3,6 @@ package co.topl.models
 import cats.data.NonEmptyChain
 
 import scala.collection.immutable.ListSet
-import scala.language.implicitConversions
 
 /**
  * Encodes the "spending logic" of a Box.  Roughly translates to a function `(Proof, Blockchain Context) => Boolean`

--- a/models/src/main/scala/co/topl/models/utility/BinaryTree.scala
+++ b/models/src/main/scala/co/topl/models/utility/BinaryTree.scala
@@ -2,8 +2,6 @@ package co.topl.models.utility
 
 import co.topl.models.utility.BinaryTree.{Empty, Leaf, Node}
 
-import scala.language.postfixOps
-
 /**
  * AMS 2021: Modified for use with MMM construction, ported from: https://gist.github.com/dholbrook/2967371
  * All credit and praise goes to: https://gist.github.com/dholbrook
@@ -224,7 +222,7 @@ trait BinaryTree[+A] {
    * P02
    * (*) Count the number of nodes in a binary tree.
    */
-  def size: Int = fold(0)((sum, v) => sum + 1)
+  def size: Int = fold(0)((sum, _) => sum + 1)
 
   /**
    * P03
@@ -233,7 +231,7 @@ trait BinaryTree[+A] {
    */
   def height: Int = {
     def loop(t: BinaryTree[A]): Int = t match {
-      case l: Leaf[A] => 1
+      case _: Leaf[A] => 1
       case n: Node[A] => Seq(loop(n.left.get), loop(n.right.get)).max + 1
       case _          => 0
     }
@@ -247,7 +245,7 @@ trait BinaryTree[+A] {
   def leafCount: Int = {
     @tailrec
     def loop(t: List[BinaryTree[A]], z: Int): Int = t match {
-      case (l: Leaf[A]) :: tl => loop(tl, z + 1)
+      case (_: Leaf[A]) :: tl => loop(tl, z + 1)
       case (n: Node[A]) :: tl => loop(n.left.get :: n.right.get :: tl, z)
       case _ :: tl            => loop(tl, z)
       case _                  => z


### PR DESCRIPTION
## Purpose
Fix 4 warnings

```
[warn] /home/runner/work/Bifrost/Bifrost/cats-akka/src/main/scala/co/topl/catsakka/AbandonerFlow.scala:8:23: Unused import
[warn] import cats.implicits._
[warn]                       ^
[warn] /home/runner/work/Bifrost/Bifrost/byte-codecs/src/main/scala/co/topl/codecs/bytes/typeclasses/Signable.scala:7:[23](https://github.com/Topl/Bifrost/actions/runs/3462833355/jobs/5782244706#step:8:24): Unused import
[warn] import scala.language.implicitConversions
[warn]                       ^
[warn] one warning found
[info] done compiling
[info] compiling 20 Scala sources to /home/runner/work/Bifrost/Bifrost/models/target/scala-2.13/classes ...
[warn] /home/runner/work/Bifrost/Bifrost/models/src/main/scala/co/topl/models/Proposition.scala:6:23: Unused import
[warn] import scala.language.implicitConversions
[warn]                       ^
[warn] one warning found
[warn] /home/runner/work/Bifrost/Bifrost/models/src/main/scala/co/topl/models/utility/BinaryTree.scala:5:23: Unused import
[warn] import scala.language.postfixOps
[warn]                       ^
[warn] /home/runner/work/Bifrost/Bifrost/models/src/main/scala/co/topl/models/utility/BinaryTree.scala:236:12: pattern var l in method loop is never used: use a wildcard `_` or suppress this warning with `l@_`
[warn]       case l: Leaf[A] => 1
[warn]            ^
[warn] /home/runner/work/Bifrost/Bifrost/models/src/main/scala/co/topl/models/utility/BinaryTree.scala:[25](https://github.com/Topl/Bifrost/actions/runs/3462833355/jobs/5782244706#step:8:26)0:13: pattern var l in method loop is never used: use a wildcard `_` or suppress this warning with `l@_`
[warn]       case (l: Leaf[A]) :: tl => loop(tl, z + 1)
[warn]             ^
[warn] /home/runner/work/Bifrost/Bifrost/models/src/main/scala/co/topl/models/utility/BinaryTree.scala:2[27](https://github.com/Topl/Bifrost/actions/runs/3462833355/jobs/5782244706#step:8:28):33: parameter value v in anonymous function is never used
[warn]   def size: Int = fold(0)((sum, v) => sum + 1)
[warn]                                 ^

```

Related to #2586 