### PR TITLE
Upload Byzantine Test Logs

### DIFF
--- a/.github/workflows/_sbt_byzantine_tests.yml
+++ b/.github/workflows/_sbt_byzantine_tests.yml
@@ -18,6 +18,11 @@ on:
         default: false
         required: false
         type: boolean
+      debug-logging-enabled:
+        description: 'Enable Debug Logging?'
+        required: true
+        default: false
+        type: boolean
 
 jobs:
   tests:
@@ -60,6 +65,8 @@ jobs:
 
       - name: Byzantine Tests
         run: sbt ";node/Docker/publishLocal;byzantineTests/IntegrationTest/test"
+        env:
+          DEBUG: ${{ inputs.debug-logging-enabled }}
 
       # Upload JUnit test results as an artifact so that we can publish a test report in our workflow.
       # Artifacts can be found on the summary page for each individual workflow run.

--- a/.github/workflows/_sbt_byzantine_tests.yml
+++ b/.github/workflows/_sbt_byzantine_tests.yml
@@ -67,9 +67,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: Scala Integration Test Results (Java ${{ matrix.java }})
+          name: Scala Byzantine Test Results (Java ${{ matrix.java }})
           path: byzantine-tests/target/it-reports/*.xml
-
+      - name: Upload Test Logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Scala Byzantine Test Logs (Java ${{ matrix.java }})
+          path: byzantine-tests/target/logs/*.log
       - name: Cleanup before cache
         shell: bash
         run: |

--- a/.github/workflows/ad_hoc_test.yml
+++ b/.github/workflows/ad_hoc_test.yml
@@ -21,3 +21,4 @@ jobs:
   publish-test-results:
     uses: ./.github/workflows/_publish_test_results.yml
     needs: [sbt-build, sbt-integration-tests, sbt-byzantine-tests]
+    if: always()

--- a/.github/workflows/ad_hoc_test.yml
+++ b/.github/workflows/ad_hoc_test.yml
@@ -2,6 +2,12 @@ name: Ad hoc Test
 
 on:
   workflow_dispatch:
+    inputs:
+      debug-logging-enabled:
+        description: 'Enable Debug Logging?'
+        required: true
+        default: false
+        type: boolean
 
 jobs:
   sbt-build:
@@ -18,6 +24,7 @@ jobs:
     needs: [sbt-build]
     with:
       preserve-cache-between-runs: true
+      debug-logging-enabled: ${{ inputs.debug-logging-enabled }}
   publish-test-results:
     uses: ./.github/workflows/_publish_test_results.yml
     needs: [sbt-build, sbt-integration-tests, sbt-byzantine-tests]

--- a/.github/workflows/ad_hoc_test.yml
+++ b/.github/workflows/ad_hoc_test.yml
@@ -18,3 +18,6 @@ jobs:
     needs: [sbt-build]
     with:
       preserve-cache-between-runs: true
+  publish-test-results:
+    uses: ./.github/workflows/_publish_test_results.yml
+    needs: [sbt-build, sbt-integration-tests, sbt-byzantine-tests]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,3 +28,4 @@ jobs:
   publish-test-results:
     uses: ./.github/workflows/_publish_test_results.yml
     needs: [sbt-build, sbt-integration-tests]
+    if: always()

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,6 +22,9 @@ jobs:
     needs: [sbt-build]
     with:
       preserve-cache-between-runs: true
+  publish-test-results:
+    uses: ./.github/workflows/_publish_test_results.yml
+    needs: [sbt-build, sbt-integration-tests, sbt-byzantine-tests]
   build-jar:
     uses: ./.github/workflows/_sbt_jar.yml
     needs: [sbt-build]

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,6 +25,7 @@ jobs:
   publish-test-results:
     uses: ./.github/workflows/_publish_test_results.yml
     needs: [sbt-build, sbt-integration-tests, sbt-byzantine-tests]
+    if: always()
   build-jar:
     uses: ./.github/workflows/_sbt_jar.yml
     needs: [sbt-build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
   publish-test-results:
     uses: ./.github/workflows/_publish_test_results.yml
     needs: [sbt-build, sbt-integration-tests, sbt-byzantine-tests]
+    if: always()
   create-release:
     runs-on: ubuntu-latest
     needs: [sbt-build, sbt-integration-tests, sbt-byzantine-tests, build-jar]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
   build-jar:
     uses: ./.github/workflows/_sbt_jar.yml
     needs: [sbt-build]
+  publish-test-results:
+    uses: ./.github/workflows/_publish_test_results.yml
+    needs: [sbt-build, sbt-integration-tests, sbt-byzantine-tests]
   create-release:
     runs-on: ubuntu-latest
     needs: [sbt-build, sbt-integration-tests, sbt-byzantine-tests, build-jar]

--- a/byzantine-tests/src/it/resources/logback-container.xml
+++ b/byzantine-tests/src/it/resources/logback-container.xml
@@ -10,6 +10,9 @@
         <appender-ref ref="STDOUT" />
     </appender>
 
+    <logger name="co.topl" level="${BIFROST_LOG_LEVEL}" />
+    <logger name="Bifrost" level="${BIFROST_LOG_LEVEL}" />
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/ChainSelectionTest.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/ChainSelectionTest.scala
@@ -4,7 +4,6 @@ import cats.effect.implicits._
 import cats.implicits._
 import co.topl.tetra.it.util._
 import com.spotify.docker.client.DockerClient
-
 import fs2._
 
 import java.time.Instant
@@ -40,7 +39,7 @@ class ChainSelectionTest extends IntegrationSuite {
     )
 
     val resource = for {
-      (dockerSupport, _dockerClient) <- DockerSupport.make[F]
+      (dockerSupport, _dockerClient) <- DockerSupport.make[F]()
       implicit0(dockerClient: DockerClient) = _dockerClient
       node0 <- dockerSupport.createNode("ChainSelectionTest-node0", "ChainSelectionTest", config0.yaml)
       node1 <- dockerSupport.createNode("ChainSelectionTest-node1", "ChainSelectionTest", config1.yaml)

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/MultiNodeTest.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/MultiNodeTest.scala
@@ -22,7 +22,7 @@ class MultiNodeTest extends IntegrationSuite {
     val config2 = TestNodeConfig(bigBang, 3, 2, List("MultiNodeTest-node1"))
     val resource =
       for {
-        (dockerSupport, _dockerClient) <- DockerSupport.make[F]
+        (dockerSupport, _dockerClient) <- DockerSupport.make[F]()
         implicit0(dockerClient: DockerClient) = _dockerClient
         node1 <- dockerSupport.createNode("MultiNodeTest-node0", "MultiNodeTest", config0.yaml)
         node2 <- dockerSupport.createNode("MultiNodeTest-node1", "MultiNodeTest", config1.yaml)

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/SanityCheckNodeTest.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/SanityCheckNodeTest.scala
@@ -10,7 +10,7 @@ class SanityCheckNodeTest extends IntegrationSuite {
   test("A single node is successfully started, id of the genesis block is available through RPC") {
     val resource =
       for {
-        (dockerSupport, _dockerClient) <- DockerSupport.make[F]
+        (dockerSupport, _dockerClient) <- DockerSupport.make[F]()
         implicit0(dockerClient: DockerClient) = _dockerClient
         node1       <- dockerSupport.createNode("SingleNodeTest-node1", "SingleNodeTest", TestNodeConfig().yaml)
         _           <- node1.startContainer[F].toResource

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
@@ -33,8 +33,8 @@ object DockerSupport {
     import scala.jdk.CollectionConverters._
     val env = System.getenv().asScala
     env
-      .get("ACTIONS_STEP_DEBUG")
-      .orElse(env.get("DEBUG"))
+      .get("ACTIONS_STEP_DEBUG") // GitHub Actions will set this env variable if "Re-Run with Debug Logging" is selected
+      .orElse(env.get("DEBUG")) // This is just a general-purpose environment variable
       .exists(_.toBoolean)
   }
 

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
@@ -1,7 +1,9 @@
 package co.topl.tetra.it.util
 
+import cats.Applicative
 import cats.effect._
 import cats.implicits._
+import cats.effect.implicits._
 import co.topl.buildinfo.node.BuildInfo
 import com.spotify.docker.client.messages.ContainerConfig
 import com.spotify.docker.client.messages.HostConfig
@@ -9,6 +11,8 @@ import com.spotify.docker.client.messages.NetworkConfig
 import com.spotify.docker.client.messages.NetworkCreation
 import com.spotify.docker.client.DefaultDockerClient
 import com.spotify.docker.client.DockerClient
+import fs2.io.file.Files
+import fs2.io.file.Path
 
 import java.time.Instant
 import scala.jdk.CollectionConverters._
@@ -25,7 +29,9 @@ trait DockerSupport[F[_]] {
 
 object DockerSupport {
 
-  def make[F[_]: Async]: Resource[F, (DockerSupport[F], DockerClient)] =
+  def make[F[_]: Async](
+    containerLogsDirectory: Option[Path] = Some(Path("byzantine-tests") / "target" / "logs")
+  ): Resource[F, (DockerSupport[F], DockerClient)] =
     for {
       implicit0(dockerClient: DockerClient) <- Resource.make(Sync[F].blocking(DefaultDockerClient.fromEnv().build()))(
         c => Sync[F].blocking(c.close())
@@ -48,66 +54,84 @@ object DockerSupport {
             .void
         )
       )
-      dockerSupport = new DockerSupport[F] {
-
-        def createNode(name: String, nodeGroupName: String, configYaml: String): Resource[F, BifrostDockerTetraNode] =
-          Resource
-            .make(createContainer(name, nodeGroupName))(node =>
-              Sync[F]
-                .blocking(dockerClient.removeContainer(node.containerId, DockerClient.RemoveContainerParam.forceKill))
-            )
-            .evalTap(_.configure(configYaml))
-
-        private def createContainer(name: String, nodeGroupName: String): F[BifrostDockerTetraNode] =
-          for {
-            networkName       <- (DockerSupport.networkNamePrefix + nodeGroupName).pure[F]
-            containerConfig   <- buildContainerConfig(name, Map.empty).pure[F]
-            containerCreation <- Sync[F].blocking(dockerClient.createContainer(containerConfig, name))
-            node              <- BifrostDockerTetraNode(containerCreation.id(), name).pure[F]
-            _                 <- nodeCache.update(_ + node)
-            networkId <- Sync[F].blocking(dockerClient.listNetworks().asScala.find(_.name == networkName)).flatMap {
-              case Some(network) => network.id().pure[F]
-              case None =>
-                Sync[F]
-                  .blocking(dockerClient.createNetwork(NetworkConfig.builder().name(networkName).build()))
-                  .flatTap(n => networkCache.update(_ + n))
-                  .map(_.id())
-            }
-            _ <- Sync[F].blocking(dockerClient.connectToNetwork(node.containerId, networkId))
-          } yield node
-
-        private def buildContainerConfig(name: String, environment: Map[String, String]): ContainerConfig = {
-          val env =
-            environment.toList.map { case (key, value) => s"$key=$value" }
-
-          val cmd =
-            List(
-              s"-Dcom.sun.management.jmxremote.port=$jmxRemotePort",
-              s"-Dcom.sun.management.jmxremote.rmi.port=$jmxRemotePort",
-              "-Dcom.sun.management.jmxremote.ssl=false",
-              "-Dcom.sun.management.jmxremote.local.only=false",
-              "-Dcom.sun.management.jmxremote.authenticate=false",
-              "--config",
-              "/opt/docker/config/node.yaml",
-              "--debug"
-            )
-
-          val hostConfig =
-            HostConfig.builder().build()
-
-          ContainerConfig
-            .builder()
-            .image(DockerSupport.bifrostImage)
-            .env(env: _*)
-            .volumes(configDirectory)
-            .cmd(cmd: _*)
-            .hostname(name)
-            .hostConfig(hostConfig)
-            .exposedPorts(exposedPorts: _*)
-            .build()
-        }
-      }
+      _ <- containerLogsDirectory.fold(Resource.unit[F])(Files[F].createDirectories(_).toResource)
+      dockerSupport = new Impl[F](containerLogsDirectory, nodeCache, networkCache)
     } yield (dockerSupport, dockerClient)
+
+  private class Impl[F[_]: Async](
+    containerLogsDirectory: Option[Path],
+    nodeCache:              Ref[F, Set[BifrostDockerTetraNode]],
+    networkCache:           Ref[F, Set[NetworkCreation]]
+  )(implicit dockerClient: DockerClient)
+      extends DockerSupport[F] {
+
+    def createNode(name: String, nodeGroupName: String, configYaml: String): Resource[F, BifrostDockerTetraNode] =
+      for {
+        node <- Resource.make(createContainer(name, nodeGroupName))(node =>
+          Sync[F].defer(node.stop[F]) >>
+          containerLogsDirectory
+            .map(_ / s"$name-${node.containerId.take(8)}.log")
+            .fold(Applicative[F].unit)(node.saveContainerLogs[F]) >>
+          deleteContainer(node)
+        )
+        _ <- Resource.onFinalize(Sync[F].defer(nodeCache.update(_ - node)))
+        _ <- node.configure(configYaml).toResource
+      } yield node
+
+    private def createContainer(name: String, nodeGroupName: String): F[BifrostDockerTetraNode] =
+      for {
+        networkName       <- (DockerSupport.networkNamePrefix + nodeGroupName).pure[F]
+        containerConfig   <- buildContainerConfig(name, Map.empty).pure[F]
+        containerCreation <- Sync[F].blocking(dockerClient.createContainer(containerConfig, name))
+        node              <- BifrostDockerTetraNode(containerCreation.id(), name).pure[F]
+        _                 <- nodeCache.update(_ + node)
+        networkId <- Sync[F].blocking(dockerClient.listNetworks().asScala.find(_.name == networkName)).flatMap {
+          case Some(network) => network.id().pure[F]
+          case None =>
+            Sync[F]
+              .blocking(dockerClient.createNetwork(NetworkConfig.builder().name(networkName).build()))
+              .flatTap(n => networkCache.update(_ + n))
+              .map(_.id())
+        }
+        _ <- Sync[F].blocking(dockerClient.connectToNetwork(node.containerId, networkId))
+      } yield node
+
+    private def deleteContainer(node: BifrostDockerTetraNode): F[Unit] =
+      Sync[F].blocking(
+        dockerClient.removeContainer(node.containerId, DockerClient.RemoveContainerParam.forceKill)
+      )
+
+    private def buildContainerConfig(name: String, environment: Map[String, String]): ContainerConfig = {
+      val env =
+        environment.toList.map { case (key, value) => s"$key=$value" }
+
+      val cmd =
+        List(
+          s"-Dcom.sun.management.jmxremote.port=$jmxRemotePort",
+          s"-Dcom.sun.management.jmxremote.rmi.port=$jmxRemotePort",
+          "-Dcom.sun.management.jmxremote.ssl=false",
+          "-Dcom.sun.management.jmxremote.local.only=false",
+          "-Dcom.sun.management.jmxremote.authenticate=false",
+          "--config",
+          "/opt/docker/config/node.yaml",
+          "--debug"
+        )
+
+      val hostConfig =
+        HostConfig.builder().build()
+
+      ContainerConfig
+        .builder()
+        .image(DockerSupport.bifrostImage)
+        .env(env: _*)
+        .volumes(configDirectory)
+        .cmd(cmd: _*)
+        .hostname(name)
+        .hostConfig(hostConfig)
+        .exposedPorts(exposedPorts: _*)
+        .build()
+    }
+  }
 
   val configDirectory = "/opt/docker/config"
 

--- a/node/src/main/resources/logback.xml
+++ b/node/src/main/resources/logback.xml
@@ -10,7 +10,8 @@
         <appender-ref ref="STDOUT" />
     </appender>
 
-    <logger name="co.topl" level="INFO" />
+    <logger name="co.topl" level="DEBUG" />
+    <logger name="Bifrost" level="DEBUG" />
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
## Purpose
- The Byzantine Tests are flaky in GitHub Actions, but it is hard to understand why they fail without the underlying node logs
## Approach
- Add helper method to read the logs from a Docker container
- Write container logs to a file on finalize
- Upload container logs to GitHub actions
## Testing
- Publishes log [files](https://github.com/Topl/Bifrost/actions/runs/4471148927)
  ![image](https://user-images.githubusercontent.com/2218886/226428812-ddbbae90-f202-4b11-ab47-6ad32534fb78.png)
## Tickets
- Relates to BN-921