### PR TITLE
TSDK-262 | Header Mediator in Genus

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/Mediator.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/Mediator.scala
@@ -6,6 +6,7 @@ import co.topl.genusLibrary.model.BlockData
 import co.topl.models.{BlockBody, Transaction}
 import co.topl.proto.models.TypedEvidence
 
+// TODO: TSDK-278 | Split into multiple traits
 /**
  * Mediator of content inserted to a data store. Based on the Mediator software design pattern.
  * For more information, refer to <a href="https://en.wikipedia.org/wiki/Mediator_pattern">Mediator pattern</a>

--- a/genus-library/src/main/scala/co/topl/genusLibrary/failure/Failure.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/failure/Failure.scala
@@ -20,6 +20,11 @@ object Failures {
         s"Block doesn't have a previous header vertex. Previous blockId=[$blockId]"
       )
 
+  case class NoCurrentBodyVertexFailure(transactions: ByteVector)
+      extends Failure(
+        s"Block doesn't have a transactions vertex. transactions=[$transactions]"
+      )
+
   case class NoBlockHeaderFoundOnNodeFailure(blockId: TypedIdentifier)
       extends Failure(s"Block header wasn't found. BlockId=[$blockId]")
 

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphHeaderInserter.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphHeaderInserter.scala
@@ -6,13 +6,13 @@ import cats.implicits._
 import co.topl.genusLibrary.algebras.{HeaderInserter, Mediator}
 import co.topl.genusLibrary.failure.Failure
 import co.topl.genusLibrary.model.BlockData
-import co.topl.genusLibrary.orientDb.DBFacade
+import co.topl.genusLibrary.orientDb.StoreFacade
 import co.topl.genusLibrary.orientDb.GenusGraphMetadata._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 class GraphHeaderInserter[F[_]: Async](
-  orientDB: DBFacade,
+  orientDB: StoreFacade,
   mediator: Mediator[F]
 ) extends HeaderInserter[F] {
 

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphMediator.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphMediator.scala
@@ -1,0 +1,103 @@
+package co.topl.genusLibrary.interpreter
+
+import cats.data.EitherT
+import cats.effect.kernel.Async
+import cats.implicits._
+import co.topl.genusLibrary.algebras.Mediator
+import co.topl.genusLibrary.failure.{Failure, Failures}
+import co.topl.genusLibrary.model.BlockData
+import co.topl.genusLibrary.orientDb.DBFacade
+import co.topl.genusLibrary.orientDb.GenusGraphMetadata._
+import co.topl.genusLibrary.utils.BlockUtils
+import co.topl.models.{BlockBody, BlockHeader}
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import scodec.bits.ByteVector
+
+abstract class GraphMediator[F[_]: Async](
+  dbFacade:   DBFacade,
+  blockUtils: BlockUtils
+) extends Mediator[F] {
+
+  implicit private val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
+
+  override def afterHeaderInserted(block: BlockData): F[Either[Failure, Unit]] = {
+    val graph = dbFacade.getGraph
+    graph.withEffectfulTransaction {
+      (
+        for {
+          currentHeaderVertex <- EitherT(fetchCurrentHeaderVertex(block.header).flatTap {
+            case Right(_) =>
+              Logger[F].info(s"Found header vertex for block. Height=[${block.header.height}]")
+            case Left(_) =>
+              Logger[F].error(s"Didn't find header vertex for block. Height=[${block.header.height}]")
+          })
+          previousHeaderVertex <- EitherT(fetchPreviousHeaderVertex(block.header).flatTap {
+            case Right(_) => Logger[F].info(s"Found previous header vertex for block. Height=[${block.header.height}]")
+            case Left(_) =>
+              Logger[F]
+                .error(s"Didn't find previous header vertex for block. Height=[${block.header.height}]")
+          })
+          bodyVertex <- EitherT(fetchBodyVertex(block.body).flatTap {
+            case Right(_) => Logger[F].info(s"Found body vertex for block. Height=[${block.header.height}]")
+            case Left(_) =>
+              Logger[F]
+                .error(s"Didn't find body vertex for block. Height=[${block.header.height}]")
+          })
+          _ <- EitherT(
+            graph.addEdge(previousHeaderVertex, currentHeaderVertex).asRight[Failure].pure[F]
+          )
+          headerAndBodyEdge <- EitherT(
+            graph.addEdge(currentHeaderVertex, bodyVertex).asRight[Failure].pure[F]
+          )
+        } yield headerAndBodyEdge
+      ).value.map(_.map(_ => ()))
+    }
+  }
+
+  private def fetchCurrentHeaderVertex(header: BlockHeader) = {
+    val blockId = blockUtils.getBlockId(header)
+    dbFacade
+      .getVertexByField[F](
+        blockHeaderSchema.name,
+        "blockId",
+        blockId
+      )
+      .map(
+        _.toRight(
+          Failures.NoCurrentHeaderVertexFailure(ByteVector(blockId))
+        )
+      )
+  }
+
+  private def fetchPreviousHeaderVertex(header: BlockHeader) = {
+    val blockId = blockUtils.getParentBlockId(header)
+    dbFacade
+      .getVertexByField[F](
+        blockHeaderSchema.name,
+        "blockId",
+        blockId
+      )
+      .map(
+        _.toRight(
+          Failures.NoPreviousHeaderVertexFailure(ByteVector(blockId))
+        )
+      )
+  }
+
+  private def fetchBodyVertex(body: BlockBody) = {
+    val transactions = blockUtils.blockBodyToByteArray(body)
+    dbFacade
+      .getVertexByField[F](
+        blockBodySchema.name,
+        "transactionIds",
+        transactions
+      )
+      .map(
+        _.toRight(
+          Failures.NoCurrentBodyVertexFailure(ByteVector(transactions))
+        )
+      )
+  }
+
+}

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/DBFacade.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/DBFacade.scala
@@ -1,7 +1,7 @@
 package co.topl.genusLibrary.orientDb
 
 import cats.effect.kernel.Async
-import com.tinkerpop.blueprints.Vertex
+import co.topl.genusLibrary.orientDb.wrapper.WrappedVertex
 import com.tinkerpop.blueprints.impls.orient.OrientGraphNoTx
 
 private[genusLibrary] trait DBFacade {
@@ -32,11 +32,11 @@ private[genusLibrary] trait DBFacade {
    * @tparam F the effect-ful context to retrieve the value in
    * @return Optional Vertex
    */
