### PR TITLE
Mempool.make Return Resource, Reduce Min Success Tests

### DIFF
--- a/ledger/src/main/scala/co/topl/ledger/interpreters/Mempool.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/Mempool.scala
@@ -1,7 +1,9 @@
 package co.topl.ledger.interpreters
 
+import cats.{Applicative, MonadThrow}
+import cats.data.OptionT
 import cats.effect.kernel.Spawn
-import cats.effect.{Async, Fiber, Ref, Sync}
+import cats.effect.{Async, Deferred, Fiber, Ref, Resource, Sync}
 import cats.implicits._
 import co.topl.algebras.ClockAlgebra
 import co.topl.codecs.bytes.tetra.instances._
@@ -35,9 +37,11 @@ object Mempool {
     onExpiration:                 TypedIdentifier => F[Unit],
     defaultExpirationLimit:       Long,
     duplicateSpenderSlotLifetime: Long
-  ): F[MempoolAlgebra[F]] =
+  ): Resource[F, MempoolAlgebra[F]] =
     for {
-      state <- Ref.of(Map.empty[TypedIdentifier, MempoolEntry[F]])
+      state <- Resource.make(Ref.of(Map.empty[TypedIdentifier, MempoolEntry[F]]))(
+        _.get.flatMap(_.values.toList.traverse(_.expirationFiber.cancel).void)
+      )
       // A function which inserts a transaction into the mempool and schedules its expiration using a Fiber
       addTransaction = (transaction: Transaction, expirationSlot: Slot) =>
         for {
@@ -91,24 +95,46 @@ object Mempool {
           .map(_.transactionIds.map(t => t: TypedIdentifier).toList)
           .flatMap(_.traverse(fetchTransaction(_).flatMap(addTransactionWithDefaultExpiration)))
           .as(state)
-      eventSourcedState <- EventSourcedState.OfTree.make[F, State[F], TypedIdentifier](
-        state.pure[F],
-        currentBlockId,
-        applyEvent = applyBlock,
-        unapplyEvent = unapplyBlock,
-        parentChildTree,
-        currentEventChanged
+      eventSourcedState <- Resource.eval(
+        EventSourcedState.OfTree.make[F, State[F], TypedIdentifier](
+          state.pure[F],
+          currentBlockId,
+          applyEvent = applyBlock,
+          unapplyEvent = unapplyBlock,
+          parentChildTree,
+          currentEventChanged
+        )
       )
+      finalizing <- Resource.make(Deferred[F, Unit])(_.complete(()).void)
     } yield new MempoolAlgebra[F] {
 
       def read(blockId: TypedIdentifier): F[Set[TypedIdentifier]] =
-        eventSourcedState.stateAt(blockId).flatMap(_.get).map(_.keySet)
+        whenNotTerminated(
+          eventSourcedState.stateAt(blockId).flatMap(_.get).map(_.keySet)
+        )
 
       // TODO: Check for double-spends along current canonical chain?
       def add(transactionId: TypedIdentifier): F[Unit] =
-        fetchTransaction(transactionId).flatMap(addTransactionWithDefaultExpiration)
+        whenNotTerminated(
+          fetchTransaction(transactionId).flatMap(addTransactionWithDefaultExpiration)
+        )
 
       def remove(transactionId: TypedIdentifier): F[Unit] =
-        state.update(_ - transactionId)
+        whenNotTerminated(
+          state
+            .getAndUpdate(_ - transactionId)
+            .flatTap(entries =>
+              OptionT.fromOption[F](entries.get(transactionId)).foldF(Applicative[F].unit)(_.expirationFiber.cancel)
+            )
+            .void
+        )
+
+      /**
+       * Verifies that the mempool is not terminated/finalizing before running the provided action.  If the mempool
+       * is terminated, the call will immediately fail
+       */
+      private def whenNotTerminated[T](f: => F[T]): F[T] =
+        OptionT(finalizing.tryGet)
+          .foldF(f)(_ => MonadThrow[F].raiseError(new IllegalStateException("Mempool Terminated")))
     }
 }

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -159,18 +159,16 @@ object NodeApp
           currentEventIdGetterSetters.canonicalHead.set
         )
       )
-      mempool <- Resource.eval(
-        Mempool.make[F](
-          currentEventIdGetterSetters.mempool.get(),
-          dataStores.bodies.getOrRaise,
-          dataStores.transactions.getOrRaise,
-          blockIdTree,
-          currentEventIdGetterSetters.mempool.set,
-          clock,
-          id => Logger[F].info(show"Expiring transaction id=$id"),
-          appConfig.bifrost.mempool.defaultExpirationSlots,
-          appConfig.bifrost.mempool.duplicateSpenderExpirationSlots
-        )
+      mempool <- Mempool.make[F](
+        currentEventIdGetterSetters.mempool.get(),
+        dataStores.bodies.getOrRaise,
+        dataStores.transactions.getOrRaise,
+        blockIdTree,
+        currentEventIdGetterSetters.mempool.set,
+        clock,
+        id => Logger[F].info(show"Expiring transaction id=$id"),
+        appConfig.bifrost.mempool.defaultExpirationSlots,
+        appConfig.bifrost.mempool.duplicateSpenderExpirationSlots
       )
       implicit0(networkRandom: Random) = new Random(new SecureRandom())
       staking <- privateBigBang.localStakerIndex


### PR DESCRIPTION
## Purpose
- MempoolSpec occasionally fails in GitHub Actions due to a timeout
## Approach
- Update Mempool.make to return a Resource
  - Cancel any background expiration fibers during resource finalization
- Reduce the minimum successful unit test requirement for MempoolSpec (main fix)
## Testing
- `preparePR`
## Tickets
N/A