### PR TITLE
BN-###-cleanup BlockHeader Protobuf Refactor

### DIFF
--- a/consensus/src/test/scala/co/topl/consensus/interpreters/BlockHeaderValidationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/BlockHeaderValidationSpec.scala
@@ -713,10 +713,10 @@ class BlockHeaderValidationSpec
   }
 
   private def withPartialOperationalCertificate( // new models, remove the other and rename this
-    slot: Slot,
-    unsignedF: legacyModels.BlockHeader.UnsignedConsensus.PartialOperationalCertificate => legacyModels.BlockHeader.UnsignedConsensus,
-    parentSK: SecretKeys.KesProduct
-  ): (legacyModels.BlockHeader.UnsignedConsensus, SecretKeys.Ed25519) = {
+    slot:      Slot,
+    unsignedF: legacyModels.BlockHeader.Unsigned.PartialOperationalCertificate => legacyModels.BlockHeader.Unsigned,
+    parentSK:  SecretKeys.KesProduct
+  ): (legacyModels.BlockHeader.Unsigned, SecretKeys.Ed25519) = {
     val (linearSKBytes, linearVKBytes) =
       Ed25519.instance.deriveKeyPairFromEntropy(Entropy.fromUuid(UUID.randomUUID()), None)
 
@@ -724,7 +724,7 @@ class BlockHeaderValidationSpec
     val parentSignatureLegacy = kesProduct.sign(parentSK, message) // TODO, it should return new Models
     val parentSignature = ReplaceModelUtil.signatureKesProduct(parentSignatureLegacy)
     val kesProductVerificationKey = kesProduct.getVerificationKey(parentSK) // TODO, it should return new Models
-    val partialCertificate = legacyModels.BlockHeader.UnsignedConsensus.PartialOperationalCertificate(
+    val partialCertificate = legacyModels.BlockHeader.Unsigned.PartialOperationalCertificate(
       VerificationKeyKesProduct.of(
         ByteString.copyFrom(kesProductVerificationKey.bytes.data.toArray),
         kesProductVerificationKey.step
@@ -736,7 +736,7 @@ class BlockHeaderValidationSpec
   }
 
   private def genValid(
-    preSign:    legacyModels.BlockHeader.UnsignedConsensus => legacyModels.BlockHeader.UnsignedConsensus = identity,
+    preSign:    legacyModels.BlockHeader.Unsigned => legacyModels.BlockHeader.Unsigned = identity,
     parentSlot: Slot = 5000L
   ): Gen[(BlockHeader, BlockHeader, Box.Values.Registrations.Operator, Eta, Ratio)] =
     for {
@@ -765,7 +765,7 @@ class BlockHeaderValidationSpec
         withPartialOperationalCertificate(
           slot,
           partial =>
-            legacyModels.BlockHeader.UnsignedConsensus(
+            legacyModels.BlockHeader.Unsigned(
               parentHeaderId = BlockId.of(ByteString.copyFrom(parent.id._2.toArray)),
               parentSlot = parent.slot,
               txRoot = txRoot.data,

--- a/minting/src/main/scala/co/topl/minting/algebras/StakingAlgebra.scala
+++ b/minting/src/main/scala/co/topl/minting/algebras/StakingAlgebra.scala
@@ -19,7 +19,7 @@ trait StakingAlgebra[F[_]] {
   def certifyBlock(
     parentSlotId:         SlotId,
     slot:                 Slot,
-    unsignedBlockBuilder: BlockHeader.UnsignedConsensus.PartialOperationalCertificate => co.topl.models.Block.Unsigned
+    unsignedBlockBuilder: BlockHeader.Unsigned.PartialOperationalCertificate => co.topl.models.Block.Unsigned
   ): F[Option[Block]]
 
   def getHit(

--- a/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
@@ -121,11 +121,11 @@ object BlockProducer {
       body:           co.topl.models.BlockBody.Full,
       timestamp:      Timestamp,
       nextHit:        VrfHit
-    ): BlockHeader.UnsignedConsensus.PartialOperationalCertificate => co.topl.models.Block.Unsigned =
-      (partialOperationalCertificate: BlockHeader.UnsignedConsensus.PartialOperationalCertificate) =>
+    ): BlockHeader.Unsigned.PartialOperationalCertificate => co.topl.models.Block.Unsigned =
+      (partialOperationalCertificate: BlockHeader.Unsigned.PartialOperationalCertificate) =>
         co.topl.models.Block
           .Unsigned(
-            BlockHeader.UnsignedConsensus(
+            BlockHeader.Unsigned(
               parentHeaderId = parentSlotData.slotId.blockId,
               parentSlot = parentSlotData.slotId.slot,
               txRoot = body.merkleTreeRootHash.data,

--- a/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
@@ -63,12 +63,12 @@ object Staking {
       def certifyBlock(
         parentSlotId: SlotId,
         slot:         Slot,
-        unsignedBlockBuilder: co.topl.models.BlockHeader.UnsignedConsensus.PartialOperationalCertificate => co.topl.models.Block.Unsigned
+        unsignedBlockBuilder: co.topl.models.BlockHeader.Unsigned.PartialOperationalCertificate => co.topl.models.Block.Unsigned
       ): F[Option[Block]] =
         OptionT(operationalKeyMaker.operationalKeyForSlot(slot, parentSlotId)).semiflatMap { operationalKeyOut =>
           for {
             partialCertificate <- Sync[F].delay(
-              co.topl.models.BlockHeader.UnsignedConsensus.PartialOperationalCertificate(
+              co.topl.models.BlockHeader.Unsigned.PartialOperationalCertificate(
                 operationalKeyOut.parentVK,
                 operationalKeyOut.parentSignature,
                 operationalKeyOut.childVK

--- a/models/src/main/scala/co/topl/models/Block.scala
+++ b/models/src/main/scala/co/topl/models/Block.scala
@@ -9,6 +9,7 @@ import co.topl.consensus.models._
 import com.google.protobuf.ByteString
 
 // id = hash(headerBytes) INCLUDING kesCertificate proofs
+// TODO Remove after protobuf refactor is complete
 case class BlockHeader(
   parentHeaderId:         TypedIdentifier,
   parentSlot:             Slot,
@@ -30,30 +31,7 @@ object BlockHeader {
 
   type Metadata = Sized.Max[Latin1Data, Lengths.`32`.type]
 
-  case class Unsigned( // TODO rename to legacyUnsigned
-    parentHeaderId:                TypedIdentifier,
-    parentSlot:                    Slot,
-    txRoot:                        TxRoot,
-    bloomFilter:                   BloomFilter,
-    timestamp:                     Timestamp,
-    height:                        Long,
-    slot:                          Slot,
-    eligibilityCertificate:        legacyModels.EligibilityCertificate,
-    partialOperationalCertificate: Unsigned.PartialOperationalCertificate,
-    metadata:                      Option[Sized.Max[Latin1Data, Lengths.`32`.type]],
-    address:                       StakingAddresses.Operator
-  )
-
-  object Unsigned { // TODO rename to legacyUnsigned
-
-    case class PartialOperationalCertificate(
-      parentVK:        VerificationKeys.KesProduct,
-      parentSignature: Proofs.Knowledge.KesProduct,
-      childVK:         VerificationKeys.Ed25519
-    )
-  }
-
-  case class UnsignedConsensus( // TODO rename Unsigned
+  case class Unsigned(
     parentHeaderId:                BlockId,
     parentSlot:                    Slot,
     txRoot:                        ByteString,
@@ -62,12 +40,12 @@ object BlockHeader {
     height:                        Long,
     slot:                          Slot,
     eligibilityCertificate:        EligibilityCertificate,
-    partialOperationalCertificate: UnsignedConsensus.PartialOperationalCertificate,
+    partialOperationalCertificate: Unsigned.PartialOperationalCertificate,
     metadata:                      ByteString,
     address:                       ByteString
   )
 
-  object UnsignedConsensus { // TODO rename Unsigned
+  object Unsigned {
 
     case class PartialOperationalCertificate(
       parentVK:        VerificationKeyKesProduct,
@@ -88,13 +66,8 @@ object BlockBody {
 
 object Block {
 
-  case class UnsignedLegacy(
-    unsignedHeader: BlockHeader.Unsigned,
-    body:           BlockBody
-  )
-
   case class Unsigned( // TODO ask if we need a new protobuf-spec for BlockUnsigned
-    unsignedHeader: BlockHeader.UnsignedConsensus,
+    unsignedHeader: BlockHeader.Unsigned,
     body:           co.topl.node.models.BlockBody
   )
 

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraImmutableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraImmutableCodecs.scala
@@ -3,7 +3,6 @@ package co.topl.codecs.bytes.tetra
 import co.topl.codecs.bytes.scodecs.valuetypes.{intCodec, longCodec}
 import co.topl.codecs.bytes.typeclasses.ImmutableCodec
 import co.topl.consensus.models.VerificationKeyVrfEd25519
-import co.topl.models.BlockHeader.Unsigned.PartialOperationalCertificate
 import co.topl.models._
 import co.topl.models.utility.Ratio
 
@@ -43,16 +42,10 @@ trait TetraImmutableCodecs {
   implicit val operationalCertificateConsensusCodec: ImmutableCodec[co.topl.consensus.models.OperationalCertificate] =
     ImmutableCodec.fromScodecCodec
 
-  implicit val partialOperationalCertificateStableCodec: ImmutableCodec[PartialOperationalCertificate] =
-    ImmutableCodec.fromScodecCodec
-
   implicit val headerImmutableCodec: ImmutableCodec[co.topl.consensus.models.BlockHeader] =
     ImmutableCodec.fromScodecCodec
 
-  implicit val unsignedHeaderV2StableCodec: ImmutableCodec[BlockHeader.Unsigned] =
-    ImmutableCodec.fromScodecCodec
-
-  implicit val unsignedHeaderConsensusCodec: ImmutableCodec[BlockHeader.UnsignedConsensus] =
+  implicit val unsignedHeaderConsensusCodec: ImmutableCodec[BlockHeader.Unsigned] =
     ImmutableCodec.fromScodecCodec
 
   implicit val transactionStableCodec: ImmutableCodec[Transaction] =
@@ -129,7 +122,6 @@ trait TetraImmutableCodecs {
   implicit val propositionCompositionalNotImmutableCodec: ImmutableCodec[Propositions.Compositional.Not] =
     ImmutableCodec.fromScodecCodec
 
-  // TODO Remove after full model replacement
   implicit val propositionContextualHeightLockImmutableCodec: ImmutableCodec[Propositions.Contextual.HeightLock] =
     ImmutableCodec.fromScodecCodec
 

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -847,15 +847,10 @@ trait TetraScodecBlockCodecs {
 
   implicit val partialOperationalCertificateCodec
     : Codec[legacyModels.BlockHeader.Unsigned.PartialOperationalCertificate] =
-    (vkKesProductCodec :: proofSignatureKesProductCodec :: vkEd25519Codec)
-      .as[legacyModels.BlockHeader.Unsigned.PartialOperationalCertificate]
-
-  implicit val partialOperationalCertificateConsensusCodec
-    : Codec[legacyModels.BlockHeader.UnsignedConsensus.PartialOperationalCertificate] =
     (consensusVkKesProductCodec ::
       consensusProofSignatureKesProductCodec ::
       cryptoVkEd25519Codec)
-      .as[legacyModels.BlockHeader.UnsignedConsensus.PartialOperationalCertificate]
+      .as[legacyModels.BlockHeader.Unsigned.PartialOperationalCertificate]
 
   implicit val blockHeaderCodec: Codec[legacyModels.BlockHeader] =
     (
@@ -916,21 +911,6 @@ trait TetraScodecBlockCodecs {
 
   implicit val unsignedBlockHeaderCodec: Codec[legacyModels.BlockHeader.Unsigned] =
     (
-      typedBytesCodec ::
-        longCodec ::
-        Codec[TxRoot] ::
-        Codec[BloomFilter] ::
-        longCodec ::
-        longCodec ::
-        longCodec ::
-        eligibilityCertificateCodec ::
-        partialOperationalCertificateCodec ::
-        optionCodec(maxSizedCodec[Latin1Data, Lengths.`32`.type]) ::
-        stakingAddressesOperatorCodec
-    ).as[legacyModels.BlockHeader.Unsigned]
-
-  implicit val unsignedConsensusBlockHeaderCodec: Codec[legacyModels.BlockHeader.UnsignedConsensus] =
-    (
       consensusBlockIdCodec ::
         longCodec ::
         protobufByteStringCodec ::
@@ -939,10 +919,10 @@ trait TetraScodecBlockCodecs {
         longCodec ::
         longCodec ::
         consensusEligibilityCertificateCodec ::
-        partialOperationalCertificateConsensusCodec ::
+        partialOperationalCertificateCodec ::
         protobufByteStringCodec ::
         protobufByteStringCodec
-    ).as[legacyModels.BlockHeader.UnsignedConsensus]
+    ).as[legacyModels.BlockHeader.Unsigned]
 
   implicit val blockBodyCodec: Codec[BlockBody] = listSetCodec[TypedIdentifier]
 

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraSignableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraSignableCodecs.scala
@@ -2,44 +2,21 @@ package co.topl.codecs.bytes.tetra
 
 import co.topl.codecs.bytes.typeclasses._
 import co.topl.{models => legacyModels}
-import co.topl.consensus.models.{BlockHeader, BlockId, VerificationKeyEd25519}
+import co.topl.consensus.models.BlockHeader
 import co.topl.models.utility._
-import com.google.protobuf.ByteString
 
 trait TetraSignableCodecs {
 
   import TetraImmutableCodecs._
   import co.topl.codecs.bytes.typeclasses.implicits._
 
-  implicit val signableUnsignedConsensusBlockHeader: Signable[legacyModels.BlockHeader.UnsignedConsensus] =
+  implicit val signableUnsignedConsensusBlockHeader: Signable[legacyModels.BlockHeader.Unsigned] =
     _.immutableBytes
-
-  implicit val signableUnsignedBlockHeader: Signable[legacyModels.BlockHeader.Unsigned] =
-    t =>
-      legacyModels.BlockHeader
-        .UnsignedConsensus(
-          BlockId(t.parentHeaderId.dataBytes),
-          t.parentSlot,
-          t.txRoot.data,
-          t.bloomFilter.data,
-          t.timestamp,
-          t.height,
-          t.slot,
-          ReplaceModelUtil.eligibilityCertificate(t.eligibilityCertificate),
-          legacyModels.BlockHeader.UnsignedConsensus.PartialOperationalCertificate(
-            ReplaceModelUtil.verificationKeyKesProduct(t.partialOperationalCertificate.parentVK),
-            ReplaceModelUtil.signatureKesProduct(t.partialOperationalCertificate.parentSignature),
-            VerificationKeyEd25519(t.partialOperationalCertificate.childVK.bytes.data)
-          ),
-          t.metadata.fold(ByteString.EMPTY)(m => ByteString.copyFrom(m.data.bytes)),
-          t.address.vk.bytes.data
-        )
-        .signableBytes
 
   implicit val signableBlockConsensusHeader: Signable[BlockHeader] =
     t =>
       legacyModels.BlockHeader
-        .UnsignedConsensus(
+        .Unsigned(
           t.parentHeaderId,
           t.parentSlot,
           t.txRoot,
@@ -48,7 +25,7 @@ trait TetraSignableCodecs {
           t.height,
           t.slot,
           t.eligibilityCertificate,
-          legacyModels.BlockHeader.UnsignedConsensus.PartialOperationalCertificate(
+          legacyModels.BlockHeader.Unsigned.PartialOperationalCertificate(
             t.operationalCertificate.parentVK,
             t.operationalCertificate.parentSignature,
             t.operationalCertificate.childVK


### PR DESCRIPTION
## Purpose
cleanup BlockHeader Protobuf Refactor

## Approach
In previous Prs, we replace BlockHeader with protobuf-specs model.
The old model was not deleted, and instead was prefixed with "Legacy" naming
This PR removes the old model for BlockHeader.Unsigned, (We still need the blockheader, it is used on Blockchain and Networking modules) 

## Testing
preparePr
## Tickets
*
