### PR TITLE
Mempool Rebroadcast Fix

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -65,8 +65,8 @@ object Blockchain {
   )(implicit system: ActorSystem[_], random: Random): Resource[F, Unit] = {
     implicit val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](Blockchain.getClass)
     for {
-      (localChain, blockAdoptionsTopic)    <- Resource.eval(LocalChainBroadcaster.make(_localChain))
-      (mempool, transactionAdoptionsTopic) <- Resource.eval(MempoolBroadcaster.make(_mempool))
+      (localChain, blockAdoptionsTopic)    <- LocalChainBroadcaster.make(_localChain)
+      (mempool, transactionAdoptionsTopic) <- MempoolBroadcaster.make(_mempool)
       clientHandler <- Resource.pure[F, BlockchainPeerHandlerAlgebra[F]](
         List(
           BlockchainPeerHandler.ChainSynchronizer.make[F](

--- a/blockchain/src/main/scala/co/topl/blockchain/BlockchainPeerHandler.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BlockchainPeerHandler.scala
@@ -1,6 +1,5 @@
 package co.topl.blockchain
 
-import akka.stream.Materializer
 import cats.data._
 import cats.effect.Async
 import cats.effect.kernel.Sync
@@ -383,7 +382,7 @@ object BlockchainPeerHandler {
       transactionSyntaxValidation: TransactionSyntaxValidationAlgebra[F],
       transactionStore:            Store[F, TypedIdentifier, Transaction],
       mempool:                     MempoolAlgebra[F]
-    )(implicit materializer:       Materializer): BlockchainPeerHandlerAlgebra[F] =
+    ): BlockchainPeerHandlerAlgebra[F] =
       (client: BlockchainPeerClient[F]) =>
         createPeerLogger[F](client)("P2P.MempoolSync").flatMap(implicit logger =>
           client.remoteTransactionNotifications

--- a/blockchain/src/main/scala/co/topl/blockchain/BlockchainPeerHandler.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BlockchainPeerHandler.scala
@@ -1,12 +1,12 @@
 package co.topl.blockchain
 
 import akka.stream.Materializer
-import akka.stream.scaladsl.{Keep, Sink, Source}
 import cats.data._
 import cats.effect.Async
 import cats.effect.kernel.Sync
 import cats.implicits._
 import cats.{Applicative, Monad, MonadThrow, Monoid, Parallel, Show}
+import fs2._
 import co.topl.algebras.ClockAlgebra.implicits.ClockOps
 import co.topl.algebras.{ClockAlgebra, Store, StoreReader}
 import co.topl.blockchain.algebras.BlockHeaderToBodyValidationAlgebra
@@ -61,7 +61,7 @@ object BlockchainPeerHandler {
    */
   object ChainSynchronizer {
 
-    def make[F[_]: Async: FToFuture: RunnableGraphToF](
+    def make[F[_]: Async](
       clock:                       ClockAlgebra[F],
       localChain:                  LocalChainAlgebra[F],
       headerValidation:            BlockHeaderValidationAlgebra[F],
@@ -77,12 +77,8 @@ object BlockchainPeerHandler {
     )(implicit mat:                Materializer): BlockchainPeerHandlerAlgebra[F] =
       (client: BlockchainPeerClient[F]) =>
         for {
-          remotePeer <- client.remotePeer
-          implicit0(logger: Logger[F]) = Slf4jLogger
-            .getLoggerFromClass[F](this.getClass)
-            .withModifiedString(value => show"peer=${remotePeer.remoteAddress} $value")
-          _adoptions <- client.remotePeerAdoptions
-          adoptions  <- _adoptions.withCancel[F]
+          implicit0(logger: Logger[F]) <- createPeerLogger[F](client)("P2P.ChainSync")
+          adoptions                    <- client.remotePeerAdoptions.flatMap(_.withCancel).map(_.asFS2Stream)
           _fetchAndValidateMissingHeaders = fetchAndValidateMissingHeaders(
             client,
             headerValidation,
@@ -101,7 +97,7 @@ object BlockchainPeerHandler {
             transactionStore
           ) _
           _ <- adoptions
-            .mapAsyncF(1) { id =>
+            .evalMap(id =>
               slotDataStore
                 .contains(id)
                 .ifM(
@@ -163,10 +159,7 @@ object BlockchainPeerHandler {
                                 .ifM(
                                   ifTrue =
                                     // And finally, adopt the remote peer's tine
-                                    localChain.adopt(Validated.Valid(tine.last)) >>
-                                    Logger[F].info(
-                                      show"Adopted head block id=${tine.last.slotId.blockId} height=${tine.last.height} slot=${tine.last.slotId.slot}"
-                                    ),
+                                    localChain.adopt(Validated.Valid(tine.last)),
                                   ifFalse = Logger[F].debug(show"Ignoring weaker (or equal) block header id=$id")
                                 )
                           } yield (),
@@ -175,9 +168,9 @@ object BlockchainPeerHandler {
                         )
                   } yield ()
                 )
-            }
-            .toMat(Sink.ignore)(Keep.right)
-            .liftFutureTo[F]
+            )
+            .compile
+            .drain
         } yield ()
 
     implicit private val showBlockHeaderValidationFailure: Show[BlockHeaderValidationFailure] =
@@ -200,7 +193,7 @@ object BlockchainPeerHandler {
      * the sequence of missing header IDs by comparing IDs known in the SlotDataStore with IDs known in the HeaderStore.
      * Once the list of missing IDs is assembled, the headers are requested from the remote peer and validated in-order
      */
-    private[blockchain] def fetchAndValidateMissingHeaders[F[_]: Async: FToFuture: RunnableGraphToF: Logger](
+    private[blockchain] def fetchAndValidateMissingHeaders[F[_]: Async: Logger](
       client:           BlockchainPeerClient[F],
       headerValidation: BlockHeaderValidationAlgebra[F],
       slotDataStore:    Store[F, TypedIdentifier, SlotData],
@@ -211,29 +204,30 @@ object BlockchainPeerHandler {
         slotDataStore.getOrRaise(_).map(_.parentSlotId.blockId)
       )(from)
         .flatMap(missingHeaders =>
-          Source
-            .fromIterator(() => missingHeaders.iterator)
-            .tapAsyncF(1)(blockId => Logger[F].info(show"Fetching remote header id=$blockId"))
-            .mapAsyncF(1)(blockId =>
-              OptionT(client.getRemoteHeader(blockId))
-                .filter(_.id.asTypedBytes === blockId)
-                .getOrNoSuchElement(blockId.show)
-                .tupleLeft(blockId)
+          Stream
+            .foldable(missingHeaders)
+            .evalMap(blockId =>
+              for {
+                _      <- Logger[F].info(show"Fetching remote header id=$blockId")
+                header <- OptionT(client.getRemoteHeader(blockId)).getOrNoSuchElement(blockId.show)
+                _ <- MonadThrow[F].raiseWhen(header.id.asTypedBytes =!= blockId)(
+                  new IllegalArgumentException("Claimed block ID did not match provided header")
+                )
+                _ <- Logger[F].debug(show"Validating remote header id=$blockId")
+                _ <- EitherT(
+                  headerStore.getOrRaise(header.parentHeaderId).flatMap(headerValidation.validate(header, _))
+                )
+                  .leftSemiflatTap(error =>
+                    Logger[F].warn(show"Received invalid block header id=$blockId error=$error")
+                  )
+                  .leftMap(error => new IllegalArgumentException(error.show))
+                  .rethrowT
+                _ <- Logger[F].debug(show"Saving header id=$blockId")
+                _ <- headerStore.put(blockId, header)
+              } yield ()
             )
-            .tapAsyncF(1) { case (blockId, _) =>
-              Logger[F].debug(show"Validating remote header id=$blockId")
-            }
-            .tapAsyncF(1) { case (blockId, header) =>
-              EitherT(headerStore.getOrRaise(header.parentHeaderId).flatMap(headerValidation.validate(header, _)))
-                .leftSemiflatTap(error => Logger[F].warn(show"Received invalid block header id=$blockId error=$error"))
-                .leftMap(error => new IllegalArgumentException(error.show))
-                .rethrowT >>
-              Logger[F].debug(show"Saving header id=$blockId") >>
-              headerStore.put(blockId, header)
-            }
-            .toMat(Sink.ignore)(Keep.right)
-            .liftFutureTo[F]
-            .void
+            .compile
+            .drain
         )
 
     /**
@@ -242,7 +236,7 @@ object BlockchainPeerHandler {
      * Once the list of missing IDs is assembled, the bodies (and any locally missing transactions) are requested from
      * the remote peer and validated in-order.
      */
-    private def fetchAndValidateMissingBodies[F[_]: Async: FToFuture: RunnableGraphToF: Logger](
+    private def fetchAndValidateMissingBodies[F[_]: Async: Logger](
       client:                      BlockchainPeerClient[F],
       headerToBodyValidation:      BlockHeaderToBodyValidationAlgebra[F],
       bodySyntaxValidation:        BodySyntaxValidationAlgebra[F],
@@ -258,55 +252,50 @@ object BlockchainPeerHandler {
         slotDataStore.getOrRaise(_).map(_.parentSlotId.blockId)
       )(from)
         .flatMap(missingBodyIds =>
-          Source
-            .fromIterator(() => missingBodyIds.iterator)
-            .tapAsyncF(1)(blockId => Logger[F].info(show"Fetching remote body id=$blockId"))
-            .mapAsyncF(1)(blockId =>
-              OptionT(client.getRemoteBody(blockId)) // TODO: Verify against Header#txRoot
-                .getOrNoSuchElement(blockId.show)
-                .tupleLeft(blockId)
-            )
-            .mapAsyncF(1) { case (blockId, body) =>
-              body.toList
-                .traverse(transactionId =>
-                  OptionT(transactionStore.get(transactionId))
-                    .getOrElseF(
-                      Logger[F].info(show"Fetching remote transaction id=$transactionId") >>
-                      OptionT(client.getRemoteTransaction(transactionId))
-                        .filter(_.id.asTypedBytes === transactionId)
-                        .getOrNoSuchElement(transactionId.show)
-                        .flatTap(_ => Logger[F].debug(show"Saving transaction id=$transactionId"))
-                        .flatTap(transaction => transactionStore.put(transactionId, transaction))
-                    )
-                )
-                .map((blockId, body, _))
-            }
-            .tapAsyncF(1) { case (blockId, body, _) =>
-              headerStore
-                .getOrRaise(blockId)
-                .map(header => Block(header, body))
-                .flatMap(block =>
+          Stream
+            .foldable(missingBodyIds)
+            .evalMap(blockId =>
+              for {
+                _      <- Logger[F].info(show"Fetching remote body id=$blockId")
+                header <- headerStore.getOrRaise(blockId)
+                body   <- OptionT(client.getRemoteBody(blockId)).getOrNoSuchElement(blockId.show)
+                block = Block(header, body)
+                _ <- Stream
+                  .iterable(body)
+                  .evalMap(transactionId =>
+                    transactionStore
+                      .contains(transactionId)
+                      .ifM(
+                        Applicative[F].unit,
+                        for {
+                          _ <- Logger[F].info(show"Fetching remote transaction id=$transactionId")
+                          transaction <- OptionT(client.getRemoteTransaction(transactionId))
+                            .getOrNoSuchElement(transactionId.show)
+                          _ <- MonadThrow[F].raiseWhen(transaction.id.asTypedBytes =!= transactionId)(
+                            new IllegalArgumentException("Claimed transaction ID did not match provided transaction")
+                          )
+                          _ <- Logger[F].debug(show"Saving transaction id=$transactionId")
+                          _ <- transactionStore.put(transactionId, transaction)
+                        } yield ()
+                      )
+                  )
+                  .compile
+                  .drain
+                _ <-
                   (
                     for {
                       _ <- EitherT.liftF(Logger[F].debug(show"Validating header to body consistency for id=$blockId"))
                       _ <- EitherT(headerToBodyValidation.validate(block)).leftMap(e => e.show)
                       _ <- EitherT.liftF(Logger[F].debug(show"Validating syntax of body id=$blockId"))
-                      _ <- EitherT(
-                        bodySyntaxValidation
-                          .validate(block.body)
-                          .map(_.toEither.leftMap(_.show))
-                      )
+                      _ <- EitherT(bodySyntaxValidation.validate(block.body).map(_.toEither.leftMap(_.show)))
                       _ <- EitherT.liftF(Logger[F].debug(show"Validating semantics of body id=$blockId"))
+                      validationContext = StaticBodyValidationContext(
+                        block.header.parentHeaderId,
+                        block.header.height,
+                        block.header.slot
+                      )
                       _ <- EitherT(
-                        bodySemanticValidation
-                          .validate(
-                            StaticBodyValidationContext(
-                              block.header.parentHeaderId,
-                              block.header.height,
-                              block.header.slot
-                            )
-                          )(block.body)
-                          .map(_.toEither.leftMap(_.show))
+                        bodySemanticValidation.validate(validationContext)(block.body).map(_.toEither.leftMap(_.show))
                       )
                       _ <- EitherT.liftF(Logger[F].debug(show"Validating authorization of body id=$blockId"))
                       _ <- EitherT(
@@ -319,14 +308,12 @@ object BlockchainPeerHandler {
                     .leftSemiflatTap(e => Logger[F].warn(show"Received invalid block body id=$blockId errors=$e"))
                     .leftMap((e: String) => new IllegalArgumentException(e))
                     .rethrowT
-                )
-            }
-            .tapAsyncF(1) { case (blockId, body, _) =>
-              Logger[F].debug(show"Saving body id=$blockId") >>
-              bodyStore.put(blockId, body)
-            }
-            .toMat(Sink.ignore)(Keep.right)
-            .liftFutureTo[F]
+                _ <- Logger[F].debug(show"Saving body id=$blockId")
+                _ <- bodyStore.put(blockId, body)
+              } yield ()
+            )
+            .compile
+            .drain
         )
 
     /**
@@ -393,53 +380,55 @@ object BlockchainPeerHandler {
     implicit private val showTransactionSemanticError: Show[TransactionSemanticError] =
       Show.fromToString
 
-    def make[F[_]: Async: RunnableGraphToF: Logger](
+    def make[F[_]: Async](
       transactionSyntaxValidation: TransactionSyntaxValidationAlgebra[F],
       transactionStore:            Store[F, TypedIdentifier, Transaction],
       mempool:                     MempoolAlgebra[F]
     )(implicit materializer:       Materializer): BlockchainPeerHandlerAlgebra[F] =
       (client: BlockchainPeerClient[F]) =>
-        client.remoteTransactionNotifications
-          .flatMap(_.withCancel[F])
-          .flatMap(source =>
-            source.asFS2Stream
-              .evalMap(id =>
-                for {
-                  _             <- Logger[F].debug(show"Received transaction notification from remote peer id=$id")
-                  alreadyExists <- transactionStore.contains(id)
-                  _ <-
-                    if (alreadyExists)
-                      Logger[F].debug(show"Ignoring already known remote transaction id=$id")
-                    else {
-                      for {
-                        _           <- Logger[F].info(show"Fetching remote transaction id=$id")
-                        transaction <- OptionT(client.getRemoteTransaction(id)).getOrNoSuchElement(id.show)
-                        _ <- MonadThrow[F].raiseWhen(transaction.id.asTypedBytes =!= id)(
-                          new IllegalArgumentException(
-                            s"Remote peer provided transaction that did not match its claimed ID"
-                          )
-                        )
-                        _ <- EitherT(transactionSyntaxValidation.validate(transaction).map(_.toEither))
-                          .leftSemiflatMap(errors =>
-                            Logger[F].warn(
-                              show"Received syntactically invalid transaction id=$id errors=$errors"
-                            )
-                          )
-                          .leftMap(errors => new IllegalArgumentException(errors.show))
-                          .rethrowT
-                        _ <- Logger[F].debug(show"Transaction id=$id is syntactically valid")
-                        _ <- Logger[F].debug(show"Inserting transaction id=$id into Store")
-                        _ <- transactionStore.put(id, transaction)
-                        _ <- Logger[F].info(show"Inserting transaction id=$id into Mempool")
-                        _ <- mempool.add(id)
-                      } yield ()
-                    }
-                } yield ()
+        createPeerLogger[F](client)("P2P.MempoolSync").flatMap(implicit logger =>
+          client.remoteTransactionNotifications
+            .flatMap(_.withCancel[F])
+            .flatMap(source =>
+              source.asFS2Stream
+                .evalMap(processTransactionId[F](transactionSyntaxValidation, transactionStore, mempool)(client))
+                .compile
+                .drain
+            )
+            .void
+        )
+
+    private def processTransactionId[F[_]: Async: Logger](
+      transactionSyntaxValidation: TransactionSyntaxValidationAlgebra[F],
+      transactionStore:            Store[F, TypedIdentifier, Transaction],
+      mempool:                     MempoolAlgebra[F]
+    )(client:                      BlockchainPeerClient[F])(id: TypedIdentifier) =
+      for {
+        _             <- Logger[F].debug(show"Received transaction notification from remote peer id=$id")
+        alreadyExists <- transactionStore.contains(id)
+        _ <-
+          if (alreadyExists)
+            Logger[F].debug(show"Ignoring already known remote transaction id=$id")
+          else {
+            for {
+              _           <- Logger[F].info(show"Fetching remote transaction id=$id")
+              transaction <- OptionT(client.getRemoteTransaction(id)).getOrNoSuchElement(id.show)
+              _ <- MonadThrow[F].raiseWhen(transaction.id.asTypedBytes =!= id)(
+                new IllegalArgumentException(s"Claimed transaction ID did not match provided transaction")
               )
-              .compile
-              .drain
-          )
-          .void
+              _ <- EitherT(transactionSyntaxValidation.validate(transaction).map(_.toEither))
+                .leftSemiflatMap(errors =>
+                  Logger[F].warn(show"Received syntactically invalid transaction id=$id errors=$errors")
+                )
+                .leftMap(errors => new IllegalArgumentException(errors.show))
+                .rethrowT
+              _ <- Logger[F].debug(show"Transaction id=$id is syntactically valid")
+              _ <- Logger[F].debug(show"Inserting transaction id=$id into Mempool and Store")
+              _ <- transactionStore.put(id, transaction)
+              _ <- mempool.add(id)
+            } yield ()
+          }
+      } yield ()
   }
 
   /**
@@ -448,32 +437,29 @@ object BlockchainPeerHandler {
    */
   object CommonAncestorSearch {
 
-    def make[F[_]: Async: FToFuture: RunnableGraphToF: Logger](
+    def make[F[_]: Async](
       getLocalBlockIdAtHeight: Long => F[TypedIdentifier],
       currentHeight:           () => F[Long],
       slotDataStore:           StoreReader[F, TypedIdentifier, SlotData]
-    )(implicit mat:            Materializer): BlockchainPeerHandlerAlgebra[F] =
+    ): BlockchainPeerHandlerAlgebra[F] =
       (client: BlockchainPeerClient[F]) =>
-        Source
-          .tick(0.seconds, 10.seconds, ())
-          .withCancel[F]
-          .flatMap(
-            _.tapAsyncF(1)(_ =>
-              traceAndLogCommonAncestor(getLocalBlockIdAtHeight, currentHeight, slotDataStore)(client)
-            )
-              .toMat(Sink.ignore)(Keep.right)
-              .liftFutureTo[F]
+        createPeerLogger[F](client)("P2P.CommonAncestorTrace")
+          .flatMap(implicit logger =>
+            Stream
+              .awakeEvery[F](10.seconds)
+              .evalMap(_ => traceAndLogCommonAncestor(getLocalBlockIdAtHeight, currentHeight, slotDataStore)(client))
+              .compile
+              .drain
           )
-          .void
 
     private def traceAndLogCommonAncestor[F[_]: Sync: Logger](
       getLocalBlockIdAtHeight: Long => F[TypedIdentifier],
       currentHeight:           () => F[Long],
       slotDataStore:           StoreReader[F, TypedIdentifier, SlotData]
     )(client:                  BlockchainPeerClient[F]) =
-      client.remotePeer
-        .flatMap(peer =>
-          Logger[F].debug(show"Starting common ancestor trace with remote=${peer.remoteAddress}") >>
+      Sync[F]
+        .defer(
+          Logger[F].debug(show"Starting common ancestor trace") >>
           client
             .findCommonAncestor(getLocalBlockIdAtHeight, currentHeight)
             .flatTap(ancestor =>
@@ -481,7 +467,7 @@ object BlockchainPeerHandler {
                 .getOrNoSuchElement(ancestor)
                 .flatMap(slotData =>
                   Logger[F].info(
-                    show"Traced remote=${peer.remoteAddress} common ancestor to" +
+                    show"Traced common ancestor to" +
                     show" id=$ancestor" +
                     show" height=${slotData.height}" +
                     show" slot=${slotData.slotId.slot}"
@@ -500,4 +486,12 @@ object BlockchainPeerHandler {
     def getOrNoSuchElement(id: Any)(implicit M: MonadThrow[F]): F[T] =
       optionT.toRight(new NoSuchElementException(id.toString)).rethrowT
   }
+
+  private def createPeerLogger[F[_]: Sync](client: BlockchainPeerClient[F])(processName: String) =
+    client.remotePeer.map(remotePeer =>
+      Slf4jLogger
+        .getLoggerFromName[F](processName)
+        .withModifiedString(value => show"peer=${remotePeer.remoteAddress} $value")
+    )
+
 }

--- a/blockchain/src/main/scala/co/topl/blockchain/LocalChainBroadcaster.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/LocalChainBroadcaster.scala
@@ -1,11 +1,8 @@
 package co.topl.blockchain
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
 import cats.data.{EitherT, Validated}
 import cats.effect.kernel.Async
 import cats.implicits._
-import co.topl.catsakka._
 import co.topl.consensus.algebras.LocalChainAlgebra
 import co.topl.models.{SlotData, TypedIdentifier}
 import fs2.concurrent.Topic

--- a/blockchain/src/main/scala/co/topl/blockchain/MempoolBroadcaster.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/MempoolBroadcaster.scala
@@ -1,5 +1,6 @@
 package co.topl.blockchain
 
+import cats.effect.Resource
 import cats.effect.kernel.Async
 import cats.implicits._
 import co.topl.ledger.algebras.MempoolAlgebra
@@ -8,8 +9,9 @@ import fs2.concurrent.Topic
 
 object MempoolBroadcaster {
 
-  def make[F[_]: Async](mempool: MempoolAlgebra[F]): F[(MempoolAlgebra[F], Topic[F, TypedIdentifier])] =
-    Topic[F, TypedIdentifier]
+  def make[F[_]: Async](mempool: MempoolAlgebra[F]): Resource[F, (MempoolAlgebra[F], Topic[F, TypedIdentifier])] =
+    Resource
+      .make(Topic[F, TypedIdentifier])(_.close.void)
       .map { txsAdoptionsTopic =>
         val interpreter =
           new MempoolAlgebra[F] {

--- a/blockchain/src/test/scala/co/topl/blockchain/LocalChainBroadcasterSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/LocalChainBroadcasterSpec.scala
@@ -1,25 +1,21 @@
 package co.topl.blockchain
 
-import akka.actor.ActorSystem
-import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.{TestKit, TestKitBase}
 import cats.data.Validated
 import cats.effect.IO
+import cats.effect.kernel.Sync
 import cats.implicits._
 import co.topl.consensus.algebras.LocalChainAlgebra
 import co.topl.models.ModelGenerators._
-import co.topl.models.{SlotData, TypedIdentifier}
+import co.topl.models.SlotData
 import co.topl.typeclasses.implicits._
-import fs2.concurrent.Topic
+import fs2._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 
-class LocalChainBroadcasterSpec
-    extends CatsEffectSuite
-    with ScalaCheckEffectSuite
-    with AsyncMockFactory
-    with TestKitBase {
+import scala.concurrent.duration._
+
+class LocalChainBroadcasterSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
   type F[A] = IO[A]
 
@@ -28,24 +24,22 @@ class LocalChainBroadcasterSpec
       withMock {
         for {
           delegate <- mock[LocalChainAlgebra[F]].pure[F]
-          _ = (delegate.adopt _).expects(Validated.Valid(slotData)).once().returning(IO.unit)
-          adoptionsTopic <- mock[Topic[F, TypedIdentifier]].pure[F]
-          _ = (adoptionsTopic.publish1 _).expects(slotData.slotId.blockId).once().returning(Right(()).pure[F])
-          (underTest, source) <- LocalChainBroadcaster.make(delegate, adoptionsTopic)
-          sub = source.runWith(TestSink.probe)
-          _ = sub.request(1)
-          _ <- underTest.adopt(Validated.Valid(slotData))
-          id = sub.expectNext()
+          _ = (delegate.adopt _).expects(*).once().returning(IO.unit)
+          (underTest, adoptionsTopic) <- LocalChainBroadcaster.make(delegate)
+          id <- adoptionsTopic.subscribeUnbounded
+            .concurrently(
+              Stream.eval(
+                underTest.adopt(Validated.Valid(slotData)) >> Sync[F].delay(
+                  adoptionsTopic.close.unsafeRunAndForget()
+                )
+              )
+            )
+            .timeout(3.seconds)
+            .compile
+            .lastOrError
           _ = IO(id === slotData.slotId.blockId).assert
         } yield ()
       }
     }
-  }
-
-  implicit val system: ActorSystem = ActorSystem("LocalChainBroadcasterSpec")
-
-  override def afterAll(): Unit = {
-    super.afterAll()
-    TestKit.shutdownActorSystem(system)
   }
 }

--- a/blockchain/src/test/scala/co/topl/blockchain/MempoolBroadcasterSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/MempoolBroadcasterSpec.scala
@@ -1,20 +1,17 @@
 package co.topl.blockchain
 
-import akka.actor.ActorSystem
-import akka.testkit.{TestKit, TestKitBase}
-
 import cats.effect.IO
 import cats.implicits._
 import co.topl.ledger.algebras.MempoolAlgebra
 import co.topl.models.ModelGenerators._
 import co.topl.models.TypedIdentifier
 import co.topl.typeclasses.implicits._
-import fs2.concurrent.Topic
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
+import fs2._
 
-class MempoolBroadcasterSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory with TestKitBase {
+class MempoolBroadcasterSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
   type F[A] = IO[A]
 
@@ -24,24 +21,15 @@ class MempoolBroadcasterSpec extends CatsEffectSuite with ScalaCheckEffectSuite 
         for {
           delegate <- mock[MempoolAlgebra[F]].pure[F]
           _ = (delegate.add _).expects(transactionId).once().returning(IO.unit)
-          txsAdoptionsTopic <- Topic[F, TypedIdentifier]
-          (underTest)       <- MempoolBroadcaster.make(delegate, txsAdoptionsTopic)
-          _ <- txsAdoptionsTopic.subscribeAwait(Int.MaxValue).use { stream =>
-            for {
-              _ <- underTest.add(transactionId)
-              i <- stream.take(1).compile.toVector
-              _ = IO(i.head === transactionId).assert
-            } yield ()
-          }
+          (underTest, txsAdoptionsTopic) <- MempoolBroadcaster.make(delegate)
+          i <- txsAdoptionsTopic.subscribeUnbounded
+            .concurrently(Stream.eval(underTest.add(transactionId)))
+            .head
+            .compile
+            .lastOrError
+          _ = IO(i === transactionId).assert
         } yield ()
       }
     }
-  }
-
-  implicit val system: ActorSystem = ActorSystem("MempoolBroadcasterSpec")
-
-  override def afterAll(): Unit = {
-    super.afterAll()
-    TestKit.shutdownActorSystem(system)
   }
 }

--- a/cats-akka/src/main/scala/co/topl/catsakka/StreamOps.scala
+++ b/cats-akka/src/main/scala/co/topl/catsakka/StreamOps.scala
@@ -1,11 +1,10 @@
 package co.topl.catsakka
 
 import akka.NotUsed
-import akka.stream.scaladsl.{BroadcastHub, Keep, RunnableGraph, Source}
+import akka.stream.scaladsl.{BroadcastHub, Keep, Source}
 import cats.effect.Async
-import cats.effect.kernel.{Resource, Sync}
+import cats.effect.kernel.Resource
 import cats.effect.std.Queue
-import cats.~>
 import fs2.Stream
 import fs2.concurrent.Topic
 import fs2.interop.reactivestreams.StreamOps
@@ -14,7 +13,7 @@ import scala.language.implicitConversions
 
 trait AsFS2StreamOps {
 
-  implicit def streamAsStreamOps[F[_]: Async, T](stream: Stream[F, T]): StreamFS2Ops[F, T] =
+  implicit def streamAsStreamOps[F[_], T](stream: Stream[F, T]): StreamFS2Ops[F, T] =
     new StreamFS2Ops(stream)
 
 }
@@ -39,14 +38,10 @@ class StreamFS2Ops[F[_], T](val stream: Stream[F, T]) extends AnyVal {
 }
 
 trait AsFS2TopicOps {
-  implicit def topicAsTopicOps[F[_]: Async, T](topic: Topic[F, T]): FS2TopicOps[F, T] = new FS2TopicOps(topic)
+  implicit def topicAsTopicOps[F[_], T](topic: Topic[F, T]): FS2TopicOps[F, T] = new FS2TopicOps(topic)
 }
 
 class FS2TopicOps[F[_], T](val topic: Topic[F, T]) extends AnyVal {
-
-  def toAkkaBroadcastSource(implicit asyncF: Async[F], r: RunnableGraphToF[F]): Resource[F, Source[T, NotUsed]] =
-    topic.subscribeUnbounded.toAkkaSource
-      .flatMap(_.toMat(BroadcastHub.sink)(Keep.right).resource[F])
 
   def subscribeDropOldest(buffer: Int)(implicit asyncF: Async[F]): Stream[F, T] =
     topic.subscribeUnbounded.dropOldest(buffer)

--- a/cats-akka/src/main/scala/co/topl/catsakka/StreamOps.scala
+++ b/cats-akka/src/main/scala/co/topl/catsakka/StreamOps.scala
@@ -1,24 +1,53 @@
 package co.topl.catsakka
 
 import akka.NotUsed
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{BroadcastHub, Keep, RunnableGraph, Source}
 import cats.effect.Async
+import cats.effect.kernel.{Resource, Sync}
+import cats.effect.std.Queue
+import cats.~>
 import fs2.Stream
+import fs2.concurrent.Topic
 import fs2.interop.reactivestreams.StreamOps
+
 import scala.language.implicitConversions
 
-trait FS2StreamOps {
+trait AsFS2StreamOps {
 
   implicit def streamAsStreamOps[F[_]: Async, T](stream: Stream[F, T]): StreamFS2Ops[F, T] =
     new StreamFS2Ops(stream)
 
 }
 
-class StreamFS2Ops[F[_]: Async, T](val stream: Stream[F, T]) {
+class StreamFS2Ops[F[_], T](val stream: Stream[F, T]) extends AnyVal {
 
-  def toAkkaSource: F[Source[T, NotUsed]] =
-    stream.toUnicastPublisher.use { p =>
-      Async[F].delay(Source.fromPublisher(p.publisher))
-    }
+  def toAkkaSource(implicit asyncF: Async[F]): Resource[F, Source[T, NotUsed]] =
+    stream.toUnicastPublisher.map(p => Source.fromPublisher(p.publisher))
 
+  /**
+   * Slow downstream consumers normally block upstream producers.  This method prevents this behavior by buffering
+   * upstream elements, dropping old elements in the buffer as it becomes full.
+   */
+  def dropOldest(buffer: Int)(implicit asyncF: Async[F]): Stream[F, T] =
+    Stream
+      .eval(Queue.circularBuffer[F, Option[T]](buffer))
+      .flatMap(queue =>
+        Stream
+          .fromQueueNoneTerminated(queue)
+          .concurrently(stream.enqueueNoneTerminated(queue))
+      )
+}
+
+trait AsFS2TopicOps {
+  implicit def topicAsTopicOps[F[_]: Async, T](topic: Topic[F, T]): FS2TopicOps[F, T] = new FS2TopicOps(topic)
+}
+
+class FS2TopicOps[F[_], T](val topic: Topic[F, T]) extends AnyVal {
+
+  def toAkkaBroadcastSource(implicit asyncF: Async[F], r: RunnableGraphToF[F]): Resource[F, Source[T, NotUsed]] =
+    topic.subscribeUnbounded.toAkkaSource
+      .flatMap(_.toMat(BroadcastHub.sink)(Keep.right).resource[F])
+
+  def subscribeDropOldest(buffer: Int)(implicit asyncF: Async[F]): Stream[F, T] =
+    topic.subscribeUnbounded.dropOldest(buffer)
 }

--- a/cats-akka/src/main/scala/co/topl/catsakka/StreamOps.scala
+++ b/cats-akka/src/main/scala/co/topl/catsakka/StreamOps.scala
@@ -1,7 +1,7 @@
 package co.topl.catsakka
 
 import akka.NotUsed
-import akka.stream.scaladsl.{BroadcastHub, Keep, Source}
+import akka.stream.scaladsl.Source
 import cats.effect.Async
 import cats.effect.kernel.Resource
 import cats.effect.std.Queue

--- a/cats-akka/src/main/scala/co/topl/catsakka/package.scala
+++ b/cats-akka/src/main/scala/co/topl/catsakka/package.scala
@@ -9,7 +9,13 @@ import cats.~>
 
 import scala.concurrent.Future
 
-package object catsakka extends SourceOps with RunnableGraphOps with FlowOps with FOps with FS2StreamOps {
+package object catsakka
+    extends SourceOps
+    with RunnableGraphOps
+    with FlowOps
+    with FOps
+    with AsFS2StreamOps
+    with AsFS2TopicOps {
 
   type FToFuture[F[_]] = F ~> Future
   type RunnableGraphToF[F[_]] = RunnableGraph ~> F

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/LocalChain.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/LocalChain.scala
@@ -6,6 +6,9 @@ import cats.effect.kernel.Sync
 import cats.implicits._
 import co.topl.consensus.algebras.{ChainSelectionAlgebra, LocalChainAlgebra}
 import co.topl.models.{SlotData, TypedIdentifier}
+import co.topl.typeclasses.implicits._
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.{Logger, SelfAwareStructuredLogger}
 
 object LocalChain {
 
@@ -19,11 +22,25 @@ object LocalChain {
       .map(headRef =>
         new LocalChainAlgebra[F] {
 
+          implicit private val logger: SelfAwareStructuredLogger[F] =
+            Slf4jLogger.getLoggerFromClass[F](LocalChain.getClass)
+
           def isWorseThan(newHead: SlotData): F[Boolean] =
             head.flatMap(chainSelection.compare(_, newHead).map(_ < 0))
 
-          def adopt(newHead: Validated.Valid[SlotData]): F[Unit] =
-            Sync[F].uncancelable(_ => onAdopted(newHead.a.slotId.blockId) >> headRef.update(_ => newHead.a))
+          def adopt(newHead: Validated.Valid[SlotData]): F[Unit] = {
+            val slotData = newHead.a
+            Sync[F].uncancelable(_ =>
+              onAdopted(slotData.slotId.blockId) >>
+              headRef.set(slotData) >>
+              Logger[F].info(
+                show"Adopted head block" +
+                show" id=${slotData.slotId.blockId}" +
+                show" height=${slotData.height}" +
+                show" slot=${slotData.slotId.slot}"
+              )
+            )
+          }
 
           val head: F[SlotData] =
             headRef.get

--- a/consensus/src/test/resources/logback-test.xml
+++ b/consensus/src/test/resources/logback-test.xml
@@ -13,6 +13,7 @@
     </appender>
 
     <logger name="co.topl" level="INFO" />
+    <logger name="co.topl.consensus.interpreters" level="WARN" />
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BoxState.scala
@@ -98,9 +98,8 @@ object BoxState {
       _ <- transactions.traverse(transaction =>
         state.remove(transaction.id) >>
         transaction.inputs.traverse(input =>
-          state
-            .getOrRaise(input.boxId.transactionId)
-            .map(_.add(input.boxId.transactionOutputIndex))
+          OptionT(state.get(input.boxId.transactionId))
+            .fold(NonEmptySet.one(input.boxId.transactionOutputIndex))(_.add(input.boxId.transactionOutputIndex))
             .flatMap(state.put(input.boxId.transactionId, _))
         )
       )

--- a/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
@@ -48,6 +48,7 @@ object BlockProducer {
     clock:         ClockAlgebra[F],
     blockPacker:   BlockPackerAlgebra[F]
   ) extends BlockProducerAlgebra[F] {
+
     implicit val logger: SelfAwareStructuredLogger[F] =
       Slf4jLogger.getLoggerFromClass[F](BlockProducer.getClass)
 

--- a/minting/src/test/resources/logback-test.xml
+++ b/minting/src/test/resources/logback-test.xml
@@ -13,6 +13,8 @@
     </appender>
 
     <logger name="co.topl" level="INFO" />
+    <logger name="co.topl.minting.interpreters" level="WARN" />
+
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
+++ b/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
@@ -1,15 +1,14 @@
 package co.topl.networking
 
 import akka.NotUsed
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
-import akka.stream.{Materializer, OverflowStrategy}
+import akka.stream.scaladsl.{Flow, Sink}
 import akka.util.ByteString
 import cats.data.{EitherT, NonEmptyChain, OptionT}
-import cats.effect.Async
 import cats.effect.kernel.Sync
 import cats.effect.std.Queue
+import cats.effect.{Async, Deferred, Resource}
 import cats.implicits._
-import cats.{Applicative, MonadThrow, Show}
+import cats.{MonadThrow, Show}
 import co.topl.catsakka._
 import co.topl.codecs.bytes.typeclasses.Transmittable
 import co.topl.networking.blockchain.NetworkTypeTags._
@@ -18,10 +17,9 @@ import co.topl.networking.multiplexer._
 import co.topl.networking.p2p.{ConnectedPeer, ConnectionLeader, ConnectionLeaders}
 import co.topl.networking.typedprotocols.TypedProtocol.CommonStates
 import co.topl.networking.typedprotocols._
+import fs2._
 import org.typelevel.log4cats.Logger
 import scodec.bits.ByteVector
-
-import scala.concurrent.Promise
 
 /**
  * Helper for transforming a collection of Typed Sub Handlers into a multiplexed akka stream Flow
@@ -51,7 +49,7 @@ object TypedProtocolSetFactory {
       def multiplexed(
         connectedPeer:    ConnectedPeer,
         connectionLeader: ConnectionLeader
-      ): F[Flow[ByteString, ByteString, Client]] =
+      ): Resource[F, Flow[ByteString, ByteString, Client]] =
         multiplexerHandlersIn(connectedPeer, connectionLeader).map { case (subHandlers, client) =>
           Multiplexer(subHandlers, client)
         }
@@ -59,9 +57,9 @@ object TypedProtocolSetFactory {
       private def multiplexerHandlersIn(
         connectedPeer:    ConnectedPeer,
         connectionLeader: ConnectionLeader
-      ): F[(NonEmptyChain[SubHandler], Client)] =
-        factory
-          .protocolsForPeer(connectedPeer, connectionLeader)
+      ): Resource[F, (NonEmptyChain[SubHandler], Client)] =
+        Resource
+          .eval(factory.protocolsForPeer(connectedPeer, connectionLeader))
           .flatMap { case (typedProtocolSet, client) =>
             typedProtocolSet
               .traverse { multiplexedSubHandler =>
@@ -69,14 +67,17 @@ object TypedProtocolSetFactory {
                   multiplexedSubHandler.asInstanceOf[TypedSubHandler[F, multiplexedSubHandler.InState]]
                 val s = sh.initialState.asInstanceOf[Any]
                 implicit val ct: NetworkTypeTag[Any] = sh.initialStateNetworkTypeTag.asInstanceOf[NetworkTypeTag[Any]]
-                sh.instance
-                  .applier(s)
-                  .map(applier =>
-                    SubHandler(
-                      multiplexedSubHandler.sessionId,
-                      handlerSink(multiplexedSubHandler, applier, multiplexedSubHandler.sessionId),
-                      handlerSource(multiplexedSubHandler, applier, multiplexedSubHandler.sessionId)
-                    )
+                Resource
+                  .eval(sh.instance.applier(s))
+                  .flatMap(applier =>
+                    handlerSource(multiplexedSubHandler, applier, multiplexedSubHandler.sessionId).toAkkaSource
+                      .map(
+                        SubHandler(
+                          multiplexedSubHandler.sessionId,
+                          handlerSink(multiplexedSubHandler, applier, multiplexedSubHandler.sessionId),
+                          _
+                        )
+                      )
                   )
               }
               .tupleRight(client)
@@ -111,9 +112,9 @@ object TypedProtocolSetFactory {
         multiplexedSubHandler: TypedSubHandler[F, _],
         applier:               TypedProtocolInstance[F]#MessageApplier,
         protocolInstanceId:    Byte
-      ): Source[ByteString, _] =
+      ): Stream[F, ByteString] =
         multiplexedSubHandler.outboundMessages
-          .mapAsyncF(1)(outboundMessage =>
+          .evalMap(outboundMessage =>
             EitherT(
               applier
                 .apply(outboundMessage.data, multiplexedSubHandler.instance.localParty)(
@@ -125,7 +126,9 @@ object TypedProtocolSetFactory {
               .rethrowT
               .as(outboundMessage)
           )
-          .log(s"Sending outbound message in protocolInstanceId=$protocolInstanceId", o => o.data)
+          .evalTap(o =>
+            Logger[F].debug(s"Sending outbound message in protocolInstanceId=$protocolInstanceId. ${o.data}")
+          )
           .map { o =>
             val (prefix, byteVector) =
               multiplexedSubHandler.codec.encode(o.data)(o.networkTypeTag.asInstanceOf[NetworkTypeTag[Any]]) match {
@@ -134,7 +137,7 @@ object TypedProtocolSetFactory {
               }
             prefix -> ByteString(byteVector.toArray)
           }
-          .via(MessageSerializerFramer())
+          .map((MessageSerializerFramer.function _).tupled)
 
     }
   }
@@ -143,28 +146,26 @@ object TypedProtocolSetFactory {
 
   object CommonProtocols {
 
-    def notificationReciprocated[F[_]: Async: Logger: FToFuture, T: Show: Transmittable](
+    def notificationReciprocated[F[_]: Async: Logger, T: Show: Transmittable](
       protocol:      NotificationProtocol[T],
-      notifications: F[Source[T, NotUsed]],
+      notifications: Stream[F, T],
       byteA:         Byte,
       byteB:         Byte
     )(implicit
-      materializer: Materializer,
       tPushTypeTag: NetworkTypeTag[TypedProtocol.CommonMessages.Push[T]]
-    ): F[ConnectionLeader => (NonEmptyChain[TypedSubHandler[F, CommonStates.None.type]], Source[T, NotUsed])] =
+    ): F[ConnectionLeader => (NonEmptyChain[TypedSubHandler[F, CommonStates.None.type]], Stream[F, T])] =
       (notificationServer[F, T](protocol, notifications), notificationClient[F, T](protocol)).tupled
         .map { case (f1, (f2, source)) =>
           (connectionLeader: ConnectionLeader) =>
             (ReciprocatedTypedSubHandler(f1, f2, byteA, byteB).handlers(connectionLeader), source)
         }
 
-    def requestResponseReciprocated[F[_]: Async: Logger: FToFuture, Query: Transmittable, T: Transmittable](
+    def requestResponseReciprocated[F[_]: Async: Logger, Query: Transmittable, T: Transmittable](
       protocol: RequestResponseProtocol[Query, T],
       fetch:    Query => F[Option[T]],
       byteA:    Byte,
       byteB:    Byte
     )(implicit
-      materializer:     Materializer,
       queryGetTypeTag:  NetworkTypeTag[TypedProtocol.CommonMessages.Get[Query]],
       tResponseTypeTag: NetworkTypeTag[TypedProtocol.CommonMessages.Response[T]]
     ): F[
@@ -176,17 +177,17 @@ object TypedProtocolSetFactory {
             (ReciprocatedTypedSubHandler(f1, f2, byteA, byteB).handlers(connectionLeader), callback)
         }
 
-    def notificationServer[F[_]: Async: Logger: FToFuture, T: Show: Transmittable](
+    def notificationServer[F[_]: Async: Logger, T: Show: Transmittable](
       protocol:      NotificationProtocol[T],
-      notifications: F[Source[T, NotUsed]]
+      notifications: Stream[F, T]
     )(implicit
       tPushTypeTag: NetworkTypeTag[TypedProtocol.CommonMessages.Push[T]]
     ): F[Byte => TypedSubHandler[F, CommonStates.None.type]] =
       for {
-        clientSignalPromise <- Sync[F].delay(Promise[Unit]())
+        clientSignalPromise <- Deferred[F, Unit]
         protocolInstance <- Sync[F].delay {
           val transitions =
-            new protocol.StateTransitionsServer[F](() => Sync[F].delay(clientSignalPromise.success(())).void)
+            new protocol.StateTransitionsServer[F](() => clientSignalPromise.complete(()).void)
           import transitions._
           TypedProtocolInstance(Parties.A)
             .withTransition(startNoneBusy)
@@ -204,39 +205,36 @@ object TypedProtocolSetFactory {
             sessionId,
             instance = protocolInstance,
             initialState = TypedProtocol.CommonStates.None,
-            outboundMessages = Source
-              .lazyFutureSource(() => implicitly[FToFuture[F]].apply(notifications))
-              .buffer(1, OverflowStrategy.dropHead)
-              .zip(Source.repeat(()).mapAsync(1)(_ => clientSignalPromise.future))
+            outboundMessages = notifications
+              .dropOldest(1)
+              .zip(Stream.repeatEval(clientSignalPromise.get))
               .map(_._1)
-              .tapAsyncF(1)(data => Logger[F].debug(show"Notifying peer of data=$data"))
+              .evalTap(data => Logger[F].debug(show"Notifying peer of data=$data"))
               .map(TypedProtocol.CommonMessages.Push(_))
               .map(OutboundMessage(_)),
             codec = multiplexerCodec
           )
       )
 
-    def notificationClient[F[_]: Async: Logger: FToFuture, T: Show: Transmittable](
+    def notificationClient[F[_]: Async: Logger, T: Show: Transmittable](
       protocol: NotificationProtocol[T]
     )(implicit
-      materializer: Materializer,
       tPushTypeTag: NetworkTypeTag[TypedProtocol.CommonMessages.Push[T]]
-    ): F[(Byte => TypedSubHandler[F, CommonStates.None.type], Source[T, NotUsed])] =
+    ): F[(Byte => TypedSubHandler[F, CommonStates.None.type], Stream[F, T])] =
       for {
-        (((offerF, completeF), demandSignal), source) <-
-          Sync[F].delay(
-            Source
-              .dropHeadQueue[F, T](8)
-              .tapAsyncF(1)(data => Logger[F].debug(show"Remote peer sent notification data=$data"))
-              // A Notification Client must send a `Start` message to the server before it will start
-              // pushing notifications. We can signal this message to the server once the returned Source here requests
-              // data for the first time
-              .viaMat(OnFirstDemandFlow[T])(Keep.both)
-              .preMaterialize()
-          )
+        demandSignal <- Deferred[F, Unit]
+        queue        <- Queue.circularBuffer[F, T](8)
+        stream =
+          // A Notification Client must send a `Start` message to the server before it will start
+          // pushing notifications. We can signal this message to the server once the returned Source here requests
+          // data for the first time
+          Stream.eval(demandSignal.complete(())) >>
+          Stream
+            .fromQueueUnterminated(queue)
+            .evalTap(data => Logger[F].debug(show"Remote peer sent notification data=$data"))
         instance <- Sync[F].delay {
           val transitions =
-            new protocol.StateTransitionsClient[F](update => offerF(update))
+            new protocol.StateTransitionsClient[F](update => queue.offer(update))
           import transitions._
           TypedProtocolInstance(Parties.B)
             .withTransition(startNoneBusy)
@@ -253,37 +251,23 @@ object TypedProtocolSetFactory {
             sessionId,
             instance,
             TypedProtocol.CommonStates.None,
-            Source
-              .future(demandSignal)
-              .map(_ => OutboundMessage(TypedProtocol.CommonMessages.Start))
-              .concat(Source.never)
-              .alsoTo(
-                Sink.onComplete(res => implicitly[FToFuture[F]].apply(completeF(res.failed.toOption)))
-              ),
+            Stream.eval(demandSignal.get.as(OutboundMessage(TypedProtocol.CommonMessages.Start))) ++
+            Stream.never[F],
             multiplexerCodec
           )
-      } yield (
-        subHandler,
-        source
-          .alsoTo(
-            Sink.onComplete(res => implicitly[FToFuture[F]].apply(completeF(res.failed.toOption)))
-          )
-          .mapMaterializedValue(_ => NotUsed)
-      )
+      } yield (subHandler, stream)
 
-    def requestResponseServer[F[_]: Async: FToFuture, Query: Transmittable, T: Transmittable](
+    def requestResponseServer[F[_]: Async, Query: Transmittable, T: Transmittable](
       protocol: RequestResponseProtocol[Query, T],
       fetch:    Query => F[Option[T]]
     )(implicit
-      materializer:     Materializer,
       queryGetTypeTag:  NetworkTypeTag[TypedProtocol.CommonMessages.Get[Query]],
       tResponseTypeTag: NetworkTypeTag[TypedProtocol.CommonMessages.Response[T]]
     ): F[Byte => TypedSubHandler[F, CommonStates.None.type]] =
       for {
-        ((offerResponse, completeResponse), responseSource) <- Sync[F].delay(
-          Source.backpressuredQueue[F, Option[T]](1).preMaterialize()
-        )
-        transitions = new protocol.ServerStateTransitions[F](fetch(_).flatMap(offerResponse))
+        queue <- Queue.bounded[F, Option[T]](1)
+        stream = Stream.fromQueueUnterminated(queue)
+        transitions = new protocol.ServerStateTransitions[F](fetch(_).flatMap(queue.offer))
         instance = {
           import transitions._
           TypedProtocolInstance(Parties.A)
@@ -303,35 +287,29 @@ object TypedProtocolSetFactory {
           sessionId,
           instance,
           TypedProtocol.CommonStates.None,
-          Source
-            .single(OutboundMessage(TypedProtocol.CommonMessages.Start))
-            .concat(responseSource.map(TypedProtocol.CommonMessages.Response(_)).map(OutboundMessage(_)))
-            .alsoTo(
-              Sink.onComplete(res => implicitly[FToFuture[F]].apply(completeResponse(res.failed.toOption)))
-            ),
+          Stream(OutboundMessage(TypedProtocol.CommonMessages.Start)) ++
+          stream.map(TypedProtocol.CommonMessages.Response(_)).map(OutboundMessage(_)),
           multiplexerCodec
         )
 
-    def requestResponseClient[F[_]: Async: FToFuture: Logger, Query: Transmittable, T: Transmittable](
+    def requestResponseClient[F[_]: Async: Logger, Query: Transmittable, T: Transmittable](
       protocol: RequestResponseProtocol[Query, T]
     )(implicit
-      materializer:     Materializer,
       queryGetTypeTag:  NetworkTypeTag[TypedProtocol.CommonMessages.Get[Query]],
       tResponseTypeTag: NetworkTypeTag[TypedProtocol.CommonMessages.Response[T]]
     ): F[(Byte => TypedSubHandler[F, CommonStates.None.type], Query => F[Option[T]])] =
       for {
-        responsePromisesQueue <- Sync[F].defer(Queue.bounded[F, Promise[Option[T]]](2))
-        serverSentStartPromise = Promise[Unit]()
+        responsePromisesQueue  <- Sync[F].defer(Queue.bounded[F, Deferred[F, Option[T]]](2))
+        serverSentStartPromise <- Deferred[F, Unit]
         transitions =
           new protocol.ClientStateTransitions[F](
             r =>
               OptionT(responsePromisesQueue.tryTake).foldF(
                 MonadThrow[F].raiseError(new IllegalStateException("Unexpected response from server")).void
-              )(_.success(r).pure[F].void),
+              )(_.complete(r).void),
             () =>
-              Sync[F].delay(serverSentStartPromise.success(())) >> Logger[F].debug(
-                s"Server is accepting request-response requests of type=${tResponseTypeTag.name}"
-              )
+              serverSentStartPromise.complete(()) >>
+              Logger[F].debug(s"Server is accepting request-response requests of type=${tResponseTypeTag.name}")
           )
         instance = {
           import transitions._
@@ -341,18 +319,15 @@ object TypedProtocolSetFactory {
             .withTransition(responseBusyIdle)
             .withTransition(doneIdleDone)
         }
-        ((offerOutbound, completeOutbound), outboundSource) =
-          Source
-            .backpressuredQueue[F, OutboundMessage](1)
-            .preMaterialize()
+        queue <- Queue.bounded[F, OutboundMessage](1)
+        stream = Stream.fromQueueUnterminated(queue)
         clientCallback = (query: Query) =>
-          Sync[F]
-            .delay(Promise[Option[T]]())
-            .flatMap(promise =>
+          Deferred[F, Option[T]]
+            .flatMap(deferred =>
               responsePromisesQueue
-                .offer(promise)
-                .flatTap(_ => offerOutbound(OutboundMessage(TypedProtocol.CommonMessages.Get(query))))
-                .productR(Async[F].fromFuture(promise.future.pure[F]))
+                .offer(deferred)
+                .flatTap(_ => queue.offer(OutboundMessage(TypedProtocol.CommonMessages.Get(query))))
+                .productR(deferred.get)
             )
         multiplexerCodec = MultiplexerCodecBuilder()
           .withCodec[TypedProtocol.CommonMessages.Start.type](1: Byte)
@@ -365,23 +340,7 @@ object TypedProtocolSetFactory {
             sessionId,
             instance,
             TypedProtocol.CommonStates.None,
-            Source
-              .future(serverSentStartPromise.future)
-              .flatMapConcat(_ => outboundSource)
-              .alsoTo(
-                Sink
-                  .onComplete(res =>
-                    implicitly[FToFuture[F]].apply(
-                      completeOutbound(res.failed.toOption) >> {
-                        def f: F[Unit] = OptionT(responsePromisesQueue.tryTake)
-                          .map(_.failure(res.failed.toOption.getOrElse(new IllegalStateException("Done early"))))
-                          .isEmpty
-                          .ifM(Applicative[F].unit, f)
-                        f
-                      }
-                    )
-                  )
-              ),
+            Stream.eval(serverSentStartPromise.get) >> stream,
             multiplexerCodec
           )
       } yield (subHandler, clientCallback)
@@ -411,7 +370,7 @@ case class TypedSubHandler[F[_], InitialState: NetworkTypeTag](
   sessionId:        Byte,
   instance:         TypedProtocolInstance[F],
   initialState:     InitialState,
-  outboundMessages: Source[OutboundMessage, _],
+  outboundMessages: Stream[F, OutboundMessage],
   codec:            MultiplexerCodec
 ) {
   type InState = InitialState
@@ -442,16 +401,12 @@ case class ReciprocatedTypedSubHandler[F[_], InitialState: NetworkTypeTag](
   byteB:          Byte
 ) {
 
-  def handlers(
-    connectionLeader: ConnectionLeader
-  ): NonEmptyChain[TypedSubHandler[F, InitialState]] =
+  def handlers(connectionLeader: ConnectionLeader): NonEmptyChain[TypedSubHandler[F, InitialState]] =
     NonEmptyChain(serverHandler(connectionLeader), clientHandler(connectionLeader))
 
-  def serverHandler(connectionLeader: ConnectionLeader): TypedSubHandler[F, InitialState] = serverHandlerF(
-    if (connectionLeader == ConnectionLeaders.Local) byteA else byteB
-  )
+  def serverHandler(connectionLeader: ConnectionLeader): TypedSubHandler[F, InitialState] =
+    serverHandlerF(if (connectionLeader == ConnectionLeaders.Local) byteA else byteB)
 
-  def clientHandler(connectionLeader: ConnectionLeader): TypedSubHandler[F, InitialState] = clientHandlerF(
-    if (connectionLeader == ConnectionLeaders.Local) byteB else byteA
-  )
+  def clientHandler(connectionLeader: ConnectionLeader): TypedSubHandler[F, InitialState] =
+    clientHandlerF(if (connectionLeader == ConnectionLeaders.Local) byteB else byteA)
 }

--- a/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
+++ b/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
@@ -137,7 +137,7 @@ object TypedProtocolSetFactory {
               }
             prefix -> ByteString(byteVector.toArray)
           }
-          .map((MessageSerializerFramer.function _).tupled)
+          .map(MessageSerializerFramer.functionTupled)
 
     }
   }

--- a/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
+++ b/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
@@ -394,7 +394,7 @@ case class TypedProtocolTransitionFailureException(message: Any, reason: TypedPr
  * @param byteB The session ID byte of the client when the local node is the connection leader, or the ID byte of the
  *              server when the remote node is the connection leader
  */
-case class ReciprocatedTypedSubHandler[F[_], InitialState: NetworkTypeTag](
+case class ReciprocatedTypedSubHandler[F[_], InitialState](
   serverHandlerF: Byte => TypedSubHandler[F, InitialState],
   clientHandlerF: Byte => TypedSubHandler[F, InitialState],
   byteA:          Byte,

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
@@ -1,7 +1,5 @@
 package co.topl.networking.blockchain
 
-import akka.NotUsed
-import akka.stream.scaladsl.Source
 import cats._
 import cats.data.OptionT
 import cats.effect.kernel.Sync
@@ -11,6 +9,7 @@ import co.topl.models.utility.Ratio
 import co.topl.networking.p2p.ConnectedPeer
 import co.topl.numerics.implicits._
 import co.topl.typeclasses.implicits._
+import fs2.Stream
 import org.typelevel.log4cats.Logger
 
 /**
@@ -26,12 +25,12 @@ trait BlockchainPeerClient[F[_]] {
   /**
    * A Source of block IDs that were adopted by the remote node
    */
-  def remotePeerAdoptions: F[Source[TypedIdentifier, NotUsed]]
+  def remotePeerAdoptions: F[Stream[F, TypedIdentifier]]
 
   /**
    * A Source of transaction IDs that were observed by the remote node
    */
-  def remoteTransactionNotifications: F[Source[TypedIdentifier, NotUsed]]
+  def remoteTransactionNotifications: F[Stream[F, TypedIdentifier]]
 
   /**
    * A Lookup to retrieve a remote SlotData by ID

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServer.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServer.scala
@@ -1,21 +1,20 @@
 package co.topl.networking.blockchain
 
-import akka.NotUsed
-import akka.stream.OverflowStrategy
-import akka.stream.scaladsl.Source
-import cats._
+import cats.effect.Async
 import co.topl.algebras.Store
+import co.topl.catsakka._
 import co.topl.models.{BlockBody, BlockHeader, SlotData, Transaction, TypedIdentifier}
 import cats.implicits._
 import co.topl.consensus.algebras.LocalChainAlgebra
 import co.topl.eventtree.EventSourcedState
+import fs2._
 
 /**
  * Serves local blockchain data to a remote peer
  */
 trait BlockchainPeerServer[F[_]] {
-  def localBlockAdoptions: F[Source[TypedIdentifier, NotUsed]]
-  def localTransactionNotifications: F[Source[TypedIdentifier, NotUsed]]
+  def localBlockAdoptions: F[Stream[F, TypedIdentifier]]
+  def localTransactionNotifications: F[Stream[F, TypedIdentifier]]
   def getLocalSlotData(id:          TypedIdentifier): F[Option[SlotData]]
   def getLocalHeader(id:            TypedIdentifier): F[Option[BlockHeader]]
   def getLocalBody(id:              TypedIdentifier): F[Option[BlockBody]]
@@ -27,23 +26,23 @@ object BlockchainPeerServer {
 
   object FromStores {
 
-    def make[F[_]: Monad](
+    def make[F[_]: Async](
       slotDataStore:                Store[F, TypedIdentifier, SlotData],
       headerStore:                  Store[F, TypedIdentifier, BlockHeader],
       bodyStore:                    Store[F, TypedIdentifier, BlockBody],
       transactionStore:             Store[F, TypedIdentifier, Transaction],
       blockHeights:                 EventSourcedState[F, Long => F[Option[TypedIdentifier]], TypedIdentifier],
       localChain:                   LocalChainAlgebra[F],
-      locallyAdoptedBlockIds:       F[Source[TypedIdentifier, NotUsed]],
-      locallyAdoptedTransactionIds: F[Source[TypedIdentifier, NotUsed]]
+      locallyAdoptedBlockIds:       F[Stream[F, TypedIdentifier]],
+      locallyAdoptedTransactionIds: F[Stream[F, TypedIdentifier]]
     ): F[BlockchainPeerServer[F]] =
       new BlockchainPeerServer[F] {
 
-        def localBlockAdoptions: F[Source[TypedIdentifier, NotUsed]] =
-          locallyAdoptedBlockIds.map(_.buffer(1, OverflowStrategy.dropHead))
+        def localBlockAdoptions: F[Stream[F, TypedIdentifier]] =
+          locallyAdoptedBlockIds.map(_.dropOldest(1))
 
-        def localTransactionNotifications: F[Source[TypedIdentifier, NotUsed]] =
-          locallyAdoptedTransactionIds.map(_.buffer(5, OverflowStrategy.dropHead))
+        def localTransactionNotifications: F[Stream[F, TypedIdentifier]] =
+          locallyAdoptedTransactionIds.map(_.dropOldest(5))
 
         def getLocalSlotData(id: TypedIdentifier): F[Option[SlotData]] = slotDataStore.get(id)
 

--- a/networking/src/main/scala/co/topl/networking/multiplexer/MessageSerializerFramer.scala
+++ b/networking/src/main/scala/co/topl/networking/multiplexer/MessageSerializerFramer.scala
@@ -12,9 +12,8 @@ import akka.util.ByteString
 object MessageSerializerFramer {
 
   def apply(): Flow[(Byte, ByteString), ByteString, NotUsed] =
-    Flow[(Byte, ByteString)]
-      .map((function _).tupled)
+    Flow[(Byte, ByteString)].map(functionTupled)
 
-  def function(typeByte: Byte, data: ByteString): ByteString =
-    ByteString(typeByte) ++ intToBytestring(data.length) ++ data
+  val functionTupled: Function1[(Byte, ByteString), ByteString] =
+    t => ByteString(t._1) ++ intToBytestring(t._2.length) ++ t._2
 }

--- a/networking/src/main/scala/co/topl/networking/multiplexer/MessageSerializerFramer.scala
+++ b/networking/src/main/scala/co/topl/networking/multiplexer/MessageSerializerFramer.scala
@@ -13,7 +13,8 @@ object MessageSerializerFramer {
 
   def apply(): Flow[(Byte, ByteString), ByteString, NotUsed] =
     Flow[(Byte, ByteString)]
-      .map { case (typeByte, data) =>
-        ByteString(typeByte) ++ intToBytestring(data.length) ++ data
-      }
+      .map((function _).tupled)
+
+  def function(typeByte: Byte, data: ByteString): ByteString =
+    ByteString(typeByte) ++ intToBytestring(data.length) ++ data
 }

--- a/networking/src/main/scala/co/topl/networking/p2p/AkkaP2PServer.scala
+++ b/networking/src/main/scala/co/topl/networking/p2p/AkkaP2PServer.scala
@@ -86,7 +86,7 @@ object AkkaP2PServer {
       }
       .to(Sink.ignore)
 
-  private def makePeerHandlerFlowWithRemovalF[F[_]: Monad: FToFuture, Client](
+  private def makePeerHandlerFlowWithRemovalF[F[_]: FToFuture, Client](
     peerHandler:           ConnectedPeer => F[Flow[ByteString, ByteString, F[Client]]],
     offerConnectionChange: PeerConnectionChange[Client] => F[Unit]
   ) =

--- a/networking/src/main/scala/co/topl/networking/typedprotocols/TypedProtocolInstance.scala
+++ b/networking/src/main/scala/co/topl/networking/typedprotocols/TypedProtocolInstance.scala
@@ -39,7 +39,7 @@ case class TypedProtocolInstance[F[_]] private (
       )
     )
 
-  private def applyMessage[Message: NetworkTypeTag](
+  private def applyMessage[Message](
     message:                    Message,
     sender:                     Party,
     currentState:               Any,

--- a/networking/src/test/resources/logback-test.xml
+++ b/networking/src/test/resources/logback-test.xml
@@ -13,6 +13,7 @@
     </appender>
 
     <logger name="co.topl" level="INFO" />
+    <logger name="co.topl.networking" level="ERROR" />
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
@@ -1,17 +1,14 @@
 package co.topl.networking.blockchain
 
-import akka.NotUsed
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
-import akka.testkit.TestKit
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.implicits._
-import co.topl.catsakka._
 import co.topl.models._
 import co.topl.networking.p2p.ConnectedPeer
+import fs2._
 import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, EitherValues}
 import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}
@@ -19,8 +16,7 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 class BlockchainClientSpec
-    extends TestKit(ActorSystem("BlockchainClientSpec"))
-    with AnyFlatSpecLike
+    extends AnyFlatSpec
     with BeforeAndAfterAll
     with MockFactory
     with Matchers
@@ -40,9 +36,9 @@ class BlockchainClientSpec
         val client = new BlockchainPeerClient[F] {
           def remotePeer: F[ConnectedPeer] = ???
 
-          def remotePeerAdoptions: F[Source[TypedIdentifier, NotUsed]] = ???
+          def remotePeerAdoptions: F[Stream[F, TypedIdentifier]] = ???
 
-          def remoteTransactionNotifications: F[Source[TypedIdentifier, NotUsed]] = ???
+          def remoteTransactionNotifications: F[Stream[F, TypedIdentifier]] = ???
 
           def getRemoteSlotData(id: TypedIdentifier): F[Option[SlotData]] = ???
 

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactorySpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactorySpec.scala
@@ -1,17 +1,15 @@
 package co.topl.networking.blockchain
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
-import akka.testkit.TestKit
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.implicits._
-import co.topl.catsakka._
 import co.topl.models.TypedIdentifier
 import co.topl.networking.NetworkGen._
 import co.topl.networking.p2p.{ConnectedPeer, ConnectionLeader}
+import fs2._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}
 import org.typelevel.log4cats.Logger
@@ -20,8 +18,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scala.collection.immutable.SortedSet
 
 class BlockchainPeerConnectionFlowFactorySpec
-    extends TestKit(ActorSystem("BlockchainPeerConnectionFlowFactorySpec"))
-    with AnyFlatSpecLike
+    extends AnyFlatSpec
     with BeforeAndAfterAll
     with MockFactory
     with Matchers
@@ -42,12 +39,12 @@ class BlockchainPeerConnectionFlowFactorySpec
       (() => server.localBlockAdoptions)
         .expects()
         .once()
-        .returning(Source.never[TypedIdentifier].pure[F])
+        .returning(Stream.never[F].pure[F]: F[Stream[F, TypedIdentifier]])
 
       (() => server.localTransactionNotifications)
         .expects()
         .once()
-        .returning(Source.never[TypedIdentifier].pure[F])
+        .returning(Stream.never[F].pure[F]: F[Stream[F, TypedIdentifier]])
 
       val factory = BlockchainPeerConnectionFlowFactory.createFactory[F](server)
 

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -204,35 +204,33 @@ object NodeApp
         )
       )
       // Finally, run the program
-      _ <- Resource.eval(
-        Blockchain
-          .run[F](
-            clock,
-            staking,
-            dataStores.slotData,
-            dataStores.headers,
-            dataStores.bodies,
-            dataStores.transactions,
-            localChain,
-            blockIdTree,
-            blockHeightTree,
-            validators.header,
-            validators.headerToBody,
-            validators.transactionSyntax,
-            validators.bodySyntax,
-            validators.bodySemantics,
-            validators.bodyAuthorization,
-            mempool,
-            cryptoResources.ed25519VRF,
-            localPeer,
-            Stream.eval(clock.delayedUntilSlot(canonicalHeadSlotData.slotId.slot)) >>
-            Stream.iterable[F, DisconnectedPeer](appConfig.bifrost.p2p.knownPeers) ++
-            Stream.never[F],
-            (_: ConnectedPeer, flow) => flow,
-            appConfig.bifrost.rpc.bindHost,
-            appConfig.bifrost.rpc.bindPort
-          )
-      )
+      _ <- Blockchain
+        .make[F](
+          clock,
+          staking,
+          dataStores.slotData,
+          dataStores.headers,
+          dataStores.bodies,
+          dataStores.transactions,
+          localChain,
+          blockIdTree,
+          blockHeightTree,
+          validators.header,
+          validators.headerToBody,
+          validators.transactionSyntax,
+          validators.bodySyntax,
+          validators.bodySemantics,
+          validators.bodyAuthorization,
+          mempool,
+          cryptoResources.ed25519VRF,
+          localPeer,
+          Stream.eval(clock.delayedUntilSlot(canonicalHeadSlotData.slotId.slot)) >>
+          Stream.iterable[F, DisconnectedPeer](appConfig.bifrost.p2p.knownPeers) ++
+          Stream.never[F],
+          (_: ConnectedPeer, flow) => flow,
+          appConfig.bifrost.rpc.bindHost,
+          appConfig.bifrost.rpc.bindPort
+        )
     } yield ()
 
   private def makeStaking(


### PR DESCRIPTION
## Purpose
- An issue appears when multiple nodes try to exchange transactions due to an issue when converting between FS2 and akka-stream
  - The FS2 unicast stream was allocated to construct an akka-stream, but the FS2 stream was immediately closed
- Tracing the issue down led to some substantial refactoring of the Blockchain Peer Handler and Typed Protocol framework to rely less on akka-stream
- Unrelated, the Block Packer was slightly optimized to ignore transactions for which it did not locally possess its necessary ancestors.  This fixes a sporadic error log.
## Approach
- Updated rebroadcasters to return their own Topics instead of accepting as parameters
- Updated rebroadcasters to return Resources which close the Topics on exit
- Updated BlockchainPeerHandler to use FS2 instead of akka-stream
- Updated TypedProtocolSetFactory to (mostly) use FS2 instead of akka-stream
- Also added an FS2 helper which drops elements in the event of a slow downstream consumer
## Testing
- preparePR
- Local testnet simulation
## Tickets
- Relates to #2589 