### PR TITLE
TSDK-135 | Added NodeBlockFetcher implementation [2]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -860,7 +860,7 @@ lazy val genusLibrary = project
   )
   .dependsOn(
     typeclasses,
-    models,
+    models % "compile->compile;test->test",
     tetraByteCodecs,
     toplGrpc,
     munitScalamock % "test->test",

--- a/build.sbt
+++ b/build.sbt
@@ -858,7 +858,13 @@ lazy val genusLibrary = project
     buildInfoPackage := "co.topl.buildinfo.genusLibrary",
     libraryDependencies ++= Dependencies.genusLibrary
   )
-  .dependsOn(typeclasses, models, tetraByteCodecs)
+  .dependsOn(
+    typeclasses,
+    models,
+    tetraByteCodecs,
+    toplGrpc,
+    munitScalamock % "test->test",
+  )
 
 lazy val munitScalamock = project
   .in(file("munit-scalamock"))

--- a/genus-library/src/main/scala/co/topl/genusLibrary/failure/Failure.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/failure/Failure.scala
@@ -1,5 +1,25 @@
 package co.topl.genusLibrary.failure
 
-sealed abstract case class Failure(message: String, exception: Option[Exception])
+import co.topl.models.TypedIdentifier
+import scodec.bits.ByteVector
 
-object Failures {}
+import scala.collection.immutable.ListSet
+
+sealed abstract class Failure(message: String, exception: Option[Exception] = None)
+
+object Failures {
+
+  case class NoPreviousHeaderVertexFailure(blockId: (Byte, ByteVector), parentHeaderId: TypedIdentifier)
+      extends Failure(
+        s"Block doesn't have a previous header vertex. blockId=[$blockId] parentHeaderId=[$parentHeaderId]"
+      )
+
+  case class NoBlockHeaderFoundOnNodeFailure(blockId: TypedIdentifier)
+      extends Failure(s"Block header wasn't found. BlockId=[$blockId]")
+
+  case class NoBlockBodyFoundOnNodeFailure(blockId: TypedIdentifier)
+      extends Failure(s"Block body wasn't found. BlockId=[$blockId]")
+
+  case class NonExistentTransactionsFailure(transactions: ListSet[TypedIdentifier])
+      extends Failure(s"Transactions weren't found. Transactions=[$transactions]")
+}

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
@@ -1,0 +1,57 @@
+package co.topl.genusLibrary.interpreter
+
+import cats.data.{Chain, EitherT}
+import cats.effect.kernel.Sync
+import cats.implicits._
+import co.topl.algebras.ToplRpc
+import co.topl.genusLibrary.algebras.{BlockFetcherAlgebra, ServiceResponse}
+import co.topl.genusLibrary.failure.{Failure, Failures}
+import co.topl.models.{BlockBodyV2, BlockHeaderV2, BlockV2, Transaction, TypedIdentifier}
+
+import scala.collection.immutable.ListSet
+
+class NodeBlockFetcher[F[_]: Sync](toplRpc: ToplRpc[F, Any]) extends BlockFetcherAlgebra[F] {
+
+  // TODO: TSDK-186 | Do calls concurrently.
+  override def fetch(height: Long): ServiceResponse[F, Option[BlockV2.Full]] = toplRpc.blockIdAtHeight(height) flatMap {
+    case None => Option.empty[BlockV2.Full].asRight[Failure].pure[F]
+    case Some(blockId) =>
+      (
+        for {
+          header       <- EitherT(fetchBlockHeader(blockId))
+          body         <- EitherT(fetchBlockBody(blockId))
+          transactions <- EitherT(fetchTransactions(body))
+        } yield Option(BlockV2.Full(header, transactions))
+      ).value
+  }
+
+  private def fetchBlockHeader(blockId: TypedIdentifier): ServiceResponse[F, BlockHeaderV2] =
+    toplRpc
+      .fetchBlockHeader(blockId)
+      .map(_.toRight[Failure](Failures.NoBlockHeaderFoundOnNodeFailure(blockId)))
+
+  private def fetchBlockBody(blockId: TypedIdentifier): ServiceResponse[F, BlockBodyV2] =
+    toplRpc
+      .fetchBlockBody(blockId)
+      .map(_.toRight[Failure](Failures.NoBlockBodyFoundOnNodeFailure(blockId)))
+
+  /*
+   * If all transactions were retrieved correctly, then all transactions are returned.
+   * If one or more transactions is missing, then a failure listing all missing transactions is returned.
+   */
+  private def fetchTransactions(body: BlockBodyV2): ServiceResponse[F, Chain[Transaction]] =
+    body.toList.traverse(typedIdentifier =>
+      toplRpc
+        .fetchTransaction(typedIdentifier)
+        .map(maybeTransaction => (typedIdentifier, maybeTransaction))
+    ) map { e =>
+      e.foldLeft(Chain.empty[Transaction].asRight[ListSet[TypedIdentifier]]) {
+        case (Right(transactions), (_, Some(transaction)))     => transactions.+:(transaction).asRight
+        case (Right(_), (typedIdentifier, None))               => ListSet(typedIdentifier).asLeft
+        case (nonExistentTransactions @ Left(_), (_, Some(_))) => nonExistentTransactions
+        case (Left(nonExistentTransactions), (typedIdentifier, None)) =>
+          Left(nonExistentTransactions + typedIdentifier)
+      }
+    } map [Either[Failure, Chain[Transaction]]] (_.left.map(Failures.NonExistentTransactionsFailure))
+
+}

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
@@ -1,7 +1,7 @@
 package co.topl.genusLibrary.interpreter
 
 import cats.data.{Chain, EitherT}
