### PR TITLE
Protobuf-Specs Hash Version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -738,6 +738,10 @@ lazy val toplRpc = project
   )
   .dependsOn(akkaHttpRpc, common, jsonCodecs)
 
+// A task (meant to be run before compile) which ensures that the protobuf-specs git submodule is up-to-date
+// The protobuf specifications are defined in a remote repository and are downloaded locally for compilation.
+lazy val updateSubmodulesTask = TaskKey[Unit]("updateSubmodules", "Update git submodules")
+
 lazy val toplGrpc = project
   .in(file("topl-grpc"))
   .enablePlugins(Fs2Grpc)
@@ -745,7 +749,13 @@ lazy val toplGrpc = project
     name := "topl-grpc",
     commonSettings,
     libraryDependencies ++= Dependencies.toplGrpc,
-    scalapbCodeGeneratorOptions += CodeGeneratorOption.FlatPackage
+    scalapbCodeGeneratorOptions += CodeGeneratorOption.FlatPackage,
+    updateSubmodulesTask := {
+      import sys.process._
+      Process.apply(Seq("git", "submodule", "add", "-f", "git@github.com:Topl/protobuf-specs.git", "./topl-grpc/src/main/protobuf")).!
+      Process.apply(Seq("git", "checkout", Dependencies.protobufSpecsHash), Some(new File("./topl-grpc/src/main/protobuf"))).!
+    },
+    (Compile / compile) := (Compile / compile).dependsOn(updateSubmodulesTask).value
   )
   .dependsOn(
     models % "compile->compile;test->test",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,8 @@ object Dependencies {
   val fs2Version = "3.5-1c0be5c"
   val logback = "1.4.5"
 
+  val protobufSpecsHash = "e48b7bf2de03e263bd263f1c586baa2334fbcefb"
+
   val catsSlf4j =
     "org.typelevel" %% "log4cats-slf4j" % "2.5.0"
 


### PR DESCRIPTION
## Purpose
- The git submodules approach only works on branch names directly
- To use a "commit hash", an extra step must be taken
## Approach
- Add an SBT task that initializes the git submodules, and checks out a specific hash
## Testing
- Locally in daily review
## Tickets
