### PR TITLE
Publish all GCR images to the topl-artifacts-dev repository

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
       - 'dev'
       - 'release-**'
-      - 'BN-804-push-destination'
+      # - 'BN-804-remote-repository-destination'
 
 jobs:
   validate-helm:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
       - 'dev'
       - 'release-**'
-      # - 'BN-804-remote-repository-destination'
+      - 'BN-804-remote-repository-destination'
 
 jobs:
   validate-helm:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
       - 'dev'
       - 'release-**'
+      - 'BN-804-push-destination'
 
 jobs:
   validate-helm:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,6 @@ on:
       - 'main'
       - 'dev'
       - 'release-**'
-      - 'BN-804-remote-repository-destination'
 
 jobs:
   validate-helm:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,9 +23,5 @@ jobs:
     uses: ./.github/workflows/_docker_publish_private.yml
     needs: [sbt-build, sbt-integration-tests]
     with:
-      # Use the branch name to determine the "folder" in which the Docker images should be published.
-      # If this was a push to "main", the path would include `topl-artifacts-main`
-      # If this was a push to "dev", the path would include `topl-artifacts-dev`
-      # If this was a push to "release-2.0", the path would include `topl-artifacts-2.0`
-      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-${GITHUB_REF_NAME}"
+      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
     secrets: inherit


### PR DESCRIPTION
## Purpose
- The GCR images were originally expected to land in a repository based on the branch name (main, dev, release-**), but this approach requires the repository to already exist.
- This PR updates the destination to always publish to the dev repository
## Approach
- Set the remote-repository to always point to `topl-artifacts-dev`
## Testing
- Needs to be merged to main to verify
## Tickets
- Relates to BN-804