### PR TITLE
Create RBAC for Testnet Orchestrator Helm Chart

### DIFF
--- a/helm/bifrost-consensus-testnet/README.md
+++ b/helm/bifrost-consensus-testnet/README.md
@@ -1,5 +1,6 @@
 # Usage
 1. Copy file `override-example.yaml` into `override.yaml`.  Update values accordingly.
 1. Install the helm chart: `helm install -f /path/to/override.yaml --create-namespace --namespace scenario1 scenario1 ./bifrost-consensus-testnet`
-1. Observe the logs of each node the Kubernetes cluster in the `scenario1` namespace
-1. Terminate the scenario using  `helm delete -n scenario1 scenario1`
+   1. To capture output from the orchestrator: `(DEMO_NAME=your-demo-name; helm upgrade --install -f ./helm/bifrost-consensus-testnet/override-example.yaml --namespace $DEMO_NAME --create-namespace $DEMO_NAME ./helm/bifrost-consensus-testnet/ &&  kubectl wait --timeout=-1s --for=condition=Ready pod/$DEMO_NAME-bifrost-consensus-testnet-orchestrator -n $DEMO_NAME && kubectl logs --follow $DEMO_NAME-bifrost-consensus-testnet-orchestrator -n $DEMO_NAME)`
+2. Observe the logs of each node the Kubernetes cluster in the `scenario1` namespace
+3. Terminate the scenario using  `helm delete -n scenario1 scenario1`

--- a/helm/bifrost-consensus-testnet/templates/bifrost/orchestrator-pod.yaml
+++ b/helm/bifrost-consensus-testnet/templates/bifrost/orchestrator-pod.yaml
@@ -10,6 +10,7 @@ metadata:
     {{ $labels | nindent 4 }}
 spec:
   automountServiceAccountToken: true
+  serviceAccountName: {{ include "bifrost.serviceAccountName" . }}
   securityContext:
     {{- toYaml $Values.podSecurityContext | nindent 4 }}
   containers:
@@ -29,7 +30,7 @@ spec:
           cpu: 1500m
           memory: 1500Mi
         requests:
-          cpu: 100m
+          cpu: 400m
           memory: 1500Mi
       volumeMounts:
         - name: config-map

--- a/helm/bifrost-consensus-testnet/templates/bifrost/orchestrator-rb.yaml
+++ b/helm/bifrost-consensus-testnet/templates/bifrost/orchestrator-rb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "bifrost.fullname" . }}-rolebinding
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "bifrost.fullname" . }}-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bifrost.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/bifrost-consensus-testnet/templates/bifrost/orchestrator-role.yaml
+++ b/helm/bifrost-consensus-testnet/templates/bifrost/orchestrator-role.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "bifrost.fullname" . }}-role
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/exec", "pods/status", "events", "secrets", "configmaps", "serviceaccounts", "namespaces"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
+{{- end }}

--- a/helm/bifrost-consensus-testnet/templates/bifrost/orchestrator-sa.yaml
+++ b/helm/bifrost-consensus-testnet/templates/bifrost/orchestrator-sa.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bifrost.serviceAccountName" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/bifrost-consensus-testnet/values.yaml
+++ b/helm/bifrost-consensus-testnet/values.yaml
@@ -1,8 +1,8 @@
 name: bifrost-consensus-testnet
 
 image:
-#  name: bifrost-node
-#  name: ghcr.io/topl/bifrost-node
+  #  name: bifrost-node
+  #  name: ghcr.io/topl/bifrost-node
   name: localhost:32000/topl/bifrost-node
   tag: latest
 
@@ -78,3 +78,10 @@ readinessProbe:
   initialDelaySeconds: 30
   timeoutSeconds: 30
   periodSeconds: 60
+
+serviceAccount:
+  create: true
+  name: bifrost-orchestrator-account
+
+rbac:
+  create: true


### PR DESCRIPTION
## Purpose
In our GKE cluster, editing k8s objects is not allowed by default. This causes an issue with the testnet orchestrator since it tears itself down after running.

## Approach
* Create a service account for the orchestrator
* Create a k8s role to allow it to modify k8s objects, only in the namespace it is deployed to.
* Create a role binding to give the service account that role.

## Testing
Deployed in k8s

## Tickets
