### PR TITLE
Disable Docker "latest" Tag

### DIFF
--- a/.github/workflows/_docker_publish_public.yml
+++ b/.github/workflows/_docker_publish_public.yml
@@ -30,4 +30,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images to registries
-        run: sbt Docker/publish
+        run: DOCKER_PUBLISH_LATEST_TAG=false sbt Docker/publish

--- a/.github/workflows/_docker_publish_public.yml
+++ b/.github/workflows/_docker_publish_public.yml
@@ -30,4 +30,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images to registries
-        run: DOCKER_PUBLISH_LATEST_TAG=false sbt Docker/publish
+        run: DOCKER_PUBLISH_LATEST_TAG=false sbt node/Docker/publish

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ lazy val commonSettings = Seq(
 
 lazy val dockerSettings = Seq(
   dockerBaseImage := "eclipse-temurin:11-jre",
-  dockerUpdateLatest := true,
+  dockerUpdateLatest := sys.env.get("DOCKER_PUBLISH_LATEST_TAG").fold(true)(_.toBoolean),
   dockerLabels ++= Map(
     "bifrost.version" -> version.value
   ),


### PR DESCRIPTION
## Purpose
- Publishing the public Tetra docker image to DockerHub and GHCR would result in updating the `latest` tag.  This may break environments that still expect `latest` to point to Dion
- For now, disable setting the "latest" tag in our public Tetra images
- Also, only publish the `node` image (disables publishing the `network-delayer` and `testnet-simulation-orchestrator` images)
## Approach
- Modify build.sbt `dockerUpdateLatest` setting to read from environment variable `DOCKER_PUBLISH_LATEST_TAG` or default to `true`
- Defaulting to `true` is convenient for working in local environments (i.e. local testnet simulations)
## Testing
- Locally tested the command `sbt Docker/publishLocal` which resulted in locally publishing the `latest` tags
- Locally tested the command `DOCKER_PUBLISH_LATEST_TAG=false sbt Docker/publishLocal` which did not result in locally publishing the `latest` tags
## Tickets
- BN-804