### PR TITLE
use 'source' to start 'dev_setup.sh'

### DIFF
--- a/docs/DevelopmentSetup.md
+++ b/docs/DevelopmentSetup.md
@@ -2,7 +2,12 @@
 Bifrost officially supports development on Ubuntu.  Other operating systems may still work, but the Topl team may be unable to support certain questions.
 
 ## Installation
-A [convenience script](./scripts/dev_setup.sh) is provided which will run the following steps automatically.  We highly recommend reading the contents of the script before running it.  The convenience script can be run by typing `./docs/scripts/dev_setup.sh` from the command line (from the repository root).
+A [convenience script](./scripts/dev_setup.sh) is provided which will run the following steps automatically. We highly recommend reading the contents of the script before running it. The convenience script can be run by typing
+```sh
+source ./docs/scripts/dev_setup.sh
+```
+
+from the command line (from the repository root).
 Otherwise, the directions below will suffice.
 
 ### Docker, Java, and SBT


### PR DESCRIPTION
(supersedes #2868)

## Purpose

Ensure that sbt/scala is available on cli right after dev_setup.sh is executed.

## Approach

Use `source ./docs/scripts/dev_setup.sh`

## Testing

On a fresh ubuntu22.04 container

```sh
# within the bifrost repo root
sbt # => not found
source ./docs/scripts/dev_setup.sh
sbt compile
sbt test
```
## Tickets
* none