### PR TITLE
Reduce "eventTree" Module Dependencies

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -44,7 +44,7 @@ object Blockchain {
     transactionStore:            Store[F, TypedIdentifier, Transaction],
     _localChain:                 LocalChainAlgebra[F],
     blockIdTree:                 ParentChildTree[F, TypedIdentifier],
-    blockHeights:                EventSourcedState[F, Long => F[Option[TypedIdentifier]]],
+    blockHeights:                EventSourcedState[F, Long => F[Option[TypedIdentifier]], TypedIdentifier],
     headerValidation:            BlockHeaderValidationAlgebra[F],
     blockHeaderToBodyValidation: BlockHeaderToBodyValidationAlgebra[F],
     transactionSyntaxValidation: TransactionSyntaxValidationAlgebra[F],

--- a/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
@@ -42,7 +42,7 @@ object ToplRpcServer {
     mempool:                   MempoolAlgebra[F],
     syntacticValidation:       TransactionSyntaxValidationAlgebra[F],
     localChain:                LocalChainAlgebra[F],
-    blockHeights:              EventSourcedState[F, Long => F[Option[TypedIdentifier]]],
+    blockHeights:              EventSourcedState[F, Long => F[Option[TypedIdentifier]], TypedIdentifier],
     blockIdTree:               ParentChildTree[F, TypedIdentifier],
     localBlockAdoptionsStream: Stream[F, TypedIdentifier]
   ): F[ToplRpc[F, Stream[F, *]]] =

--- a/blockchain/src/test/scala/co/topl/blockchain/ToplRpcServerSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/ToplRpcServerSpec.scala
@@ -30,7 +30,7 @@ class ToplRpcServerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
         for {
           localChain <- mock[LocalChainAlgebra[F]].pure[F]
           _ = (() => localChain.head).expects().once().returning(canonicalHead.pure[F])
-          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]]]]
+          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]], TypedIdentifier]]
           _ = (blockHeights
             .useStateAt[Option[TypedIdentifier]](_: TypedIdentifier)(
               _: (Long => F[Option[TypedIdentifier]]) => F[Option[TypedIdentifier]]
@@ -49,7 +49,7 @@ class ToplRpcServerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
         for {
           localChain <- mock[LocalChainAlgebra[F]].pure[F]
           _ = (() => localChain.head).expects().once().returning(canonicalHead.pure[F])
-          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]]]]
+          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]], TypedIdentifier]]
           underTest <- ToplRpcServer.make[F](
             mock[Store[F, TypedIdentifier, BlockHeader]],
             mock[Store[F, TypedIdentifier, BlockBody]],
@@ -69,7 +69,7 @@ class ToplRpcServerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
         for {
           localChain <- mock[LocalChainAlgebra[F]].pure[F]
           _ = (() => localChain.head).expects().once().returning(canonicalHead.pure[F])
-          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]]]]
+          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]], TypedIdentifier]]
           underTest <- ToplRpcServer.make[F](
             mock[Store[F, TypedIdentifier, BlockHeader]],
             mock[Store[F, TypedIdentifier, BlockBody]],
@@ -88,7 +88,7 @@ class ToplRpcServerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
       withMock {
         for {
           localChain <- mock[LocalChainAlgebra[F]].pure[F]
-          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]]]]
+          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]], TypedIdentifier]]
           underTest <- ToplRpcServer.make[F](
             mock[Store[F, TypedIdentifier, BlockHeader]],
             mock[Store[F, TypedIdentifier, BlockBody]],
@@ -115,7 +115,7 @@ class ToplRpcServerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
         for {
           localChain <- mock[LocalChainAlgebra[F]].pure[F]
           _ = (() => localChain.head).expects().once().returning(canonicalHead.pure[F])
-          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]]]]
+          blockHeights = mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]], TypedIdentifier]]
           _ = (blockHeights
             .useStateAt[Option[TypedIdentifier]](_: TypedIdentifier)(
               _: (Long => F[Option[TypedIdentifier]]) => F[Option[TypedIdentifier]]
@@ -199,8 +199,8 @@ class ToplRpcServerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
     mempool:             MempoolAlgebra[F] = mock[MempoolAlgebra[F]],
     syntacticValidation: TransactionSyntaxValidationAlgebra[F] = mock[TransactionSyntaxValidationAlgebra[F]],
     localChain:          LocalChainAlgebra[F] = mock[LocalChainAlgebra[F]],
-    blockHeights: EventSourcedState[F, Long => F[Option[TypedIdentifier]]] =
-      mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]]]],
+    blockHeights: EventSourcedState[F, Long => F[Option[TypedIdentifier]], TypedIdentifier] =
+      mock[EventSourcedState[F, Long => F[Option[TypedIdentifier]], TypedIdentifier]],
     blockIdTree:               ParentChildTree[F, TypedIdentifier] = mock[ParentChildTree[F, TypedIdentifier]],
     localBlockAdoptionsStream: Stream[F, TypedIdentifier] = Stream.empty
   ) =

