### PR TITLE
Create ad_hoc_test Workflow

### DIFF
--- a/.github/workflows/_sbt_byzantine_tests.yml
+++ b/.github/workflows/_sbt_byzantine_tests.yml
@@ -1,4 +1,4 @@
-name: Scala Integration Tests
+name: Scala Byzantine Tests
 
 on:
   workflow_call:
@@ -58,7 +58,7 @@ jobs:
           key: ${{ format('{0}-project-{1}-{2}', runner.os, github.base_ref, github.run_number) }}
           restore-keys: ${{ inputs.preserve-cache-between-runs && format('{0}-project-{1}-', runner.os, github.base_ref) || format('{0}-project-{1}-{2}', runner.os, github.base_ref, github.run_number) }}
 
-      - name: Integration Tests
+      - name: Byzantine Tests
         run: sbt ";node/Docker/publishLocal;byzantineTests/IntegrationTest/test"
 
       # Upload JUnit test results as an artifact so that we can publish a test report in our workflow.

--- a/.github/workflows/ad_hoc_test.yml
+++ b/.github/workflows/ad_hoc_test.yml
@@ -1,0 +1,20 @@
+name: Ad hoc Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sbt-build:
+    uses: ./.github/workflows/_sbt_build.yml
+    with:
+      preserve-cache-between-runs: true
+  sbt-integration-tests:
+    uses: ./.github/workflows/_sbt_integration_tests.yml
+    needs: [sbt-build]
+    with:
+      preserve-cache-between-runs: true
+  sbt-byzantine-tests:
+    uses: ./.github/workflows/_sbt_byzantine_tests.yml
+    needs: [sbt-build]
+    with:
+      preserve-cache-between-runs: true


### PR DESCRIPTION
## Purpose
- It is sometimes helpful to run the byzantine tests from a branch before merging it into `dev`
## Approach
- Add a new GitHub Workflow which uses `workflow_dispatch` as the event, allowing for runs from the GitHub web interface
  - Runs compile+test, node integration tests, and byzantine tests
## Testing
N/A (Needs to be merged into `dev` before the workflow is accessible)
## Tickets
N/A
