### PR TITLE
Typed Protocol Pipelining (Part 1)

### DIFF
--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactory.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactory.scala
@@ -10,7 +10,6 @@ import co.topl.{models => legacyModels}
 import legacyModels.{SlotData, Transaction, TypedIdentifier}
 import co.topl.consensus.models.BlockHeader
 import co.topl.node.models.BlockBody
-import co.topl.networking.TypedProtocolSetFactory.implicits._
 import co.topl.networking._
 import co.topl.networking.blockchain.NetworkTypeTags._
 import co.topl.networking.p2p.{ConnectedPeer, ConnectionLeader}
@@ -33,7 +32,7 @@ object BlockchainPeerConnectionFlowFactory {
     (peer, leader) =>
       peerServerF(peer)
         .map(server => createFactory(server))
-        .flatMap(_.multiplexed(peer, leader))
+        .flatMap(TypedProtocolSetFactory.multiplexed(_)(peer, leader))
 
   private[blockchain] def createFactory[F[_]: Async: Logger](
     protocolServer: BlockchainPeerServerAlgebra[F]

--- a/networking/src/test/scala/co/topl/networking/typedprotocols/RequestResponseProtocolSpec.scala
+++ b/networking/src/test/scala/co/topl/networking/typedprotocols/RequestResponseProtocolSpec.scala
@@ -1,7 +1,7 @@
 package co.topl.networking.typedprotocols
 
 import cats.Applicative
-import cats.effect.IO
+import cats.effect.{Deferred, IO}
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import co.topl.networking.{NetworkTypeTag, Parties}
@@ -41,26 +41,31 @@ class RequestResponseProtocolSpec
         .withTransition(doneIdleDone)
     }
 
-    val applier = instance.applier(TypedProtocol.CommonStates.None).unsafeRunSync()
+    instance
+      .applier(TypedProtocol.CommonStates.None)(_ => Applicative[F].unit)
+      .use { applier =>
+        for {
+          _ <- applier(TypedProtocol.CommonMessages.Start, Parties.A)
 
-    val computation =
-      for {
-        _ <- applier(TypedProtocol.CommonMessages.Start, Parties.A).map(_.value)
-        _ = handlerF.expects(*).once().returning(Applicative[F].unit)
-        _ <- applier(TypedProtocol.CommonMessages.Get("foo"), Parties.B).map(_.value)
-        _ = handlerF.expects(*).never()
-        _ <- applier(TypedProtocol.CommonMessages.Response(none[Int]), Parties.A).map(_.value)
-        _ = handlerF.expects(*).once().returning(Applicative[F].unit)
-        _ <- applier(TypedProtocol.CommonMessages.Get("foo"), Parties.B).map(_.value)
-        _ = handlerF.expects(*).never()
-        _          <- applier(TypedProtocol.CommonMessages.Response(none[Int]), Parties.A).map(_.value)
-        finalState <- applier(TypedProtocol.CommonMessages.Done, Parties.B).map(_.value)
-      } yield finalState
+          d1 <- Deferred[F, Unit]
+          _ = handlerF.expects(*).once().returning(d1.complete(()).void)
+          _ <- applier(TypedProtocol.CommonMessages.Get("foo"), Parties.B)
+          _ <- d1.get
 
-    val finalState = computation.unsafeRunSync()
+          _ = handlerF.expects(*).never()
+          _ <- applier(TypedProtocol.CommonMessages.Response(none[Int]), Parties.A)
 
-    finalState shouldBe TypedProtocol.CommonStates.Done
+          d2 <- Deferred[F, Unit]
+          _ = handlerF.expects(*).once().returning(d2.complete(()).void)
+          _ <- applier(TypedProtocol.CommonMessages.Get("foo"), Parties.B)
+          _ <- d2.get
 
+          _ = handlerF.expects(*).never()
+          _ <- applier(TypedProtocol.CommonMessages.Response(none[Int]), Parties.A)
+          _ <- applier(TypedProtocol.CommonMessages.Done, Parties.B)
+        } yield ()
+      }
+      .unsafeRunSync()
   }
 
 }


### PR DESCRIPTION
## Purpose
- A TypedProtocol expects the "next message" to come from a particular party (depending on the previous message).  Receiving a message from the wrong party is a protocol violation.
- To enable better throughput, instead of a protocol violation, backpressure can instead be applied.  This would allow for multiple messages to be sent without waiting for a response for the first
## Approach
- Add queues to TypedProtocolInstance's "applier".  Add a background process to handle messages from the queues until failure or completion
## Testing
- preparePR
- Local Testnet Simulation
## Tickets
- BN-796
  - NOTE: There will be follow-up PRs for this ticket.  This PR only enables pipelined messages, but the rest of the code doesn't make use of it yet.