### PR TITLE
Add .jvmopts file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,6 @@
 .vscode/
 out/
 *.iml
-.jvmopts
-.sbtopts
 localVersion.sbt
 
 # scala build folders

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,3 @@
+-Xmx4G
+-Xms1G
+-Xss32M

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ Testing
 
 To run the Bifrost unit test suite from the project directory: `sbt test`
 
-   - On some systems, the tests may fail with an `java.lang.OutOfMemoryError`. To solve this problem, provide the JVM more space: `echo "-Xmx4G -Xms1G" >> .jvmopts`
-      
 To publish a Docker image from the project directory for local testing: `sbt 'node/docker:publishLocal'`
    
    - To run the published container: `docker run bifrost:x.x.x` (where `x.x.x` is the version that was published).


### PR DESCRIPTION
## Purpose
- Compiling Bifrost may result in a stack overflow on default JVM configurations
  - In particular, a 1kb default Xss makes it hard to compile macros
- Main purpose is just to test the "Default Reviewers" change
## Approach
- Adds a .jvmopts file which increases the memory allocation to SBT
## Testing
- Works for me locally :shrug: 
## Tickets
N/A