### PR TITLE
TSDK-405 Support Changes to Ecosystem Crypto

### DIFF
--- a/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
@@ -193,9 +193,9 @@ object BlockHeaderValidation {
                 // Use the ed25519 instance to verify the childSignature against the header's bytes
                 ed25519
                   .verify(
-                    header.operationalCertificate.childSignature,
-                    header.unsigned.signableBytes,
-                    header.operationalCertificate.childVK
+                    header.operationalCertificate.childSignature.toByteArray,
+                    header.unsigned.signableBytes.toByteArray,
+                    Ed25519.PublicKey(header.operationalCertificate.childVK.toByteArray)
                   )
                   .pure[F]
               )

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/QuivrContext.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/QuivrContext.scala
@@ -59,7 +59,9 @@ object QuivrContext {
         Sync[F].delay(
           Either.cond(
             ed25519.verify(
-              t.signature.toByteArray, t.message.toByteArray, Ed25519.PublicKey(t.verificationKey.toByteArray)
+              t.signature.toByteArray,
+              t.message.toByteArray,
+              Ed25519.PublicKey(t.verificationKey.toByteArray)
             ),
             t,
             QuivrRuntimeErrors.ValidationError.UserProvidedInterfaceFailure // TODO

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/QuivrContext.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/QuivrContext.scala
@@ -58,7 +58,9 @@ object QuivrContext {
       def validate(t: SignatureVerification): F[Either[QuivrRuntimeError, SignatureVerification]] =
         Sync[F].delay(
           Either.cond(
-            ed25519.verify(t.signature.value, t.message.value, t.verificationKey.value),
+            ed25519.verify(
+              t.signature.toByteArray, t.message.toByteArray, Ed25519.PublicKey(t.verificationKey.toByteArray)
+            ),
             t,
             QuivrRuntimeErrors.ValidationError.UserProvidedInterfaceFailure // TODO
           )

--- a/minting/src/main/scala/co/topl/minting/interpreters/OperationalKeyMaker.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/OperationalKeyMaker.scala
@@ -214,7 +214,12 @@ object OperationalKeyMaker {
                   ed.deriveKeyPairFromEntropy(Entropy.fromUuid(UUID.randomUUID()), None)
                 )
               )
-              .map { case (sk, vk) => (sk: ByteString, vk: ByteString) }
+              .map { keyPair =>
+                (
+                  ByteString.copyFrom(keyPair.signingKey.bytes),
+                  ByteString.copyFrom(keyPair.verificationKey.bytes)
+                )
+              }
           )
         )
         .flatMap(children =>

--- a/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
@@ -14,7 +14,7 @@ import co.topl.crypto.hash.Blake2b256
 import co.topl.crypto.signing.Ed25519
 import co.topl.minting.algebras._
 import co.topl.minting.models.VrfHit
-import co.topl.models._
+import co.topl.models._
 import co.topl.typeclasses.implicits._
 import com.google.protobuf.ByteString
 import org.typelevel.log4cats.Logger

--- a/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
@@ -14,8 +14,7 @@ import co.topl.crypto.hash.Blake2b256
 import co.topl.crypto.signing.Ed25519
 import co.topl.minting.algebras._
 import co.topl.minting.models.VrfHit
-import co.topl.models._
-import co.topl.models.utility._
+import co.topl.models._
 import co.topl.typeclasses.implicits._
 import com.google.protobuf.ByteString
 import org.typelevel.log4cats.Logger
@@ -88,12 +87,17 @@ object Staking {
               )
               unsignedBlock = unsignedBlockBuilder(partialCertificate)
               messageToSign = unsignedBlock.signableBytes
-              signature <- ed25519Resource.use(_.sign(operationalKeyOut.childSK, messageToSign).pure[F])
+              signature <- ed25519Resource.use(
+                _.sign(
+                  Ed25519.SecretKey(operationalKeyOut.childSK.toByteArray),
+                  messageToSign.toByteArray
+                ).pure[F]
+              )
               operationalCertificate = OperationalCertificate(
                 operationalKeyOut.parentVK,
                 operationalKeyOut.parentSignature,
                 partialCertificate.childVK,
-                signature
+                ByteString.copyFrom(signature)
               )
               header = BlockHeader(
                 unsignedBlock.parentHeaderId,

--- a/minting/src/test/scala/co/topl/minting/interpreters/OperationalKeyMakerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/OperationalKeyMakerSpec.scala
@@ -149,7 +149,8 @@ class OperationalKeyMakerSpec
                   kesProduct
                     .verify(
                       out.parentSignature,
-                      ed25519.getVerificationKey(out.childSK: Bytes).toArray ++ Longs.toByteArray(i),
+                      ed25519.getVerificationKey(Ed25519.SecretKey(out.childSK.toByteArray)).bytes ++ Longs
+                        .toByteArray(i),
                       vk
                     )
                     .pure[F],
@@ -274,7 +275,8 @@ class OperationalKeyMakerSpec
                   kesProduct
                     .verify(
                       out.parentSignature,
-                      ed25519.getVerificationKey(out.childSK: Bytes).toArray ++ Longs.toByteArray(i),
+                      ed25519.getVerificationKey(Ed25519.SecretKey(out.childSK.toByteArray)).bytes ++ Longs
+                        .toByteArray(i),
                       expectedVK
                     )
                     .pure[F],

--- a/node-crypto/src/test/scala/co/topl/crypto/signing/Ed25519VRFSpec.scala
+++ b/node-crypto/src/test/scala/co/topl/crypto/signing/Ed25519VRFSpec.scala
@@ -11,6 +11,8 @@ import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scodec.bits.ByteVector
 
+import java.nio.charset.StandardCharsets
+
 /**
  * Reference -https://github.com/Topl/reference_crypto/tree/main/specs/crypto/signing/VRF-Ed25519-Sha512-TAI
  *
@@ -52,7 +54,7 @@ class Ed25519VRFSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks wit
   }
 
   property("Topl specific seed generation mechanism should generate a fixed secret key given an entropy and password") {
-    val e = Entropy(ByteVector.encodeUtf8("topl").toOption.get)
+    val e = Entropy("topl".getBytes(StandardCharsets.UTF_8))
     val p = "topl"
     val specOutSK =
       ByteVector(Hex.decode("d8f0ad4d22ec1a143905af150e87c7f0dadd13749ef56fbd1bb380c37bc18cf8"))

--- a/node-crypto/src/test/scala/co/topl/crypto/utils/KesTestHelper.scala
+++ b/node-crypto/src/test/scala/co/topl/crypto/utils/KesTestHelper.scala
@@ -1,7 +1,6 @@
 package co.topl.crypto.utils
 
 import co.topl.crypto.models._
-import scodec.bits.ByteVector
 
 object KesTestHelper {
 
@@ -10,26 +9,26 @@ object KesTestHelper {
     // false-true corresponds to left or right child node with respect to the parent being constructed
     // witness elements and seeds should be provided for each level of the tree in order of highest to lowest
     // sk and vk are the leaf (lowest) level private and public keys
-    type Args = (Boolean, (ByteVector, ByteVector, ByteVector))
+    type Args = (Boolean, (Array[Byte], Array[Byte], Array[Byte]))
 
-    def build(sk: ByteVector, vk: ByteVector, args: Args*): KesBinaryTree =
+    def build(sk: Array[Byte], vk: Array[Byte], args: Args*): KesBinaryTree =
       args.length match {
         case 0 =>
-          KesBinaryTree.SigningLeaf(sk.toArray, vk.toArray)
+          KesBinaryTree.SigningLeaf(sk, vk)
         case _ =>
           if (args.head._1) {
             KesBinaryTree.MerkleNode(
-              args.head._2._1.toArray,
-              args.head._2._2.toArray,
-              args.head._2._3.toArray,
+              args.head._2._1,
+              args.head._2._2,
+              args.head._2._3,
               KesBinaryTree.Empty(),
               this.build(sk, vk, args.tail: _*)
             )
           } else {
             KesBinaryTree.MerkleNode(
-              args.head._2._1.toArray,
-              args.head._2._2.toArray,
-              args.head._2._3.toArray,
+              args.head._2._1,
+              args.head._2._2,
+              args.head._2._3,
               this.build(sk, vk, args.tail: _*),
               KesBinaryTree.Empty()
             )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val logback = "1.4.6"
   val orientDbVersion = "3.2.17"
   val protobufSpecsVersion = "951cead" // scala-steward:off
-  val bramblScVersion = "7e7b380" // scala-steward:off
+  val bramblScVersion = "8150ea6" // scala-steward:off
   val quivr4sVersion = "69c2605" // scala-steward:off
 
   val catsSlf4j =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,9 +11,9 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.6"
   val orientDbVersion = "3.2.17"
-  val protobufSpecsVersion = "76af295" // scala-steward:off
-  val bramblScVersion = "7a4db31" // scala-steward:off
-  val quivr4sVersion = "ad5d05e" // scala-steward:off
+  val protobufSpecsVersion = "951cead" // scala-steward:off
+  val bramblScVersion = "7e7b380" // scala-steward:off
+  val quivr4sVersion = "69c2605" // scala-steward:off
 
   val catsSlf4j =
     "org.typelevel" %% "log4cats-slf4j" % "2.5.0"


### PR DESCRIPTION
## Purpose

There will be breaking changes in Ecosystem Crypto after https://github.com/Topl/BramblSc/pull/29 and https://github.com/Topl/BramblSc/pull/30 are merged. Bifrost needs to be updated to support these changes.

## Approach

Fix code that is necessary for all the tests (that broke due to ecosystem crypto changes) to pass.

## Testing

- Ran `checkPR`
![image](https://user-images.githubusercontent.com/17934976/226761850-c6723b53-7ede-45d9-8ced-81db46cd130c.png)
- Ran `preparePR`
![image](https://user-images.githubusercontent.com/17934976/226761890-f19d1741-d6fb-4f5b-9f8c-bc026d2e776b.png)
- Ran `checkPRTestQuick`
![image](https://user-images.githubusercontent.com/17934976/226761918-560454ad-103c-457a-bbfe-62d987b783e1.png)

## Tickets
* Closes TSDK-405