### PR TITLE
BN-714-2635-replace-models-with-protobuf v1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "topl-grpc/src/main/protobuf"]
-	path = topl-grpc/src/main/protobuf
+[submodule "protobuf/src/main/protobuf"]
+	path = protobuf/src/main/protobuf
 	url = git@github.com:Topl/protobuf-specs.git

--- a/node-tetra/src/it/scala/co/topl/tetra/it/util/NodeRpcApi.scala
+++ b/node-tetra/src/it/scala/co/topl/tetra/it/util/NodeRpcApi.scala
@@ -3,7 +3,6 @@ package co.topl.tetra.it.util
 import cats.Monad
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-import cats.implicits.catsSyntaxApplicativeError
 import co.topl.algebras.ToplRpc
 import co.topl.grpc.ToplGrpc
 import co.topl.tetra.it.util.NodeRpcApi.{rpcWaitAttempts, rpcWaitSleepMs}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -329,7 +329,11 @@ object Dependencies {
     Seq(akka("actor"), akka("actor-typed"), akka("stream")) ++
     Seq(fs2Core, fs2IO, fs2ReactiveStreams)
 
+  // TODO remove BN-714, PR v2
   lazy val models: Seq[ModuleID] =
+    cats ++ simulacrum ++ newType ++ scodec
+
+  lazy val protobuf: Seq[ModuleID] =
     cats ++ simulacrum ++ newType ++ scodec
 
   lazy val consensus: Seq[ModuleID] =

--- a/protobuf/src/main/scala/co/topl/protobuf/package.scala
+++ b/protobuf/src/main/scala/co/topl/protobuf/package.scala
@@ -1,0 +1,4 @@
+package co.topl
+
+// TODO BN-714 this package will contain co.topl.models.package object, PR v2
+package object protobuf {}


### PR DESCRIPTION
## Purpose
Tetra defines a package models that serve as pure Scala ADTs and offer very minimal functionality.  We have since adopted protobuf to define the models of Topl’s ecosystem since it leads to accurate code generation.  Clients will use generated models from protobuf, so the protocol/server/node would benefit from referencing the same models.

## Approach

- [x] - Create new `protobuf` SBT module
- [x] - Move protobuf generation from `topl-grpc` to `protobuf` module. Update `topl-grpc` to depend on `protobuf`
- [ ] - Delete `models` SBT module
- [ ] - Update old references to `models` to use the generated models from `protobuf`


Pr v2 and v3 will address pendings items

## Testing
unit test checks

## Tickets

https://topl.atlassian.net/browse/BN-714


