### PR TITLE
Bn 879 block body sync error handling part 1

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
@@ -15,6 +15,7 @@ import co.topl.ledger.models.StaticBodyValidationContext
 import co.topl.networking.fsnetwork.BlockChecker.Message._
 import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
+import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
 import co.topl.node.models._
 import co.topl.typeclasses.implicits._
 import fs2.Stream
@@ -57,6 +58,7 @@ object BlockChecker {
   case class State[F[_]](
     reputationAggregator:        ReputationAggregatorActor[F],
     peersManager:                PeersManagerActor[F],
+    requestsProxy:               RequestsProxyActor[F],
     localChain:                  LocalChainAlgebra[F],
     slotDataStore:               Store[F, BlockId, SlotData],
     headerStore:                 Store[F, BlockId, BlockHeader],
@@ -86,6 +88,7 @@ object BlockChecker {
   def makeActor[F[_]: Async: Logger](
     reputationAggregator:        ReputationAggregatorActor[F],
     peersManager:                PeersManagerActor[F],
+    requestsProxy:               RequestsProxyActor[F],
     localChain:                  LocalChainAlgebra[F],
     slotDataStore:               Store[F, BlockId, SlotData],
     headerStore:                 Store[F, BlockId, BlockHeader],
@@ -103,6 +106,7 @@ object BlockChecker {
       State(
         reputationAggregator,
         peersManager,
+        requestsProxy,
         localChain,
         slotDataStore,
         headerStore,
@@ -212,7 +216,7 @@ object BlockChecker {
         newHeadersOpt = state.headerStore.filterKnownBlocks(blockHeaders)
         newHeaders       <- EitherT.fromOptionF(newHeadersOpt, "Skip validation for known headers")
         (verifiedIds, _) <- verifyAndSaveHeaders(state, newHeaders)
-        _                <- EitherT.right[String](requestBlockBodies(state, hostId, verifiedIds))
+        _                <- EitherT.right[String](requestBlockBodies(state, hostId, verifiedIds.last))
         // we no need to request next headers if we are no longer on the best chain
         receivedHeadersAreInBestChain = state.bestKnownRemoteSlotDataOpt.exists(_.contains(verifiedIds.last))
         _ <- EitherT.right[String](if (receivedHeadersAreInBestChain) requestNextHeaders(state) else ().pure[F])
@@ -256,12 +260,20 @@ object BlockChecker {
   }
 
   private def requestBlockBodies[F[_]: Async: Logger](
-    state:    State[F],
-    hostId:   HostId,
-    blockIds: NonEmptyChain[BlockId]
-  ): F[Unit] =
-    Logger[F].info(show"Send request to get missed bodies for blockIds: $blockIds") >>
-    state.peersManager.sendNoWait(PeersManager.Message.BlockDownloadRequest(hostId, blockIds))
+    state:             State[F],
+    hostId:            HostId,
+    bestKnownHeaderId: BlockId
+  ): F[Unit] = {
+    val getMissedBodiesFun =
+      getFromChainUntil[F, BlockId](state.slotDataStore.getOrRaise, id => id.pure[F], state.bodyStore.contains) _
+
+    for {
+      missedBodies <- getMissedBodiesFun(bestKnownHeaderId)
+      _            <- Logger[F].info(show"Send request to get missed bodies for blockIds: $missedBodies")
+      message = RequestsProxy.Message.DownloadBlocksRequest(hostId, NonEmptyChain.fromSeq(missedBodies).get)
+      _ <- state.requestsProxy.sendNoWait(message)
+    } yield ()
+  }
 
   private def processRemoteBodies[F[_]: Async: Logger](
     state:       State[F],

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
@@ -62,6 +62,7 @@ object NetworkManager {
       _ <- Resource.liftK(requestsProxy.sendNoWait(RequestsProxy.Message.SetupBlockChecker(blocksChecker)))
       _ <- Resource.liftK(peerManager.sendNoWait(PeersManager.Message.SetupReputationAggregator(reputationAggregator)))
       _ <- Resource.liftK(peerManager.sendNoWait(PeersManager.Message.SetupBlockChecker(blocksChecker)))
+      _ <- Resource.liftK(peerManager.sendNoWait(PeersManager.Message.SetupRequestsProxy(requestsProxy)))
       // TODO send initial host list to peer manager
     } yield peerManager
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
@@ -42,9 +42,11 @@ object NetworkManager {
         blockIdTree
       )
       reputationAggregator <- networkAlgebra.makeReputationAggregation(peerManager)
+      requestsProxy <- networkAlgebra.makeRequestsProxy(reputationAggregator, peerManager, headerStore, bodyStore)
       blocksChecker <- networkAlgebra.makeBlockChecker(
         reputationAggregator,
         peerManager,
+        requestsProxy,
         localChain,
         slotDataStore,
         headerStore,
@@ -57,6 +59,7 @@ object NetworkManager {
         chainSelectionAlgebra
       )
 
+      _ <- Resource.liftK(requestsProxy.sendNoWait(RequestsProxy.Message.SetupBlockChecker(blocksChecker)))
       _ <- Resource.liftK(peerManager.sendNoWait(PeersManager.Message.SetupReputationAggregator(reputationAggregator)))
       _ <- Resource.liftK(peerManager.sendNoWait(PeersManager.Message.SetupBlockChecker(blocksChecker)))
       // TODO send initial host list to peer manager

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
@@ -5,7 +5,6 @@ import cats.effect.{Async, Resource}
 import cats.implicits._
 import co.topl.actor.{Actor, Fsm}
 import co.topl.algebras.Store
-import co.topl.codecs.bytes.tetra.instances._
 import co.topl.consensus.models.{BlockHeader, BlockId}
 import co.topl.networking.fsnetwork.BlockChecker.BlockCheckerActor
 import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
@@ -1,0 +1,200 @@
+package co.topl.networking.fsnetwork
+
+import cats.data.{NonEmptyChain, OptionT}
+import cats.effect.{Async, Resource}
+import cats.implicits._
+import co.topl.actor.{Actor, Fsm}
+import co.topl.algebras.Store
+import co.topl.codecs.bytes.tetra.instances._
+import co.topl.consensus.models.{BlockHeader, BlockId}
+import co.topl.networking.fsnetwork.BlockChecker.BlockCheckerActor
+import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
+import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
+import co.topl.networking.fsnetwork.RequestsProxy.Message._
+import co.topl.node.models.BlockBody
+import org.typelevel.log4cats.Logger
+import co.topl.typeclasses.implicits._
+
+object RequestsProxy {
+  sealed trait Message
+
+  object Message {
+    case class SetupBlockChecker[F[_]](blockCheckerActor: BlockCheckerActor[F]) extends Message
+
+    case class DownloadBlocksRequest(hostId: HostId, blockIds: NonEmptyChain[BlockId]) extends Message
+
+    case class DownloadBlockResponse(
+      source:   HostId,
+      response: NonEmptyChain[(BlockId, Either[BlockBodyDownloadError, BlockBody])]
+    ) extends Message
+  }
+
+  case class State[F[_]](
+    reputationAggregator: ReputationAggregatorActor[F],
+    peersManager:         PeersManagerActor[F],
+    blockCheckerOpt:      Option[BlockCheckerActor[F]],
+    headerStore:          Store[F, BlockId, BlockHeader],
+    bodyStore:            Store[F, BlockId, BlockBody],
+    bodyRequests:         Map[BlockId, Option[BlockBody]] = Map.empty
+  )
+
+  type Response[F[_]] = State[F]
+  type RequestsProxyActor[F[_]] = Actor[F, Message, Response[F]]
+
+  def getFsm[F[_]: Async: Logger]: Fsm[F, State[F], Message, Response[F]] =
+    Fsm {
+      case (state, message: SetupBlockChecker[F] @unchecked) =>
+        setupBlockChecker(state, message.blockCheckerActor)
+      case (state, DownloadBlocksRequest(hostId, blockIds)) =>
+        downloadBlockRequest(state, hostId, blockIds)
+      case (state, DownloadBlockResponse(source, response)) =>
+        downloadBlockResponse(state, source, response)
+    }
+
+  def makeActor[F[_]: Async: Logger](
+    reputationAggregator: ReputationAggregatorActor[F],
+    peersManager:         PeersManagerActor[F],
+    headerStore:          Store[F, BlockId, BlockHeader],
+    bodyStore:            Store[F, BlockId, BlockBody]
+  ): Resource[F, RequestsProxyActor[F]] = {
+    val initialState =
+      State(
+        reputationAggregator,
+        peersManager,
+        blockCheckerOpt = None,
+        headerStore,
+        bodyStore
+      )
+    Actor.make(initialState, getFsm[F])
+  }
+
+  private def setupBlockChecker[F[_]: Async: Logger](
+    state:        State[F],
+    blockChecker: BlockCheckerActor[F]
+  ): F[(State[F], Response[F])] = {
+    val newState = state.copy(blockCheckerOpt = Option(blockChecker))
+    Logger[F].info("Setup block checker for RequestsProxy") >>
+    (newState, newState).pure[F]
+  }
+
+  private def downloadBlockRequest[F[_]: Async: Logger](
+    state:    State[F],
+    hostId:   HostId,
+    blockIds: NonEmptyChain[BlockId]
+  ): F[(State[F], Response[F])] =
+    for {
+      _              <- Logger[F].debug(show"Get request for blocks downloads $blockIds")
+      idsDownloaded  <- sendAlreadyDownloadedBlocksToBlockChecker(state, hostId, blockIds)
+      _              <- Logger[F].debug(show"Send already downloaded block to block checker $idsDownloaded")
+      idsForDownload <- sendDownloadRequestForNewBlocks(state, hostId, blockIds)
+      _              <- Logger[F].debug(show"Send request for additional block body download $idsForDownload")
+      bodyReq: Map[BlockId, Option[BlockBody]] = state.bodyRequests -- idsDownloaded ++ idsForDownload.map((_, None))
+      newState = state.copy(bodyRequests = bodyReq)
+    } yield (newState, newState)
+
+  // response with longest possible prefix for request ids
+  // where for each block id corresponding block body is already downloaded
+  private def sendAlreadyDownloadedBlocksToBlockChecker[F[_]: Async](
+    state:    State[F],
+    hostId:   HostId,
+    blockIds: NonEmptyChain[BlockId]
+  ): F[List[BlockId]] = {
+    val alreadyDownloadedBodies =
+      blockIds
+        .map(id => (id, state.bodyRequests.get(id).flatten))
+        .takeWhile_ { case (_, bodyOpt) => bodyOpt.isDefined }
+        .map { case (id, bodyOpt) => (id, bodyOpt.get) }
+
+    // TODO add meta information about downloaded blocks so we could get actual source of block
+    val sendMessage: Option[F[Unit]] =
+      for {
+        downloadedPrefix <- NonEmptyChain.fromSeq(alreadyDownloadedBodies)
+        blockChecker     <- state.blockCheckerOpt
+      } yield blockChecker.sendNoWait(BlockChecker.Message.RemoteBlockBodies(hostId, downloadedPrefix))
+
+    sendMessage.getOrElse(().pure[F]) >> alreadyDownloadedBodies.map(_._1).pure[F]
+  }
+
+  // send block download request only for new blocks
+  private def sendDownloadRequestForNewBlocks[F[_]: Async](
+    state:    State[F],
+    hostId:   HostId,
+    blockIds: NonEmptyChain[BlockId]
+  ): F[List[BlockId]] = {
+    val newBlockIds = blockIds.filter(state.bodyRequests.contains)
+    NonEmptyChain
+      .fromChain(newBlockIds)
+      .map { blockIds =>
+        state.peersManager.sendNoWait(PeersManager.Message.BlockDownloadRequest(hostId, blockIds)) >>
+        blockIds.toList.pure[F]
+      }
+      .getOrElse(List.empty[BlockId].pure[F])
+  }
+
+  private def downloadBlockResponse[F[_]: Async: Logger](
+    state:    State[F],
+    hostId:   HostId,
+    response: NonEmptyChain[(BlockId, Either[BlockBodyDownloadError, BlockBody])]
+  ): F[(State[F], Response[F])] = {
+    val successfullyDownloadedBlocks =
+      response.collect { case (id, Right(body)) => (id, Option(body)) }
+
+    for {
+      _       <- processDownloadErrors(state.reputationAggregator, state.peersManager, hostId, response)
+      sentIds <- sendSuccessfulBodiesPrefix(state.headerStore, state.bodyStore, state.blockCheckerOpt, hostId, response)
+      _       <- Logger[F].info(show"Send bodies prefix to block checker $sentIds")
+      bodyReq: Map[BlockId, Option[BlockBody]] = state.bodyRequests -- sentIds ++ successfullyDownloadedBlocks.toList
+      newState = state.copy(bodyRequests = bodyReq)
+    } yield (newState, newState)
+  }
+
+  private def processDownloadErrors[F[_]: Async](
+    reputationAggregator: ReputationAggregatorActor[F],
+    peersManager:         PeersManagerActor[F],
+    source:               HostId,
+    response:             NonEmptyChain[(BlockId, Either[BlockBodyDownloadError, BlockBody])]
+  ): F[Unit] = {
+    val errorsOpt =
+      NonEmptyChain.fromChain(response.collect { case (id, Left(error)) => (id, error) })
+
+    errorsOpt match {
+
+      case Some(errors) =>
+        // TODO translate error to reputation value or send error itself?
+        val reputationMessage: ReputationAggregator.Message =
+          ReputationAggregator.Message.UpdatePeerReputation(source, -1)
+        // TODO we shall not try to download body from the same host, peer manager shall decide it
+        val repeatDownloadMessage: PeersManager.Message =
+          PeersManager.Message.BlockDownloadRequest(source, errors.map(_._1))
+
+        errors.traverse(_ => reputationAggregator.sendNoWait(reputationMessage)) >>
+        peersManager.sendNoWait(repeatDownloadMessage)
+
+      case None => ().pure[F]
+    }
+  }
+
+  // If parent of first block in response is already in storage then we send prefix to block checker
+  private def sendSuccessfulBodiesPrefix[F[_]: Async](
+    headerStore:     Store[F, BlockId, BlockHeader],
+    bodyStore:       Store[F, BlockId, BlockBody],
+    blockCheckerOpt: Option[BlockCheckerActor[F]],
+    source:          HostId,
+    response:        NonEmptyChain[(BlockId, Either[BlockBodyDownloadError, BlockBody])]
+  ): F[List[BlockId]] = {
+    val firstBlock = response.head._1
+    def prefix =
+      response.takeWhile_ { case (_, res) => res.isRight }.collect { case (id, Right(body)) => (id, body) }
+
+    val sendMessage =
+      for {
+        firstBlockHeader <- OptionT(headerStore.get(firstBlock))
+        _                <- OptionT(bodyStore.get(firstBlockHeader.id))
+        blockChecker     <- OptionT.fromOption[F](blockCheckerOpt)
+        idAndBodies      <- OptionT.fromOption[F](NonEmptyChain.fromSeq(prefix))
+      } yield blockChecker.sendNoWait(BlockChecker.Message.RemoteBlockBodies(source, idAndBodies)) >>
+      idAndBodies.map(_._1).toList.pure[F]
+
+    sendMessage.getOrElse(List.empty[BlockId].pure[F]).flatten
+  }
+}

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -1,21 +1,11 @@
 package co.topl.networking
 
-import cats.data.EitherT
-import cats.data.NonEmptyChain
-import cats.data.OptionT
+import cats.data.{EitherT, NonEmptyChain, OptionT}
 import cats.implicits._
-import cats.Applicative
-import cats.Monad
-import cats.MonadThrow
-import cats.Show
+import cats.{Applicative, Monad, MonadThrow, Show}
 import co.topl.algebras.Store
-import co.topl.consensus.models.BlockId
-import co.topl.consensus.models.BlockHeaderToBodyValidationFailure
-import co.topl.consensus.models.BlockHeaderValidationFailure
-import co.topl.consensus.models.SlotData
-import co.topl.ledger.models.BodyAuthorizationError
-import co.topl.ledger.models.BodySemanticError
-import co.topl.ledger.models.BodySyntaxError
+import co.topl.consensus.models.{BlockHeaderToBodyValidationFailure, BlockHeaderValidationFailure, BlockId, SlotData}
+import co.topl.ledger.models.{BodyAuthorizationError, BodySemanticError, BodySyntaxError}
 import co.topl.networking.blockchain.BlockchainPeerClient
 import co.topl.typeclasses.implicits._
 import org.typelevel.log4cats.Logger
@@ -137,4 +127,7 @@ package object fsnetwork {
         .map(_.take(size))
         .map(NonEmptyChain.fromSeq)
     )
+
+  sealed trait BlockBodyDownloadError
+  object BlockBodyDownloadError {}
 }

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
@@ -993,7 +993,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
       val allIdSlotDataHeaderBlock =
-        arbitraryLinkedSlotDataHeaderBlockNoTx(Gen.choose(3, maxChainSize)).arbitrary.first
+        arbitraryLinkedSlotDataHeaderBlockNoTx(Gen.choose(4, maxChainSize)).arbitrary.first
 
       val knownIdSlotDataHeaderBlock = allIdSlotDataHeaderBlock.head
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
@@ -18,6 +18,7 @@ import co.topl.models.generators.node.ModelGenerators
 import co.topl.networking.fsnetwork.BlockCheckerTest.F
 import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
+import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
 import co.topl.networking.fsnetwork.TestHelper._
 import co.topl.node.models.{Block, BlockBody}
 import co.topl.quivr.runtime.DynamicContext
@@ -46,6 +47,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
 
       val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
 
       val localChain = mock[LocalChainAlgebra[F]]
       val currentSlotDataHead = arbitrarySlotData.arbitrary.first
@@ -67,6 +69,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .makeActor(
           reputationAggregator,
           peersManager,
+          requestsProxy,
           localChain,
           slotDataStore,
           headerStore,
@@ -90,6 +93,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     withMock {
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
@@ -124,6 +128,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .makeActor(
           reputationAggregator,
           peersManager,
+          requestsProxy,
           localChain,
           slotDataStore,
           headerStore,
@@ -149,6 +154,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     withMock {
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
@@ -186,6 +192,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .makeActor(
           reputationAggregator,
           peersManager,
+          requestsProxy,
           localChain,
           slotDataStore,
           headerStore,
@@ -211,6 +218,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     withMock {
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
@@ -266,6 +274,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .makeActor(
           reputationAggregator,
           peersManager,
+          requestsProxy,
           localChain,
           slotDataStore,
           headerStore,
@@ -290,6 +299,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     withMock {
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
@@ -341,6 +351,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .makeActor(
           reputationAggregator,
           peersManager,
+          requestsProxy,
           localChain,
           slotDataStore,
           headerStore,
@@ -372,6 +383,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
 
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
@@ -390,6 +402,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .makeActor(
           reputationAggregator,
           peersManager,
+          requestsProxy,
           localChain,
           slotDataStore,
           headerStore,
@@ -417,6 +430,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
 
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
@@ -435,6 +449,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .makeActor(
           reputationAggregator,
           peersManager,
+          requestsProxy,
           localChain,
           slotDataStore,
           headerStore,
@@ -458,6 +473,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     withMock {
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
@@ -499,9 +515,29 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .rep(newIdAndHeaders.size)
         .onCall((header: BlockHeader) => Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F])
 
-      val expectedIds = NonEmptyChain.fromSeq(newIdAndHeaders.map(_._1)).get
-      val expectedMessage: PeersManager.Message = PeersManager.Message.BlockDownloadRequest(hostId, expectedIds)
-      (peersManager.sendNoWait _).expects(expectedMessage).returning(().pure[F])
+      val bodyStoreData = idAndHeaders.toList.toMap
+      (bodyStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+        (!bodyStoreData.contains(id)).pure[F]
+      }
+
+      (slotDataStore
+        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+        .expects(*, *, *)
+        .rep(idAndHeaders.size.toInt)
+        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
+          val header = headerStoreData(id)
+          val arbSlotData = arbitrarySlotData.arbitrary.first
+          val slotData =
+            arbSlotData.copy(
+              slotId = arbSlotData.slotId.copy(blockId = header.id),
+              parentSlotId = arbSlotData.parentSlotId.copy(blockId = header.parentHeaderId)
+            )
+          slotData.pure[F]
+        }
+
+      val expectedIds = idAndHeaders.map(_._1)
+      val expectedMessage: RequestsProxy.Message = RequestsProxy.Message.DownloadBlocksRequest(hostId, expectedIds)
+      (requestsProxy.sendNoWait _).expects(expectedMessage).returning(().pure[F])
 
       (peersManager.sendNoWait _).expects(*).never() // no other requests
 
@@ -509,6 +545,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .makeActor(
           reputationAggregator,
           peersManager,
+          requestsProxy,
           localChain,
           slotDataStore,
           headerStore,
@@ -533,6 +570,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     withMock {
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
@@ -574,9 +612,29 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .rep(newIdAndHeaders.size)
         .onCall((header: BlockHeader) => Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F])
 
-      val expectedIds = NonEmptyChain.fromSeq(newIdAndHeaders.map(_._1)).get
-      val expectedMessage: PeersManager.Message = PeersManager.Message.BlockDownloadRequest(hostId, expectedIds)
-      (peersManager.sendNoWait _).expects(expectedMessage).returning(().pure[F])
+      val bodyStoreData = idAndHeaders.toList.toMap
+      (bodyStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+        (!bodyStoreData.contains(id)).pure[F]
+      }
+
+      (slotDataStore
+        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+        .expects(*, *, *)
+        .rep(idAndHeaders.size.toInt)
+        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
+          val header = headerStoreData(id)
+          val arbSlotData = arbitrarySlotData.arbitrary.first
+          val slotData =
+            arbSlotData.copy(
+              slotId = arbSlotData.slotId.copy(blockId = header.id),
+              parentSlotId = arbSlotData.parentSlotId.copy(blockId = header.parentHeaderId)
+            )
+          slotData.pure[F]
+        }
+
+      val expectedIds = idAndHeaders.map(_._1)
+      val expectedMessage: RequestsProxy.Message = RequestsProxy.Message.DownloadBlocksRequest(hostId, expectedIds)
+      (requestsProxy.sendNoWait _).expects(expectedMessage).returning(().pure[F])
 
       val bestChainForKnownAndNewIds: NonEmptyChain[SlotData] =
         idAndHeaders.map { case (id, header) =>
@@ -613,6 +671,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .makeActor(
           reputationAggregator,
           peersManager,
+          requestsProxy,
           localChain,
           slotDataStore,
           headerStore,
@@ -639,6 +698,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     withMock {
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
@@ -668,6 +728,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .makeActor(
           reputationAggregator,
           peersManager,
+          requestsProxy,
           localChain,
           slotDataStore,
           headerStore,
@@ -691,6 +752,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     withMock {
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
@@ -777,6 +839,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .makeActor(
           reputationAggregator,
           peersManager,
+          requestsProxy,
           localChain,
           slotDataStore,
           headerStore,
@@ -800,6 +863,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     withMock {
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
@@ -887,6 +951,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .makeActor(
           reputationAggregator,
           peersManager,
+          requestsProxy,
           localChain,
           slotDataStore,
           headerStore,


### PR DESCRIPTION
## Purpose
Change way how downloading of block bodies is done:
Previous:
 -- Download the body for each downloaded header
Current:
 -- Request downloading of all bodies for the current better tip, to avoid duplication of block download requestsProxy had been created. That proxy sends download requests only for new blocks. If the proxy already contains requested blocks or blocks could be applied to the current chain then the proxy immediately returns block bodies

## Approach
By introducing requests proxy

## Testing
Unit tests + Multinode test
## Tickets
*Bn 879