### PR TITLE
Inherit Secrets in Publish DockerHub Step

### DIFF
--- a/.github/workflows/_docker_publish_public.yml
+++ b/.github/workflows/_docker_publish_public.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: olafurpg/setup-scala@v10
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
   publish-docker-images-official:
     uses: ./.github/workflows/_docker_publish_public.yml
     needs: [sbt-build, sbt-integration-tests]
+    secrets: inherit
   build-jar:
     uses: ./.github/workflows/_sbt_jar.yml
     needs: [sbt-build, sbt-integration-tests]


### PR DESCRIPTION
## Purpose
- When using sub-workflows, secrets are not inherited by default
- This caused null values for the DockerHub Username/Password in [this](https://github.com/Topl/Bifrost/actions/runs/4147987774/jobs/7175587288) workflow
## Approach
- Inherit secrets when publishing images
- Update action to v2
## Testing
N/A
## Tickets
- BN-804