### PR TITLE
fix warnings

### DIFF
--- a/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusValidationStateSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusValidationStateSpec.scala
@@ -7,7 +7,7 @@ import co.topl.algebras.testInterpreters.TestStore
 import co.topl.consensus.interpreters.EpochBoundariesEventSourcedState.EpochBoundaries
 import co.topl.eventtree.EventSourcedState
 import co.topl.models.utility.Ratio
-import co.topl.models.{Box, Epoch, Int128, StakingAddress, StakingAddresses, TypedIdentifier}
+import co.topl.models.{Box, Epoch, Int128, StakingAddresses, TypedIdentifier}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory

--- a/networking/src/main/scala/co/topl/networking/multiplexer/SubHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/multiplexer/SubHandler.scala
@@ -1,6 +1,6 @@
 package co.topl.networking.multiplexer
 
-import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 
 /**

--- a/networking/src/main/scala/co/topl/networking/p2p/AkkaP2PServer.scala
+++ b/networking/src/main/scala/co/topl/networking/p2p/AkkaP2PServer.scala
@@ -2,7 +2,6 @@ package co.topl.networking.p2p
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream._
 import akka.stream.scaladsl._
 import akka.util.ByteString
 import cats._
@@ -13,9 +12,7 @@ import co.topl.catsakka._
 import org.typelevel.log4cats.Logger
 
 import java.net.InetSocketAddress
-import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Random
 
 /**
  * Interprets P2PServer[F, Client] using akka-stream. Binds to the requested host/port to accept incoming connections,

--- a/networking/src/main/scala/co/topl/networking/p2p/ConnectedPeer.scala
+++ b/networking/src/main/scala/co/topl/networking/p2p/ConnectedPeer.scala
@@ -1,7 +1,6 @@
 package co.topl.networking.p2p
 
 import java.net.InetSocketAddress
-import scala.concurrent.duration.FiniteDuration
 
 case class ConnectedPeer(remoteAddress: InetSocketAddress, coordinate: (Double, Double))
 

--- a/networking/src/test/scala/co/topl/networking/multiplexer/DynamicMultiplexerSpec.scala
+++ b/networking/src/test/scala/co/topl/networking/multiplexer/DynamicMultiplexerSpec.scala
@@ -1,7 +1,7 @@
 package co.topl.networking.multiplexer
 
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.testkit.TestKitBase
 import akka.util.ByteString

--- a/node-tetra/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node-tetra/src/main/scala/co/topl/node/NodeApp.scala
@@ -19,7 +19,6 @@ import co.topl.codecs.bytes.typeclasses.implicits._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.models._
 import co.topl.typeclasses.implicits._
-import co.topl.codecs.bytes.tetra.instances._
 import co.topl.common.application.{IOAkkaApp, IOBaseApp}
 import co.topl.consensus.LeaderElectionValidation.VrfConfig
 import co.topl.consensus._
@@ -218,7 +217,7 @@ object NodeApp
                     )
                   )
                   .concat(Source.never),
-                (peer, flow) => flow,
+                (_, flow) => flow,
                 appConfig.bifrost.rpc.bindHost,
                 appConfig.bifrost.rpc.bindPort
               )

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/TransactionGeneratorApp.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/TransactionGeneratorApp.scala
@@ -14,12 +14,10 @@ import co.topl.interpreters._
 import co.topl.models._
 import co.topl.transactiongenerator.interpreters._
 import co.topl.typeclasses.implicits._
-import com.typesafe.config.ConfigFactory
 import fs2._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-import scala.collection.immutable.ListSet
 import scala.concurrent.duration._
 
 object TransactionGeneratorApp

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/ToplRpcWalletInitializer.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/ToplRpcWalletInitializer.scala
@@ -8,9 +8,6 @@ import co.topl.models._
 import co.topl.transactiongenerator.algebras.WalletInitializer
 import co.topl.transactiongenerator.models.Wallet
 import fs2._
-import co.topl.typeclasses.implicits._
-import co.topl.codecs.bytes.tetra.instances._
-import co.topl.codecs.bytes.typeclasses.implicits._
 
 object ToplRpcWalletInitializer {
 


### PR DESCRIPTION
## Purpose
Fix warnings
## Approach

Fix below warnings
```
[warn] 7 warnings found
[info] done compiling
[info] compiling 11 Scala sources to /home/runner/work/Bifrost/Bifrost/transaction-generator/target/scala-2.13/classes ...
[warn] /home/runner/work/Bifrost/Bifrost/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/TransactionGeneratorApp.scala:17:28: Unused import
[warn] import com.typesafe.config.ConfigFactory
[warn]                            ^
[warn] /home/runner/work/Bifrost/Bifrost/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/TransactionGeneratorApp.scala:22:35: Unused import
[warn] import scala.collection.immutable.ListSet
[warn]                                   ^
[warn] /home/runner/work/Bifrost/Bifrost/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/ToplRpcWalletInitializer.scala:11:38: Unused import
[warn] import co.topl.typeclasses.implicits._
[warn]                                      ^
[warn] /home/runner/work/Bifrost/Bifrost/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/ToplRpcWalletInitializer.scala:12:45: Unused import
[warn] import co.topl.codecs.bytes.tetra.instances._
[warn]                                             ^
[warn] /home/runner/work/Bifrost/Bifrost/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/ToplRpcWalletInitializer.scala:13:51: Unused import
[warn] import co.topl.codecs.bytes.typeclasses.implicits._
[warn]                                                   ^
[warn] one warning found
[info] done compiling
[info] compiling 2 Scala sources to /home/runner/work/Bifrost/Bifrost/topl-grpc/target/scala-2.13/test-classes ...
[warn] 5 warnings found
```

## Testing

unit test pass

## Tickets
Partially changes to BN-962

