### PR TITLE
TSDK-135 | Added fetchHeaders stream implementation [3]

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/BlockFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/BlockFetcherAlgebra.scala
@@ -1,15 +1,40 @@
 package co.topl.genusLibrary.algebras
 
-import co.topl.models.BlockV2
+import co.topl.models.{BlockHeaderV2, BlockV2}
 
 /**
  * Fetcher of blocks on the chain.
  * @tparam F the effect-ful context to retrieve the value in
+ * @tparam G sequence container. Ex: Stream, Seq
  */
-trait BlockFetcherAlgebra[F[_]] {
+trait BlockFetcherAlgebra[F[_], G[_]] {
+
+  /**
+   * Look-up block headers on the chain, starting from a given inclusive height.
+   * @param height The height to start the lookup. It's inclusive.
+   * @return a sequence container of headers
+   */
+  def fetchHeaders(height: Long): SequenceResponse[F, G, Option[BlockHeaderV2]]
+
+  /**
+   * Look-up block bodies on the chain, starting from a given inclusive height.
+   *
+   * @param height The height to start the lookup. It's inclusive.
+   * @return a sequence container of headers
+   */
+  // def fetchBodies(height: Long): SequenceResponse[F, G, Option[BlockBodyV2]]
+
+  /**
+   * Look-up block transactions on the chain, starting from a given inclusive height.
+   *
+   * @param height The height to start the lookup. It's inclusive.
+   * @return a sequence container of headers
+   */
+  // def fetchTransactions(height: Long): SequenceResponse[Option[BlockBodyV2.Full]]
 
   /**
    * Look-up a block on the chain with a given height
+   *
    * @param height The height to lookup
    * @return the full block
    */

--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/package.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/package.scala
@@ -15,4 +15,6 @@ package object algebras {
    */
   type ServiceResponse[F[_], T] = F[Either[Failure, T]]
   type StoreResponse[F[_], T] = ServiceResponse[F, T]
+
+  type SequenceResponse[F[_], G[_], T] = F[G[Either[Failure, T]]]
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
@@ -4,13 +4,29 @@ import cats.data.{Chain, EitherT}
 import cats.effect.kernel.Async
 import cats.implicits._
 import co.topl.algebras.ToplRpc
-import co.topl.genusLibrary.algebras.{BlockFetcherAlgebra, ServiceResponse}
+import co.topl.genusLibrary.algebras.{BlockFetcherAlgebra, SequenceResponse, ServiceResponse}
 import co.topl.genusLibrary.failure.{Failure, Failures}
 import co.topl.models.{BlockBodyV2, BlockHeaderV2, BlockV2, Transaction, TypedIdentifier}
+import fs2.Stream
 
 import scala.collection.immutable.ListSet
 
-class NodeBlockFetcher[F[_]: Async](toplRpc: ToplRpc[F, Any]) extends BlockFetcherAlgebra[F] {
+class NodeBlockFetcher[F[_]: Async](toplRpc: ToplRpc[F, Any]) extends BlockFetcherAlgebra[F, Stream[F, *]] {
+
+  override def fetchHeaders(height: Long): SequenceResponse[F, Stream[F, *], Option[BlockHeaderV2]] = Async[F].delay {
+    Stream
+      // Range from given height to "positive infinity". If height is one, then the range would be [1, 2, 3, ...]
+      .range(height, Long.MaxValue)
+      .covary[F]
+      // Map each height to a block id. Range ends up being [blockId_01, blockId02, blockId03, ...]
+      .evalMap(toplRpc.blockIdAtHeight)
+      .evalMap {
+        case Some(blockId) =>
+          val blockHeader: F[Either[Failure, BlockHeaderV2]] = fetchBlockHeader(blockId)
+          blockHeader.map(_.map(_.some))
+        case None => Option.empty[BlockHeaderV2].asRight[Failure].pure[F]
+      }
+  }
 
   // TODO: TSDK-186 | Do calls concurrently.
   override def fetch(height: Long): ServiceResponse[F, Option[BlockV2.Full]] = toplRpc.blockIdAtHeight(height) flatMap {


### PR DESCRIPTION
## Purpose
Third iteration on how to implement capture of Blocks in Genus. `BlockFetcherAlgebra` has a new method and `NodeBlockFetcher` implements it. It's the `fetchHeaders` method. It's part of an alternate way of returning a full block.

## Approach
The implementation creates a Stream from a given height to "positive infinity", then for each height the block id is fetched. If no block id exists, then a `Right(None)` element is returned. In case it exists, then the block header is fetched. If it exists, a `Right(Some(header))` is returned. If it doesn't then a `Left(Failure)` element is returned.

## Testing
No tests yet. Awaiting review of design.

## Tickets
* TSDK-135