### PR TITLE
Publish Docker Official Use Java 11

### DIFF
--- a/.github/workflows/_docker_publish_public.yml
+++ b/.github/workflows/_docker_publish_public.yml
@@ -10,11 +10,11 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout current branch
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
-      - uses: olafurpg/setup-scala@v10
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v2


### PR DESCRIPTION
## Purpose
- The "Official" Docker Release workflow installs Java 8, but the code requires Java 11
- See workflow [run](https://github.com/Topl/Bifrost/actions/runs/4164350811/jobs/7205981749)
## Approach
- Delete the "setup scala" step (fallback to assuming java/SBT are already installed, like the "Unofficial" workflow
## Testing
N/A
## Tickets
- BN-804