### PR TITLE
Move RhoHash Calculations to Consensus

### DIFF
--- a/consensus/src/main/scala/co/topl/consensus/interpreters/ChainSelection.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/ChainSelection.scala
@@ -7,10 +7,10 @@ import cats.implicits._
 import co.topl.algebras.UnsafeResource
 import co.topl.consensus.algebras.ChainSelectionAlgebra
 import co.topl.crypto.hash.Blake2b512
-import co.topl.crypto.signing.Ed25519VRF
 import co.topl.models._
 import co.topl.models.utility._
 import co.topl.consensus.models.SlotData
+import co.topl.consensus.rhoToRhoTestHash
 import co.topl.typeclasses.implicits._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -33,7 +33,7 @@ object ChainSelection {
     val slotOrder = Order.by[NonEmptyChain[SlotData], Slot](-_.last.slotId.slot)
     val rhoTestHashOrder =
       Order.reverse(
-        Order.by[NonEmptyChain[SlotData], BigInt](h => BigInt(Ed25519VRF.rhoToRhoTestHash(h.last.rho).toArray))
+        Order.by[NonEmptyChain[SlotData], BigInt](h => BigInt(rhoToRhoTestHash(h.last.rho).toArray))
       )
 
     lengthOrder

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/EtaCalculation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/EtaCalculation.scala
@@ -8,8 +8,8 @@ import co.topl.algebras.ClockAlgebra.implicits._
 import co.topl.algebras.{ClockAlgebra, UnsafeResource}
 import co.topl.consensus.algebras.EtaCalculationAlgebra
 import co.topl.consensus.models.{EtaCalculationArgs, SlotData, SlotId}
+import co.topl.consensus.rhoToRhoNonceHash
 import co.topl.crypto.hash.{Blake2b256, Blake2b512}
-import co.topl.crypto.signing.Ed25519VRF
 import co.topl.models._
 import co.topl.models.utility._
 import co.topl.models.utility.HasLength.instances.bytesLength
@@ -125,7 +125,7 @@ object EtaCalculation {
           .map(_.sizedBytes.data)
           .parTraverse(rho =>
             blake2b512Resource
-              .use(implicit b2b => Sync[F].delay(Ed25519VRF.rhoToRhoNonceHash(rho)))
+              .use(implicit b2b => Sync[F].delay(rhoToRhoNonceHash(rho)))
               .map(nonceHashBytes => RhoNonceHash(Sized.strictUnsafe(nonceHashBytes)))
           )
         nextEta <- calculateFromNonceHashValues(previousEta, epoch, rhoNonceHashes)

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/LeaderElectionValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/LeaderElectionValidation.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import co.topl.algebras.UnsafeResource
 import co.topl.consensus.algebras.LeaderElectionValidationAlgebra
 import co.topl.consensus.models.VrfConfig
-import co.topl.crypto.signing.Ed25519VRF
+import co.topl.consensus.rhoToRhoTestHash
 import co.topl.crypto.hash.Blake2b512
 import co.topl.models._
 import co.topl.models.utility.Ratio
@@ -52,7 +52,7 @@ object LeaderElectionValidation {
       def isSlotLeaderForThreshold(threshold: Ratio)(rho: Rho): F[Boolean] =
         blake2b512Resource.use(implicit blake2b512 =>
           Sync[F].delay {
-            val testRhoHashBytes = Ed25519VRF.rhoToRhoTestHash(rho.sizedBytes.data).toArray
+            val testRhoHashBytes = rhoToRhoTestHash(rho.sizedBytes.data).toArray
             val test = Ratio(BigInt(Array(0x00.toByte) ++ testRhoHashBytes), NormalizationConstant, BigInt(1))
             (threshold > test)
           }

--- a/consensus/src/main/scala/co/topl/consensus/package.scala
+++ b/consensus/src/main/scala/co/topl/consensus/package.scala
@@ -6,6 +6,8 @@ import co.topl.codecs.bytes.typeclasses.implicits._
 import co.topl.crypto.signing.Ed25519VRF
 import co.topl.models.utility.HasLength.instances.bytesLength
 import co.topl.consensus.{models => consensusModels}
+import co.topl.crypto.hash.Blake2b512
+import scodec.bits.ByteVector
 
 package object consensus {
 
@@ -49,4 +51,24 @@ package object consensus {
         blockHeader.height
       )
   }
+
+  private val TestStringByteVector =
+    ByteVector.encodeUtf8("TEST").toOption.get
+
+  private val NonceStringByteVector =
+    ByteVector.encodeUtf8("NONCE").toOption.get
+
+  /**
+   * @param rho length = 64
+   * @return length = 64
+   */
+  def rhoToRhoTestHash(rho: ByteVector)(implicit blake2b512: Blake2b512): ByteVector =
+    blake2b512.hash(rho ++ TestStringByteVector)
+
+  /**
+   * @param rho length = 64
+   * @return length = 64
+   */
+  def rhoToRhoNonceHash(rho: ByteVector)(implicit blake2b512: Blake2b512): ByteVector =
+    blake2b512.hash(rho ++ NonceStringByteVector)
 }

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/ChainSelectionSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/ChainSelectionSpec.scala
@@ -5,13 +5,13 @@ import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import co.topl.algebras.UnsafeResource
 import co.topl.crypto.hash.Blake2b512
-import co.topl.crypto.signing.Ed25519VRF
 import co.topl.models.ModelGenerators._
 import co.topl.models._
 import co.topl.models.utility.HasLength.instances._
 import co.topl.models.utility.Lengths._
 import co.topl.models.utility.{Lengths, Sized}
 import co.topl.consensus.models.{BlockId, SlotData, SlotId}
+import co.topl.consensus.rhoToRhoTestHash
 import co.topl.models.generators.common.ModelGenerators.genSizedStrictByteString
 import com.google.protobuf.ByteString
 import org.scalamock.scalatest.MockFactory
@@ -134,7 +134,7 @@ class ChainSelectionSpec
     val List(rhoX, rhoY) =
       List
         .tabulate(2)(i => Rho(Sized.strictUnsafe[Bytes, Lengths.`64`.type](Bytes(Array.fill[Byte](64)(i.toByte)))))
-        .sortBy(r => BigInt(Ed25519VRF.rhoToRhoTestHash(r.sizedBytes.data).toArray))
+        .sortBy(r => BigInt(rhoToRhoTestHash(r.sizedBytes.data).toArray))
 
     val xSegment = {
       val base = LazyList

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/EtaCalculationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/EtaCalculationSpec.scala
@@ -9,6 +9,7 @@ import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
 import co.topl.consensus.BlockHeaderOps
 import co.topl.consensus.models.{BlockId, SlotData, SlotId, VrfArgument}
+import co.topl.consensus.rhoToRhoNonceHash
 import co.topl.crypto.signing.Ed25519VRF
 import co.topl.crypto.hash.{Blake2b256, Blake2b512}
 import co.topl.models.ModelGenerators._
@@ -199,7 +200,7 @@ object EtaCalculationSpec {
     val messages: List[Bytes] =
       List(previousEta.data) ++ List(Bytes(BigInt(epoch).toByteArray)) ++ rhoValues
         .map(_.sizedBytes.data)
-        .map(Ed25519VRF.rhoToRhoNonceHash)
+        .map(rhoToRhoNonceHash)
     Sized.strictUnsafe(blake2b256.hash(Bytes.concat(messages)))
   }
 }

--- a/crypto/src/main/scala/co/topl/crypto/signing/Ed25519VRF.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signing/Ed25519VRF.scala
@@ -2,7 +2,6 @@ package co.topl.crypto.signing
 
 import co.topl.crypto.generation.EntropyToSeed
 import co.topl.crypto.generation.mnemonic.Entropy
-import co.topl.crypto.hash.Blake2b512
 import co.topl.crypto.signing.eddsa.ECVRF25519
 import scodec.bits.ByteVector
 
@@ -76,24 +75,4 @@ object Ed25519VRF {
 
   def precomputed(): Ed25519VRF =
     new Ed25519VRF
-
-  private val TestStringByteVector =
-    ByteVector.encodeUtf8("TEST").toOption.get
-
-  private val NonceStringByteVector =
-    ByteVector.encodeUtf8("NONCE").toOption.get
-
-  /**
-   * @param rho length = 64
-   * @return length = 64
-   */
-  def rhoToRhoTestHash(rho: ByteVector)(implicit blake2b512: Blake2b512): ByteVector =
-    blake2b512.hash(rho ++ TestStringByteVector)
-
-  /**
-   * @param rho length = 64
-   * @return length = 64
-   */
-  def rhoToRhoNonceHash(rho: ByteVector)(implicit blake2b512: Blake2b512): ByteVector =
-    blake2b512.hash(rho ++ NonceStringByteVector)
 }


### PR DESCRIPTION
## Purpose
- A Rho value can be combined with a predefined string to produce a "RhoHash" value
- The pre-defined strings are use-case specific, so they don't need to be defined with the general purpose Ed25519VRF
## Approach
- Move the `rhoToRhoTestHash` and `rhoToRhoNonceHash` methods to the `consensus` package object
## Testing
- `preparePR`
## Tickets
- BN-847