### PR TITLE
TSDK-261 | Header Inserter in Genus

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/failure/Failure.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/failure/Failure.scala
@@ -10,9 +10,14 @@ abstract class Failure(message: String, exception: Option[RuntimeException] = No
 
 object Failures {
 
-  case class NoPreviousHeaderVertexFailure(blockId: (Byte, ByteVector), parentHeaderId: TypedIdentifier)
+  case class NoCurrentHeaderVertexFailure(blockId: ByteVector)
       extends Failure(
-        s"Block doesn't have a previous header vertex. blockId=[$blockId] parentHeaderId=[$parentHeaderId]"
+        s"Block doesn't have a header vertex. blockId=[$blockId]"
+      )
+
+  case class NoPreviousHeaderVertexFailure(blockId: ByteVector)
+      extends Failure(
+        s"Block doesn't have a previous header vertex. Previous blockId=[$blockId]"
       )
 
   case class NoBlockHeaderFoundOnNodeFailure(blockId: TypedIdentifier)

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphHeaderInserter.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphHeaderInserter.scala
@@ -1,0 +1,32 @@
+package co.topl.genusLibrary.interpreter
+
+import cats.data.EitherT
+import cats.effect.kernel.Async
+import cats.implicits._
+import co.topl.genusLibrary.algebras.{HeaderInserter, Mediator}
+import co.topl.genusLibrary.failure.Failure
+import co.topl.genusLibrary.model.BlockData
+import co.topl.genusLibrary.orientDb.DBFacade
+import co.topl.genusLibrary.orientDb.GenusGraphMetadata._
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+class GraphHeaderInserter[F[_]: Async](
+  orientDB: DBFacade,
+  mediator: Mediator[F]
+) extends HeaderInserter[F] {
+
+  implicit private val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
+
+  override def insert(block: BlockData): F[Either[Failure, Unit]] = {
+    val graph = orientDB.getGraph[F]
+
+    (for {
+      _ <- EitherT(graph.withEffectfulTransaction {
+        graph.createVertex(block.header).asRight[Failure].pure[F]
+      })
+      mediation <- EitherT(mediator.afterHeaderInserted(block))
+    } yield mediation).value
+  }
+
+}

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/DBFacade.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/DBFacade.scala
@@ -1,0 +1,81 @@
+package co.topl.genusLibrary.orientDb
+
+import cats.effect.kernel.Async
+import com.tinkerpop.blueprints.Vertex
+import com.tinkerpop.blueprints.impls.orient.OrientGraphNoTx
+
+private[genusLibrary] trait DBFacade {
+
+  type VertexTypeName = String
+
+  type PropertyKey = String
+  type PropertyQuery = (PropertyKey, AnyRef)
+
+  /**
+   * Shut down the OrientDB server.
+   *
+   * @return true if the server was running and got shut down
+   */
+  def shutdown(): Boolean
+
+  def getGraph[F[_]: Async: org.typelevel.log4cats.Logger]: GraphTxDAO[F]
+
+  def getGraphNoTx: OrientGraphNoTx
+
+  // TODO Unify VertexTypeName and PropertyKey with VertexSchema (VertexSchema.BlockHeader.BlockId)
+  /**
+   * Get single vertex filtered by only one field
+   *
+   * @param vertexTypeName Vertex class
+   * @param filterKey      Vertex key to filter by
+   * @param filterValue    Vertex value of given key to filter by
+   * @tparam F the effect-ful context to retrieve the value in
+   * @return Optional Vertex
+   */
+  def getVertex[F[_]: Async](
+    vertexTypeName: VertexTypeName,
+    filterKey:      PropertyKey,
+    filterValue:    AnyRef
+  ): F[Option[Vertex]]
+
+  /**
+   * Get single vertex filtered by multiple properties
+   *
+   * @param vertexTypeName   Vertex class
+   * @param propertiesFilter Vertex properties to filter by
+   * @tparam F the effect-ful context to retrieve the value in
+   * @return Optional Vertex
+   */
+  def getVertex[F[_]: Async](
+    vertexTypeName:   VertexTypeName,
+    propertiesFilter: Set[PropertyQuery]
+  ): F[Option[Vertex]]
+
+  /**
+   * Get vertices filtered by only one field
+   *
+   * @param vertexTypeName Vertices class
+   * @param filterKey      Vertices key to filter by
+   * @param filterValue    Vertices value of given key to filter by
+   * @tparam F the effect-ful context to retrieve the value in
+   * @return Vertices
+   */
+  def getVertices[F[_]: Async](
+    vertexTypeName: VertexTypeName,
+    filterKey:      PropertyKey,
+    filterValue:    AnyRef
+  ): F[Iterable[Vertex]]
+
+  /**
+   * Get vertices filtered by multiple properties
+   *
+   * @param vertexTypeName   Vertex class
+   * @param propertiesFilter Vertices properties to filter by
+   * @tparam F the effect-ful context to retrieve the value in
+   * @return Vertices
+   */
+  def getVertices[F[_]: Async](
+    vertexTypeName:   VertexTypeName,
+    propertiesFilter: Set[PropertyQuery]
+  ): F[Iterable[Vertex]]
+}

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/GraphTxDAO.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/GraphTxDAO.scala
@@ -16,12 +16,12 @@ class GraphTxDAO[F[_]: Async: Logger](wrappedGraph: GraphTxWrapper) {
   /**
    * Commits graph at the end of a function process if it ran successfully
    *
-   * @param transactionalFun function process wrapped in an effect-ful context that should be run inside a transaction
+   * @param transactional transactional process wrapped in an effect-ful context that should be run inside a transaction
    */
   def withEffectfulTransaction[T <: Any](
-    transactionalFun: GraphTxDAO[F] => F[Either[Failure, T]]
+    transactional: F[Either[Failure, T]]
   ): F[Either[Failure, T]] =
-    transactionalFun(this) flatMap withTransaction
+    transactional flatMap withTransaction
 
   /**
    * Vertex creator under the given graph on instantiation

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphHeaderInserterSpec.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphHeaderInserterSpec.scala
@@ -1,0 +1,154 @@
+package co.topl.genusLibrary.interpreter
+
+import cats.effect.IO
+import cats.effect.kernel.Async
+import cats.implicits._
+import co.topl.genusLibrary.algebras.Mediator
+import co.topl.genusLibrary.failure.Failure
+import co.topl.genusLibrary.model.BlockData
+import co.topl.genusLibrary.orientDb.GenusGraphMetadata.blockHeaderSchema
+import co.topl.genusLibrary.orientDb.wrapper.WrappedVertex
+import co.topl.genusLibrary.orientDb.{DBFacade, GraphTxDAO, VertexSchema}
+import co.topl.models.BlockHeader
+import co.topl.models.ModelGenerators._
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF
+import org.scalamock.munit.AsyncMockFactory
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+class GraphHeaderInserterSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+
+  type F[A] = IO[A]
+
+  private trait MediatorMock extends Mediator[F]
+
+  private class GraphTxDAOMock extends GraphTxDAO[F](null)
+
+  implicit private val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
+
+  private val orientDB = mock[DBFacade]
+  private val mediator = mock[MediatorMock]
+
+  val graphHeaderInserter = new GraphHeaderInserter[F](orientDB, mediator)
+
+  test("On failure to effect transaction, the mediator is not called and the DAO response is returned") {
+    PropF.forAllF { blockHeader: BlockHeader =>
+      withMock {
+        val blockData = BlockData(blockHeader, null, null)
+        val graphTxDao = mock[GraphTxDAOMock]
+        val wrappedVertex = mock[WrappedVertex]
+        val failureLeft = mock[Failure].asLeft[Unit]
+
+        (graphTxDao
+          .createVertex(_: BlockHeader)(_: VertexSchema[BlockHeader]))
+          .expects(blockHeader, blockHeaderSchema)
+          .returns((blockHeader, wrappedVertex))
+          .once()
+
+        (orientDB
+          .getGraph[F](_: Async[F], _: Logger[F]))
+          .expects(*, *)
+          .returns(graphTxDao)
+          .once()
+
+        (graphTxDao.withEffectfulTransaction[Unit] _)
+          .expects(*)
+          .returns(failureLeft.pure[F])
+          .once()
+
+        val response = graphHeaderInserter.insert(blockData)
+
+        assertIO(
+          response,
+          failureLeft
+        )
+      }
+    }
+  }
+
+  test("On success to effect transaction and successful mediator call, the successful mediator response is returned") {
+    PropF.forAllF { blockHeader: BlockHeader =>
+      withMock {
+
+        val blockData = BlockData(blockHeader, null, null)
+        val graphTxDao = mock[GraphTxDAOMock]
+        val wrappedVertex = mock[WrappedVertex]
+        val mediatorResponse = ().asRight[Failure]
+
+        (graphTxDao
+          .createVertex(_: BlockHeader)(_: VertexSchema[BlockHeader]))
+          .expects(blockHeader, blockHeaderSchema)
+          .returns((blockHeader, wrappedVertex))
+          .once()
+
+        (orientDB
+          .getGraph[F](_: Async[F], _: Logger[F]))
+          .expects(*, *)
+          .returns(graphTxDao)
+          .once()
+
+        (graphTxDao.withEffectfulTransaction[(BlockHeader, WrappedVertex)] _)
+          .expects(*)
+          .returns((blockHeader, wrappedVertex).asRight[Failure].pure[F])
+          .once()
+
+        (mediator.afterHeaderInserted _)
+          .expects(blockData)
+          .returns(mediatorResponse.pure[F])
+          .once
+
+        val response = graphHeaderInserter.insert(blockData)
+
+        assertIO(
+          response,
+          mediatorResponse
+        )
+
+      }
+    }
+  }
+
+  test("On success to effect transaction and failing mediator call, the failing mediator response is returned") {
+    PropF.forAllF { blockHeader: BlockHeader =>
+      withMock {
+
+        val blockData = BlockData(blockHeader, null, null)
+        val graphTxDao = mock[GraphTxDAOMock]
+        val wrappedVertex = mock[WrappedVertex]
+        val mediatorResponse = mock[Failure].asLeft[Unit]
+
+        (graphTxDao
+          .createVertex(_: BlockHeader)(_: VertexSchema[BlockHeader]))
+          .expects(blockHeader, blockHeaderSchema)
+          .returns((blockHeader, wrappedVertex))
+          .once()
+
+        (orientDB
+          .getGraph[F](_: Async[F], _: Logger[F]))
+          .expects(*, *)
+          .returns(graphTxDao)
+          .once()
+
+        (graphTxDao.withEffectfulTransaction[(BlockHeader, WrappedVertex)] _)
+          .expects(*)
+          .returns((blockHeader, wrappedVertex).asRight[Failure].pure[F])
+          .once()
+
+        (mediator.afterHeaderInserted _)
+          .expects(blockData)
+          .returns(mediatorResponse.pure[F])
+          .once
+
+        val response = graphHeaderInserter.insert(blockData)
+
+        assertIO(
+          response,
+          mediatorResponse
+        )
+
+      }
+    }
+  }
+
+}

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/GraphTxDAOSpec.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/GraphTxDAOSpec.scala
@@ -28,7 +28,7 @@ class GraphTxDAOSpec extends CatsEffectSuite with ScalaCheckEffectSuite with Asy
 
       val request = leftFailure.pure[F]
 
-      val response = graphTxDao.withEffectfulTransaction(_ => request)
+      val response = graphTxDao.withEffectfulTransaction(request)
 
       assertIO(
         response,
@@ -56,7 +56,7 @@ class GraphTxDAOSpec extends CatsEffectSuite with ScalaCheckEffectSuite with Asy
           .returns(())
           .once()
 
-        val response = graphTxDao.withEffectfulTransaction(_ => request)
+        val response = graphTxDao.withEffectfulTransaction(request)
 
         assertIO(
           response,
@@ -77,7 +77,7 @@ class GraphTxDAOSpec extends CatsEffectSuite with ScalaCheckEffectSuite with Asy
         .returns(())
         .once()
 
-      val response = graphTxDao.withEffectfulTransaction(_ => request)
+      val response = graphTxDao.withEffectfulTransaction(request)
 
       assertIO(
         response,


### PR DESCRIPTION
## Purpose
Developed header inserter. Refactored code to make it easier to test. Added tests.

## Approach
- Added two failures (no current vertex, no previous vertex)
- Updated `GraphTxDAO::withEffectfulTransaction` to make it more testable on the caller
- Created `DBFacade` so it's easier to mock `OrientDBFacade`.
- Updated and created tests

## Testing
- Added tests for `GraphHeaderInserter`

## Tickets
* TSDK-261