-  def getVertex[F[_]: Async](
+  def getVertexByField[F[_]: Async](
     vertexTypeName: VertexTypeName,
     filterKey:      PropertyKey,
     filterValue:    AnyRef
-  ): F[Option[Vertex]]
+  ): F[Option[WrappedVertex]]
 
   /**
    * Get single vertex filtered by multiple properties
@@ -46,10 +46,10 @@ private[genusLibrary] trait DBFacade {
    * @tparam F the effect-ful context to retrieve the value in
    * @return Optional Vertex
    */
-  def getVertex[F[_]: Async](
+  def getVertexByFields[F[_]: Async](
     vertexTypeName:   VertexTypeName,
     propertiesFilter: Set[PropertyQuery]
-  ): F[Option[Vertex]]
+  ): F[Option[WrappedVertex]]
 
   /**
    * Get vertices filtered by only one field
@@ -60,11 +60,11 @@ private[genusLibrary] trait DBFacade {
    * @tparam F the effect-ful context to retrieve the value in
    * @return Vertices
    */
-  def getVertices[F[_]: Async](
+  def getVerticesByField[F[_]: Async](
     vertexTypeName: VertexTypeName,
     filterKey:      PropertyKey,
     filterValue:    AnyRef
-  ): F[Iterable[Vertex]]
+  ): F[Iterable[WrappedVertex]]
 
   /**
    * Get vertices filtered by multiple properties
@@ -74,8 +74,8 @@ private[genusLibrary] trait DBFacade {
    * @tparam F the effect-ful context to retrieve the value in
    * @return Vertices
    */
