### PR TITLE
BlockProducer Skip Operational Period If No Keys

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ClockAlgebra.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ClockAlgebra.scala
@@ -14,6 +14,7 @@ trait ClockAlgebra[F[_]] {
   def slotLength: F[FiniteDuration]
   // `R`
   def slotsPerEpoch: F[Long]
+  def slotsPerOperationalPeriod: F[Long]
   def currentEpoch: F[Epoch]
   def globalSlot: F[Slot]
   def currentTimestamp: F[Timestamp]

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -140,6 +140,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig)(implicit syste
       clock <- SchedulerClock.make[F](
         bigBangProtocol.slotDuration,
         bigBangProtocol.epochLength,
+        bigBangProtocol.operationalPeriodLength,
         Instant.ofEpochMilli(bigBangBlock.header.timestamp),
         bigBangProtocol.forwardBiasedSlotWindow,
         ntpClockSkewer


### PR DESCRIPTION
## Purpose
- A set of keys is held in-memory, and this set changes at the start of each operational period
- If a node restarts in the same operational period in which it previously stopped, it can't recreate the set of keys needed to make blocks for the current operational period
- The block producer should instead skip any slots/eligibilities within the current operational period
## Approach
- Add `slotsPerOperationalPeriod` to Clock
- When BlockProducer is unable to certify a block via the Staker, it will try again starting from the first slot of the next operational period
## Testing
- Byzantine Tests succeed locally, but unsure if this will fix the flakiness on GitHub
  - Ad-hoc test [success](https://github.com/Topl/Bifrost/actions/runs/4450533217)
## Tickets
- #BN-899