### PR TITLE
Check block header to body consistency; invalid body no longer adapted by Node

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
@@ -60,7 +60,7 @@ object BigBang {
       BlockHeaderV2(
         parentHeaderId = ParentId,
         parentSlot = ParentSlot,
-        txRoot = transactions.merkleTree,
+        txRoot = transactions.merkleTreeRootHash,
         bloomFilter = transactions.bloomFilter,
         timestamp = config.timestamp,
         height = Height,

--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -12,7 +12,7 @@ import co.topl.catsakka._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
 import co.topl.consensus.BlockHeaderV2Ops
-import co.topl.consensus.algebras.{BlockHeaderValidationAlgebra, LocalChainAlgebra}
+import co.topl.consensus.algebras.{BlockHeaderToBodyValidationAlgebra, BlockHeaderValidationAlgebra, LocalChainAlgebra}
 import co.topl.crypto.signing.Ed25519VRF
 import co.topl.eventtree.{EventSourcedState, ParentChildTree}
 import co.topl.grpc.ToplGrpc
@@ -28,7 +28,6 @@ import co.topl.minting.{BlockPacker, BlockProducer}
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.jdk.CollectionConverters._
-
 import scala.util.Random
 
 object Blockchain {
@@ -47,6 +46,7 @@ object Blockchain {
     blockIdTree:                 ParentChildTree[F, TypedIdentifier],
     blockHeights:                EventSourcedState[F, Long => F[Option[TypedIdentifier]]],
     headerValidation:            BlockHeaderValidationAlgebra[F],
+    blockHeaderToBodyValidation: BlockHeaderToBodyValidationAlgebra[F],
     transactionSyntaxValidation: TransactionSyntaxValidationAlgebra[F],
     bodySyntaxValidation:        BodySyntaxValidationAlgebra[F],
     bodySemanticValidation:      BodySemanticValidationAlgebra[F],
@@ -74,6 +74,7 @@ object Blockchain {
             clock,
             localChain,
             headerValidation,
+            blockHeaderToBodyValidation,
             bodySyntaxValidation,
             bodySemanticValidation,
             bodyAuthorizationValidation,

--- a/consensus/src/main/scala/co/topl/consensus/BlockHeaderToBodyValidationFailure.scala
+++ b/consensus/src/main/scala/co/topl/consensus/BlockHeaderToBodyValidationFailure.scala
@@ -1,0 +1,9 @@
+package co.topl.consensus
+
+import co.topl.models.TxRoot
+
+sealed abstract class BlockHeaderToBodyValidationFailure
+
+object BlockHeaderToBodyValidationFailure {
+  case class IncorrectTxRoot(headerTxRoot: TxRoot, bodyTxRoot: TxRoot) extends BlockHeaderToBodyValidationFailure
+}

--- a/consensus/src/main/scala/co/topl/consensus/algebras/BlockHeaderToBodyValidationAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/BlockHeaderToBodyValidationAlgebra.scala
@@ -1,0 +1,8 @@
+package co.topl.consensus.algebras
+
+import co.topl.consensus.BlockHeaderToBodyValidationFailure
+import co.topl.models.BlockV2
+
+trait BlockHeaderToBodyValidationAlgebra[F[_]] {
+  def validate(block: BlockV2): F[Either[BlockHeaderToBodyValidationFailure, BlockV2]]
+}

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderToBodyValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderToBodyValidation.scala
@@ -1,0 +1,35 @@
+package co.topl.consensus.interpreters
+
+import cats.effect.kernel.Sync
+import cats.implicits.{catsSyntaxApplicativeId, catsSyntaxEq}
+import co.topl.consensus.BlockHeaderToBodyValidationFailure
+import co.topl.consensus.BlockHeaderToBodyValidationFailure.IncorrectTxRoot
+import co.topl.consensus.algebras.BlockHeaderToBodyValidationAlgebra
+import co.topl.models.BlockV2
+import co.topl.typeclasses.implicits._
+
+object BlockHeaderToBodyValidation {
+
+  object Eval {
+
+    def make[F[_]: Sync](): F[BlockHeaderToBodyValidationAlgebra[F]] = Sync[F].delay(new Impl[F]())
+
+    private class Impl[F[_]: Sync]() extends BlockHeaderToBodyValidationAlgebra[F] {
+
+      override def validate(block: BlockV2): F[Either[BlockHeaderToBodyValidationFailure, BlockV2]] =
+        blockTxRootConsistent(block).pure[F]
+    }
+
+    private def blockTxRootConsistent(block: BlockV2): Either[BlockHeaderToBodyValidationFailure, BlockV2] = {
+      val bodyMerkleTxRoot = block.blockBodyV2.merkleTreeRootHash
+      val headerMerkleTxRoot = block.headerV2.txRoot
+
+      if (bodyMerkleTxRoot === headerMerkleTxRoot) {
+        Right(block)
+      } else {
+        Left(IncorrectTxRoot(headerMerkleTxRoot, bodyMerkleTxRoot))
+      }
+    }
+
+  }
+}

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
@@ -1,11 +1,14 @@
-package co.topl.consensus
+package co.topl.consensus.interpreters
 
 import cats._
 import cats.data._
 import cats.effect.kernel.Sync
 import cats.implicits._
 import co.topl.algebras.{ClockAlgebra, Store, UnsafeResource}
+import co.topl.codecs.bytes.tetra.instances._
+import co.topl.codecs.bytes.typeclasses.implicits._
 import co.topl.consensus.algebras._
+import co.topl.consensus.{BlockHeaderValidationFailure, BlockHeaderValidationFailures}
 import co.topl.crypto.hash.Blake2b256
 import co.topl.crypto.signing.{Ed25519, Ed25519VRF, KesProduct}
 import co.topl.models._
@@ -13,8 +16,6 @@ import co.topl.models.utility.Ratio
 import co.topl.typeclasses.implicits._
 import com.google.common.primitives.Longs
 import scalacache.caffeine.CaffeineCache
-import co.topl.codecs.bytes.tetra.instances._
-import co.topl.codecs.bytes.typeclasses.implicits._
 
 import scala.language.implicitConversions
 
@@ -24,8 +25,6 @@ import scala.language.implicitConversions
 object BlockHeaderValidation {
 
   object Eval {
-
-    // TODO: Validate incoming blocks are not past the *global* slot
 
     def make[F[_]: Monad: Sync](
       etaInterpreter:           EtaCalculationAlgebra[F],

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/EtaCalculation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/EtaCalculation.scala
@@ -1,4 +1,4 @@
-package co.topl.consensus
+package co.topl.consensus.interpreters
 
 import cats.data.NonEmptyChain
 import cats.effect.{Clock, Sync}

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/LeaderElectionValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/LeaderElectionValidation.scala
@@ -1,7 +1,7 @@
-package co.topl.consensus
+package co.topl.consensus.interpreters
 
-import cats.implicits._
 import cats.effect.{Clock, Sync}
+import cats.implicits._
 import co.topl.algebras.{Exp, Log1p, UnsafeResource}
 import co.topl.codecs.bytes.typeclasses.Signable
 import co.topl.consensus.algebras.LeaderElectionValidationAlgebra

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/BlockHeaderToBodyValidationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/BlockHeaderToBodyValidationSpec.scala
@@ -1,0 +1,41 @@
+package co.topl.consensus.interpreters
+
+import cats.effect.IO
+import co.topl.consensus.BlockHeaderToBodyValidationFailure.IncorrectTxRoot
+import co.topl.models.BlockV2
+import co.topl.models.ModelGenerators._
+import co.topl.typeclasses.implicits._
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF
+import org.scalamock.munit.AsyncMockFactory
+
+class BlockHeaderToBodyValidationSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+
+  type F[A] = IO[A]
+
+  test("validation should fail if block header txRoot is not match block body, i.e. block is arbitrary") {
+    PropF.forAllF { block: BlockV2 =>
+      withMock {
+        for {
+          underTest <- BlockHeaderToBodyValidation.Eval.make[F]()
+          result    <- underTest.validate(block)
+          _         <- IO(result.left.exists(_.isInstanceOf[IncorrectTxRoot])).assert
+        } yield ()
+      }
+    }
+  }
+
+  test("validation should success if block header txRoot is match header body") {
+    PropF.forAllF { block: BlockV2 =>
+      val merkleRootHash = block.blockBodyV2.merkleTreeRootHash
+      val correctBlock = block.copy(headerV2 = block.headerV2.copy(txRoot = merkleRootHash))
+      withMock {
+        for {
+          underTest <- BlockHeaderToBodyValidation.Eval.make[F]()
+          result    <- underTest.validate(correctBlock)
+          _         <- IO(result.exists(_ == correctBlock)).assert
+        } yield ()
+      }
+    }
+  }
+}

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/BlockHeaderValidationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/BlockHeaderValidationSpec.scala
@@ -1,4 +1,4 @@
-package co.topl.consensus
+package co.topl.consensus.interpreters
 
 import cats.effect._
 import cats.effect.unsafe.implicits.global
@@ -6,8 +6,9 @@ import cats.implicits._
 import co.topl.algebras.{ClockAlgebra, UnsafeResource}
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
-import co.topl.consensus.LeaderElectionValidation.VrfConfig
+import co.topl.consensus.BlockHeaderValidationFailures
 import co.topl.consensus.algebras._
+import co.topl.consensus.interpreters.LeaderElectionValidation.VrfConfig
 import co.topl.crypto.generation.KeyInitializer
 import co.topl.crypto.generation.KeyInitializer.Instances.ed25519Initializer
 import co.topl.crypto.hash.{blake2b256, Blake2b256, Blake2b512}

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/EtaCalculationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/EtaCalculationSpec.scala
@@ -1,4 +1,4 @@
-package co.topl.consensus
+package co.topl.consensus.interpreters
 
 import cats.data.NonEmptyChain
 import cats.effect.IO
@@ -6,6 +6,11 @@ import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import co.topl.algebras.testInterpreters.NoOpLogger
 import co.topl.algebras.{ClockAlgebra, UnsafeResource}
+import co.topl.codecs.bytes.tetra.instances._
+import co.topl.codecs.bytes.typeclasses.implicits._
+import co.topl.consensus.BlockHeaderV2Ops
+import co.topl.crypto.generation.KeyInitializer
+import co.topl.crypto.generation.KeyInitializer.Instances.vrfInitializer
 import co.topl.crypto.hash.{Blake2b256, Blake2b512}
 import co.topl.crypto.signing.Ed25519VRF
 import co.topl.models.ModelGenerators._
@@ -18,10 +23,6 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import co.topl.codecs.bytes.tetra.instances._
-import co.topl.codecs.bytes.typeclasses.implicits._
-import co.topl.crypto.generation.KeyInitializer
-import co.topl.crypto.generation.KeyInitializer.Instances.vrfInitializer
 
 class EtaCalculationSpec
     extends AnyFlatSpec

--- a/demo/src/main/scala/co/topl/demo/DemoUtils.scala
+++ b/demo/src/main/scala/co/topl/demo/DemoUtils.scala
@@ -9,7 +9,7 @@ import co.topl.algebras._
 import co.topl.blockchain.StakerInitializers
 import co.topl.catsakka.FToFuture
 import co.topl.codecs.bytes.tetra.instances._
-import co.topl.consensus.LeaderElectionValidation.VrfConfig
+import co.topl.consensus.interpreters.LeaderElectionValidation.VrfConfig
 import co.topl.consensus.algebras.{
   ConsensusValidationStateAlgebra,
   EtaCalculationAlgebra,

--- a/demo/src/main/scala/co/topl/demo/TetraSuperDemo.scala
+++ b/demo/src/main/scala/co/topl/demo/TetraSuperDemo.scala
@@ -222,6 +222,7 @@ object TetraSuperDemo extends IOApp {
           blake2b256Resource
         )
         cachedHeaderValidation <- BlockHeaderValidation.WithCache.make[F](underlyingHeaderValidation, blockHeaderStore)
+        headerToBodyValidation <- BlockHeaderToBodyValidation.Eval.make[F]()
         localChain <- LocalChain.Eval.make(
           bigBangBlock.headerV2.slotData(Ed25519VRF.precomputed()),
           ChainSelection
@@ -291,6 +292,7 @@ object TetraSuperDemo extends IOApp {
             blockIdTree,
             blockHeightTree,
             cachedHeaderValidation,
+            headerToBodyValidation,
             transactionSyntaxValidation,
             bodySyntaxValidation,
             bodySemanticValidation,

--- a/minting/src/main/scala/co/topl/minting/BlockProducer.scala
+++ b/minting/src/main/scala/co/topl/minting/BlockProducer.scala
@@ -110,7 +110,7 @@ object BlockProducer {
                 BlockHeaderV2.Unsigned(
                   parentHeaderId = parentSlotData.slotId.blockId,
                   parentSlot = parentSlotData.slotId.slot,
-                  txRoot = body.merkleTree,
+                  txRoot = body.merkleTreeRootHash,
                   bloomFilter = body.bloomFilter,
                   timestamp = timestamp,
                   height = parentSlotData.height + 1,

--- a/minting/src/main/scala/co/topl/minting/VrfProof.scala
+++ b/minting/src/main/scala/co/topl/minting/VrfProof.scala
@@ -7,9 +7,9 @@ import cats.{MonadError, Parallel}
 import co.topl.algebras.ClockAlgebra.implicits._
 import co.topl.algebras.{ClockAlgebra, UnsafeResource}
 import co.topl.codecs.bytes.typeclasses.implicits._
-import co.topl.consensus.LeaderElectionValidation
-import co.topl.consensus.LeaderElectionValidation.VrfConfig
+import co.topl.consensus.interpreters.LeaderElectionValidation.VrfConfig
 import co.topl.consensus.algebras.LeaderElectionValidationAlgebra
+import co.topl.consensus.interpreters.LeaderElectionValidation
 import co.topl.crypto.signing.Ed25519VRF
 import co.topl.minting.algebras.VrfProofAlgebra
 import co.topl.models._

--- a/node-tetra/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node-tetra/src/main/scala/co/topl/node/NodeApp.scala
@@ -4,32 +4,31 @@ import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import akka.stream.scaladsl.Source
 import akka.util.Timeout
-import cats.effect.IO
-import co.topl.catsakka._
-import cats.implicits._
-import co.topl.algebras._
-import ClockAlgebra.implicits._
 import cats.Applicative
 import cats.data.OptionT
+import cats.effect.IO
+import cats.implicits._
+import co.topl.algebras.ClockAlgebra.implicits._
+import co.topl.algebras._
 import co.topl.blockchain._
-import co.topl.crypto.hash.Blake2b512
-import co.topl.crypto.signing._
-import co.topl.interpreters._
+import co.topl.catsakka._
+import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
-import co.topl.codecs.bytes.tetra.instances._
-import co.topl.models._
-import co.topl.typeclasses.implicits._
-import co.topl.codecs.bytes.tetra.instances._
 import co.topl.common.application.{IOAkkaApp, IOBaseApp}
-import co.topl.consensus.LeaderElectionValidation.VrfConfig
 import co.topl.consensus._
 import co.topl.consensus.algebras._
+import co.topl.consensus.interpreters.LeaderElectionValidation.VrfConfig
 import co.topl.consensus.interpreters._
+import co.topl.crypto.hash.Blake2b512
+import co.topl.crypto.signing._
 import co.topl.eventtree.ParentChildTree
+import co.topl.interpreters._
 import co.topl.ledger.interpreters._
 import co.topl.minting._
-import co.topl.networking.p2p.LocalPeer
+import co.topl.models._
+import co.topl.networking.p2p.{ConnectedPeer, LocalPeer}
 import co.topl.numerics._
+import co.topl.typeclasses.implicits._
 import fs2.io.file.{Files, Path}
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -202,6 +201,7 @@ object NodeApp
                 blockIdTree,
                 blockHeightTree,
                 validators.header,
+                validators.headerToBody,
                 validators.transactionSyntax,
                 validators.bodySyntax,
                 validators.bodySemantics,
@@ -218,7 +218,7 @@ object NodeApp
                     )
                   )
                   .concat(Source.never),
-                (peer, flow) => flow,
+                (_: ConnectedPeer, flow) => flow,
                 appConfig.bifrost.rpc.bindHost,
                 appConfig.bifrost.rpc.bindPort
               )

--- a/typeclasses/src/main/scala/co/topl/typeclasses/package.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/package.scala
@@ -17,6 +17,8 @@ package object typeclasses {
       with ContainsTimestamp.ToContainsTimestampOps
       with ContainsTransactions.Instances
       with ContainsTransactions.ToContainsTransactionsOps
+      with ContainsTransactionIds.Instances
+      with ContainsTransactionIds.ToContainsTransactionIdsOps
       with RatioOps.Implicits
       with ContainsVerificationKey.Instances
       with ContainsVerificationKey.ToContainsVerificationKeyOps


### PR DESCRIPTION
## Purpose
 -- Body of block now checked against block header by txRoot
 -- Invalid body is no longer saved to the storage, thus invalid body lo nonger could be adopted by Node

## Approach
Added appropriate validator to validators, call that validator during body checking;
Body of block now is saved AFTER all successful checks

## Testing
Appropriate unit test for validator had been added

## Tickets
closes #2581 