-  def getVertices[F[_]: Async](
+  def getVerticesByFields[F[_]: Async](
     vertexTypeName:   VertexTypeName,
     propertiesFilter: Set[PropertyQuery]
-  ): F[Iterable[Vertex]]
+  ): F[Iterable[WrappedVertex]]
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/GraphTxDAO.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/GraphTxDAO.scala
@@ -82,7 +82,7 @@ class GraphTxDAO[F[_]: Async: Logger](wrappedGraph: GraphTxWrapper) {
     transactionalFun match {
       case Left(ex) =>
         Logger[F]
-          .error(s"Something went wrong with the transaction function, won't commit. Error=[$ex]")
+          .error(s"Something went wrong with the processed transaction, won't commit. Error=[$ex]")
           .as(ex.asLeft)
       case Right(value) =>
         Logger[F].info("Committing transaction") >>

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBFacade.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBFacade.scala
@@ -19,7 +19,7 @@ import scala.util.{Random, Success, Try}
 /**
  * This is a class to hide the details of interacting with OrientDB.
  */
-private[genusLibrary] class OrientDBFacade(dir: File, password: String) extends DBFacade {
+private[genusLibrary] class OrientDBFacade(dir: File, password: String) extends StoreFacade {
   import OrientDBFacade._
   logger.info("Starting OrientDB with DB server")
   private val dbUserName = "admin"

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/StoreFacade.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/StoreFacade.scala
@@ -4,7 +4,7 @@ import cats.effect.kernel.Async
 import co.topl.genusLibrary.orientDb.wrapper.WrappedVertex
 import com.tinkerpop.blueprints.impls.orient.OrientGraphNoTx
 
-private[genusLibrary] trait DBFacade {
+private[genusLibrary] trait StoreFacade {
 
   type VertexTypeName = String
 

--- a/genus-library/src/main/scala/co/topl/genusLibrary/utils/BlockUtils.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/utils/BlockUtils.scala
@@ -1,0 +1,38 @@
+package co.topl.genusLibrary.utils
+
+import co.topl.codecs.bytes.tetra.{TetraIdentifiableInstances, TetraScodecCodecs}
+import co.topl.genusLibrary.GenusException
+import co.topl.models.{BlockBody, BlockHeader, TypePrefix}
+import scodec.Codec
+
+trait BlockUtils {
+
+  def getParentBlockId(header: BlockHeader): Array[Byte] = header.parentHeaderId.allBytes.toArray
+
+  def getBlockId(header: BlockHeader): Array[Byte] = {
+    val (typePrefix, bytes) = TetraIdentifiableInstances.identifiableBlockHeader.idOf(header)
+    typedBytesTupleToByteArray((typePrefix, bytes.toArray))
+  }
+
+  def blockBodyToByteArray(blockBody: BlockBody): Array[Byte] =
+    encodeToByteArray(blockBody, TetraScodecCodecs.blockBodyCodec, "BlockBody")
+
+  def typedBytesTupleToByteArray(id: (TypePrefix, Array[Byte])): Array[Byte] = {
+    val a: Array[Byte] = new Array(1 + id._2.length)
+    a(0) = id._1
+    Array.copy(id._2, 0, a, 1, id._2.length)
+    a
+  }
+
+  protected def encodeToByteArray[T <: java.io.Serializable](
+    scalaObject: T,
+    codec:       Codec[T],
+    typeName:    String
+  ): Array[Byte] =
+    codec
+      .encode(scalaObject)
+      .mapErr(err => throw GenusException(s"Error encoding $typeName: ${err.messageWithContext}"))
+      .require
+      .toByteArray
+
+}

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphHeaderInserterSpec.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphHeaderInserterSpec.scala
@@ -8,7 +8,7 @@ import co.topl.genusLibrary.failure.Failure
 import co.topl.genusLibrary.model.BlockData
 import co.topl.genusLibrary.orientDb.GenusGraphMetadata.blockHeaderSchema
 import co.topl.genusLibrary.orientDb.wrapper.WrappedVertex
-import co.topl.genusLibrary.orientDb.{DBFacade, GraphTxDAO, VertexSchema}
+import co.topl.genusLibrary.orientDb.{GraphTxDAO, StoreFacade, VertexSchema}
 import co.topl.models.BlockHeader
 import co.topl.models.ModelGenerators._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -27,7 +27,7 @@ class GraphHeaderInserterSpec extends CatsEffectSuite with ScalaCheckEffectSuite
 
   implicit private val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
 
-  private val orientDB = mock[DBFacade]
+  private val orientDB = mock[StoreFacade]
   private val mediator = mock[MediatorMock]
 
   val graphHeaderInserter = new GraphHeaderInserter[F](orientDB, mediator)

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphMediatorSpec.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphMediatorSpec.scala
@@ -8,7 +8,7 @@ import co.topl.genusLibrary.failure.{Failure, Failures}
 import co.topl.genusLibrary.model.BlockData
 import co.topl.genusLibrary.orientDb.GenusGraphMetadata.{blockBodySchema, blockHeaderSchema}
 import co.topl.genusLibrary.orientDb.wrapper.{WrappedEdge, WrappedVertex}
-import co.topl.genusLibrary.orientDb.{DBFacade, GraphTxDAO}
+import co.topl.genusLibrary.orientDb.{GraphTxDAO, StoreFacade}
 import co.topl.genusLibrary.utils.BlockUtils
 import co.topl.models.ModelGenerators._
 import co.topl.models.{BlockBody, BlockHeader, Transaction}
@@ -28,7 +28,7 @@ class GraphMediatorSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
 
   implicit private val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
 
-  private val dbFacade = mock[DBFacade]
+  private val dbFacade = mock[StoreFacade]
   private val blockUtils = mock[BlockUtils]
 
   private val graphMediator = new GraphMediator[F](dbFacade, blockUtils) {

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphMediatorSpec.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphMediatorSpec.scala
@@ -1,0 +1,385 @@
+package co.topl.genusLibrary.interpreter
+
+import cats.effect.IO
+import cats.effect.kernel.Async
+import cats.implicits._
+import co.topl.genusLibrary.Txo
+import co.topl.genusLibrary.failure.{Failure, Failures}
+import co.topl.genusLibrary.model.BlockData
+import co.topl.genusLibrary.orientDb.GenusGraphMetadata.{blockBodySchema, blockHeaderSchema}
+import co.topl.genusLibrary.orientDb.wrapper.{WrappedEdge, WrappedVertex}
+import co.topl.genusLibrary.orientDb.{DBFacade, GraphTxDAO}
+import co.topl.genusLibrary.utils.BlockUtils
+import co.topl.models.ModelGenerators._
+import co.topl.models.{BlockBody, BlockHeader, Transaction}
+import co.topl.proto.models.TypedEvidence
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF
+import org.scalamock.munit.AsyncMockFactory
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import scodec.bits.ByteVector
+
+class GraphMediatorSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+
+  type F[A] = IO[A]
+
+  private class GraphTxDAOMock extends GraphTxDAO[F](null)
+
+  implicit private val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
+
+  private val dbFacade = mock[DBFacade]
+  private val blockUtils = mock[BlockUtils]
+
+  private val graphMediator = new GraphMediator[F](dbFacade, blockUtils) {
+    override def afterBodyInserted(body: BlockBody, block: BlockData): F[Either[Failure, Unit]] = ???
+    override def afterTxInserted(transaction: Transaction, block: BlockData): F[Either[Failure, Unit]] = ???
+    override def afterAddressInserted(address: TypedEvidence, block: BlockData): F[Either[Failure, Unit]] = ???
+    override def afterTxoInserted(txo: Txo, block: BlockData): F[Either[Failure, Unit]] = ???
+    override def afterAddressStateInserted(block: BlockData): F[Either[Failure, Unit]] = ???
+  }
+
+  test("On no current header vertex, a NoCurrentHeaderVertexFailure should be returned") {
+
+    PropF.forAllF {
+      (
+        header:  BlockHeader,
+        blockId: Array[Byte]
+      ) =>
+        withMock {
+          val graphTxDao = mock[GraphTxDAOMock]
+
+          val leftFailure = Failures.NoCurrentHeaderVertexFailure(ByteVector(blockId)).asLeft[Unit]
+
+          (dbFacade
+            .getGraph[F](_: Async[F], _: Logger[F]))
+            .expects(*, *)
+            .returns(graphTxDao)
+            .once()
+
+          (blockUtils.getBlockId _)
+            .expects(header)
+            .returns(blockId)
+            .once()
+
+          (dbFacade
+            .getVertexByField[F](_: String, _: String, _: AnyRef)(_: Async[F]))
+            .expects(blockHeaderSchema.name, "blockId", blockId, *)
+            .returns(Option.empty[WrappedVertex].pure[F])
+            .once()
+
+          (graphTxDao.withEffectfulTransaction[Unit] _)
+            .expects(*)
+            .onCall((f: F[Either[Failure, Unit]]) => f.ensure(new IllegalArgumentException())(_ == leftFailure))
+            .once()
+
+          assertIO(
+            graphMediator.afterHeaderInserted(BlockData(header = header, body = null, transactions = null)),
+            leftFailure
+          )
+        }
+    }
+
+  }
+
+  test("On no previous header vertex, a NoCurrentHeaderVertexFailure should be returned") {
+
+    PropF.forAllF {
+      (
+        header:        BlockHeader,
+        blockId:       Array[Byte],
+        parentBlockId: Array[Byte]
+      ) =>
+        withMock {
+          val graphTxDao = mock[GraphTxDAOMock]
+          val currentHeaderVertex = mock[WrappedVertex]
+
+          val leftFailure = Failures.NoPreviousHeaderVertexFailure(ByteVector(parentBlockId)).asLeft[Unit]
+
+          (dbFacade
+            .getGraph[F](_: Async[F], _: Logger[F]))
+            .expects(*, *)
+            .returns(graphTxDao)
+            .once()
+
+          (blockUtils.getBlockId _)
+            .expects(header)
+            .returns(blockId)
+            .once()
+
+          (blockUtils.getParentBlockId _)
+            .expects(header)
+            .returns(parentBlockId)
+            .once()
+
+          (dbFacade
+            .getVertexByField[F](_: String, _: String, _: AnyRef)(_: Async[F]))
+            .expects(blockHeaderSchema.name, "blockId", blockId, *)
+            .returns(currentHeaderVertex.some.pure[F])
+            .once()
+
+          (dbFacade
+            .getVertexByField[F](_: String, _: String, _: AnyRef)(_: Async[F]))
+            .expects(blockHeaderSchema.name, "blockId", parentBlockId, *)
+            .returns(Option.empty[WrappedVertex].pure[F])
+            .once()
+
+          (graphTxDao.withEffectfulTransaction[Unit] _)
+            .expects(*)
+            .onCall((f: F[Either[Failure, Unit]]) => f.ensure(new IllegalArgumentException())(_ == leftFailure))
+            .once()
+
+          assertIO(
+            graphMediator.afterHeaderInserted(BlockData(header = header, body = null, transactions = null)),
+            leftFailure
+          )
+        }
+    }
+
+  }
+
+  test("On no body vertex, a NoCurrentBodyVertexFailure should be returned") {
+
+    PropF.forAllF {
+      (
+        header:        BlockHeader,
+        body:          BlockBody,
+        blockId:       Array[Byte],
+        parentBlockId: Array[Byte],
+        bodyArray:     Array[Byte]
+      ) =>
+        withMock {
+          val graphTxDao = mock[GraphTxDAOMock]
+          val currentHeaderVertex = mock[WrappedVertex]
+          val previousHeaderVertex = mock[WrappedVertex]
+
+          val leftFailure = Failures.NoCurrentBodyVertexFailure(ByteVector(bodyArray)).asLeft[Unit]
+
+          (dbFacade
+            .getGraph[F](_: Async[F], _: Logger[F]))
+            .expects(*, *)
+            .returns(graphTxDao)
+            .once()
+
+          (blockUtils.getBlockId _)
+            .expects(header)
+            .returns(blockId)
+            .once()
+
+          (blockUtils.getParentBlockId _)
+            .expects(header)
+            .returns(parentBlockId)
+            .once()
+
+          (blockUtils.blockBodyToByteArray _)
+            .expects(body)
+            .returns(bodyArray)
+            .once()
+
+          (dbFacade
+            .getVertexByField[F](_: String, _: String, _: AnyRef)(_: Async[F]))
+            .expects(blockHeaderSchema.name, "blockId", blockId, *)
+            .returns(currentHeaderVertex.some.pure[F])
+            .once()
+
+          (dbFacade
+            .getVertexByField[F](_: String, _: String, _: AnyRef)(_: Async[F]))
+            .expects(blockHeaderSchema.name, "blockId", parentBlockId, *)
+            .returns(previousHeaderVertex.some.pure[F])
+            .once()
+
+          (dbFacade
+            .getVertexByField[F](_: String, _: String, _: AnyRef)(_: Async[F]))
+            .expects(blockBodySchema.name, "transactionIds", bodyArray, *)
+            .returns(Option.empty[WrappedVertex].pure[F])
+            .once()
+
+          (graphTxDao.withEffectfulTransaction[Unit] _)
+            .expects(*)
+            .onCall((f: F[Either[Failure, Unit]]) => f.ensure(new IllegalArgumentException())(_ == leftFailure))
+            .once()
+
+          assertIO(
+            graphMediator.afterHeaderInserted(BlockData(header = header, body = body, transactions = null)),
+            leftFailure
+          )
+        }
+    }
+  }
+
+  test(
+    "On header, previous header and body vertices, " +
+    "on all edges created successfully but with transaction failure, it should be bubbled up"
+  ) {
+
+    PropF.forAllF {
+      (
+        header:        BlockHeader,
+        body:          BlockBody,
+        blockId:       Array[Byte],
+        parentBlockId: Array[Byte],
+        bodyArray:     Array[Byte]
+      ) =>
+        withMock {
+          val graphTxDao = mock[GraphTxDAOMock]
+          val currentHeaderVertex = mock[WrappedVertex]
+          val previousHeaderVertex = mock[WrappedVertex]
+          val bodyVertex = mock[WrappedVertex]
+          val headersEdge = mock[WrappedEdge]
+          val headerBodyEdge = mock[WrappedEdge]
+
+          val leftFailure = mock[Failure].asLeft[Unit]
+
+          (dbFacade
+            .getGraph[F](_: Async[F], _: Logger[F]))
+            .expects(*, *)
+            .returns(graphTxDao)
+            .once()
+
+          (blockUtils.getBlockId _)
+            .expects(header)
+            .returns(blockId)
+            .once()
+
+          (blockUtils.getParentBlockId _)
+            .expects(header)
+            .returns(parentBlockId)
+            .once()
+
+          (blockUtils.blockBodyToByteArray _)
+            .expects(body)
+            .returns(bodyArray)
+            .once()
+
+          (dbFacade
+            .getVertexByField[F](_: String, _: String, _: AnyRef)(_: Async[F]))
+            .expects(blockHeaderSchema.name, "blockId", blockId, *)
+            .returns(currentHeaderVertex.some.pure[F])
+            .once()
+
+          (dbFacade
+            .getVertexByField[F](_: String, _: String, _: AnyRef)(_: Async[F]))
+            .expects(blockHeaderSchema.name, "blockId", parentBlockId, *)
+            .returns(previousHeaderVertex.some.pure[F])
+            .once()
+
+          (dbFacade
+            .getVertexByField[F](_: String, _: String, _: AnyRef)(_: Async[F]))
+            .expects(blockBodySchema.name, "transactionIds", bodyArray, *)
+            .returns(bodyVertex.some.pure[F])
+            .once()
+
+          (graphTxDao
+            .addEdge(_: WrappedVertex, _: WrappedVertex, _: Option[String]))
+            .expects(previousHeaderVertex, currentHeaderVertex, None)
+            .returns(headersEdge)
+            .once()
+
+          (graphTxDao
+            .addEdge(_: WrappedVertex, _: WrappedVertex, _: Option[String]))
+            .expects(currentHeaderVertex, bodyVertex, None)
+            .returns(headerBodyEdge)
+            .once()
+
+          (graphTxDao.withEffectfulTransaction[Unit] _)
+            .expects(*)
+            .onCall((f: F[Either[Failure, Unit]]) =>
+              f.ensure(new IllegalArgumentException())(_ == ().asRight[Failure])
+                .map(_ => leftFailure)
+            )
+            .once()
+
+          assertIO(
+            graphMediator.afterHeaderInserted(BlockData(header = header, body = body, transactions = null)),
+            leftFailure
+          )
+        }
+    }
+  }
+
+  test(
+    "On header, previous header and body vertices, " +
+    "on all edges created successfully but with transaction success, original return should be bubbled up"
+  ) {
+
+    PropF.forAllF {
+      (
+        header:        BlockHeader,
+        body:          BlockBody,
+        blockId:       Array[Byte],
+        parentBlockId: Array[Byte],
+        bodyArray:     Array[Byte]
+      ) =>
+        withMock {
+          val graphTxDao = mock[GraphTxDAOMock]
+          val currentHeaderVertex = mock[WrappedVertex]
+          val previousHeaderVertex = mock[WrappedVertex]
+          val bodyVertex = mock[WrappedVertex]
+          val headersEdge = mock[WrappedEdge]
+          val headerBodyEdge = mock[WrappedEdge]
+
+          (dbFacade
+            .getGraph[F](_: Async[F], _: Logger[F]))
+            .expects(*, *)
+            .returns(graphTxDao)
+            .once()
+
+          (blockUtils.getBlockId _)
+            .expects(header)
+            .returns(blockId)
+            .once()
+
+          (blockUtils.getParentBlockId _)
+            .expects(header)
+            .returns(parentBlockId)
+            .once()
+
+          (blockUtils.blockBodyToByteArray _)
+            .expects(body)
+            .returns(bodyArray)
+            .once()
+
+          (dbFacade
+            .getVertexByField[F](_: String, _: String, _: AnyRef)(_: Async[F]))
+            .expects(blockHeaderSchema.name, "blockId", blockId, *)
+            .returns(currentHeaderVertex.some.pure[F])
+            .once()
+
+          (dbFacade
+            .getVertexByField[F](_: String, _: String, _: AnyRef)(_: Async[F]))
+            .expects(blockHeaderSchema.name, "blockId", parentBlockId, *)
+            .returns(previousHeaderVertex.some.pure[F])
+            .once()
+
+          (dbFacade
+            .getVertexByField[F](_: String, _: String, _: AnyRef)(_: Async[F]))
+            .expects(blockBodySchema.name, "transactionIds", bodyArray, *)
+            .returns(bodyVertex.some.pure[F])
+            .once()
+
+          (graphTxDao
+            .addEdge(_: WrappedVertex, _: WrappedVertex, _: Option[String]))
+            .expects(previousHeaderVertex, currentHeaderVertex, None)
+            .returns(headersEdge)
+            .once()
+
+          (graphTxDao
+            .addEdge(_: WrappedVertex, _: WrappedVertex, _: Option[String]))
+            .expects(currentHeaderVertex, bodyVertex, None)
+            .returns(headerBodyEdge)
+            .once()
+
+          (graphTxDao.withEffectfulTransaction[Unit] _)
+            .expects(*)
+            .onCall((f: F[Either[Failure, Unit]]) => f.ensure(new IllegalArgumentException())(_ == ().asRight[Failure]))
+            .once()
+
+          assertIO(
+            graphMediator.afterHeaderInserted(BlockData(header = header, body = body, transactions = null)),
+            ().asRight[Failure]
+          )
+        }
+    }
+  }
+
+}


### PR DESCRIPTION
## Purpose
Added functionality to apply after header inserted logic through the mediator. Had to do some refactors to get it working. Tests were added.

## Approach
- Created `GraphHeaderMediator` and its tests
- Created `BlockUtils` utils trait
- `GenusGraphMetadata` object was refactored to use methods from `BlockUtils`. It's now easier to mock and test.
- 

## Testing
Created tests for `GraphHeaderMediator`.

## Tickets
* TSDK-262