### PR TITLE
Private Testnet Relative Stakes

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/StakerInitializer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/StakerInitializer.scala
@@ -1,6 +1,5 @@
 package co.topl.blockchain
 
-import cats.data.Chain
 import cats.implicits._
 import co.topl.brambl.common.ContainsEvidence
 import co.topl.brambl.common.ContainsImmutable.instances.lockImmutable
@@ -95,10 +94,10 @@ object StakerInitializers {
     /**
      * This staker's initial stake in the network
      */
-    def bigBangOutputs(stake: Int128)(implicit networkPrefix: NetworkPrefix): Chain[UnspentTransactionOutput] = {
+    def bigBangOutputs(stake: Int128)(implicit networkPrefix: NetworkPrefix): List[UnspentTransactionOutput] = {
       val toplValue = Value().withTopl(Value.TOPL(stake, stakingAddress.some))
       val registrationValue = Value().withRegistration(Value.Registration(registration, stakingAddress))
-      Chain(
+      List(
         UnspentTransactionOutput(lockAddress, toplValue),
         UnspentTransactionOutput(lockAddress, registrationValue)
       )

--- a/build.sbt
+++ b/build.sbt
@@ -671,6 +671,6 @@ lazy val byzantineTests = project
   .configs(IntegrationTest)
   .dependsOn(node)
 
-addCommandAlias("checkPR", s"; scalafixAll --check; scalafmtCheckAll; +test; it:compile")
-addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; +test; it:compile")
-addCommandAlias("checkPRTestQuick", s"; scalafixAll --check; scalafmtCheckAll; testQuick; it:compile")
+addCommandAlias("checkPR", s"; scalafixAll --check; scalafmtCheckAll; +test; IntegrationTest/compile")
+addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; +test; IntegrationTest/compile")
+addCommandAlias("checkPRTestQuick", s"; scalafixAll --check; scalafmtCheckAll; testQuick; IntegrationTest/compile")

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/ChainSelectionTest.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/ChainSelectionTest.scala
@@ -55,7 +55,7 @@ class ChainSelectionTest extends IntegrationSuite {
         .parTraverse(node =>
           node
             .rpcClient[F]
-            .use(_.adoptedHeaders.takeWhile(_.slot < (epochSlotLength)).timeout(5.minutes).compile.lastOrError)
+            .use(_.adoptedHeaders.takeWhile(_.slot < (epochSlotLength)).timeout(4.minutes).compile.lastOrError)
         )
         .toResource
 
@@ -82,7 +82,7 @@ class ChainSelectionTest extends IntegrationSuite {
       thirdEpochHeads <- nodes
         .parTraverse(
           _.rpcClient[F]
-            .use(_.adoptedHeaders.takeWhile(_.slot < (epochSlotLength * 3)).timeout(10.minutes).compile.lastOrError)
+            .use(_.adoptedHeaders.takeWhile(_.slot < (epochSlotLength * 3)).timeout(6.minutes).compile.lastOrError)
         )
         .toResource
       _ <- Logger[F].info("Nodes have reached target epoch").toResource

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/ChainSelectionTest.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/ChainSelectionTest.scala
@@ -2,7 +2,6 @@ package co.topl.tetra.it
 
 import cats.effect.implicits._
 import cats.implicits._
-import co.topl.models.utility.Ratio
 import co.topl.tetra.it.util._
 import com.spotify.docker.client.DockerClient
 
@@ -26,13 +25,13 @@ class ChainSelectionTest extends IntegrationSuite {
   test("Disconnected nodes can forge independently and later sync up to a proper chain") {
     val epochSlotLength = 500 // (50/4) * (100/15) * 6
     val bigBang = Instant.now().plusSeconds(30)
-    val relativeStakes = List(Ratio(3, 6), Ratio(2, 6), Ratio(1, 6)).some
+    val stakes = List(BigInt(500), BigInt(400), BigInt(300)).some
     val config0 =
-      TestNodeConfig(bigBang, stakerCount = 3, localStakerIndex = 0, knownPeers = Nil, relativeStakes = relativeStakes)
+      TestNodeConfig(bigBang, stakerCount = 3, localStakerIndex = 0, knownPeers = Nil, stakes = stakes)
     val config1 =
-      TestNodeConfig(bigBang, stakerCount = 3, localStakerIndex = 1, knownPeers = Nil, relativeStakes = relativeStakes)
+      TestNodeConfig(bigBang, stakerCount = 3, localStakerIndex = 1, knownPeers = Nil, stakes = stakes)
     val config2 =
-      TestNodeConfig(bigBang, stakerCount = 3, localStakerIndex = 2, knownPeers = Nil, relativeStakes = relativeStakes)
+      TestNodeConfig(bigBang, stakerCount = 3, localStakerIndex = 2, knownPeers = Nil, stakes = stakes)
 
     val nodesWithknownPeers = List(
       config0,

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/MultiNodeTest.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/MultiNodeTest.scala
@@ -17,16 +17,16 @@ class MultiNodeTest extends IntegrationSuite {
   test("Multiple nodes launch and maintain consensus for three epochs") {
     val epochSlotLength = 500 // (50/4) * (100/15) * 6
     val bigBang = Instant.now().plusSeconds(30)
-    val config0 = DefaultConfig(bigBang, 3, 0, Nil)
-    val config1 = DefaultConfig(bigBang, 3, 1, List("MultiNodeTest-node0"))
-    val config2 = DefaultConfig(bigBang, 3, 2, List("MultiNodeTest-node1"))
+    val config0 = TestNodeConfig(bigBang, 3, 0, Nil)
+    val config1 = TestNodeConfig(bigBang, 3, 1, List("MultiNodeTest-node0"))
+    val config2 = TestNodeConfig(bigBang, 3, 2, List("MultiNodeTest-node1"))
     val resource =
       for {
         (dockerSupport, _dockerClient) <- DockerSupport.make[F]
         implicit0(dockerClient: DockerClient) = _dockerClient
-        node1 <- dockerSupport.createNode("MultiNodeTest-node0", "MultiNodeTest", config0)
-        node2 <- dockerSupport.createNode("MultiNodeTest-node1", "MultiNodeTest", config1)
-        node3 <- dockerSupport.createNode("MultiNodeTest-node2", "MultiNodeTest", config2)
+        node1 <- dockerSupport.createNode("MultiNodeTest-node0", "MultiNodeTest", config0.yaml)
+        node2 <- dockerSupport.createNode("MultiNodeTest-node1", "MultiNodeTest", config1.yaml)
+        node3 <- dockerSupport.createNode("MultiNodeTest-node2", "MultiNodeTest", config2.yaml)
         nodes = List(node1, node2, node3)
         _ <- nodes.parTraverse(_.startContainer[F]).toResource
         _ <- nodes.parTraverse(_.rpcClient[F].use(_.waitForRpcStartUp)).toResource

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/SanityCheckNodeTest.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/SanityCheckNodeTest.scala
@@ -12,7 +12,7 @@ class SanityCheckNodeTest extends IntegrationSuite {
       for {
         (dockerSupport, _dockerClient) <- DockerSupport.make[F]
         implicit0(dockerClient: DockerClient) = _dockerClient
-        node1       <- dockerSupport.createNode("SingleNodeTest-node1", "SingleNodeTest", DefaultConfig())
+        node1       <- dockerSupport.createNode("SingleNodeTest-node1", "SingleNodeTest", TestNodeConfig().yaml)
         _           <- node1.startContainer[F].toResource
         node1Client <- node1.rpcClient[F]
         _           <- node1Client.waitForRpcStartUp.toResource

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
@@ -3,9 +3,12 @@ package co.topl.tetra.it.util
 import cats.effect._
 import cats.implicits._
 import co.topl.buildinfo.node.BuildInfo
-import co.topl.models.utility.Ratio
-import com.spotify.docker.client.messages.{ContainerConfig, HostConfig, NetworkConfig, NetworkCreation}
-import com.spotify.docker.client.{DefaultDockerClient, DockerClient}
+import com.spotify.docker.client.messages.ContainerConfig
+import com.spotify.docker.client.messages.HostConfig
+import com.spotify.docker.client.messages.NetworkConfig
+import com.spotify.docker.client.messages.NetworkCreation
+import com.spotify.docker.client.DefaultDockerClient
+import com.spotify.docker.client.DockerClient
 
 import java.time.Instant
 import scala.jdk.CollectionConverters._
@@ -123,12 +126,12 @@ case class TestNodeConfig(
   stakerCount:      Int = 1,
   localStakerIndex: Int = 0,
   knownPeers:       List[String] = Nil,
-  relativeStakes:   Option[List[Ratio]] = None
+  stakes:           Option[List[BigInt]] = None
 ) {
 
   def yaml: String = {
-    val relativeStakesStr = relativeStakes.fold("")(
-      _.map(ratio => s"\"${ratio.numerator}/${ratio.denominator}\"").mkString("relative-stakes: [", ",", "]")
+    val stakesStr = stakes.fold("")(
+      _.map(v => s"\"$v\"").mkString("stakes: [", ",", "]")
     )
     s"""
        |bifrost:
@@ -139,11 +142,11 @@ case class TestNodeConfig(
        |    bind-host: 0.0.0.0
        |    port: 9085
        |    known-peers: "${knownPeers.map(p => s"$p:9085").mkString(",")}"
-       |    $relativeStakesStr
        |  big-bang:
        |    staker-count: $stakerCount
        |    local-staker-index: $localStakerIndex
        |    timestamp: ${bigBangTimestamp.toEpochMilli}
+       |    $stakesStr
        |""".stripMargin
   }
 

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -42,10 +42,14 @@ bifrost {
   big-bang {
     // Big-Bang configuration type (i.e. `private`)
     type = "private"
+    // The timestamp to use for the genesis block.  If not provided, will default to the current time (padded with a few seconds)
+    // timestamp = 12345667
     // The number of stakers to create and register in the big bang block
     staker-count = 1
     // The 0-based index of this node out of `staker-count` (i.e. if `10` total stakers, `local-staker-index` may be `3`)
     local-staker-index = 0
+    // The relative stake to assign to each of the stakers.  If not provided, will default to uniform stake distribution.
+    // relative-stakes = ["1/2", "1/4", "1/4"]
   }
   // Settings of the protocol (consensus)
   protocols {

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -42,14 +42,14 @@ bifrost {
   big-bang {
     // Big-Bang configuration type (i.e. `private`)
     type = "private"
-    // The timestamp to use for the genesis block.  If not provided, will default to the current time (padded with a few seconds)
-    // timestamp = 12345667
+    // The timestamp (unix epoch ms) to use for the genesis block.  If not provided, will default to the current time (padded with a few seconds)
+    // timestamp = 1678979124081
     // The number of stakers to create and register in the big bang block
     staker-count = 1
     // The 0-based index of this node out of `staker-count` (i.e. if `10` total stakers, `local-staker-index` may be `3`)
     local-staker-index = 0
-    // The relative stake to assign to each of the stakers.  If not provided, will default to uniform stake distribution.
-    // relative-stakes = ["1/2", "1/4", "1/4"]
+    // The stake quantity to assign to each of the stakers.  If not provided, will default to uniform stake distribution.
+    // stakes = ["500", "400", "300"]
   }
   // Settings of the protocol (consensus)
   protocols {

--- a/node/src/main/scala/co/topl/node/ApplicationConfig.scala
+++ b/node/src/main/scala/co/topl/node/ApplicationConfig.scala
@@ -66,6 +66,7 @@ object ApplicationConfig {
       case class Private(
         timestamp:        Long = System.currentTimeMillis() + 5_000L,
         stakerCount:      Int,
+        relativeStakes:   Option[List[Ratio]],
         localStakerIndex: Option[Int]
       ) extends BigBang
     }
@@ -149,9 +150,9 @@ object ApplicationConfig {
         simpleArgApplications.bifrost.bigBang match {
           case p: Bifrost.BigBangs.Private =>
             p.copy(
-              cmdArgs.runtime.testnetArgs.testnetTimestamp.getOrElse(p.timestamp),
-              cmdArgs.runtime.testnetArgs.testnetStakerCount.getOrElse(p.stakerCount),
-              cmdArgs.runtime.testnetArgs.testnetStakerIndex.orElse(p.localStakerIndex)
+              timestamp = cmdArgs.runtime.testnetArgs.testnetTimestamp.getOrElse(p.timestamp),
+              stakerCount = cmdArgs.runtime.testnetArgs.testnetStakerCount.getOrElse(p.stakerCount),
+              localStakerIndex = cmdArgs.runtime.testnetArgs.testnetStakerIndex.orElse(p.localStakerIndex)
             )
         }
       genLens(_.bifrost.bigBang).replace(bigBangConfig)(simpleArgApplications)

--- a/node/src/main/scala/co/topl/node/ApplicationConfig.scala
+++ b/node/src/main/scala/co/topl/node/ApplicationConfig.scala
@@ -66,7 +66,7 @@ object ApplicationConfig {
       case class Private(
         timestamp:        Long = System.currentTimeMillis() + 5_000L,
         stakerCount:      Int,
-        relativeStakes:   Option[List[Ratio]],
+        stakes:           Option[List[BigInt]],
         localStakerIndex: Option[Int]
       ) extends BigBang
     }
@@ -160,6 +160,9 @@ object ApplicationConfig {
       simpleArgApplications
     }
   }
+
+  implicit val bigIntConfigReader: ConfigReader[BigInt] =
+    ConfigReader.fromNonEmptyStringTry(str => Try(BigInt(str)))
 
   implicit val ratioConfigReader: ConfigReader[Ratio] =
     ConfigReader.fromNonEmptyStringTry { str =>

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -86,7 +86,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig)(implicit syste
           PrivateTestnet.config(
             privateBigBang.timestamp,
             stakerInitializers,
-            privateBigBang.relativeStakes
+            privateBigBang.stakes
           )
         )
         .toResource

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -10,7 +10,6 @@ import co.topl.algebras._
 import co.topl.blockchain._
 import co.topl.catsakka._
 import co.topl.codecs.bytes.tetra.instances._
-import co.topl.codecs.bytes.typeclasses.implicits._
 import co.topl.common.application.{IOAkkaApp, IOBaseApp}
 import co.topl.consensus.algebras._
 import co.topl.consensus.models.{SlotData, VrfConfig}
@@ -86,7 +85,8 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig)(implicit syste
         .delay(
           PrivateTestnet.config(
             privateBigBang.timestamp,
-            stakerInitializers
+            stakerInitializers,
+            privateBigBang.relativeStakes
           )
         )
         .toResource

--- a/numerics/src/main/scala/co/topl/numerics/RatioOps.scala
+++ b/numerics/src/main/scala/co/topl/numerics/RatioOps.scala
@@ -53,6 +53,12 @@ object RatioOps {
           ratio.denominator
         )
 
+      def *(that: BigInt) =
+        Ratio(
+          ratio.numerator * that,
+          ratio.denominator
+        )
+
       def /(that: Long) =
         Ratio(
           ratio.numerator,


### PR DESCRIPTION
## Purpose
- Enables launching a Private Testnet using configurable relative stake values
- Updates ChainSelectionTest to use different stake values per staker
## Approach
- Add ApplicationConfig and application.conf settings for private testnet relative-stakes
- Use configuration settings when initializing a private testnet
- Update ChainSelectionTest to use 3/6, 2/6, and 1/6 relative stakes for each staker
- Update ChainSelectionTest to relaunch nodes in the order required by the P2P known peers
- Update ChainSelectionTest timeouts to be shorter (closer to expected durations)
## Testing
- Local test runs
## Tickets
N/A