### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @scasplte2 @tuxman @SeanCheatham @hwbehrens @ignaciofernandezsoto @nandotorterolo @o-aleksandrov-topl @aaronschutza
+*       @scasplte2 @tuxman @SeanCheatham @hwbehrens @nandotorterolo @o-aleksandrov-topl @aaronschutza
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @scasplte2 @tuxman @SeanCheatham @hwbehrens @nandotorterolo @o-aleksandrov-topl @aaronschutza
+*       @Topl/bifrost_reviewers
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners


### PR DESCRIPTION
## Purpose
- Set the default reviewers to be based on GitHub team rather than individual usernames
## Approach
- Use `@org/team-name` syntax -> `@Topl/bifrost_reviewers`


**<3**