### PR TITLE
fix more warnigs

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ClockAlgebra.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ClockAlgebra.scala
@@ -6,7 +6,6 @@ import co.topl.models.{Epoch, Slot, Timestamp}
 
 import scala.collection.immutable.NumericRange
 import scala.concurrent.duration.FiniteDuration
-import scala.language.implicitConversions
 
 /**
  * Provides global slot, epoch, and timing operations

--- a/algebras/src/main/scala/co/topl/algebras/Store.scala
+++ b/algebras/src/main/scala/co/topl/algebras/Store.scala
@@ -1,6 +1,6 @@
 package co.topl.algebras
 
-import cats.{ApplicativeThrow, Functor, MonadThrow, Show}
+import cats.{Functor, MonadThrow, Show}
 import cats.implicits._
 import cats.data.OptionT
 

--- a/crypto/src/test/scala/co/topl/crypto/accumulators/MerkleTreeSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/accumulators/MerkleTreeSpec.scala
@@ -4,7 +4,6 @@ import co.topl.crypto.accumulators.merkle.{Leaf, MerkleTree}
 import co.topl.crypto.hash.digest.{Digest, Digest32}
 import co.topl.crypto.hash.implicits._
 import co.topl.crypto.hash.{Blake2b, Hash}
-import co.topl.crypto.utils.Generators._
 import co.topl.crypto.utils.randomBytes
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers

--- a/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/LanguageSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/LanguageSpec.scala
@@ -3,8 +3,6 @@ package co.topl.crypto.generation.mnemonic
 import cats.implicits._
 import co.topl.crypto.generation.mnemonic.Language._
 import co.topl.crypto.utils.Generators
-import org.scalacheck.Gen
-import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}

--- a/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala
@@ -1,9 +1,6 @@
 package co.topl.crypto.generation.mnemonic
 
-import co.topl.crypto.generation.mnemonic.Language.LanguageWordList
-import co.topl.crypto.generation.mnemonic.MnemonicSizes.{`12`, `18`, `24`}
 import co.topl.crypto.utils.Generators
-import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}

--- a/crypto/src/test/scala/co/topl/crypto/utils/EntropySupport.scala
+++ b/crypto/src/test/scala/co/topl/crypto/utils/EntropySupport.scala
@@ -2,7 +2,6 @@ package co.topl.crypto.utils
 
 import cats.Eq
 import co.topl.crypto.generation.mnemonic.Entropy
-import co.topl.models.Bytes
 import org.scalacheck.Arbitrary
 
 trait EntropySupport {

--- a/network-delayer/src/main/scala/co/topl/networkdelayer/ApplicationConfig.scala
+++ b/network-delayer/src/main/scala/co/topl/networkdelayer/ApplicationConfig.scala
@@ -25,7 +25,7 @@ object ApplicationConfig {
     case class Throttle(latency: FiniteDuration, downloadBytesPerSecond: Long, uploadBytesPerSecond: Long)
   }
 
-  def unsafe(args: Args, config: Config): ApplicationConfig =
+  def unsafe(config: Config): ApplicationConfig =
     ConfigSource.fromConfig(config).loadOrThrow[ApplicationConfig]
 
   implicit val showApplicationConfig: Show[ApplicationConfig] =

--- a/network-delayer/src/main/scala/co/topl/networkdelayer/NetworkDelayer.scala
+++ b/network-delayer/src/main/scala/co/topl/networkdelayer/NetworkDelayer.scala
@@ -20,7 +20,7 @@ object NetworkDelayer
     extends IOBaseApp[Args, ApplicationConfig](
       createArgs = args => Args.parserArgs.constructOrThrow(args),
       createConfig = IOBaseApp.createTypesafeConfig,
-      parseConfig = (_, conf) => ApplicationConfig.unsafe(conf)
+      parseConfig = (_: Args, conf) => ApplicationConfig.unsafe(conf)
     ) {
 
   implicit private val logger: Logger[F] =

--- a/network-delayer/src/main/scala/co/topl/networkdelayer/NetworkDelayer.scala
+++ b/network-delayer/src/main/scala/co/topl/networkdelayer/NetworkDelayer.scala
@@ -20,7 +20,7 @@ object NetworkDelayer
     extends IOBaseApp[Args, ApplicationConfig](
       createArgs = args => Args.parserArgs.constructOrThrow(args),
       createConfig = IOBaseApp.createTypesafeConfig,
-      parseConfig = (args, conf) => ApplicationConfig.unsafe(args, conf)
+      parseConfig = (_, conf) => ApplicationConfig.unsafe(conf)
     ) {
 
   implicit private val logger: Logger[F] =

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraBinaryShowCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraBinaryShowCodecs.scala
@@ -1,7 +1,3 @@
 package co.topl.codecs.bytes.tetra
 
-import co.topl.codecs.bytes.typeclasses._
-import co.topl.models.{BlockHeaderV2, Bytes, StakingAddress, Transaction, TypedIdentifier}
-import com.google.common.primitives.{Ints, Longs}
-
 trait TetraBinaryShowCodecs {}


### PR DESCRIPTION
## Purpose
Avoid imports

## Approach
Added a new flag in Scalac options raising warnings, without fixing them, which will be addressed on several minor following PRs.

## Testing
No additional testing

```
[warn] /home/runner/work/Bifrost/Bifrost/network-delayer/src/main/scala/co/topl/networkdelayer/ApplicationConfig.scala:28:14: parameter value args in method unsafe is never used
[warn]   def unsafe(args: Args, config: Config): ApplicationConfig =
[warn]              ^
[warn] one warning found

[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/test/scala/co/topl/crypto/accumulators/MerkleTreeSpec.scala:7:40: Unused import
[warn] import co.topl.crypto.utils.Generators._
[warn]                                        ^
[info] compiling 9 Scala sources to /home/runner/work/Bifrost/Bifrost/tetra-byte-codecs/target/scala-2.13/classes ...
[warn] /home/runner/work/Bifrost/Bifrost/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraBinaryShowCodecs.scala:3:41: Unused import
[warn] import co.topl.codecs.bytes.typeclasses._
[warn]                                         ^
[warn] /home/runner/work/Bifrost/Bifrost/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraBinaryShowCodecs.scala:4:24: Unused import
[warn] import co.topl.models.{BlockHeaderV2, Bytes, StakingAddress, Transaction, TypedIdentifier}
[warn]                        ^
[warn] /home/runner/work/Bifrost/Bifrost/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraBinaryShowCodecs.scala:4:39: Unused import
[warn] import co.topl.models.{BlockHeaderV2, Bytes, StakingAddress, Transaction, TypedIdentifier}
[warn]                                       ^
[warn] /home/runner/work/Bifrost/Bifrost/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraBinaryShowCodecs.scala:4:46: Unused import
[warn] import co.topl.models.{BlockHeaderV2, Bytes, StakingAddress, Transaction, TypedIdentifier}
[warn]                                              ^
[warn] /home/runner/work/Bifrost/Bifrost/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraBinaryShowCodecs.scala:4:62: Unused import
[warn] import co.topl.models.{BlockHeaderV2, Bytes, StakingAddress, Transaction, TypedIdentifier}
[warn]                                                              ^
[warn] /home/runner/work/Bifrost/Bifrost/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraBinaryShowCodecs.scala:4:75: Unused import
[warn] import co.topl.models.{BlockHeaderV2, Bytes, StakingAddress, Transaction, TypedIdentifier}
[warn]                                                                           ^
[warn] /home/runner/work/Bifrost/Bifrost/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraBinaryShowCodecs.scala:5:38: Unused import
[warn] import com.google.common.primitives.{Ints, Longs}
[warn]                                      ^
[warn] /home/runner/work/Bifrost/Bifrost/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraBinaryShowCodecs.scala:5:44: Unused import
[warn] import com.google.common.primitives.{Ints, Longs}
[warn]                                            ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/LanguageSpec.scala:6:23: Unused import
[warn] import org.scalacheck.Gen
[warn]                       ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/LanguageSpec.scala:7:30: Unused import
[warn] import org.scalatest.funspec.AnyFunSpec
[warn]                              ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala:3:[52](https://github.com/Topl/Bifrost/actions/runs/3479454364/jobs/5818020730#step:8:53): Unused import
[warn] import co.topl.crypto.generation.mnemonic.Language.LanguageWordList
[warn]                                                    ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala:4:58: Unused import
[warn] import co.topl.crypto.generation.mnemonic.MnemonicSizes.{`12`, `18`, `24`}
[warn]                                                          ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala:4:64: Unused import
[warn] import co.topl.crypto.generation.mnemonic.MnemonicSizes.{`12`, `18`, `24`}
[warn]                                                                ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala:4:70: Unused import
[warn] import co.topl.crypto.generation.mnemonic.MnemonicSizes.{`12`, `18`, `24`}
[warn]                                                                      ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala:6:23: Unused import
[warn] import org.scalacheck.Gen
[warn]                       ^
[warn] /home/runner/work/Bifrost/Bifrost/crypto/src/test/scala/co/topl/crypto/utils/EntropySupport.scala:5:23: Unused import
[warn] import co.topl.models.Bytes
[warn]                       ^
[warn] 9 warnings found
[info] done compiling

```