--- a/build.sbt
+++ b/build.sbt
@@ -331,7 +331,7 @@ lazy val eventTree = project
   )
   .settings(libraryDependencies ++= Dependencies.eventTree)
   .settings(scalamacrosParadiseSettings)
-  .dependsOn(models, typeclasses, algebras % "compile->compile;test->test")
+  .dependsOn(algebras % "compile->test")
 
 lazy val byteCodecs = project
   .in(file("byte-codecs"))

--- a/common-interpreters/src/main/scala/co/topl/interpreters/BlockHeightTree.scala
+++ b/common-interpreters/src/main/scala/co/topl/interpreters/BlockHeightTree.scala
@@ -17,9 +17,9 @@ object BlockHeightTree {
     slotDataStore:       StoreReader[F, TypedIdentifier, SlotData],
     blockTree:           ParentChildTree[F, TypedIdentifier],
     currentEventChanged: TypedIdentifier => F[Unit]
-  ): F[EventSourcedState[F, State[F]]] = {
+  ): F[EventSourcedState[F, State[F], TypedIdentifier]] = {
     val heightStore = slotDataStore.mapRead[TypedIdentifier, Long](identity, _.height)
-    EventSourcedState.OfTree.make[F, State[F]](
+    EventSourcedState.OfTree.make[F, State[F], TypedIdentifier](
       Async[F].delay(store.get),
       initialEventId = initialEventId,
       (state, id) => heightStore.getOrRaise(id).flatTap(store.put(_, id)).as(state),

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusDataEventSourcedState.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusDataEventSourcedState.scala
@@ -37,7 +37,7 @@ object ConsensusDataEventSourcedState {
     fetchBlockBody:         TypedIdentifier => F[BlockBody],
     fetchTransaction:       TypedIdentifier => F[Transaction],
     fetchTransactionOutput: Box.Id => F[Transaction.Output]
-  ): F[EventSourcedState[F, ConsensusData[F]]] =
+  ): F[EventSourcedState[F, ConsensusData[F], TypedIdentifier]] =
     EventSourcedState.OfTree.make(
       initialState = initialState,
       initialEventId = currentBlockId,

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusValidationState.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusValidationState.scala
@@ -17,10 +17,14 @@ object ConsensusValidationState {
    * EventSourcecdState.  Requests for blocks at the tip of the chain will return data from 2 epochs before that block.
    */
   def make[F[_]: MonadThrow](
-    genesisBlockId:                 TypedIdentifier,
-    epochBoundaryEventSourcedState: EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[F]],
-    consensusDataEventSourcedState: EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[F]],
-    clock:                          ClockAlgebra[F]
+    genesisBlockId: TypedIdentifier,
+    epochBoundaryEventSourcedState: EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
+      F
+    ], TypedIdentifier],
+    consensusDataEventSourcedState: EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[
+      F
+    ], TypedIdentifier],
+    clock: ClockAlgebra[F]
   ): F[ConsensusValidationStateAlgebra[F]] =
     Applicative[F].pure {
       new ConsensusValidationStateAlgebra[F] {

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/EpochBoundariesEventSourcedState.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/EpochBoundariesEventSourcedState.scala
@@ -6,6 +6,7 @@ import co.topl.algebras.ClockAlgebra.implicits._
 import co.topl.algebras._
 import co.topl.eventtree.{EventSourcedState, ParentChildTree}
 import co.topl.models._
+import co.topl.typeclasses.implicits._
 
 /**
  * An EventSourcedState which operates on an `EpochBoundaries`.
@@ -28,7 +29,7 @@ object EpochBoundariesEventSourcedState {
     currentEventChanged: TypedIdentifier => F[Unit],
     initialState:        F[EpochBoundaries[F]],
     fetchSlotData:       TypedIdentifier => F[SlotData]
-  ): F[EventSourcedState[F, EpochBoundaries[F]]] = {
+  ): F[EventSourcedState[F, EpochBoundaries[F], TypedIdentifier]] = {
     def applyBlock(state: EpochBoundaries[F], blockId: TypedIdentifier) =
       for {
         slotData <- fetchSlotData(blockId)

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusValidationStateSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusValidationStateSpec.scala
@@ -40,7 +40,7 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
             _ <- consensusData.totalActiveStake.put((), 5)
             epochBoundaryEventSourcedState = new EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
               F
-            ]] {
+            ], TypedIdentifier] {
               def stateAt(eventId: TypedIdentifier): F[EpochBoundaries[F]] = ???
 
               def useStateAt[U](eventId: TypedIdentifier)(f: EpochBoundaries[F] => F[U]): F[U] = {
@@ -48,7 +48,9 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
                 f(boundaryStore)
               }
             }
-            consensusDataEventSourcedState = new EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[F]] {
+            consensusDataEventSourcedState = new EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[
+              F
+            ], TypedIdentifier] {
               def stateAt(eventId: TypedIdentifier): F[ConsensusDataEventSourcedState.ConsensusData[F]] = ???
 
               def useStateAt[U](
@@ -99,7 +101,7 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
             _ <- consensusData.registrations.put(address, registration)
             epochBoundaryEventSourcedState = new EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
               F
-            ]] {
+            ], TypedIdentifier] {
               def stateAt(eventId: TypedIdentifier): F[EpochBoundaries[F]] = ???
 
               def useStateAt[U](eventId: TypedIdentifier)(f: EpochBoundaries[F] => F[U]): F[U] = {
@@ -107,7 +109,9 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
                 f(boundaryStore)
               }
             }
-            consensusDataEventSourcedState = new EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[F]] {
+            consensusDataEventSourcedState = new EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[
+              F
+            ], TypedIdentifier] {
               def stateAt(eventId: TypedIdentifier): F[ConsensusDataEventSourcedState.ConsensusData[F]] = ???
 
               def useStateAt[U](
@@ -155,7 +159,7 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
             _ <- consensusData.totalActiveStake.put((), 5)
             epochBoundaryEventSourcedState = new EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
               F
-            ]] {
+            ], TypedIdentifier] {
               def stateAt(eventId: TypedIdentifier): F[EpochBoundaries[F]] = ???
 
               def useStateAt[U](eventId: TypedIdentifier)(f: EpochBoundaries[F] => F[U]): F[U] = {
@@ -163,7 +167,9 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
                 f(boundaryStore)
               }
             }
-            consensusDataEventSourcedState = new EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[F]] {
+            consensusDataEventSourcedState = new EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[
+              F
+            ], TypedIdentifier] {
               def stateAt(eventId: TypedIdentifier): F[ConsensusDataEventSourcedState.ConsensusData[F]] = ???
 
               def useStateAt[U](
@@ -211,7 +217,7 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
             _ <- consensusData.registrations.put(address, registration)
             epochBoundaryEventSourcedState = new EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
               F
-            ]] {
+            ], TypedIdentifier] {
               def stateAt(eventId: TypedIdentifier): F[EpochBoundaries[F]] = ???
 
               def useStateAt[U](eventId: TypedIdentifier)(f: EpochBoundaries[F] => F[U]): F[U] = {
@@ -219,7 +225,9 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
                 f(boundaryStore)
               }
             }
-            consensusDataEventSourcedState = new EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[F]] {
+            consensusDataEventSourcedState = new EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[
+              F
+            ], TypedIdentifier] {
               def stateAt(eventId: TypedIdentifier): F[ConsensusDataEventSourcedState.ConsensusData[F]] = ???
 
               def useStateAt[U](

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
@@ -34,7 +34,7 @@ object BoxState {
     initialState:        F[State[F]]
   ): F[BoxStateAlgebra[F]] =
     for {
-      eventSourcedState <- EventSourcedState.OfTree.make[F, State[F]](
+      eventSourcedState <- EventSourcedState.OfTree.make[F, State[F], TypedIdentifier](
         initialState,
         currentBlockId,
         applyEvent = applyBlock(fetchBlockBody, fetchTransaction),

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/Mempool.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/Mempool.scala
@@ -88,7 +88,7 @@ object Mempool {
           .map(_.toList)
           .flatMap(_.traverse(fetchTransaction(_).flatMap(addTransactionWithDefaultExpiration)))
           .as(state)
-      eventSourcedState <- EventSourcedState.OfTree.make[F, State[F]](
+      eventSourcedState <- EventSourcedState.OfTree.make[F, State[F], TypedIdentifier](
         state.pure[F],
         currentBlockId,
         applyEvent = applyBlock,

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServer.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServer.scala
@@ -32,7 +32,7 @@ object BlockchainPeerServer {
       headerStore:                  Store[F, TypedIdentifier, BlockHeader],
       bodyStore:                    Store[F, TypedIdentifier, BlockBody],
       transactionStore:             Store[F, TypedIdentifier, Transaction],
-      blockHeights:                 EventSourcedState[F, Long => F[Option[TypedIdentifier]]],
+      blockHeights:                 EventSourcedState[F, Long => F[Option[TypedIdentifier]], TypedIdentifier],
       localChain:                   LocalChainAlgebra[F],
       locallyAdoptedBlockIds:       F[Source[TypedIdentifier, NotUsed]],
       locallyAdoptedTransactionIds: F[Source[TypedIdentifier, NotUsed]]

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -90,8 +90,12 @@ object NodeApp
       _                     <- Resource.eval(Logger[F].info(show"Canonical head id=$canonicalHeadId"))
 
       blockIdTree <- Resource.eval(
-        ParentChildTree.FromStore
-          .make[F, TypedIdentifier](dataStores.parentChildTree, bigBangBlock.header.parentHeaderId)
+        ParentChildTree.FromReadWrite
+          .make[F, TypedIdentifier](
+            dataStores.parentChildTree.get,
+            dataStores.parentChildTree.put,
+            bigBangBlock.header.parentHeaderId
+          )
           .flatTap(_.associate(bigBangBlock.header.id, bigBangBlock.header.parentHeaderId))
       )
 


### PR DESCRIPTION
## Purpose
- The `eventTree` module is meant to be self-contained and as dependency-free as possible
  - It currently depends on `models` because it is coupled to `TypedIdentifier`
  - It currently depends on `typeclasses` because it is coupled to `TypedIdentifier`'s `Eq` instance
  - It currently depends on `algebras` because it uses a `Store` for one of the implementations
## Approach
- Remove dependencies on `models`, `typeclasses`, and `algebras`
- Make `Id` a type parameter
- Change `EventSourceState.FromStore` to `EventSourceState.FromReadWrite` which accepts two functions
## Testing
- preparePR locally
## Tickets
- Relates to BN-698