### PR TITLE
fix 13 warnings found

### DIFF
--- a/crypto/src/main/scala/co/topl/crypto/accumulators/merkle/MerkleTree.scala
+++ b/crypto/src/main/scala/co/topl/crypto/accumulators/merkle/MerkleTree.scala
@@ -7,7 +7,6 @@ import co.topl.crypto.hash.digest.implicits._
 import co.topl.models.Bytes
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
 /* Forked from https://github.com/input-output-hk/scrypto */
 

--- a/crypto/src/main/scala/co/topl/crypto/generation/KeyInitializer.scala
+++ b/crypto/src/main/scala/co/topl/crypto/generation/KeyInitializer.scala
@@ -6,7 +6,7 @@ import co.topl.crypto.generation.mnemonic.{Entropy, EntropyFailure, Language}
 import co.topl.crypto.signing._
 import co.topl.models._
 import co.topl.models.utility.HasLength.instances._
-import co.topl.models.utility.{Lengths, Sized}
+import co.topl.models.utility.Sized
 import scodec.bits.BitVector
 import simulacrum.typeclass
 

--- a/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/Phrase.scala
+++ b/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/Phrase.scala
@@ -2,7 +2,6 @@ package co.topl.crypto.generation.mnemonic
 
 import cats.implicits._
 import co.topl.crypto.generation.mnemonic.Language.LanguageWordList
-import co.topl.crypto.generation.mnemonic.PhraseFailures.InvalidWordLength
 import co.topl.crypto.hash.sha256
 
 /**

--- a/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/mnemonic.scala
+++ b/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/mnemonic.scala
@@ -1,6 +1,5 @@
 package co.topl.crypto.generation
 
-import scala.language.implicitConversions
 import scala.math.BigInt
 
 /**

--- a/crypto/src/main/scala/co/topl/crypto/hash/digest/digest.scala
+++ b/crypto/src/main/scala/co/topl/crypto/hash/digest/digest.scala
@@ -1,7 +1,6 @@
 package co.topl.crypto.hash
 
 import cats.data.{Validated, ValidatedNec}
-import cats.{Eq, Show}
 import io.estatico.newtype.macros.newtype
 import io.estatico.newtype.ops._
 import simulacrum.typeclass

--- a/crypto/src/main/scala/co/topl/crypto/hash/hash.scala
+++ b/crypto/src/main/scala/co/topl/crypto/hash/hash.scala
@@ -2,8 +2,6 @@ package co.topl.crypto
 
 import co.topl.crypto.hash.digest._
 
-import scala.language.implicitConversions
-
 /* Forked from https://github.com/input-output-hk/scrypto */
 
 package object hash {

--- a/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala
@@ -1,8 +1,6 @@
 package co.topl.crypto.signing
 
-import co.topl.crypto.generation.{Bip32Index, Bip32Indexes, EntropyToSeed, Pbkdf2Sha512}
-import co.topl.crypto.generation.mnemonic.Entropy
-import co.topl.models.SecretKeys.ExtendedEd25519.Length
+import co.topl.crypto.generation.{Bip32Index, Bip32Indexes}
 import co.topl.models._
 import co.topl.models.utility.HasLength.instances._
 import co.topl.models.utility.{Lengths, Sized}
@@ -10,7 +8,6 @@ import org.bouncycastle.crypto.digests.SHA512Digest
 import org.bouncycastle.crypto.macs.HMac
 import org.bouncycastle.crypto.params.KeyParameter
 
-import java.nio.charset.StandardCharsets
 import java.nio.{ByteBuffer, ByteOrder}
 
 class ExtendedEd25519

--- a/crypto/src/main/scala/co/topl/crypto/signing/package.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signing/package.scala
@@ -2,7 +2,6 @@ package co.topl.crypto
 
 import io.estatico.newtype.macros.newtype
 
-import java.security.SecureRandom
 import scala.language.implicitConversions
 
 package object signing {


### PR DESCRIPTION
## Purpose
avoid unused imports

## Approach
Added a new flag in Scalac options raising warnings, without fixing them, which will be addressed on several minor following PRs.

## Testing
No additional testing, the compiler will show:

```
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/accumulators/merkle/MerkleTree.scala:10:25: Unused import
[warn] import scala.collection.mutable
[warn]                         ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/generation/KeyInitializer.scala:9:32: Unused import
[warn] import co.topl.models.utility.{Lengths, Sized}
[warn]                                ^
[info] done compiling
[info] compiling 2 Scala sources to /home/runner/work/Bifrost/Bifrost/models/target/scala-2.13/test-classes ...
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/Phrase.scala:5:58: Unused import
[warn] import co.topl.crypto.generation.mnemonic.PhraseFailures.InvalidWordLength
[warn]                                                          ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/mnemonic.scala:3:23: Unused import
[warn] import scala.language.implicitConversions
[warn]                       ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/hash/digest/digest.scala:4:14: Unused import
[warn] import cats.{Eq, Show}
[warn]              ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/hash/digest/digest.scala:4:18: Unused import
[warn] import cats.{Eq, Show}
[warn]                  ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/hash/hash.scala:5:23: Unused import
[warn] import scala.language.implicitConversions
[warn]                       ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala:3:61: Unused import
[warn] import co.topl.crypto.generation.{Bip32Index, Bip32Indexes, EntropyToSeed, Pbkdf2Sha512}
[warn]                                                             ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala:3:76: Unused import
[warn] import co.topl.crypto.generation.{Bip32Index, Bip32Indexes, EntropyToSeed, Pbkdf2Sha512}
[warn]                                                                            ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala:4:43: Unused import
[warn] import co.topl.crypto.generation.mnemonic.Entropy
[warn]                                           ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala:5:50: Unused import
[warn] import co.topl.models.SecretKeys.ExtendedEd25519.Length
[warn]                                                  ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala:13:25: Unused import
[warn] import java.nio.charset.StandardCharsets
[warn]                         ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/main/scala/co/topl/crypto/signing/package.scala:5:22: Unused import
[warn] import java.security.SecureRandom
[warn]                      ^
[info] done compiling
[info] Running scalafix on 3 Scala sources
[info] Running scalafix on 2 Scala sources
[info] compiling 2 Scala sources to /home/runner/work/Bifrost/Bifrost/byte-codecs/target/scala-2.13/test-classes ...
[info] done compiling
[info] Running scalafix on 2 Scala sources
[warn] 13 warnings found
```




## Tickets
Partial Pr related to BN-692


