### PR TITLE
Multi-Node Byzantine Test

### DIFF
--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/IntegrationSuite.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/IntegrationSuite.scala
@@ -1,30 +1,17 @@
 package co.topl.tetra.it
 
-import co.topl.tetra.it.util.DockerSupport
-import com.spotify.docker.client.DefaultDockerClient
-import com.typesafe.scalalogging.{Logger, StrictLogging}
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, EitherValues, Suite}
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.concurrent.duration._
 
-trait IntegrationSuite extends BeforeAndAfterAll with ScalaFutures with EitherValues with StrictLogging {
-  self: Suite =>
+trait IntegrationSuite extends CatsEffectSuite {
+  type F[A] = IO[A]
 
-  protected def log: Logger = logger
+  implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
 
-  implicit val dockerClient: DefaultDockerClient = DefaultDockerClient.fromEnv().build()
-
-  val dockerSupport: DockerSupport = new DockerSupport(dockerClient)
-
-  implicit override val patienceConfig: PatienceConfig = PatienceConfig(2.seconds)
-
-  override def beforeAll(): Unit =
-    log.debug("Starting integration test")
-
-  override def afterAll(): Unit = {
-    dockerSupport.close()
-    dockerClient.close()
-  }
+  override def munitTimeout: Duration = 10.minutes
 
 }

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/MultiNodeTest.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/MultiNodeTest.scala
@@ -12,11 +12,11 @@ import scala.concurrent.duration._
 
 class MultiNodeTest extends IntegrationSuite {
 
-  override def munitTimeout: Duration = 30.minutes
+  override def munitTimeout: Duration = 15.minutes
 
   test("Multiple nodes launch and maintain consensus for three epochs") {
     val epochSlotLength = 500 // (50/4) * (100/15) * 6
-    val bigBang = Instant.now().plusSeconds(15)
+    val bigBang = Instant.now().plusSeconds(30)
     val config0 = DefaultConfig(bigBang, 3, 0, List("MultiNodeTest-node2"))
     val config1 = DefaultConfig(bigBang, 3, 1, List("MultiNodeTest-node0"))
     val config2 = DefaultConfig(bigBang, 3, 2, List("MultiNodeTest-node1"))
@@ -36,7 +36,7 @@ class MultiNodeTest extends IntegrationSuite {
         thirdEpochHeads <- nodes
           .parTraverse(
             _.rpcClient[F]
-              .use(_.adoptedHeaders.takeWhile(_.slot < (epochSlotLength * 3)).timeout(12.minutes).compile.lastOrError)
+              .use(_.adoptedHeaders.takeWhile(_.slot < (epochSlotLength * 3)).timeout(9.minutes).compile.lastOrError)
           )
           .toResource
         _ <- Logger[F].info("Nodes have reached target epoch").toResource

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/MultiNodeTest.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/MultiNodeTest.scala
@@ -1,0 +1,59 @@
+package co.topl.tetra.it
+
+import cats.effect.IO
+import cats.effect.implicits._
+import cats.implicits._
+import co.topl.tetra.it.util._
+import com.spotify.docker.client.DockerClient
+import org.typelevel.log4cats.Logger
+
+import java.time.Instant
+import scala.concurrent.duration._
+
+class MultiNodeTest extends IntegrationSuite {
+
+  override def munitTimeout: Duration = 30.minutes
+
+  test("Multiple nodes launch and maintain consensus for three epochs") {
+    val epochSlotLength = 500 // (50/4) * (100/15) * 6
+    val bigBang = Instant.now().plusSeconds(15)
+    val config0 = DefaultConfig(bigBang, 3, 0, List("MultiNodeTest-node2"))
+    val config1 = DefaultConfig(bigBang, 3, 1, List("MultiNodeTest-node0"))
+    val config2 = DefaultConfig(bigBang, 3, 1, List("MultiNodeTest-node1"))
+    val resource =
+      for {
+        (dockerSupport, _dockerClient) <- DockerSupport.make[F]
+        implicit0(dockerClient: DockerClient) = _dockerClient
+        node1 <- dockerSupport.createNode("MultiNodeTest-node0", "MultiNodeTest", config0)
+        node2 <- dockerSupport.createNode("MultiNodeTest-node1", "MultiNodeTest", config1)
+        node3 <- dockerSupport.createNode("MultiNodeTest-node2", "MultiNodeTest", config2)
+        nodes = List(node1, node2, node3)
+        _ <- nodes.parTraverse { node =>
+          node.startContainer[F] >>
+          node.rpcClient[F].use(_.waitForRpcStartUp)
+        }.toResource
+        _ <- Logger[F].info("Waiting for nodes to reach target epoch.  This may take several minutes.").toResource
+        thirdEpochHeads <- nodes
+          .parTraverse(
+            _.rpcClient[F]
+              .use(_.adoptedHeaders.takeWhile(_.slot < (epochSlotLength * 3)).timeout(12.minutes).compile.lastOrError)
+          )
+          .toResource
+        _ <- Logger[F].info("Nodes have reached target epoch").toResource
+        heights = thirdEpochHeads.map(_.height)
+        _ <- IO(heights.max - heights.min <= 5).assert.toResource // All nodes should be at _roughly_ equal height
+        _ <- nodes
+          .parTraverse(
+            _.rpcClient[F].use(
+              _.blockIdAtHeight(heights.min - 5)
+            )
+          )
+          .map(_.toSet.size)
+          .assertEquals(1)
+          .toResource // All nodes should have a shared common ancestor near the tip of the chain
+      } yield ()
+
+    resource.use_
+
+  }
+}

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/BifrostDockerTetraNode.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/BifrostDockerTetraNode.scala
@@ -1,3 +1,3 @@
 package co.topl.tetra.it.util
 
-case class BifrostDockerTetraNode(containerId: String)
+case class BifrostDockerTetraNode(containerId: String, name: String)

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
@@ -89,7 +89,7 @@ object DockerSupport {
             )
 
           val hostConfig =
-            HostConfig.builder().nanoCpus((1d * 1000000000).toLong).build()
+            HostConfig.builder().build()
 
           ContainerConfig
             .builder()

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
@@ -133,7 +133,7 @@ object DefaultConfig {
        |  p2p:
        |    bind-host: 0.0.0.0
        |    port: 9085
-       |    known-peers: ${knownPeers.map(p => s"$p:9085").mkString(",")}
+       |    known-peers: "${knownPeers.map(p => s"$p:9085").mkString(",")}"
        |  big-bang:
        |    staker-count: $stakerCount
        |    local-staker-index: $localStakerIndex

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
@@ -1,142 +1,142 @@
 package co.topl.tetra.it.util
 
+import cats.effect._
+import cats.implicits._
 import co.topl.buildinfo.node.BuildInfo
-import co.topl.tetra.it.util.DockerSupport._
-import com.spotify.docker.client.DockerClient
 import com.spotify.docker.client.messages.{ContainerConfig, HostConfig, NetworkConfig, NetworkCreation}
-import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
-import com.typesafe.scalalogging.StrictLogging
+import com.spotify.docker.client.{DefaultDockerClient, DockerClient}
 
-import java.nio.file.{Files, Path, Paths}
-import java.util.Comparator
+import java.time.Instant
 import scala.jdk.CollectionConverters._
 
-class DockerSupport(dockerClient: DockerClient) extends StrictLogging {
+trait DockerSupport[F[_]] {
 
-  private var nodeCache: Set[BifrostDockerTetraNode] = Set.empty
-
-  private var networkCache: Set[NetworkCreation] = Set.empty
-
-  // @TODO required exposed ports could be read from config
   def createNode(
     name:          String,
     nodeGroupName: String,
-    config:        Config = ConfigFactory.empty()
-  ): BifrostDockerTetraNode = {
-    val node = createContainer(name, nodeGroupName)
-    configureContainer(node.containerId, config)
-    node
-  }
+    configYaml:    String = ""
+  ): Resource[F, BifrostDockerTetraNode]
 
-  private def createContainer(name: String, nodeGroupName: String): BifrostDockerTetraNode = {
-    val networkName = DockerSupport.networkNamePrefix + nodeGroupName
-    val containerConfig = buildContainerConfig(name, Map.empty)
-    val containerCreation = dockerClient.createContainer(containerConfig, name)
-
-    val node = BifrostDockerTetraNode(containerCreation.id())
-    nodeCache += node
-
-    val networkId =
-      dockerClient.listNetworks().asScala.find(_.name == networkName) match {
-        case Some(network) => network.id()
-        case None =>
-          val network =
-            dockerClient.createNetwork(NetworkConfig.builder().name(networkName).build())
-          networkCache += network
-          network.id()
-      }
-
-    dockerClient.connectToNetwork(node.containerId, networkId)
-
-    node
-  }
-
-  private def configureContainer(containerId: String, config: Config): Unit = {
-    val configWithDefault = config.withFallback(DefaultConfig.config)
-    val renderedConfig = configWithDefault.root().render(ConfigRenderOptions.concise())
-    checkConfig(configWithDefault)
-
-    logger.info(s"Reconfiguring to: $renderedConfig")
-    require(!dockerClient.inspectContainer(containerId).state().running(), "Try to set configuration on running node")
-
-    val tmpConfigDirectory = Files.createTempDirectory("bifrost-test-config")
-    val testConfigPath = Paths.get(tmpConfigDirectory.toString, configFileName)
-    Files.write(testConfigPath, renderedConfig.getBytes("UTF-8"))
-
-    dockerClient.copyToContainer(tmpConfigDirectory, containerId, configDirectory)
-
-    Files
-      .walk(tmpConfigDirectory)
-      .sorted(Comparator.reverseOrder[Path]())
-      .iterator()
-      .asScala
-      .foreach(Files.delete)
-  }
-
-  private def checkConfig(configToCheck: Config): Unit =
-    require(configToCheck.getString(rpcPortKeyPath) == rpcPort, "Custom RPC port is not supported now")
-
-  private def buildContainerConfig(name: String, environment: Map[String, String]): ContainerConfig = {
-    val env =
-      environment.toList.map { case (key, value) => s"$key=$value" }
-
-    val cmd =
-      List(
-        s"-Dcom.sun.management.jmxremote.port=$jmxRemotePort",
-        s"-Dcom.sun.management.jmxremote.rmi.port=$jmxRemotePort",
-        "-Dcom.sun.management.jmxremote.ssl=false",
-        "-Dcom.sun.management.jmxremote.local.only=false",
-        "-Dcom.sun.management.jmxremote.authenticate=false",
-        "--config",
-        s"$configDirectory/$configFileName",
-        "--debug"
-      )
-
-    val hostConfig =
-      HostConfig.builder().nanoCpus((1d * 1000000000).toLong).build()
-
-    ContainerConfig
-      .builder()
-      .image(DockerSupport.bifrostImage)
-      .env(env: _*)
-      .volumes(configDirectory)
-      .cmd(cmd: _*)
-      .hostname(name)
-      .hostConfig(hostConfig)
-      .exposedPorts(exposedPorts: _*)
-      .build()
-  }
-
-  def close(): Unit = {
-    nodeCache
-      .map(_.containerId)
-      .foreach(containerId => dockerClient.removeContainer(containerId, DockerClient.RemoveContainerParam.forceKill))
-    networkCache
-      .map(_.id())
-      .foreach(dockerClient.removeNetwork)
-  }
-
-}
-
-object DefaultConfig {
-
-  private val configMap = Map(
-    "bifrost.rpc.bind-host" -> "0.0.0.0", // rpc will listen all interfaces instead of just localhost
-    rpcPortKeyPath          -> rpcPort
-  )
-
-  val config: Config = ConfigFactory.parseMap(configMap.asJava)
 }
 
 object DockerSupport {
+
+  def make[F[_]: Async]: Resource[F, (DockerSupport[F], DockerClient)] =
+    for {
+      implicit0(dockerClient: DockerClient) <- Resource.make(Sync[F].blocking(DefaultDockerClient.fromEnv().build()))(
+        c => Sync[F].blocking(c.close())
+      )
+      nodeCache <- Resource.make[F, Ref[F, Set[BifrostDockerTetraNode]]](Ref.of(Set.empty[BifrostDockerTetraNode]))(
+        _.get.flatMap(
+          _.toList
+            .traverse(node =>
+              Sync[F]
+                .blocking(dockerClient.removeContainer(node.containerId, DockerClient.RemoveContainerParam.forceKill))
+                .voidError
+            )
+            .void
+        )
+      )
+      networkCache <- Resource.make[F, Ref[F, Set[NetworkCreation]]](Ref.of(Set.empty[NetworkCreation]))(
+        _.get.flatMap(
+          _.toList
+            .traverse(network => Sync[F].blocking(dockerClient.removeNetwork(network.id())).voidError)
+            .void
+        )
+      )
+      dockerSupport = new DockerSupport[F] {
+
+        def createNode(name: String, nodeGroupName: String, configYaml: String): Resource[F, BifrostDockerTetraNode] =
+          Resource
+            .make(createContainer(name, nodeGroupName))(node =>
+              Sync[F]
+                .blocking(dockerClient.removeContainer(node.containerId, DockerClient.RemoveContainerParam.forceKill))
+            )
+            .evalTap(_.configure(configYaml))
+
+        private def createContainer(name: String, nodeGroupName: String): F[BifrostDockerTetraNode] =
+          for {
+            networkName       <- (DockerSupport.networkNamePrefix + nodeGroupName).pure[F]
+            containerConfig   <- buildContainerConfig(name, Map.empty).pure[F]
+            containerCreation <- Sync[F].blocking(dockerClient.createContainer(containerConfig, name))
+            node              <- BifrostDockerTetraNode(containerCreation.id(), name).pure[F]
+            _                 <- nodeCache.update(_ + node)
+            networkId <- Sync[F].blocking(dockerClient.listNetworks().asScala.find(_.name == networkName)).flatMap {
+              case Some(network) => network.id().pure[F]
+              case None =>
+                Sync[F]
+                  .blocking(dockerClient.createNetwork(NetworkConfig.builder().name(networkName).build()))
+                  .flatTap(n => networkCache.update(_ + n))
+                  .map(_.id())
+            }
+            _ <- Sync[F].blocking(dockerClient.connectToNetwork(node.containerId, networkId))
+          } yield node
+
+        private def buildContainerConfig(name: String, environment: Map[String, String]): ContainerConfig = {
+          val env =
+            environment.toList.map { case (key, value) => s"$key=$value" }
+
+          val cmd =
+            List(
+              s"-Dcom.sun.management.jmxremote.port=$jmxRemotePort",
+              s"-Dcom.sun.management.jmxremote.rmi.port=$jmxRemotePort",
+              "-Dcom.sun.management.jmxremote.ssl=false",
+              "-Dcom.sun.management.jmxremote.local.only=false",
+              "-Dcom.sun.management.jmxremote.authenticate=false",
+              "--config",
+              "/opt/docker/config/node.yaml",
+              "--debug"
+            )
+
+          val hostConfig =
+            HostConfig.builder().nanoCpus((1d * 1000000000).toLong).build()
+
+          ContainerConfig
+            .builder()
+            .image(DockerSupport.bifrostImage)
+            .env(env: _*)
+            .volumes(configDirectory)
+            .cmd(cmd: _*)
+            .hostname(name)
+            .hostConfig(hostConfig)
+            .exposedPorts(exposedPorts: _*)
+            .build()
+        }
+      }
+    } yield (dockerSupport, dockerClient)
+
   val configDirectory = "/opt/docker/config"
-  val configFileName = "testConfig.conf"
 
   val bifrostImage: String = s"toplprotocol/bifrost-node:${BuildInfo.version}"
   val networkNamePrefix: String = "bifrost-it"
 
   val rpcPortKeyPath = "bifrost.rpc.bind-port"
   val rpcPort = "9084"
+  val p2pPort = "9085"
   val jmxRemotePort = "9083"
-  val exposedPorts: Seq[String] = List(rpcPort, jmxRemotePort)
+  val exposedPorts: Seq[String] = List(rpcPort, p2pPort, jmxRemotePort)
+}
+
+object DefaultConfig {
+
+  def apply(
+    bigBangTimestamp: Instant = Instant.now().plusSeconds(5),
+    stakerCount:      Int = 1,
+    localStakerIndex: Int = 0,
+    knownPeers:       List[String] = Nil
+  ): String =
+    s"""
+       |bifrost:
+       |  rpc:
+       |    bind-host: 0.0.0.0
+       |    port: 9084
+       |  p2p:
+       |    bind-host: 0.0.0.0
+       |    port: 9085
+       |    known-peers: ${knownPeers.map(p => s"$p:9085").mkString(",")}
+       |  big-bang:
+       |    staker-count: $stakerCount
+       |    local-staker-index: $localStakerIndex
+       |    timestamp: ${bigBangTimestamp.toEpochMilli}
+       |""".stripMargin
 }

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/NodeDockerApi.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/NodeDockerApi.scala
@@ -1,44 +1,77 @@
 package co.topl.tetra.it.util
 
+import cats.effect._
+import cats.implicits._
+import cats.effect.implicits._
+import co.topl.algebras.ToplRpc
+import co.topl.grpc.ToplGrpc
 import com.spotify.docker.client.DockerClient
-import org.slf4j.{Logger, LoggerFactory}
+import org.typelevel.log4cats.Logger
+import fs2._
+import fs2.io.file.Files
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-case class NodeDockerApi(containerId: String)(implicit dockerClient: DockerClient) {
+import java.nio.charset.StandardCharsets
 
-  private val timeout = 10
-  val logger: Logger = LoggerFactory.getLogger(this.toString)
+class NodeDockerApi(containerId: String)(implicit dockerClient: DockerClient) {
 
-  def start(): Unit = {
-    logger.info(s"Starting")
-    dockerClient.startContainer(containerId)
-    awaitContainerStart()
-    logger.info(s"Successfully started container $containerId on IP ${ipAddress()}")
+  implicit def logger[F[_]: Sync]: Logger[F] =
+    Slf4jLogger.getLoggerFromName[F](s"DockerNode(${containerId.take(8)})")
+
+  def startContainer[F[_]: Async]: F[Unit] =
+    for {
+      _  <- Logger[F].info("Starting")
+      _  <- Sync[F].blocking(dockerClient.startContainer(containerId))
+      _  <- awaitContainerStart
+      ip <- ipAddress
+      _  <- Logger[F].info(s"Successfully started container $containerId on IP $ip")
+    } yield ()
+
+  def stop[F[_]: Async]: F[Unit] =
+    Logger[F].info("Stopping") >>
+    Sync[F].blocking(dockerClient.stopContainer(containerId, 10))
+
+  def ipAddress[F[_]: Sync]: F[String] =
+    Sync[F].blocking(dockerClient.inspectContainer(containerId).networkSettings().ipAddress())
+
+  def rpcClient[F[_]: Async]: Resource[F, ToplRpc[F, Stream[F, *]]] =
+    ipAddress.toResource.flatMap(ToplGrpc.Client.make[F](_, 9084, tls = false)) // TODO: Don't hardcode
+
+  def configure[F[_]: Async](configYaml: String): F[Unit] =
+    for {
+      _         <- Logger[F].info("Reconfiguring container")
+      isRunning <- Sync[F].blocking(dockerClient.inspectContainer(containerId).state().running())
+      _ <-
+        if (isRunning)
+          Sync[F].raiseError(new IllegalStateException("Attempted to set configuration on running node"))
+        else Sync[F].unit
+      _ <- Files[F].tempDirectory.use(tmpConfigDir =>
+        for {
+          tmpConfigFile <- (tmpConfigDir / "node.yaml").pure[F]
+          _ <- Stream
+            .chunk(Chunk.array(configYaml.getBytes(StandardCharsets.UTF_8)))
+            .through(Files[F].writeAll(tmpConfigFile))
+            .compile
+            .drain
+          _ <- Sync[F].blocking(
+            dockerClient.copyToContainer(
+              tmpConfigDir.toNioPath,
+              containerId,
+              "/opt/docker/config"
+            )
+          )
+        } yield ()
+      )
+    } yield ()
+
+  private def awaitContainerStart[F[_]: Async]: F[Unit] = {
+    def go(remainingAttempts: Int): F[Unit] =
+      if (remainingAttempts > 0) ipAddress.void.recoverWith { case _ =>
+        go(remainingAttempts - 1)
+      }
+      else Async[F].raiseError(throw new IllegalStateException(s"Container IP not found. ContainerId=$containerId"))
+
+    go(10)
   }
-
-  def stop(): Unit = {
-    logger.info(s"Stopping")
-    dockerClient.stopContainer(containerId, timeout)
-  }
-
-  def ipAddress(): String =
-    dockerClient.inspectContainer(containerId).networkSettings().ipAddress()
-
-  private def awaitContainerStart(): Unit = {
-    var remainingAttempts = 10
-    var ip = ipAddress()
-    while (ip.isEmpty && remainingAttempts > 0) {
-      Thread.sleep(1000)
-      ip = ipAddress()
-      remainingAttempts -= 1
-    }
-    if (ip.isEmpty) throw new IllegalStateException(s"Container IP not found. ContainerId=$containerId")
-  }
-
-}
-
-object NodeDockerApi {
-
-  def apply(node: BifrostDockerTetraNode)(implicit dockerClient: DockerClient): NodeDockerApi =
-    new NodeDockerApi(node.containerId)
 
 }

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/NodeRpcApi.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/NodeRpcApi.scala
@@ -1,55 +1,46 @@
 package co.topl.tetra.it.util
 
-import cats.Monad
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
-import co.topl.algebras.ToplRpc
-import co.topl.grpc.ToplGrpc
-import co.topl.tetra.it.util.NodeRpcApi.{rpcWaitAttempts, rpcWaitSleepMs}
-import com.spotify.docker.client.DockerClient
-import org.slf4j.{Logger, LoggerFactory}
+import cats.Applicative
+import cats.effect._
+import cats.implicits._
+import co.topl.algebras.{SynchronizationTraversalSteps, ToplRpc}
+import co.topl.consensus.models.BlockHeader
 import fs2.Stream
+import org.typelevel.log4cats.Logger
 
-case class NodeRpcApi(host: String, rpcPort: Int) {
-  val logger: Logger = LoggerFactory.getLogger(this.toString)
+import scala.concurrent.duration._
 
-  def waitForRpcStartUp(): Unit = {
-    logger.info(s"Start waiting of RPC startup for host $host")
+class NodeRpcApi[F[_]](val client: ToplRpc[F, Stream[F, *]]) extends AnyVal {
 
-    ToplGrpc.Client
-      .make[IO](host, rpcPort, tls = false)
-      .use(waitRpcIO)
-      .unsafeRunSync()
-
-    logger.info(s"RPC is started and run for host $host")
-  }
-
-  private def waitRpcIO(rpc: ToplRpc[IO, Stream[IO, *]]): IO[Unit] = {
-    var remainingAttempts = rpcWaitAttempts
-
-    def sleepWithCounter = IO {
-      if (remainingAttempts > 0) {
-        Thread.sleep(rpcWaitSleepMs)
-        remainingAttempts -= 1
-      } else {
-        throw new IllegalStateException(s"Failed to connect RPC on $host:$rpcPort")
+  def adoptedHeaders: Stream[F, BlockHeader] =
+    Stream
+      .force(client.synchronizationTraversal())
+      .collect { case SynchronizationTraversalSteps.Applied(id) =>
+        id
       }
-    }
+      .evalMap(client.fetchBlockHeader)
+      .map(_.get)
 
-    def rpcIsAvailable =
-      rpc.blockIdAtHeight(1).recover(_ => None).map(_.isDefined)
-
-    Monad[IO].untilM_(sleepWithCounter)(rpcIsAvailable)
-  }
-}
-
-object NodeRpcApi {
-  val rpcWaitAttempts = 30
-  val rpcWaitSleepMs = 1000
-
-  def apply(node: BifrostDockerTetraNode)(implicit dockerClient: DockerClient): NodeRpcApi = {
-    val host = dockerClient.inspectContainer(node.containerId).networkSettings().ipAddress()
-    require(host.nonEmpty, s"Docker container is missing IP address. ContainerId=${node.containerId}")
-    new NodeRpcApi(host, DockerSupport.rpcPort.toInt)
-  }
+  def waitForRpcStartUp(implicit asyncF: Async[F], loggerF: Logger[F]): F[Unit] =
+    for {
+      _ <- Logger[F].info("Waiting for RPC to start up")
+      genesisHeader <-
+        Stream
+          .retry(
+            client
+              .blockIdAtHeight(1)
+              .map(_.get)
+              .flatMap(client.fetchBlockHeader)
+              .map(_.get),
+            250.milli,
+            identity,
+            200
+          )
+          .compile
+          .lastOrError
+      _        <- Logger[F].info(s"Node RPC is ready. Awaiting Genesis block timestamp=${genesisHeader.timestamp}")
+      duration <- Async[F].realTimeInstant.map(genesisHeader.timestamp - _.toEpochMilli).map(_.milli)
+      _        <- Applicative[F].whenA(duration.toMillis > 0)(Async[F].sleep(duration))
+      _        <- Logger[F].info("Genesis block timestamp reached.  Node is ready.")
+    } yield ()
 }

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/package.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/package.scala
@@ -1,16 +1,17 @@
 package co.topl.tetra.it
 
+import co.topl.algebras.ToplRpc
 import com.spotify.docker.client.DockerClient
 
 import scala.language.implicitConversions
 
 package object util {
 
-  implicit def nodeToRpcApi(
-    node:                  BifrostDockerTetraNode
-  )(implicit dockerClient: DockerClient): NodeRpcApi =
-    NodeRpcApi(node)
+  implicit def rpcToRpcApi[F[_]](rpc: ToplRpc[F, fs2.Stream[F, *]]): NodeRpcApi[F] =
+    new NodeRpcApi(rpc)
 
-  implicit def nodeToDockerApi(node: BifrostDockerTetraNode)(implicit dockerClient: DockerClient): NodeDockerApi =
-    NodeDockerApi(node)
+  implicit def nodeToDockerApi(node: BifrostDockerTetraNode)(implicit
+    dockerClient:                    DockerClient
+  ): NodeDockerApi =
+    new NodeDockerApi(node.containerId)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,10 +49,7 @@ object Dependencies {
 
   val mUnitTest: Seq[ModuleID] = mUnitTestBase.map(_ % Test)
 
-  val it: Seq[ModuleID] = Seq(
-    "org.scalatest" %% "scalatest"     % "3.2.12" % "it",
-    "com.spotify"    % "docker-client" % "8.16.0" % "it"
-  )
+  val dockerClient = "com.spotify" % "docker-client" % "8.16.0"
 
   def akka(name: String): ModuleID =
     "com.typesafe.akka" %% s"akka-$name" % akkaVersion
@@ -292,5 +289,5 @@ object Dependencies {
     mUnitTest
 
   lazy val byzantineTests: Seq[ModuleID] =
-    it
+    (mUnitTestBase :+ dockerClient).map(_ % IntegrationTest)
 }


### PR DESCRIPTION
## Purpose
- Modifies the Byzantine Tests to use mUnit, cats, and fs2
- Adds MultiNodeTest to Byzantine Tests
  - Creates 3 nodes and allows them to produce blocks for 3 epochs.  Verifies that the nodes are in near-consensus.
## Approach
- Use cats-effect Resources to capture Docker container functionality
- Create new test with 3 new containers, configured to communicate
## Testing
- Local success
  ![image](https://user-images.githubusercontent.com/2218886/221695822-d0f36501-af39-451e-8f0e-db3547ee5495.png)
## Tickets
- #2636 