### PR TITLE
Workflow Dependency Fixes

### DIFF
--- a/.github/workflows/_docker_publish_public.yml
+++ b/.github/workflows/_docker_publish_public.yml
@@ -23,7 +23,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to the Github Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/_sbt_jar.yml
+++ b/.github/workflows/_sbt_jar.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Bifrost Node Jar (${{ matrix.java }})
-          path: node/target/scala-2.13/*.jar
+          path: node/target/scala-2.13/bifrost-node-*.jar
           if-no-files-found: error
       
       - name: Cleanup before cache

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,9 +22,12 @@ jobs:
     needs: [sbt-build]
     with:
       preserve-cache-between-runs: true
+  build-jar:
+    uses: ./.github/workflows/_sbt_jar.yml
+    needs: [sbt-build]
   publish-docker-images-unofficial:
     uses: ./.github/workflows/_docker_publish_private.yml
-    needs: [sbt-build, sbt-integration-tests]
+    needs: [sbt-build, sbt-integration-tests, sbt-byzantine-tests, build-jar]
     with:
       remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,16 +20,12 @@ jobs:
     needs: [sbt-build]
     with:
       preserve-cache-between-runs: true
-  publish-docker-images-official:
-    uses: ./.github/workflows/_docker_publish_public.yml
-    needs: [sbt-build, sbt-integration-tests]
-    secrets: inherit
   build-jar:
     uses: ./.github/workflows/_sbt_jar.yml
-    needs: [sbt-build, sbt-integration-tests]
+    needs: [sbt-build]
   create-release:
     runs-on: ubuntu-latest
-    needs: [sbt-build, sbt-integration-tests, build-jar]
+    needs: [sbt-build, sbt-integration-tests, sbt-byzantine-tests, build-jar]
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v3
@@ -60,3 +56,7 @@ jobs:
             ${{ env.JAR_LOCATION }}
             ${{ env.MD5_LOCATION }}
             ${{ env.SHA256_LOCATION }}
+  publish-docker-images-official:
+    uses: ./.github/workflows/_docker_publish_public.yml
+    needs: [create-release]
+    secrets: inherit


### PR DESCRIPTION
## Purpose
- In the three main workflows, there were missing step dependencies that allowed for partial releases despite partial failures
- The uploaded JAR artifacts now include multiple files, which causes an error when attempting to select the right one
## Approach
- Require byzantine test success in push/release
- Only publish public docker images if the release step succeeds
- Select the correct JAR file in the _sbt_build.yml step
## Testing
N/A
## Tickets
- BN-870