-import cats.effect.kernel.Sync
+import cats.effect.kernel.Async
 import cats.implicits._
 import co.topl.algebras.ToplRpc
 import co.topl.genusLibrary.algebras.{BlockFetcherAlgebra, ServiceResponse}
@@ -10,7 +10,7 @@ import co.topl.models.{BlockBodyV2, BlockHeaderV2, BlockV2, Transaction, TypedId
 
 import scala.collection.immutable.ListSet
 
-class NodeBlockFetcher[F[_]: Sync](toplRpc: ToplRpc[F, Any]) extends BlockFetcherAlgebra[F] {
+class NodeBlockFetcher[F[_]: Async](toplRpc: ToplRpc[F, Any]) extends BlockFetcherAlgebra[F] {
 
   // TODO: TSDK-186 | Do calls concurrently.
   override def fetch(height: Long): ServiceResponse[F, Option[BlockV2.Full]] = toplRpc.blockIdAtHeight(height) flatMap {

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
@@ -46,7 +46,7 @@ class NodeBlockFetcher[F[_]: Async](toplRpc: ToplRpc[F, Any]) extends BlockFetch
         .map(maybeTransaction => (typedIdentifier, maybeTransaction))
     ) map { e =>
       e.foldLeft(Chain.empty[Transaction].asRight[ListSet[TypedIdentifier]]) {
-        case (Right(transactions), (_, Some(transaction)))     => transactions.+:(transaction).asRight
+        case (Right(transactions), (_, Some(transaction)))     => (transactions :+ transaction).asRight
         case (Right(_), (typedIdentifier, None))               => ListSet(typedIdentifier).asLeft
         case (nonExistentTransactions @ Left(_), (_, Some(_))) => nonExistentTransactions
         case (Left(nonExistentTransactions), (typedIdentifier, None)) =>

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcherSpec.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcherSpec.scala
@@ -1,0 +1,357 @@
+package co.topl.genusLibrary.interpreter
+
+import cats.data.Chain
+import cats.effect.IO
+import cats.implicits._
+import co.topl.algebras.ToplRpc
+import co.topl.genusLibrary.failure.Failures.{
+  NoBlockBodyFoundOnNodeFailure,
+  NoBlockHeaderFoundOnNodeFailure,
+  NonExistentTransactionsFailure
+}
+import co.topl.genusLibrary.interpreter.NodeBlockFetcherSpec.{
+  BLOCK_ID,
+  HEIGHT,
+  TRANSACTION_ID_01,
+  TRANSACTION_ID_02,
+  TRANSACTION_ID_03
+}
+import co.topl.models.{BlockBodyV2, BlockHeaderV2, BlockV2, Bytes, Transaction, TypedBytes, TypedIdentifier}
+import munit.FunSuite
+import org.scalamock.munit.AsyncMockFactory
+
+import scala.collection.immutable.ListSet
+
+class NodeBlockFetcherSpec extends FunSuite with AsyncMockFactory {
+
+  type F[A] = IO[A]
+
+  val toplRpc: ToplRpc[F, Any] = mock[ToplRpc[F, Any]]
+
+  val nodeBlockFetcher = new NodeBlockFetcher(toplRpc)
+
+  test("On no block at given height, a None should be returned") {
+    withMock {
+
+      (toplRpc.blockIdAtHeight _)
+        .expects(HEIGHT)
+        .returning(Option.empty[TypedIdentifier].pure[F])
+        .once()
+
+      val result = nodeBlockFetcher fetch HEIGHT
+
+      result map { actualResult =>
+        assertEquals(actualResult, None.asRight)
+      }
+
+    }
+  }
+
+  test(
+    "On a block without a header, a Left of NoBlockHeaderFoundOnNodeFailure should be returned"
+  ) {
+    withMock {
+
+      val blockBody: BlockBodyV2 = ListSet.empty
+
+      (toplRpc.blockIdAtHeight _)
+        .expects(HEIGHT)
+        .returning(Option(BLOCK_ID).pure[F])
+        .once()
+
+      (toplRpc.fetchBlockHeader _)
+        .expects(BLOCK_ID)
+        .returning(Option.empty[BlockHeaderV2].pure[F])
+        .once()
+
+      (toplRpc.fetchBlockBody _)
+        .expects(BLOCK_ID)
+        .returning(Option(blockBody).pure[F])
+        .once()
+
+      val result = nodeBlockFetcher fetch HEIGHT
+
+      result map { actualResult =>
+        assertEquals(actualResult, NoBlockHeaderFoundOnNodeFailure(BLOCK_ID).asLeft)
+      }
+
+    }
+  }
+
+  test(
+    "On a block without a body, a Left of NoBlockBodyFoundOnNodeFailure should be returned"
+  ) {
+    withMock {
+
+      val blockHeader = mock[BlockHeaderV2]
+
+      (toplRpc.blockIdAtHeight _)
+        .expects(HEIGHT)
+        .returning(Option(BLOCK_ID).pure[F])
+        .once()
+
+      (toplRpc.fetchBlockHeader _)
+        .expects(BLOCK_ID)
+        .returning(Option(blockHeader).pure[F])
+        .once()
+
+      (toplRpc.fetchBlockBody _)
+        .expects(BLOCK_ID)
+        .returning(Option.empty[BlockBodyV2].pure[F])
+        .once()
+
+      val result = nodeBlockFetcher fetch HEIGHT
+
+      result map { actualResult =>
+        assertEquals(actualResult, NoBlockBodyFoundOnNodeFailure(BLOCK_ID).asLeft)
+      }
+
+    }
+  }
+
+  test(
+    "On a block without header and body, a Left of NoBlockHeaderFoundOnNodeFailure should be returned"
+  ) {
+    withMock {
+
+      (toplRpc.blockIdAtHeight _)
+        .expects(HEIGHT)
+        .returning(Option(BLOCK_ID).pure[F])
+        .once()
+
+      (toplRpc.fetchBlockHeader _)
+        .expects(BLOCK_ID)
+        .returning(Option.empty[BlockHeaderV2].pure[F])
+        .once()
+
+      (toplRpc.fetchBlockBody _)
+        .expects(BLOCK_ID)
+        .returning(Option.empty[BlockBodyV2].pure[F])
+        .once()
+
+      val result = nodeBlockFetcher fetch HEIGHT
+
+      result map { actualResult =>
+        assertEquals(actualResult, NoBlockHeaderFoundOnNodeFailure(BLOCK_ID).asLeft)
+      }
+
+    }
+  }
+
+  test(
+    "On a block with a transaction and missing it, " +
+    "a Left of NonExistentTransactionsFailure with that txId should be returned"
+  ) {
+    withMock {
+
+      val blockHeader = mock[BlockHeaderV2]
+
+      val blockBody: BlockBodyV2 = ListSet(
+        TRANSACTION_ID_01
+      )
+
+      (toplRpc.blockIdAtHeight _)
+        .expects(HEIGHT)
+        .returning(Option(BLOCK_ID).pure[F])
+        .once()
+
+      (toplRpc.fetchBlockHeader _)
+        .expects(BLOCK_ID)
+        .returning(Option(blockHeader).pure[F])
+        .once()
+
+      (toplRpc.fetchBlockBody _)
+        .expects(BLOCK_ID)
+        .returning(Option(blockBody).pure[F])
+        .once()
+
+      (toplRpc.fetchTransaction _)
+        .expects(TRANSACTION_ID_01)
+        .returning(Option.empty[Transaction].pure[F])
+
+      val result = nodeBlockFetcher fetch HEIGHT
+
+      result map { actualResult =>
+        assertEquals(actualResult, NonExistentTransactionsFailure(ListSet(TRANSACTION_ID_01)).asLeft)
+      }
+
+    }
+  }
+
+  test(
+    "On a block with three transactions and missing two of them, " +
+    "a Left of NonExistentTransactionsFailure with the missing txIds should be returned"
+  ) {
+    withMock {
+
+      val blockHeader = mock[BlockHeaderV2]
+
+      val blockBody: BlockBodyV2 = ListSet(
+        TRANSACTION_ID_01,
+        TRANSACTION_ID_02,
+        TRANSACTION_ID_03
+      )
+
+      val transaction_01 = mock[Transaction]
+
+      (toplRpc.blockIdAtHeight _)
+        .expects(HEIGHT)
+        .returning(Option(BLOCK_ID).pure[F])
+        .once()
+
+      (toplRpc.fetchBlockHeader _)
+        .expects(BLOCK_ID)
+        .returning(Option(blockHeader).pure[F])
+        .once()
+
+      (toplRpc.fetchBlockBody _)
+        .expects(BLOCK_ID)
+        .returning(Option(blockBody).pure[F])
+        .once()
+
+      (toplRpc.fetchTransaction _)
+        .expects(TRANSACTION_ID_01)
+        .returning(Option(transaction_01).pure[F])
+
+      (toplRpc.fetchTransaction _)
+        .expects(TRANSACTION_ID_02)
+        .returning(Option.empty[Transaction].pure[F])
+
+      (toplRpc.fetchTransaction _)
+        .expects(TRANSACTION_ID_03)
+        .returning(Option.empty[Transaction].pure[F])
+
+      val result = nodeBlockFetcher fetch HEIGHT
+
+      result map { actualResult =>
+        assertEquals(
+          actualResult,
+          NonExistentTransactionsFailure(ListSet(TRANSACTION_ID_02, TRANSACTION_ID_03)).asLeft
+        )
+      }
+
+    }
+  }
+
+  test(
+    "On a block with three transactions and missing all of them, " +
+    "a Left of NonExistentTransactionsFailure with the missing txIds should be returned"
+  ) {
+    withMock {
+
+      val blockHeader = mock[BlockHeaderV2]
+
+      val blockBody: BlockBodyV2 = ListSet(
+        TRANSACTION_ID_01,
+        TRANSACTION_ID_02,
+        TRANSACTION_ID_03
+      )
+
+      (toplRpc.blockIdAtHeight _)
+        .expects(HEIGHT)
+        .returning(Option(BLOCK_ID).pure[F])
+        .once()
+
+      (toplRpc.fetchBlockHeader _)
+        .expects(BLOCK_ID)
+        .returning(Option(blockHeader).pure[F])
+        .once()
+
+      (toplRpc.fetchBlockBody _)
+        .expects(BLOCK_ID)
+        .returning(Option(blockBody).pure[F])
+        .once()
+
+      (toplRpc.fetchTransaction _)
+        .expects(TRANSACTION_ID_01)
+        .returning(Option.empty[Transaction].pure[F])
+
+      (toplRpc.fetchTransaction _)
+        .expects(TRANSACTION_ID_02)
+        .returning(Option.empty[Transaction].pure[F])
+
+      (toplRpc.fetchTransaction _)
+        .expects(TRANSACTION_ID_03)
+        .returning(Option.empty[Transaction].pure[F])
+
+      val result = nodeBlockFetcher fetch HEIGHT
+
+      result map { actualResult =>
+        assertEquals(
+          actualResult,
+          NonExistentTransactionsFailure(ListSet(TRANSACTION_ID_01, TRANSACTION_ID_02, TRANSACTION_ID_03)).asLeft
+        )
+      }
+
+    }
+  }
+
+  test(
+    "On a block with a header and three transactions, a Right of the full block body should be returned"
+  ) {
+    withMock {
+
+      val blockHeader = mock[BlockHeaderV2]
+
+      val blockBody: BlockBodyV2 = ListSet(
+        TRANSACTION_ID_01,
+        TRANSACTION_ID_02,
+        TRANSACTION_ID_03
+      )
+
+      val transaction_01 = mock[Transaction]
+      val transaction_02 = mock[Transaction]
+      val transaction_03 = mock[Transaction]
+
+      (toplRpc.blockIdAtHeight _)
+        .expects(HEIGHT)
+        .returning(Option(BLOCK_ID).pure[F])
+        .once()
+
+      (toplRpc.fetchBlockHeader _)
+        .expects(BLOCK_ID)
+        .returning(Option(blockHeader).pure[F])
+        .once()
+
+      (toplRpc.fetchBlockBody _)
+        .expects(BLOCK_ID)
+        .returning(Option(blockBody).pure[F])
+        .once()
+
+      (toplRpc.fetchTransaction _)
+        .expects(TRANSACTION_ID_01)
+        .returning(Option(transaction_01).pure[F])
+
+      (toplRpc.fetchTransaction _)
+        .expects(TRANSACTION_ID_02)
+        .returning(Option(transaction_02).pure[F])
+
+      (toplRpc.fetchTransaction _)
+        .expects(TRANSACTION_ID_03)
+        .returning(Option(transaction_03).pure[F])
+
+      val result = nodeBlockFetcher fetch HEIGHT
+
+      result map { actualResult =>
+        assertEquals(
+          actualResult,
+          Option(BlockV2.Full(blockHeader, Chain(transaction_01, transaction_02, transaction_03))).asRight
+        )
+      }
+
+    }
+  }
+
+}
+
+object NodeBlockFetcherSpec {
+
+  final private val HEIGHT: Long = 1
+
+  final private val BLOCK_ID: TypedIdentifier = TypedBytes(-1: Byte, Bytes(-1: Byte))
+
+  final private val TRANSACTION_ID_01: TypedIdentifier = TypedBytes(-2: Byte, Bytes(-2: Byte))
+  final private val TRANSACTION_ID_02: TypedIdentifier = TypedBytes(-3: Byte, Bytes(-3: Byte))
+  final private val TRANSACTION_ID_03: TypedIdentifier = TypedBytes(-4: Byte, Bytes(-4: Byte))
+
+}

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcherSpec.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcherSpec.scala
@@ -4,25 +4,16 @@ import cats.data.Chain
 import cats.effect.IO
 import cats.implicits._
 import co.topl.algebras.ToplRpc
-import co.topl.genusLibrary.failure.Failures.{
-  NoBlockBodyFoundOnNodeFailure,
-  NoBlockHeaderFoundOnNodeFailure,
-  NonExistentTransactionsFailure
-}
-import co.topl.genusLibrary.interpreter.NodeBlockFetcherSpec.{
-  BLOCK_ID,
-  HEIGHT,
-  TRANSACTION_ID_01,
-  TRANSACTION_ID_02,
-  TRANSACTION_ID_03
-}
-import co.topl.models.{BlockBodyV2, BlockHeaderV2, BlockV2, Bytes, Transaction, TypedBytes, TypedIdentifier}
-import munit.FunSuite
+import co.topl.genusLibrary.failure.Failures.{NoBlockBodyFoundOnNodeFailure, NoBlockHeaderFoundOnNodeFailure, NonExistentTransactionsFailure}
+import co.topl.models.ModelGenerators._
+import co.topl.models._
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 
 import scala.collection.immutable.ListSet
 
-class NodeBlockFetcherSpec extends FunSuite with AsyncMockFactory {
+class NodeBlockFetcherSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
   type F[A] = IO[A]
 
@@ -31,110 +22,78 @@ class NodeBlockFetcherSpec extends FunSuite with AsyncMockFactory {
   val nodeBlockFetcher = new NodeBlockFetcher(toplRpc)
 
   test("On no block at given height, a None should be returned") {
-    withMock {
+    PropF.forAllF { height: Long =>
+      withMock {
 
-      (toplRpc.blockIdAtHeight _)
-        .expects(HEIGHT)
-        .returning(Option.empty[TypedIdentifier].pure[F])
-        .once()
+        (toplRpc.blockIdAtHeight _)
+          .expects(height)
+          .returning(Option.empty[TypedIdentifier].pure[F])
+          .once()
 
-      val result = nodeBlockFetcher fetch HEIGHT
+        val result = nodeBlockFetcher fetch height
 
-      result map { actualResult =>
-        assertEquals(actualResult, None.asRight)
+        result map { actualResult =>
+          assertEquals(actualResult, None.asRight)
+        }
+
       }
-
     }
   }
 
   test(
     "On a block without a header, a Left of NoBlockHeaderFoundOnNodeFailure should be returned"
   ) {
-    withMock {
+    PropF.forAllF { (height: Long, blockId: TypedIdentifier) =>
+      withMock {
 
-      val blockBody: BlockBodyV2 = ListSet.empty
+        (toplRpc.blockIdAtHeight _)
+          .expects(height)
+          .returning(blockId.some.pure[F])
+          .once()
 
-      (toplRpc.blockIdAtHeight _)
-        .expects(HEIGHT)
-        .returning(Option(BLOCK_ID).pure[F])
-        .once()
+        (toplRpc.fetchBlockHeader _)
+          .expects(blockId)
+          .returning(Option.empty[BlockHeaderV2].pure[F])
+          .once()
 
-      (toplRpc.fetchBlockHeader _)
-        .expects(BLOCK_ID)
-        .returning(Option.empty[BlockHeaderV2].pure[F])
-        .once()
+        val result = nodeBlockFetcher fetch height
 
-      (toplRpc.fetchBlockBody _)
-        .expects(BLOCK_ID)
-        .returning(Option(blockBody).pure[F])
-        .once()
+        result map { actualResult =>
+          assertEquals(actualResult, NoBlockHeaderFoundOnNodeFailure(blockId).asLeft)
+        }
 
-      val result = nodeBlockFetcher fetch HEIGHT
-
-      result map { actualResult =>
-        assertEquals(actualResult, NoBlockHeaderFoundOnNodeFailure(BLOCK_ID).asLeft)
       }
-
     }
   }
 
   test(
     "On a block without a body, a Left of NoBlockBodyFoundOnNodeFailure should be returned"
   ) {
-    withMock {
+    PropF.forAllF { (height: Long, blockId: TypedIdentifier, blockHeader: BlockHeaderV2) =>
+      withMock {
 
-      val blockHeader = mock[BlockHeaderV2]
+        (toplRpc.blockIdAtHeight _)
+          .expects(height)
+          .returning(Option(blockId).pure[F])
+          .once()
 
-      (toplRpc.blockIdAtHeight _)
-        .expects(HEIGHT)
-        .returning(Option(BLOCK_ID).pure[F])
-        .once()
+        (toplRpc.fetchBlockHeader _)
+          .expects(blockId)
+          .returning(Option(blockHeader).pure[F])
+          .once()
 
-      (toplRpc.fetchBlockHeader _)
-        .expects(BLOCK_ID)
-        .returning(Option(blockHeader).pure[F])
-        .once()
+        (toplRpc.fetchBlockBody _)
+          .expects(blockId)
+          .returning(Option.empty[BlockBodyV2].pure[F])
+          .once()
 
-      (toplRpc.fetchBlockBody _)
-        .expects(BLOCK_ID)
-        .returning(Option.empty[BlockBodyV2].pure[F])
-        .once()
+        val result = nodeBlockFetcher fetch height
 
-      val result = nodeBlockFetcher fetch HEIGHT
+        result map { actualResult =>
+          assertEquals(actualResult, NoBlockBodyFoundOnNodeFailure(blockId).asLeft)
+        }
 
-      result map { actualResult =>
-        assertEquals(actualResult, NoBlockBodyFoundOnNodeFailure(BLOCK_ID).asLeft)
       }
-
-    }
-  }
-
-  test(
-    "On a block without header and body, a Left of NoBlockHeaderFoundOnNodeFailure should be returned"
-  ) {
-    withMock {
-
-      (toplRpc.blockIdAtHeight _)
-        .expects(HEIGHT)
-        .returning(Option(BLOCK_ID).pure[F])
-        .once()
-
-      (toplRpc.fetchBlockHeader _)
-        .expects(BLOCK_ID)
-        .returning(Option.empty[BlockHeaderV2].pure[F])
-        .once()
-
-      (toplRpc.fetchBlockBody _)
-        .expects(BLOCK_ID)
-        .returning(Option.empty[BlockBodyV2].pure[F])
-        .once()
-
-      val result = nodeBlockFetcher fetch HEIGHT
-
-      result map { actualResult =>
-        assertEquals(actualResult, NoBlockHeaderFoundOnNodeFailure(BLOCK_ID).asLeft)
-      }
-
     }
   }
 
@@ -142,39 +101,43 @@ class NodeBlockFetcherSpec extends FunSuite with AsyncMockFactory {
     "On a block with a transaction and missing it, " +
     "a Left of NonExistentTransactionsFailure with that txId should be returned"
   ) {
-    withMock {
+    PropF.forAllF {
+      (
+        height:        Long,
+        blockId:       TypedIdentifier,
+        blockHeader:   BlockHeaderV2,
+        transactionId: TypedIdentifier
+      ) =>
+        withMock {
 
-      val blockHeader = mock[BlockHeaderV2]
+          val blockBody: BlockBodyV2 = ListSet(transactionId)
 
-      val blockBody: BlockBodyV2 = ListSet(
-        TRANSACTION_ID_01
-      )
+          (toplRpc.blockIdAtHeight _)
+            .expects(height)
+            .returning(Option(blockId).pure[F])
+            .once()
 
-      (toplRpc.blockIdAtHeight _)
-        .expects(HEIGHT)
-        .returning(Option(BLOCK_ID).pure[F])
-        .once()
+          (toplRpc.fetchBlockHeader _)
+            .expects(blockId)
+            .returning(Option(blockHeader).pure[F])
+            .once()
 
-      (toplRpc.fetchBlockHeader _)
-        .expects(BLOCK_ID)
-        .returning(Option(blockHeader).pure[F])
-        .once()
+          (toplRpc.fetchBlockBody _)
+            .expects(blockId)
+            .returning(Option(blockBody).pure[F])
+            .once()
 
-      (toplRpc.fetchBlockBody _)
-        .expects(BLOCK_ID)
-        .returning(Option(blockBody).pure[F])
-        .once()
+          (toplRpc.fetchTransaction _)
+            .expects(transactionId)
+            .returning(Option.empty[Transaction].pure[F])
 
-      (toplRpc.fetchTransaction _)
-        .expects(TRANSACTION_ID_01)
-        .returning(Option.empty[Transaction].pure[F])
+          val result = nodeBlockFetcher fetch height
 
-      val result = nodeBlockFetcher fetch HEIGHT
+          result map { actualResult =>
+            assertEquals(actualResult, NonExistentTransactionsFailure(ListSet(transactionId)).asLeft)
+          }
 
-      result map { actualResult =>
-        assertEquals(actualResult, NonExistentTransactionsFailure(ListSet(TRANSACTION_ID_01)).asLeft)
-      }
-
+        }
     }
   }
 
@@ -182,54 +145,62 @@ class NodeBlockFetcherSpec extends FunSuite with AsyncMockFactory {
     "On a block with three transactions and missing two of them, " +
     "a Left of NonExistentTransactionsFailure with the missing txIds should be returned"
   ) {
-    withMock {
+    PropF.forAllF {
+      (
+        height: Long,
+        blockId: TypedIdentifier,
+        blockHeader: BlockHeaderV2,
+        transactionId_01: TypedIdentifier,
+        transactionId_02: TypedIdentifier,
+        transactionId_03: TypedIdentifier,
+      ) =>
+        withMock {
 
-      val blockHeader = mock[BlockHeaderV2]
+          val blockBody: BlockBodyV2 = ListSet(
+            transactionId_01,
+            transactionId_02,
+            transactionId_03,
+          )
 
-      val blockBody: BlockBodyV2 = ListSet(
-        TRANSACTION_ID_01,
-        TRANSACTION_ID_02,
-        TRANSACTION_ID_03
-      )
+          val transaction_01 = mock[Transaction]
 
-      val transaction_01 = mock[Transaction]
+          (toplRpc.blockIdAtHeight _)
+            .expects(height)
+            .returning(blockId.some.pure[F])
+            .once()
 
-      (toplRpc.blockIdAtHeight _)
-        .expects(HEIGHT)
-        .returning(Option(BLOCK_ID).pure[F])
-        .once()
+          (toplRpc.fetchBlockHeader _)
+            .expects(blockId)
+            .returning(blockHeader.some.pure[F])
+            .once()
 
-      (toplRpc.fetchBlockHeader _)
-        .expects(BLOCK_ID)
-        .returning(Option(blockHeader).pure[F])
-        .once()
+          (toplRpc.fetchBlockBody _)
+            .expects(blockId)
+            .returning(blockBody.some.pure[F])
+            .once()
 
-      (toplRpc.fetchBlockBody _)
-        .expects(BLOCK_ID)
-        .returning(Option(blockBody).pure[F])
-        .once()
+          (toplRpc.fetchTransaction _)
+            .expects(transactionId_01)
+            .returning(transaction_01.some.pure[F])
 
-      (toplRpc.fetchTransaction _)
-        .expects(TRANSACTION_ID_01)
-        .returning(Option(transaction_01).pure[F])
+          (toplRpc.fetchTransaction _)
+            .expects(transactionId_02)
+            .returning(Option.empty[Transaction].pure[F])
 
-      (toplRpc.fetchTransaction _)
-        .expects(TRANSACTION_ID_02)
-        .returning(Option.empty[Transaction].pure[F])
+          (toplRpc.fetchTransaction _)
+            .expects(transactionId_03)
+            .returning(Option.empty[Transaction].pure[F])
 
-      (toplRpc.fetchTransaction _)
-        .expects(TRANSACTION_ID_03)
-        .returning(Option.empty[Transaction].pure[F])
+          val result = nodeBlockFetcher fetch height
 
-      val result = nodeBlockFetcher fetch HEIGHT
+          result map { actualResult =>
+            assertEquals(
+              actualResult,
+              NonExistentTransactionsFailure(ListSet(transactionId_02, transactionId_03)).asLeft
+            )
+          }
 
-      result map { actualResult =>
-        assertEquals(
-          actualResult,
-          NonExistentTransactionsFailure(ListSet(TRANSACTION_ID_02, TRANSACTION_ID_03)).asLeft
-        )
-      }
-
+        }
     }
   }
 
@@ -237,121 +208,124 @@ class NodeBlockFetcherSpec extends FunSuite with AsyncMockFactory {
     "On a block with three transactions and missing all of them, " +
     "a Left of NonExistentTransactionsFailure with the missing txIds should be returned"
   ) {
-    withMock {
+    PropF.forAllF {
+      (
+        height: Long,
+        blockId: TypedIdentifier,
+        blockHeader: BlockHeaderV2,
+        transactionId_01: TypedIdentifier,
+        transactionId_02: TypedIdentifier,
+        transactionId_03: TypedIdentifier,
+      ) =>
+        withMock {
 
-      val blockHeader = mock[BlockHeaderV2]
+          val blockBody: BlockBodyV2 = ListSet(
+            transactionId_01,
+            transactionId_02,
+            transactionId_03,
+          )
 
-      val blockBody: BlockBodyV2 = ListSet(
-        TRANSACTION_ID_01,
-        TRANSACTION_ID_02,
-        TRANSACTION_ID_03
-      )
+          (toplRpc.blockIdAtHeight _)
+            .expects(height)
+            .returning(blockId.some.pure[F])
+            .once()
 
-      (toplRpc.blockIdAtHeight _)
-        .expects(HEIGHT)
-        .returning(Option(BLOCK_ID).pure[F])
-        .once()
+          (toplRpc.fetchBlockHeader _)
+            .expects(blockId)
+            .returning(blockHeader.some.pure[F])
+            .once()
 
-      (toplRpc.fetchBlockHeader _)
-        .expects(BLOCK_ID)
-        .returning(Option(blockHeader).pure[F])
-        .once()
+          (toplRpc.fetchBlockBody _)
+            .expects(blockId)
+            .returning(blockBody.some.pure[F])
+            .once()
 
-      (toplRpc.fetchBlockBody _)
-        .expects(BLOCK_ID)
-        .returning(Option(blockBody).pure[F])
-        .once()
+          (toplRpc.fetchTransaction _)
+            .expects(transactionId_01)
+            .returning(Option.empty[Transaction].pure[F])
 
-      (toplRpc.fetchTransaction _)
-        .expects(TRANSACTION_ID_01)
-        .returning(Option.empty[Transaction].pure[F])
+          (toplRpc.fetchTransaction _)
+            .expects(transactionId_02)
+            .returning(Option.empty[Transaction].pure[F])
 
-      (toplRpc.fetchTransaction _)
-        .expects(TRANSACTION_ID_02)
-        .returning(Option.empty[Transaction].pure[F])
+          (toplRpc.fetchTransaction _)
+            .expects(transactionId_03)
+            .returning(Option.empty[Transaction].pure[F])
 
-      (toplRpc.fetchTransaction _)
-        .expects(TRANSACTION_ID_03)
-        .returning(Option.empty[Transaction].pure[F])
+          val result = nodeBlockFetcher fetch height
 
-      val result = nodeBlockFetcher fetch HEIGHT
+          result map { actualResult =>
+            assertEquals(
+              actualResult,
+              NonExistentTransactionsFailure(ListSet(transactionId_01, transactionId_02, transactionId_03)).asLeft
+            )
+          }
 
-      result map { actualResult =>
-        assertEquals(
-          actualResult,
-          NonExistentTransactionsFailure(ListSet(TRANSACTION_ID_01, TRANSACTION_ID_02, TRANSACTION_ID_03)).asLeft
-        )
-      }
-
+        }
     }
   }
 
   test(
     "On a block with a header and three transactions, a Right of the full block body should be returned"
   ) {
-    withMock {
+    PropF.forAllF {
+      (
+        height: Long,
+        blockId: TypedIdentifier,
+        blockHeader: BlockHeaderV2,
+        transactionId_01: TypedIdentifier,
+        transactionId_02: TypedIdentifier,
+        transactionId_03: TypedIdentifier,
+        transaction_01: Transaction,
+        transaction_02: Transaction,
+        transaction_03: Transaction,
+      ) =>
+        withMock {
 
-      val blockHeader = mock[BlockHeaderV2]
+          val blockBody: BlockBodyV2 = ListSet(
+            transactionId_01,
+            transactionId_02,
+            transactionId_03,
+          )
 
-      val blockBody: BlockBodyV2 = ListSet(
-        TRANSACTION_ID_01,
-        TRANSACTION_ID_02,
-        TRANSACTION_ID_03
-      )
+          (toplRpc.blockIdAtHeight _)
+            .expects(height)
+            .returning(blockId.some.pure[F])
+            .once()
 
-      val transaction_01 = mock[Transaction]
-      val transaction_02 = mock[Transaction]
-      val transaction_03 = mock[Transaction]
+          (toplRpc.fetchBlockHeader _)
+            .expects(blockId)
+            .returning(blockHeader.some.pure[F])
+            .once()
 
-      (toplRpc.blockIdAtHeight _)
-        .expects(HEIGHT)
-        .returning(Option(BLOCK_ID).pure[F])
-        .once()
+          (toplRpc.fetchBlockBody _)
+            .expects(blockId)
+            .returning(blockBody.some.pure[F])
+            .once()
 
-      (toplRpc.fetchBlockHeader _)
-        .expects(BLOCK_ID)
-        .returning(Option(blockHeader).pure[F])
-        .once()
+          (toplRpc.fetchTransaction _)
+            .expects(transactionId_01)
+            .returning(transaction_01.some.pure[F])
 
-      (toplRpc.fetchBlockBody _)
-        .expects(BLOCK_ID)
-        .returning(Option(blockBody).pure[F])
-        .once()
+          (toplRpc.fetchTransaction _)
+            .expects(transactionId_02)
+            .returning(transaction_02.some.pure[F])
 
-      (toplRpc.fetchTransaction _)
-        .expects(TRANSACTION_ID_01)
-        .returning(Option(transaction_01).pure[F])
+          (toplRpc.fetchTransaction _)
+            .expects(transactionId_03)
+            .returning(transaction_03.some.pure[F])
 
-      (toplRpc.fetchTransaction _)
-        .expects(TRANSACTION_ID_02)
-        .returning(Option(transaction_02).pure[F])
+          val result = nodeBlockFetcher fetch height
 
-      (toplRpc.fetchTransaction _)
-        .expects(TRANSACTION_ID_03)
-        .returning(Option(transaction_03).pure[F])
+          result map { actualResult =>
+            assertEquals(
+              actualResult,
+              Option(BlockV2.Full(blockHeader, Chain(transaction_01, transaction_02, transaction_03))).asRight
+            )
+          }
 
-      val result = nodeBlockFetcher fetch HEIGHT
-
-      result map { actualResult =>
-        assertEquals(
-          actualResult,
-          Option(BlockV2.Full(blockHeader, Chain(transaction_01, transaction_02, transaction_03))).asRight
-        )
-      }
-
+        }
     }
   }
-
-}
-
-object NodeBlockFetcherSpec {
-
-  final private val HEIGHT: Long = 1
-
-  final private val BLOCK_ID: TypedIdentifier = TypedBytes(-1: Byte, Bytes(-1: Byte))
-
-  final private val TRANSACTION_ID_01: TypedIdentifier = TypedBytes(-2: Byte, Bytes(-2: Byte))
-  final private val TRANSACTION_ID_02: TypedIdentifier = TypedBytes(-3: Byte, Bytes(-3: Byte))
-  final private val TRANSACTION_ID_03: TypedIdentifier = TypedBytes(-4: Byte, Bytes(-4: Byte))
 
 }


### PR DESCRIPTION
## Purpose
Second iteration on how to implement capture of Blocks in Genus. `BlockFetcherAlgebra` was implemented with `NodeBlockFetcher`. A spec for it was added.

## Approach
The implementation fetches the possible block id that may exist at a given height. If no block id exists, then a Right(None) is returned. In case it exists, then the block header and body are fetched. If any of them don't exist, then a Left(Failure) is returned. If both exist, then the transactions are fetched. If one or more transactions are missing, then a Left(Failure) with all the missing transactions is returned. If all the transactions exist, then the full block is returned.

## Testing

Eight tests were created for this. The spec contemplates all the possible outcomes, to a certain degree. 

## Tickets
* TSDK-135