### PR TITLE
BN-846-vrf-calculator-algebra-refactor-get-hit

### DIFF
--- a/minting/src/main/scala/co/topl/minting/algebras/StakingAlgebra.scala
+++ b/minting/src/main/scala/co/topl/minting/algebras/StakingAlgebra.scala
@@ -3,6 +3,7 @@ package co.topl.minting.algebras
 import co.topl.minting.models.VrfHit
 import co.topl.models._
 import co.topl.consensus.models.SlotId
+import co.topl.models.utility.Ratio
 
 /**
  * Staking means participating in the blockchain network.  A staker uses their funds to provide elgibility certificates.
@@ -19,4 +20,11 @@ trait StakingAlgebra[F[_]] {
     slot:                 Slot,
     unsignedBlockBuilder: BlockHeader.Unsigned.PartialOperationalCertificate => Block.Unsigned
   ): F[Option[Block]]
+
+  def getHit(
+    relativeStake: Ratio,
+    slot:          Slot,
+    slotDiff:      Long,
+    eta:           Eta
+  ): F[Option[VrfHit]]
 }

--- a/minting/src/main/scala/co/topl/minting/algebras/VrfCalculatorAlgebra.scala
+++ b/minting/src/main/scala/co/topl/minting/algebras/VrfCalculatorAlgebra.scala
@@ -1,6 +1,5 @@
 package co.topl.minting.algebras
 
-import co.topl.minting.models.VrfHit
 import co.topl.models._
 import co.topl.models.utility.Ratio
 
@@ -23,10 +22,4 @@ trait VrfCalculatorAlgebra[F[_]] {
     relativeStake: Ratio
   ): F[Vector[Slot]]
 
-  def getHit(
-    relativeStake: Ratio,
-    slot:          Slot,
-    slotDiff:      Long,
-    eta:           Eta
-  ): F[Option[VrfHit]]
 }

--- a/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
@@ -6,7 +6,11 @@ import cats.implicits._
 import co.topl.algebras.UnsafeResource
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
-import co.topl.consensus.algebras.{ConsensusValidationStateAlgebra, EtaCalculationAlgebra}
+import co.topl.consensus.algebras.{
+  ConsensusValidationStateAlgebra,
+  EtaCalculationAlgebra,
+  LeaderElectionValidationAlgebra
+}
 import co.topl.crypto.signing.Ed25519
 import co.topl.minting.algebras._
 import co.topl.minting.models.VrfHit
@@ -22,71 +26,91 @@ import org.typelevel.log4cats.{Logger, SelfAwareStructuredLogger}
 object Staking {
 
   def make[F[_]: Sync](
-    a:                   StakingAddresses.Operator,
-    operationalKeyMaker: OperationalKeyMakerAlgebra[F],
-    consensusState:      ConsensusValidationStateAlgebra[F],
-    etaCalculation:      EtaCalculationAlgebra[F],
-    ed25519Resource:     UnsafeResource[F, Ed25519],
-    vrfCalculator:       VrfCalculatorAlgebra[F]
-  ): StakingAlgebra[F] = new StakingAlgebra[F] {
-    implicit private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](Staking.getClass)
-    val address: F[StakingAddresses.Operator] = a.pure[F]
+    a:                        StakingAddresses.Operator,
+    vkVrf:                    VerificationKeys.VrfEd25519,
+    operationalKeyMaker:      OperationalKeyMakerAlgebra[F],
+    consensusState:           ConsensusValidationStateAlgebra[F],
+    etaCalculation:           EtaCalculationAlgebra[F],
+    ed25519Resource:          UnsafeResource[F, Ed25519],
+    vrfCalculator:            VrfCalculatorAlgebra[F],
+    leaderElectionValidation: LeaderElectionValidationAlgebra[F]
+  ): StakingAlgebra[F] =
+    new StakingAlgebra[F] { // TODO: Ask Sean, should we use the same pattern like VrfCalculator: F[StakingAlgebra[F]]
+      implicit private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](Staking.getClass)
+      val address: F[StakingAddresses.Operator] = a.pure[F]
 
-    def elect(parentSlotId: SlotId, slot: Slot): F[Option[VrfHit]] =
-      for {
-        eta <- etaCalculation.etaToBe(parentSlotId, slot)
-        maybeHit <- OptionT(consensusState.operatorRelativeStake(parentSlotId.blockId: TypedIdentifier, slot)(a))
-          .flatMapF(relativeStake => vrfCalculator.getHit(relativeStake, slot, slot - parentSlotId.slot, eta))
-          .value
-        _ <- Logger[F].debug(
-          show"Eligibility at" +
-          show" slot=$slot" +
-          show" parentId=${parentSlotId.blockId}" +
-          show" parentSlot=${parentSlotId.slot}" +
-          show" eligible=${maybeHit.nonEmpty}"
-        )
-      } yield maybeHit
-
-    def certifyBlock(
-      parentSlotId:         SlotId,
-      slot:                 Slot,
-      unsignedBlockBuilder: BlockHeader.Unsigned.PartialOperationalCertificate => Block.Unsigned
-    ): F[Option[Block]] =
-      OptionT(operationalKeyMaker.operationalKeyForSlot(slot, parentSlotId)).semiflatMap { operationalKeyOut =>
+      def elect(parentSlotId: SlotId, slot: Slot): F[Option[VrfHit]] =
         for {
-          partialCertificate <- Sync[F].delay(
-            BlockHeader.Unsigned.PartialOperationalCertificate(
+          eta <- etaCalculation.etaToBe(parentSlotId, slot)
+          maybeHit <- OptionT(consensusState.operatorRelativeStake(parentSlotId.blockId: TypedIdentifier, slot)(a))
+            .flatMapF(relativeStake => getHit(relativeStake, slot, slot - parentSlotId.slot, eta))
+            .value
+          _ <- Logger[F].debug(
+            show"Eligibility at" +
+            show" slot=$slot" +
+            show" parentId=${parentSlotId.blockId}" +
+            show" parentSlot=${parentSlotId.slot}" +
+            show" eligible=${maybeHit.nonEmpty}"
+          )
+        } yield maybeHit
+
+      def certifyBlock(
+        parentSlotId:         SlotId,
+        slot:                 Slot,
+        unsignedBlockBuilder: BlockHeader.Unsigned.PartialOperationalCertificate => Block.Unsigned
+      ): F[Option[Block]] =
+        OptionT(operationalKeyMaker.operationalKeyForSlot(slot, parentSlotId)).semiflatMap { operationalKeyOut =>
+          for {
+            partialCertificate <- Sync[F].delay(
+              BlockHeader.Unsigned.PartialOperationalCertificate(
+                operationalKeyOut.parentVK,
+                operationalKeyOut.parentSignature,
+                operationalKeyOut.childVK
+              )
+            )
+            unsignedBlock = unsignedBlockBuilder(partialCertificate)
+            messageToSign = unsignedBlock.unsignedHeader.signableBytes
+            signature <- ed25519Resource.use(_.sign(operationalKeyOut.childSK.bytes.data, messageToSign).pure[F])
+            operationalCertificate = OperationalCertificate(
               operationalKeyOut.parentVK,
               operationalKeyOut.parentSignature,
-              operationalKeyOut.childVK
+              partialCertificate.childVK,
+              Proofs.Knowledge.Ed25519(Sized.strictUnsafe(signature))
             )
-          )
-          unsignedBlock = unsignedBlockBuilder(partialCertificate)
-          messageToSign = unsignedBlock.unsignedHeader.signableBytes
-          signature <- ed25519Resource.use(_.sign(operationalKeyOut.childSK.bytes.data, messageToSign).pure[F])
-          operationalCertificate = OperationalCertificate(
-            operationalKeyOut.parentVK,
-            operationalKeyOut.parentSignature,
-            partialCertificate.childVK,
-            Proofs.Knowledge.Ed25519(Sized.strictUnsafe(signature))
-          )
-          header = BlockHeader(
-            unsignedBlock.unsignedHeader.parentHeaderId,
-            unsignedBlock.unsignedHeader.parentSlot,
-            unsignedBlock.unsignedHeader.txRoot,
-            unsignedBlock.unsignedHeader.bloomFilter,
-            unsignedBlock.unsignedHeader.timestamp,
-            unsignedBlock.unsignedHeader.height,
-            unsignedBlock.unsignedHeader.slot,
-            unsignedBlock.unsignedHeader.eligibilityCertificate,
-            operationalCertificate,
-            unsignedBlock.unsignedHeader.metadata,
-            unsignedBlock.unsignedHeader.address
-          )
-          // TODO use new models instead of Replace Model util
-          block = Block(ReplaceModelUtil.consensusHeader(header), ReplaceModelUtil.nodeBlock(unsignedBlock.body))
-        } yield block
-      }.value
-  }
+            header = BlockHeader(
+              unsignedBlock.unsignedHeader.parentHeaderId,
+              unsignedBlock.unsignedHeader.parentSlot,
+              unsignedBlock.unsignedHeader.txRoot,
+              unsignedBlock.unsignedHeader.bloomFilter,
+              unsignedBlock.unsignedHeader.timestamp,
+              unsignedBlock.unsignedHeader.height,
+              unsignedBlock.unsignedHeader.slot,
+              unsignedBlock.unsignedHeader.eligibilityCertificate,
+              operationalCertificate,
+              unsignedBlock.unsignedHeader.metadata,
+              unsignedBlock.unsignedHeader.address
+            )
+            // TODO use new models instead of Replace Model util
+            block = Block(ReplaceModelUtil.consensusHeader(header), ReplaceModelUtil.nodeBlock(unsignedBlock.body))
+          } yield block
+        }.value
 
+      def getHit(relativeStake: Ratio, slot: Slot, slotDiff: Long, eta: Eta): F[Option[VrfHit]] =
+        for {
+          threshold <- leaderElectionValidation.getThreshold(relativeStake, slotDiff)
+          testProof <- vrfCalculator.proofForSlot(slot, eta)
+          rho       <- vrfCalculator.rhoForSlot(slot, eta)
+          isLeader  <- leaderElectionValidation.isSlotLeaderForThreshold(threshold)(rho)
+          vrfHit <- OptionT
+            .when[F, VrfHit](isLeader)(
+              VrfHit(
+                EligibilityCertificate(testProof, vkVrf, threshold.typedEvidence.evidence, eta),
+                slot,
+                threshold
+              )
+            )
+            .value
+        } yield vrfHit
+
+    }
 }

--- a/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
@@ -63,7 +63,7 @@ class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
           _ = assert(result.isDefined)
           _ = assert(result.get == outputBlock)
           _ <- parents.offer(none)
-          _ <- results.take
+          _ <- results.take.assertEquals(None)
           _ <- resultFiber.joinWithNever
         } yield ()
       }

--- a/minting/src/test/scala/co/topl/minting/interpreters/StakingSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/StakingSpec.scala
@@ -1,0 +1,218 @@
+package co.topl.minting.interpreters
+
+import cats.effect.IO
+import cats.effect.IO.asyncForIO
+import cats.implicits._
+import co.topl.consensus.algebras.{
+  ConsensusValidationStateAlgebra,
+  EtaCalculationAlgebra,
+  LeaderElectionValidationAlgebra
+}
+import co.topl.consensus.models.{BlockId, SlotId}
+import co.topl.models.generators.consensus.ModelGenerators._
+import co.topl.minting.algebras.{OperationalKeyMakerAlgebra, VrfCalculatorAlgebra}
+import co.topl.minting.models.VrfHit
+import co.topl.models._
+import co.topl.models.utility._
+import co.topl.models.utility.HasLength.instances._
+import co.topl.models.utility.Lengths._
+import co.topl.models.utility.{Ratio, Sized}
+import co.topl.typeclasses.implicits._
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF
+import org.scalamock.munit.AsyncMockFactory
+import scodec.bits._
+
+class StakingSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+  type F[A] = IO[A]
+
+  test("elect: with fixed values") {
+    PropF.forAllF { (blockId: BlockId) =>
+      withMock {
+        val slot = 1L
+        val parentSlotId = SlotId.of(slot, blockId)
+        val eta = Sized.strictUnsafe(Bytes(Array.fill[Byte](32)(0))): Eta
+        val relativeStake = Ratio.One
+        val address =
+          StakingAddresses.Operator(
+            VerificationKeys.Ed25519(Sized.strictUnsafe(Bytes(Array.fill[Byte](32)(0))))
+          )
+
+        val vkVrf = VerificationKeys.VrfEd25519(Sized.strictUnsafe(Bytes(Array.fill[Byte](32)(0))))
+        val proof = Proofs.Knowledge.VrfEd25519(
+          Sized.strictUnsafe(
+            hex"bc31a2fb46995ffbe4b316176407f57378e2f3d7fee57d228a811194361d8e7040c9d15575d7a2e75506ffe1a47d772168b071a99d2e85511730e9c21397a1cea0e7fa4bd161e6d5185a94a665dd190d"
+          )
+        )
+        val rho = Rho(
+          Sized.strictUnsafe(
+            data =
+              hex"c30d2304d5d76e7cee8cc0eb66493528cc9e5a9cc03449bc8ed3dab192ba1e8edb3567b4ffc63526c69a6d05a73b57879529ccf8dd22e596080257843748d569"
+          )
+        )
+
+        val etaCalculation = mock[EtaCalculationAlgebra[F]]
+        val consensusState = mock[ConsensusValidationStateAlgebra[F]]
+        val leaderElectionValidation = mock[LeaderElectionValidationAlgebra[F]]
+        val vrfCalculator = mock[VrfCalculatorAlgebra[F]]
+
+        (etaCalculation.etaToBe _)
+          .expects(parentSlotId, slot)
+          .once()
+          .returning(eta.pure[F])
+
+        (consensusState
+          .operatorRelativeStake(_: TypedIdentifier, _: Slot)(_: StakingAddresses.Operator))
+          .expects(blockId: TypedIdentifier, slot, address)
+          .once()
+          .returning(relativeStake.some.pure[F])
+
+        (leaderElectionValidation.getThreshold _)
+          .expects(relativeStake, slot - parentSlotId.slot)
+          .once()
+          .returning(Ratio.One.pure[F])
+
+        (leaderElectionValidation
+          .isSlotLeaderForThreshold(_: Ratio)(_: Rho))
+          .expects(relativeStake, *)
+          .once()
+          .returning(true.pure[F])
+
+        (vrfCalculator.proofForSlot _)
+          .expects(slot, eta)
+          .twice()
+          .returning(proof.pure[F])
+
+        (vrfCalculator.rhoForSlot _)
+          .expects(slot, eta)
+          .once()
+          .returning(rho.pure[F])
+
+        for {
+          staking <- Staking
+            .make[F](
+              a = address,
+              vkVrf,
+              operationalKeyMaker = null,
+              consensusState,
+              etaCalculation,
+              ed25519Resource = null,
+              vrfCalculator,
+              leaderElectionValidation
+            )
+            .pure[F]
+
+          testProof <- vrfCalculator.proofForSlot(slot, eta)
+
+          expectedVrfHit = VrfHit(
+            EligibilityCertificate(testProof, vkVrf, relativeStake.typedEvidence.evidence, eta),
+            slot,
+            relativeStake
+          )
+          _ <- staking.elect(parentSlotId, slot).assertEquals(expectedVrfHit.some)
+        } yield ()
+      }
+    }
+  }
+
+  test("certifyBlock: with empty operationalKeyForSlot") {
+    PropF.forAllF { (parentSlotId: SlotId, slot: Slot) =>
+      withMock {
+        val operationalKeyMaker = mock[OperationalKeyMakerAlgebra[F]]
+        (operationalKeyMaker.operationalKeyForSlot _)
+          .expects(slot, parentSlotId)
+          .once()
+          .returning(None.pure[F])
+
+        for {
+          staking <- Staking
+            .make[F](
+              a = null,
+              vkVrf = null,
+              operationalKeyMaker,
+              consensusState = null,
+              etaCalculation = null,
+              ed25519Resource = null,
+              vrfCalculator = null,
+              leaderElectionValidation = null
+            )
+            .pure[F]
+          _ <- staking
+            .certifyBlock(parentSlotId, slot, _ => throw new NotImplementedError("unsignedBlockBuilder"))
+            .assertEquals(None)
+        } yield ()
+      }
+    }
+  }
+
+  test("getHit: with fixed values") {
+    withMock {
+      val slot = 1L
+      val slotDiff = 1L
+      val eta = Sized.strictUnsafe(Bytes(Array.fill[Byte](32)(0))): Eta
+      val relativeStake = Ratio.One
+      val vkVrf = VerificationKeys.VrfEd25519(Sized.strictUnsafe(Bytes(Array.fill[Byte](32)(0))))
+      val proof = Proofs.Knowledge.VrfEd25519(
+        Sized.strictUnsafe(
+          hex"bc31a2fb46995ffbe4b316176407f57378e2f3d7fee57d228a811194361d8e7040c9d15575d7a2e75506ffe1a47d772168b071a99d2e85511730e9c21397a1cea0e7fa4bd161e6d5185a94a665dd190d"
+        )
+      )
+      val rho = Rho(
+        Sized.strictUnsafe(
+          data =
+            hex"c30d2304d5d76e7cee8cc0eb66493528cc9e5a9cc03449bc8ed3dab192ba1e8edb3567b4ffc63526c69a6d05a73b57879529ccf8dd22e596080257843748d569"
+        )
+      )
+
+      val leaderElectionValidation = mock[LeaderElectionValidationAlgebra[F]]
+      val vrfCalculator = mock[VrfCalculatorAlgebra[F]]
+
+      (leaderElectionValidation.getThreshold _)
+        .expects(relativeStake, slotDiff)
+        .once()
+        .returning(Ratio.One.pure[F])
+
+      (leaderElectionValidation
+        .isSlotLeaderForThreshold(_: Ratio)(_: Rho))
+        .expects(relativeStake, *)
+        .once()
+        .returning(true.pure[F])
+
+      (vrfCalculator.proofForSlot _)
+        .expects(slot, eta)
+        .twice()
+        .returning(proof.pure[F])
+
+      (vrfCalculator.rhoForSlot _)
+        .expects(slot, eta)
+        .once()
+        .returning(rho.pure[F])
+
+      for {
+        staking <- Staking
+          .make[F](
+            a = null,
+            vkVrf,
+            operationalKeyMaker = null,
+            consensusState = null,
+            etaCalculation = null,
+            ed25519Resource = null,
+            vrfCalculator,
+            leaderElectionValidation
+          )
+          .pure[F]
+
+        testProof <- vrfCalculator.proofForSlot(slot, eta)
+
+        expectedVrfHit = VrfHit(
+          EligibilityCertificate(testProof, vkVrf, relativeStake.typedEvidence.evidence, eta),
+          slot,
+          relativeStake
+        )
+        _ <- staking.getHit(relativeStake, slot, slotDiff, eta).assertEquals(expectedVrfHit.some)
+      } yield ()
+
+    }
+  }
+
+}

--- a/models/src/test/scala/co/topl/models/generators/consensus/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/generators/consensus/ModelGenerators.scala
@@ -104,11 +104,15 @@ trait ModelGenerators {
       )
     )
 
-  implicit val blockIdGen: Gen[BlockId] =
-    genSizedStrictByteString[Lengths.`32`.type]().map(s => BlockId(s.data))
+  implicit val arbitraryBlockId: Arbitrary[BlockId] =
+    Arbitrary(
+      for {
+        value <- genSizedStrictByteString[Lengths.`32`.type]()
+      } yield BlockId.of(value.data)
+    )
 
   def headerGen(
-    parentHeaderIdGen:         Gen[BlockId] = blockIdGen,
+    parentHeaderIdGen:         Gen[BlockId] = arbitraryBlockId.arbitrary,
     parentSlotGen:             Gen[Long] = Gen.chooseNum(0L, 50L),
     txRootGen:                 Gen[ByteString] = genSizedStrictByteString[Lengths.`32`.type]().map(_.data),
     bloomFilterGen:            Gen[ByteString] = genSizedStrictByteString[Lengths.`256`.type]().map(_.data),
@@ -152,7 +156,7 @@ trait ModelGenerators {
     Arbitrary(
       for {
         slot    <- Gen.posNum[Long]
-        blockId <- blockIdGen
+        blockId <- arbitraryBlockId.arbitrary
       } yield SlotId.of(slot, blockId)
     )
 

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -253,7 +253,6 @@ object NodeApp
             // If uninitialized, generate a new key.  Otherwise, move on.
             .ifM(secureStore.write(UUID.randomUUID().toString, initializer.kesSK), Applicative[F].unit)
           vrfCalculator <- VrfCalculator.make[F](
-            initializer.vrfVK,
             initializer.vrfSK,
             clock,
             leaderElectionThreshold,
@@ -279,11 +278,13 @@ object NodeApp
           )
           staking = Staking.make(
             initializer.stakingAddress,
+            initializer.vrfVK,
             operationalKeys,
             consensusValidationState,
             etaCalculation,
             ed25519Resource,
-            vrfCalculator
+            vrfCalculator,
+            leaderElectionThreshold
           )
         } yield staking
       )


### PR DESCRIPTION
## Purpose
get-hit method in vrf calculator moved to staking

## Approach
move methos between algebras.

## Testing
- preparePR
- new unit test fot staking

## Tickets
closes #BN-846
