### PR TITLE
fix warnings

### DIFF
--- a/genus-library/src/test/scala/co/topl/genusLibrary/TxoTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/TxoTest.scala
@@ -15,7 +15,7 @@ class TxoTest extends munit.FunSuite {
   private val evidenceLength = 32
 
   private def randomEvidence =
-    TypedEvidence(Random.nextInt.asInstanceOf[Byte], Sized.strictUnsafe(Bytes(Random.nextBytes(evidenceLength))))
+    TypedEvidence(Random.nextInt().asInstanceOf[Byte], Sized.strictUnsafe(Bytes(Random.nextBytes(evidenceLength))))
 
   test("empty TxO") {
     val txo = Txo(

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
@@ -1,6 +1,5 @@
 package co.topl.ledger.interpreters
 
-import cats.Applicative
 import cats.data.{Chain, NonEmptySet}
 import cats.effect.IO
 import co.topl.models.{Box, Transaction, TypedIdentifier}

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionAuthorizationValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionAuthorizationValidationSpec.scala
@@ -310,7 +310,7 @@ class TransactionAuthorizationValidationSpec extends CatsEffectSuite with ScalaC
             Propositions.Contextual.HeightLock(height),
             _ => Proofs.Contextual.HeightLock()
           ).pure[F]
-          fetchSlotData = (blockId: TypedIdentifier) => slotData.pure[F]
+          fetchSlotData = (_: TypedIdentifier) => slotData.pure[F]
           underTest <- makeValidation(fetchSlotData = fetchSlotData)
           _         <- underTest.validate(blockId)(transaction).map(_.isValid == (slotData.height >= height)).assert
         } yield ()

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSyntaxValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSyntaxValidationSpec.scala
@@ -256,7 +256,7 @@ class TransactionSyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEff
         Transaction.Schedule(0L, 0L, Long.MaxValue),
         None
       )
-    PropF.forAllF { (transaction: Transaction, curveSk: SecretKeys.Curve25519, edSK: SecretKeys.Ed25519) =>
+    PropF.forAllF { (curveSk: SecretKeys.Curve25519, edSK: SecretKeys.Ed25519) =>
       val transaction1 =
         createTestTransaction(curveSk.vk.asProposition, arbitraryProofsKnowledgeEd25519.arbitrary.first)
       val transaction2 =

--- a/minting/src/main/scala/co/topl/minting/BlockPacker.scala
+++ b/minting/src/main/scala/co/topl/minting/BlockPacker.scala
@@ -55,7 +55,6 @@ object BlockPacker {
                     .flatMap { transaction =>
                       // Attempt to stuff that transaction into our current block
                       val fullBody = current.append(transaction)
-                      val body = ListSet.empty[TypedIdentifier] ++ fullBody.toList.map(_.id.asTypedBytes)
                       // If it's valid, hooray.  If not, return the previous value
                       val transactionValidationContext =
                         StaticTransactionValidationContext(parentBlockId, fullBody, height, slot)

--- a/minting/src/main/scala/co/topl/minting/algebras/OperationalKeysAlgebra.scala
+++ b/minting/src/main/scala/co/topl/minting/algebras/OperationalKeysAlgebra.scala
@@ -1,6 +1,6 @@
 package co.topl.minting.algebras
 
-import co.topl.models.{Eta, Proofs, SecretKeys, Slot, SlotId, VerificationKeys}
+import co.topl.models.{Proofs, SecretKeys, Slot, SlotId, VerificationKeys}
 
 /**
  * A KeyEvolverAlgebra is responsible for encapsulating a key locally and emitting an evolved version of

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainNetwork.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainNetwork.scala
@@ -60,9 +60,9 @@ object BlockchainNetwork {
       _ <- Spawn[F].start(
         peerTerminations
           .mapAsyncF(1) {
-            case PeerConnectionChanges.ConnectionClosed(peer, Some(error)) =>
+            case PeerConnectionChanges.ConnectionClosed(_, Some(error)) =>
               Logger[F].error(error)("Peer connection terminated with error")
-            case PeerConnectionChanges.ConnectionClosed(peer, _) =>
+            case PeerConnectionChanges.ConnectionClosed(_, _) =>
               Logger[F].info("Peer connection terminated normally")
           }
           .toMat(Sink.ignore)(Keep.right)


### PR DESCRIPTION
## Purpose
 Fix Warnings

## Approach
avoid these output
```
[warn] /home/runner/work/Bifrost/Bifrost/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala:3:13: Unused import
[warn] import cats.Applicative
[warn]             ^
[warn] /home/runner/work/Bifrost/Bifrost/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionAuthorizationValidationSpec.scala:313:35: parameter value blockId in anonymous function is never used
[warn]           fetchSlotData = (blockId: TypedIdentifier) => slotData.pure[F]
[warn]                                   ^
[info] done compiling
[info] compiling 13 Scala sources to /home/runner/work/Bifrost/Bifrost/minting/target/scala-2.13/classes ...
[warn] /home/runner/work/Bifrost/Bifrost/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSyntaxValidationSpec.scala:259:33: parameter value transaction in anonymous function is never used
[warn]     PropF.forAllF { (transaction: Transaction, curveSk: SecretKeys.Curve25519, edSK: SecretKeys.Ed25519) =>
[warn]                                 ^
[warn] /home/runner/work/Bifrost/Bifrost/minting/src/main/scala/co/topl/minting/BlockPacker.scala:58:27: local val body in value $anonfun is never used
[warn]                       val body = ListSet.empty[TypedIdentifier] ++ fullBody.toList.map(_.id.asTypedBytes)
[warn]                           ^
[warn] /home/runner/work/Bifrost/Bifrost/minting/src/main/scala/co/topl/minting/algebras/OperationalKeysAlgebra.scala:3:24: Unused import
[warn] import co.topl.models.{Eta, Proofs, SecretKeys, Slot, SlotId, VerificationKeys}
[warn]                        ^
[warn] two warnings found
[info] done compiling
[info] compiling 31 Scala sources to /home/runner/work/Bifrost/Bifrost/networking/target/scala-2.13/classes ...
[warn] /home/runner/work/Bifrost/Bifrost/networking/src/main/scala/co/topl/networking/blockchain/BlockchainNetwork.scala:63:57: pattern var peer in value $anonfun is never used: use a wildcard `_` or suppress this warning with `peer@_`
[warn]             case PeerConnectionChanges.ConnectionClosed(peer, Some(error)) =>
[warn]                                                         ^
[warn] /home/runner/work/Bifrost/Bifrost/networking/src/main/scala/co/topl/networking/blockchain/BlockchainNetwork.scala:65:57: pattern var peer in value $anonfun is never used: use a wildcard `_` or suppress this warning with `peer@_`
[warn]             case PeerConnectionChanges.ConnectionClosed(peer, _) =>
[warn]                                                         ^
[warn] three warnings found

```

## Testing
unit test pass

## Tickets
partially BN-692

