### PR TITLE
Update GitHub Workflow Triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Bifrost_CI
 
 on:
   push:
-    branches: [dev, main, release-*, rc-*, dion]
+    branches: [ dion ]
     tags: ['*']
   workflow_dispatch:
 
@@ -29,20 +29,8 @@ jobs:
       local-docker-image: "bifrost-node"
     secrets: inherit
 
-  publish-docker-image-dev-tetra:
-    if: ${{ github.ref_name == 'tetra' }}
-    uses: ./.github/workflows/_docker_publish.yml
-    needs: sbt-build
-    with:
-      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
-      registry-auth-location: "us-central1-docker.pkg.dev"
-      local-docker-repo: "toplprotocol"
-      local-docker-image: "bifrost-node-tetra"
-      scala-project: "node-tetra"
-    secrets: inherit
-
   publish-docker-image-qa:
-    if: ${{ startsWith(github.ref_name, 'release-') }}
+    if: ${{ startsWith(github.ref_name, 'release-v1') }}
     uses: ./.github/workflows/_docker_publish.yml
     needs: sbt-build
     with:
@@ -54,7 +42,7 @@ jobs:
 
   publish-docker-image-main:
     # Execute if ref is a tag, and the format starts with v like v1.2.1.
-    if: ${{ startsWith(github.ref_name, 'v') && github.ref_type == 'tag' }}
+    if: ${{ startsWith(github.ref_name, 'v1') && github.ref_type == 'tag' }}
     uses: ./.github/workflows/_docker_publish_official.yml
     needs: sbt-build
     secrets: inherit

--- a/.github/workflows/doc_gen.yml
+++ b/.github/workflows/doc_gen.yml
@@ -2,7 +2,7 @@ name: Generate Documentation
 
 on:
   push:
-    branches: [ main ]
+    branches: [dion]
 
 jobs:
   build:

--- a/.github/workflows/gjallarhorn_doc_gen.yml
+++ b/.github/workflows/gjallarhorn_doc_gen.yml
@@ -2,7 +2,7 @@ name: Generate Gjallarhorn Documentation
 
 on:
   push:
-    branches: [ gjallarhorn_2.0 ]
+    branches: [gjallarhorn_2.0]
 
 jobs:
   build:

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -1,6 +1,7 @@
 name: Maven Central Release
 on:
   release:
+    branch: [dion]
     types: [released]
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: Bifrost_PR
 
 on:
   pull_request:
-    branches: [dev, main, release-*, rc-*, dion]
+    branches: [dion]
 
 jobs:
   validate-helm:

--- a/.github/workflows/upload_jar_artifacts.yml
+++ b/.github/workflows/upload_jar_artifacts.yml
@@ -1,7 +1,7 @@
 name: Upload Artifacts
 on:
   push:
-    branches: [main]
+    branches: [dion]
     tags: ["*"]
 jobs:
   build_artifact:


### PR DESCRIPTION
## Purpose
- The GitHub workflows for release and PR will apply only to Dion.  Tetra will use different logic on the tetra branch(es)
## Approach
- Update triggers for the workflows to operate only on the `dion` branch
## Testing
- None yet (will be tested in next release)
## Tickets
- #2588 