### PR TITLE
BlockHeaderValidation Fixes

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/BlockchainPeerHandler.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BlockchainPeerHandler.scala
@@ -214,11 +214,7 @@ object BlockchainPeerHandler {
             .evalMap { case (blockId, header) =>
               for {
                 _ <- Logger[F].debug(show"Validating remote header id=$blockId")
-                _ <- EitherT(
-                  headerStore
-                    .getOrRaise(header.parentHeaderId)
-                    .flatMap(headerValidation.validate(header, _))
-                )
+                _ <- EitherT(headerValidation.validate(header))
                   .leftSemiflatTap(error =>
                     Logger[F].warn(show"Received invalid block header id=$blockId error=$error")
                   )

--- a/consensus/src/main/scala/co/topl/consensus/algebras/BlockHeaderValidationAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/BlockHeaderValidationAlgebra.scala
@@ -8,8 +8,5 @@ trait BlockHeaderValidationAlgebra[F[_]] {
   /**
    * Indicates if the claimed child is a valid descendent of the parent
    */
-  def validate(
-    child:  BlockHeader,
-    parent: BlockHeader
-  ): F[Either[BlockHeaderValidationFailure, BlockHeader]]
+  def validate(header: BlockHeader): F[Either[BlockHeaderValidationFailure, BlockHeader]]
 }

--- a/consensus/src/main/scala/co/topl/consensus/models/BlockHeaderValidationFailure.scala
+++ b/consensus/src/main/scala/co/topl/consensus/models/BlockHeaderValidationFailure.scala
@@ -20,8 +20,6 @@ object BlockHeaderValidationFailures {
 
   case class SlotBeyondForwardBiasedSlotWindow(globalSlot: Slot, blockSlot: Slot) extends BlockHeaderValidationFailure
 
-  case class ParentMismatch(expectedParentId: BlockId, parentId: BlockId) extends BlockHeaderValidationFailure
-
   case class InvalidVrfThreshold(threshold: Ratio) extends BlockHeaderValidationFailure
 
   case class IneligibleCertificate(

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
@@ -233,8 +233,7 @@ object BlockChecker {
     def verifyAndSaveHeader(headerId: BlockId, header: BlockHeader) =
       for {
         _ <- Logger[F].debug(show"Validating remote header id=$headerId")
-        validationFunction = state.headerValidation.validate(header, _)
-        _ <- EitherT(state.headerStore.getOrRaise(header.parentHeaderId).flatMap(validationFunction))
+        _ <- EitherT(state.headerValidation.validate(header))
           .leftSemiflatTap(error => Logger[F].warn(show"Received invalid block header id=$headerId error=$error"))
           .leftMap(error => new IllegalArgumentException(error.show))
           .rethrowT

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
@@ -384,7 +384,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
       (headerStore.contains _).expects(*).rep(headers.size.toInt).returning(true.pure[F])
-      (headerValidation.validate _).expects(*, *).never()
+      (headerValidation.validate _).expects(*).never()
 
       BlockChecker
         .makeActor(
@@ -429,7 +429,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
       (headerStore.contains _).expects(*).rep(headers.size.toInt).returning(true.pure[F])
-      (headerValidation.validate _).expects(*, *).never()
+      (headerValidation.validate _).expects(*).never()
 
       BlockChecker
         .makeActor(
@@ -494,10 +494,10 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         ().pure[F]
       }
 
-      (headerValidation.validate _).expects(*, *).rep(newIdAndHeaders.size).onCall {
-        case (header: BlockHeader, _: BlockHeader) =>
-          Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F]
-      }
+      (headerValidation.validate _)
+        .expects(*)
+        .rep(newIdAndHeaders.size)
+        .onCall((header: BlockHeader) => Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F])
 
       val expectedIds = NonEmptyChain.fromSeq(newIdAndHeaders.map(_._1)).get
       val expectedMessage: PeersManager.Message = PeersManager.Message.BlockDownloadRequest(hostId, expectedIds)
@@ -569,10 +569,10 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         ().pure[F]
       }
 
-      (headerValidation.validate _).expects(*, *).rep(newIdAndHeaders.size).onCall {
-        case (header: BlockHeader, _: BlockHeader) =>
-          Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F]
-      }
+      (headerValidation.validate _)
+        .expects(*)
+        .rep(newIdAndHeaders.size)
+        .onCall((header: BlockHeader) => Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F])
 
       val expectedIds = NonEmptyChain.fromSeq(newIdAndHeaders.map(_._1)).get
       val expectedMessage: PeersManager.Message = PeersManager.Message.BlockDownloadRequest(hostId, expectedIds)

--- a/node/src/main/scala/co/topl/node/CryptoResources.scala
+++ b/node/src/main/scala/co/topl/node/CryptoResources.scala
@@ -19,7 +19,9 @@ object CryptoResources {
 
   def make[F[_]: Async]: F[CryptoResources[F]] =
     Async[F]
-      .delay(Runtime.getRuntime.availableProcessors())
+      // Limit the number of each resource to the number of available processors,
+      // but with a minimum of 4 to avoid scarcity
+      .delay(Runtime.getRuntime.availableProcessors().max(4))
       .flatMap(maxParallelism =>
         (
           CatsUnsafeResource.make[F, Blake2b256](new Blake2b256, maxParallelism),

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -218,6 +218,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig)(implicit syste
         Validators.make[F](
           cryptoResources,
           dataStores,
+          bigBangBlockId,
           currentEventIdGetterSetters,
           blockIdTree,
           etaCalculation,

--- a/node/src/main/scala/co/topl/node/Validators.scala
+++ b/node/src/main/scala/co/topl/node/Validators.scala
@@ -39,6 +39,7 @@ object Validators {
   def make[F[_]: Async](
     cryptoResources:             CryptoResources[F],
     dataStores:                  DataStores[F],
+    bigBangBlockId:              BlockId,
     currentEventIdGetterSetters: CurrentEventIdGetterSetters[F],
     blockIdTree:                 ParentChildTree[F, BlockId],
     etaCalculation:              EtaCalculationAlgebra[F],
@@ -53,12 +54,14 @@ object Validators {
           consensusValidationState,
           leaderElectionThreshold,
           clockAlgebra,
+          dataStores.headers,
+          bigBangBlockId,
           cryptoResources.ed25519VRF,
           cryptoResources.kesProduct,
           cryptoResources.ed25519,
           cryptoResources.blake2b256
         )
-        .flatMap(BlockHeaderValidation.WithCache.make[F](_, dataStores.headers))
+        .flatMap(BlockHeaderValidation.WithCache.make[F](_, dataStores.headers, bigBangBlockId))
       headerToBody <- BlockHeaderToBodyValidation.make()
       boxState <- BoxState.make(
         currentEventIdGetterSetters.boxState.get(),


### PR DESCRIPTION
## Purpose
- Occasionally, a node appears to halt when performing BlockHeaderValidation
## Approach
- Update BlockHeaderValidationAlgebra to only accept the header to be validated
- Update BlockHeaderValidation to use for-comprehensions in the implementations
- Update BlockHeaderValidation to wrap `unsafeResource.use` calls with `Sync[F].delay`
- Update CatsUnsafeResource to use a `Resource` internally, to enable proper re-queue in the event of an error
- CatsUnsafeResource default parallelism minimum is now 4 to avoid starving the resource
## Testing
- Ad hoc Test runs pass (more) consistently, but there are still lingering issues that occasionally pop up
## Tickets
- Relates to #BN-921
