### PR TITLE
fix a simple warning

### DIFF
--- a/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTransactions.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTransactions.scala
@@ -28,7 +28,7 @@ import simulacrum.{op, typeclass}
     Sized.strictUnsafe[Bytes, Lengths.`32`.type](Bytes(rootHash))
   }
 
-  @op("bloomFilter") def bloomFilterOf(t: T): BloomFilter =
+  @op("bloomFilter") def bloomFilterOf(@annotation.nowarn t: T): BloomFilter =
     // TODO
     Sized.strictUnsafe[Bytes, Lengths.`256`.type](Bytes(Array.fill[Byte](256)(1)))
 }


### PR DESCRIPTION
## Purpose
Fix 1 warning

## Approach

```
[warn] /home/fernando/topl/Bifrost/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTransactions.scala:31:40: parameter value t in method bloomFilterOf is never used
[warn]   @op("bloomFilter") def bloomFilterOf(t: T): BloomFilter =
[warn]      
```             


## Testing
unit test pass
## Tickets
Partially BN 692