### PR TITLE
Debug Logging Flag Required False

### DIFF
--- a/.github/workflows/_sbt_byzantine_tests.yml
+++ b/.github/workflows/_sbt_byzantine_tests.yml
@@ -20,7 +20,7 @@ on:
         type: boolean
       debug-logging-enabled:
         description: 'Enable Debug Logging?'
-        required: true
+        required: false
         default: false
         type: boolean
 

--- a/.github/workflows/ad_hoc_test.yml
+++ b/.github/workflows/ad_hoc_test.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       debug-logging-enabled:
         description: 'Enable Debug Logging?'
-        required: true
+        required: false
         default: false
         type: boolean
 


### PR DESCRIPTION
## Purpose
- `debug-logging-enabled` input was unnecessarily marked as "required" which fails the "Push" (and Release) [workflows](https://github.com/Topl/Bifrost/actions/runs/4483895471)
## Approach
- Set `debug-logging-enabled` required to false
## Testing
N/A
## Tickets
- Relates to BN-921