### PR TITLE
Timeout Testnet Orchestrator

### DIFF
--- a/helm/bifrost-consensus-testnet/override-example.yaml
+++ b/helm/bifrost-consensus-testnet/override-example.yaml
@@ -11,6 +11,10 @@ scenario:
   targetHeight: 30
   # The number of transactions to generate and broadcast per second.  Transactions are broadcasted to nodes at random.
   transactionsPerSecond: 2.5
+  # The maximum length of time to wait for an individual node to reach the target height.  If a node fails to reach
+  # the target height within this time, the scenario will still pass, but a log message will be presented
+  # indicating that it was terminated early.
+  timeout: 10 minutes
 
 # These settings will apply to the configurations of all nodes.
 shared-config:

--- a/helm/bifrost-consensus-testnet/templates/bifrost/orchestrator-config.yaml
+++ b/helm/bifrost-consensus-testnet/templates/bifrost/orchestrator-config.yaml
@@ -16,6 +16,7 @@ data:
       scenario:
         target-height: {{ $Values.scenario.targetHeight }}
         transactions-per-second: {{ $Values.scenario.transactionsPerSecond }}
+        timeout: {{ $Values.scenario.timeout }}
       publish:
         bucket: {{ $Values.results.bucket }}
         file-prefix: {{ $Values.results.prefix }}{{ .Release.Name }}/

--- a/helm/bifrost-consensus-testnet/values.yaml
+++ b/helm/bifrost-consensus-testnet/values.yaml
@@ -28,6 +28,7 @@ results:
 scenario:
   targetHeight: 30
   transactionsPerSecond: 2.0
+  timeout: 10 minutes
 
 resources:
   limits:

--- a/testnet-simulation-orchestrator/src/main/resources/application.conf
+++ b/testnet-simulation-orchestrator/src/main/resources/application.conf
@@ -1,5 +1,6 @@
 simulation-orchestrator {
   scenario {
     transactions-per-second = 1
+    timeout = 10 minutes
   }
 }

--- a/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/app/ApplicationConfig.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/app/ApplicationConfig.scala
@@ -6,6 +6,8 @@ import monocle.macros.Lenses
 import pureconfig.ConfigSource
 import pureconfig.generic.auto._
 
+import scala.concurrent.duration.FiniteDuration
+
 @Lenses
 case class ApplicationConfig(
   simulationOrchestrator: ApplicationConfig.SimulationOrchestrator
@@ -27,7 +29,7 @@ object ApplicationConfig {
     case class Kubernetes(namespace: String)
 
     @Lenses
-    case class Scenario(targetHeight: Long, transactionsPerSecond: Double)
+    case class Scenario(targetHeight: Long, transactionsPerSecond: Double, timeout: FiniteDuration)
 
     @Lenses
     case class Node(name: String, host: String, port: Int)

--- a/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/app/Orchestrator.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/app/Orchestrator.scala
@@ -172,6 +172,11 @@ object Orchestrator
           }
           // Stop listening once a node adopts a block at the target height.
           .takeWhile(_._3.height <= appConfig.simulationOrchestrator.scenario.targetHeight)
+          .mergeHaltBoth(
+            Stream.sleep[F](appConfig.simulationOrchestrator.scenario.timeout) >> Stream.exec(
+              Logger[F].warn(show"node=$name timed out.  Simulation results may be incomplete for this node.")
+            )
+          )
           .compile
           .toVector
         _ <- Logger[F].info(show"Finished fetching adoptions+headers from node=$name")


### PR DESCRIPTION
## Purpose
- Certain testnet conditions may result in a scenario that logically never terminates (i.e. a relay node with no connected peers)
- Semi-related: The K8s API may return an error, but the error message isn't fully logged
## Approach
- Add a timeout to the header adoptions stream, make it configurable
- Add logging to the K8sSimulationController error
## Testing
- Local testnet with a timeout of 5 seconds
  ![image](https://user-images.githubusercontent.com/2218886/217903562-3b13b0c5-1790-4189-9ce2-5d487f0a638f.png)
## Tickets
- BN-826