### PR TITLE
fix warnings

### DIFF
--- a/common-interpreters/src/main/scala/co/topl/interpreters/StatsInterpreter.scala
+++ b/common-interpreters/src/main/scala/co/topl/interpreters/StatsInterpreter.scala
@@ -31,6 +31,6 @@ object StatsInterpreter {
   object Noop {
 
     def make[F[_]: Applicative]: Stats[F] =
-      (statName: String, data: Json) => Applicative[F].unit
+      (_: String, _: Json) => Applicative[F].unit
   }
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/GenusException.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/GenusException.scala
@@ -1,7 +1,5 @@
 package co.topl.genusLibrary
 
-import co.topl.typeclasses.Log
-
 /**
  * Base exception class for the Genus library.
  *

--- a/genus-library/src/main/scala/co/topl/genusLibrary/Txo.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/Txo.scala
@@ -22,7 +22,6 @@ import co.topl.genusLibrary.TxoState._
  * @param state The status of the box
  */
 case class Txo(box: Box, state: TxoState, id: Box.Id, address: Option[SpendingAddress]) {
-  import Txo._
 
   private def unsupported[T](v: Box.Value): T = throw GenusException(s"Encountered unsupported type of box value: $v")
 

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/VertexSchema.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/VertexSchema.scala
@@ -1,9 +1,7 @@
 package co.topl.genusLibrary.orientDb
 
-import co.topl.models.TypedIdentifier
 import com.orientechnologies.orient.core.metadata.schema.OClass.INDEX_TYPE
 import com.orientechnologies.orient.core.metadata.schema.{OClass, OPropertyAbstractDelegate, OType}
-import scodec.bits.ByteVector
 
 /**
  * Describe how data from a scala class will be stored in an OrientDB vertex.
@@ -69,7 +67,7 @@ object VertexSchema {
 case class Property(
   name:                    String,
   propertyType:            OType,
-  propertyAttributeSetter: OPropertyAbstractDelegate => Unit = f => ()
+  propertyAttributeSetter: OPropertyAbstractDelegate => Unit = _ => ()
 )
 
 /**

--- a/ledger/src/main/scala/co/topl/ledger/algebras/BodySemanticValidationAlgebra.scala
+++ b/ledger/src/main/scala/co/topl/ledger/algebras/BodySemanticValidationAlgebra.scala
@@ -2,7 +2,7 @@ package co.topl.ledger.algebras
 
 import co.topl.algebras.ContextualValidationAlgebra
 import co.topl.ledger.models.{BodySemanticError, BodyValidationContext}
-import co.topl.models.{BlockBodyV2, TypedIdentifier}
+import co.topl.models.BlockBodyV2
 
 trait BodySemanticValidationAlgebra[F[_]]
     extends ContextualValidationAlgebra[F, BodySemanticError, BlockBodyV2, BodyValidationContext]

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
@@ -1,7 +1,7 @@
 package co.topl.ledger.interpreters
 
 import cats.data.{NonEmptySet, OptionT}
-import cats.effect.{Async, Sync}
+import cats.effect.Async
 import cats.implicits._
 import cats.{Applicative, MonadThrow}
 import co.topl.algebras.Store

--- a/level-db-store/src/main/scala/co/topl/db/leveldb/LevelDbStore.scala
+++ b/level-db-store/src/main/scala/co/topl/db/leveldb/LevelDbStore.scala
@@ -12,7 +12,6 @@ import org.iq80.leveldb.{CompressionType, DB, Options}
 import scodec.bits.ByteVector
 
 import java.util.InputMismatchException
-import scala.language.implicitConversions
 
 /**
  * A `Store` interpreter which is backed by LevelDB.  Keys and Values must have a Persistable typeclass instance available.

--- a/typeclasses/src/main/scala/co/topl/typeclasses/ContainsSlotId.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ContainsSlotId.scala
@@ -2,8 +2,7 @@ package co.topl.typeclasses
 
 import co.topl.codecs.bytes.typeclasses.Identifiable
 import co.topl.codecs.bytes.typeclasses.implicits._
-import co.topl.codecs.bytes.tetra.instances._
-import co.topl.models.{SlotId, TypedBytes}
+import co.topl.models.SlotId
 import simulacrum._
 import IdentityOps._
 

--- a/typeclasses/src/main/scala/co/topl/typeclasses/Proposer.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/Proposer.scala
@@ -3,7 +3,6 @@ package co.topl.typeclasses
 import co.topl.models.{Proposition, Propositions, VerificationKey, VerificationKeys}
 
 import scala.collection.immutable.ListSet
-import scala.language.implicitConversions
 
 /**
  * Reveal inputs to produce a Proposition

--- a/typeclasses/src/main/scala/co/topl/typeclasses/Prover.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/Prover.scala
@@ -5,8 +5,6 @@ import co.topl.codecs.bytes.typeclasses.implicits._
 import co.topl.crypto.signing.{Curve25519, Ed25519, ExtendedEd25519}
 import co.topl.models._
 
-import scala.language.implicitConversions
-
 @simulacrum.typeclass
 trait Prover[ProofInput] {
 

--- a/typeclasses/src/main/scala/co/topl/typeclasses/RatioOps.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/RatioOps.scala
@@ -2,7 +2,6 @@ package co.topl.typeclasses
 
 import co.topl.models.utility.Ratio
 
-import scala.language.implicitConversions
 import scala.math.BigInt
 
 object RatioOps {


### PR DESCRIPTION
## Purpose
Avoid imports

## Approach
Added a new flag in Scalac options raising warnings, without fixing them, which will be addressed on several minor following PRs.

## Testing
No additional testing

```
[warn] /home/runner/work/Bifrost/Bifrost/level-db-store/src/main/scala/co/topl/db/leveldb/LevelDbStore.scala:15:23: Unused import
[warn] import scala.language.implicitConversions
[warn]                       ^
[warn] one warning found

[warn] /home/runner/work/Bifrost/Bifrost/typeclasses/src/main/scala/co/topl/typeclasses/ContainsSlotId.scala:5:45: Unused import
[warn] import co.topl.codecs.bytes.tetra.instances._
[warn]                                             ^
[warn] /home/runner/work/Bifrost/Bifrost/typeclasses/src/main/scala/co/topl/typeclasses/ContainsSlotId.scala:6:32: Unused import
[warn] import co.topl.models.{SlotId, TypedBytes}
[warn]                                ^
[warn] /home/runner/work/Bifrost/Bifrost/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTransactions.scala:31:40: parameter value t in method bloomFilterOf is never used
[warn]   @op("bloomFilter") def bloomFilterOf(t: T): BloomFilter =
[warn]                                        ^
[warn] /home/runner/work/Bifrost/Bifrost/typeclasses/src/main/scala/co/topl/typeclasses/Proposer.scala:6:23: Unused import
[warn] import scala.language.implicitConversions
[warn]                       ^
[warn] /home/runner/work/Bifrost/Bifrost/typeclasses/src/main/scala/co/topl/typeclasses/Prover.scala:8:23: Unused import
[warn] import scala.language.implicitConversions
[warn]                       ^
[warn] /home/runner/work/Bifrost/Bifrost/typeclasses/src/main/scala/co/topl/typeclasses/RatioOps.scala:5:23: Unused import
[warn] import scala.language.implicitConversions
[warn]                       ^
[warn] 6 warnings found
```

