### PR TITLE
scala-steward-config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,32 @@
+# pullRequests.grouping allows you to specify how Scala Steward should group
+# your updates in order to reduce the number of pull-requests.
+#
+# Updates will be placed in the first group with which they match, starting
+# from the first in the array. Those that do not match any group will follow
+# the default procedure (one PR per update).
+#
+# Each element in the array will have the following schema:
+#
+#   - name (mandatory): the name of the group, will be used for things like naming the branch
+#   - title (optional): if provided it will be used as the title for the PR
+#   - filter (mandatory): a non-empty list containing the filters to use to know
+#                         if an update falls into this group.
+#
+# `filter` properties would have this format:
+#
+#    {
+#       version = "major" | "minor" | "patch" | "pre-release" | "build-metadata",
+#       group = "{group}",
+#       artifact = "{artifact}"
+#    }
+#
+# For more information on the values for the `version` filter visit https://semver.org/
+#
+# Every field in a `filter` is optional but at least one must be provided.
+#
+# For grouping every update togeher a filter like {group = "*"} can be # provided.
+#
+# Default: []
+pullRequests.grouping = [
+  {name = "all", title = "Dependency updates", "filter" = [{"group" = "*"}]}
+]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val orientDbVersion = "3.2.16"
 
   // Reference https://github.com/Topl/protobuf-specs/pull/32
-  val protobufSpecs = "com.github.Topl" % "protobuf-specs" % "c920f90"
+  val protobufSpecs = "com.github.Topl" % "protobuf-specs" % "c920f90" // scala-steward:off
 
   val catsSlf4j =
     "org.typelevel" %% "log4cats-slf4j" % "2.5.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,12 +3,12 @@ import sbt._
 object Dependencies {
 
   val akkaVersion = "2.6.20"
-  val circeVersion = "0.14.3"
+  val circeVersion = "0.14.4"
   val kamonVersion = "2.5.12"
   val simulacrumVersion = "1.0.1"
   val catsCoreVersion = "2.9.0"
   val catsEffectVersion = "3.4.1"
-  val fs2Version = "3.6.0"
+  val fs2Version = "3.6.1"
   val logback = "1.4.5"
   val orientDbVersion = "3.2.16"
 
@@ -243,7 +243,7 @@ object Dependencies {
     mUnitTest ++
     Seq(
       protobufSpecs,
-      "io.grpc" % "grpc-netty-shaded" % "1.52.1"
+      "io.grpc" % "grpc-netty-shaded" % "1.53.0"
     )
 
   lazy val levelDbStore: Seq[ModuleID] =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,9 +4,9 @@ logLevel := Level.Error
 addDependencyTreePlugin
 
 Seq(
-  "com.eed3si9n"            % "sbt-assembly"              % "2.0.0",
+  "com.eed3si9n"            % "sbt-assembly"              % "2.1.1",
   "org.scalastyle"         %% "scalastyle-sbt-plugin"     % "1.0.0",
-  "org.scoverage"           % "sbt-scoverage"             % "2.0.6",
+  "org.scoverage"           % "sbt-scoverage"             % "2.0.7",
   "com.github.sbt"          % "sbt-release"               % "1.1.0",
   "io.kamon"                % "sbt-kanela-runner"         % "2.0.14",
   "com.github.cb372"        % "sbt-explicit-dependencies" % "0.2.16",
@@ -14,7 +14,7 @@ Seq(
   "org.scalameta"           % "sbt-scalafmt"              % "2.5.0",
   "ch.epfl.scala"           % "sbt-scalafix"              % "0.10.4",
   "org.wartremover"         % "sbt-wartremover"           % "3.0.7",
-  "com.github.sbt"          % "sbt-native-packager"       % "1.9.11",
+  "com.github.sbt"          % "sbt-native-packager"       % "1.9.14",
   "com.eed3si9n"            % "sbt-buildinfo"             % "0.11.0",
   "com.github.sbt"          % "sbt-ci-release"            % "1.5.11",
   "net.bzzt"                % "sbt-reproducible-builds"   % "0.30"


### PR DESCRIPTION
## Purpose
- Gruop scala-steward Pr
- disable dependencies based on commits, (protobufSpecs) , avoid issues https://github.com/Topl/Bifrost/pull/2803
## Approach

- Update sbt-assembly to 2.1.1 in dev #2809
- Update sbt-scoverage to 2.0.7 in dev #2807
- Update grpc-netty-shaded to 1.53.0 in dev #2806
- Update circe-core, circe-generic, ... to 0.14.4 in dev #2805
- Update sbt-native-packager to 1.9.14 in dev #2804
- Update fs2-core, fs2-io, ... to 3.6.1 in dev #2802

We should close Pr's  ^^ if this one is merged

## Testing
We need to wait for next  scala-steward job
## Tickets
Todo
