### PR TITLE
EligibilityCache Implementation

### DIFF
--- a/consensus/src/main/scala/co/topl/consensus/algebras/EligibilityCacheAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/EligibilityCacheAlgebra.scala
@@ -1,0 +1,19 @@
+package co.topl.consensus.algebras
+
+import co.topl.models.Bytes
+import co.topl.models.Slot
+
+/**
+ * A cache of recently used VRF eligibilities
+ */
+trait EligibilityCacheAlgebra[F[_]] {
+
+  /**
+   * Attempt to include the given eligibility in the cache
+   * @param vrfVK The staker's VRF VK
+   * @param slot The slot for which the eligibility was generated
+   * @return true if the eligibility was inserted, false if it was already in the cache
+   */
+  def tryInclude(vrfVK: Bytes, slot: Slot): F[Boolean]
+
+}

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/EligibilityCache.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/EligibilityCache.scala
@@ -1,0 +1,76 @@
+package co.topl.consensus.interpreters
+
+import cats.effect._
+import cats.effect.implicits._
+import co.topl.consensus.algebras.EligibilityCacheAlgebra
+import co.topl.models.Bytes
+import co.topl.models.Slot
+import com.google.protobuf.ByteString
+
+import scala.collection.immutable.SortedSet
+
+object EligibilityCache {
+
+  /**
+   * Constructs an EligibilityCacheAlgebra that is backed by a Ref containing a "State" object.  The State maintains a
+   * set of "recently" claimed eligibilities.  "Recently" is defined in terms of claimed slot number, not in terms of time.
+   *
+   * This mechanism only prevents eligibility re-use near the current global slot.  An adversary may still attempt to feed
+   * old eligibilities into the system which would make it past this check, but the adversary would need to overcome
+   * the chain growth of the honest chain for the attack to work anyway.
+   *
+   * @param maximumLength The maximum number of entries allowed in the cache.  Older entries (based on slot) are evicted
+   *                      as new entries are received.
+   */
+  def make[F[_]: Async](maximumLength: Int): Resource[F, EligibilityCacheAlgebra[F]] =
+    for {
+      ref <- Ref.of(State(maximumLength)).toResource
+    } yield new EligibilityCacheAlgebra[F] {
+
+      def tryInclude(vrfVK: Bytes, slot: Slot): F[Boolean] =
+        ref.modify(_.tryInclude(vrfVK, slot))
+    }
+
+  /**
+   * The internal state of the cache
+   * @param maxLength The maximum number of entries allowed in the cache.  If the cache is full and a new
+   *                  entry is provided, the oldest entry (by slot) will be removed
+   * @param entries A set of entries in the cache, sorted by Slot
+   */
+  private case class State(maxLength: Int, entries: SortedSet[(Slot, Bytes)] = SortedSet.empty) {
+
+    /**
+     * Attempt to include the entry.  If the entry already existed, the state remains unchanged, and "false" is returned.
+     * Otherwise, a new state and "true" is returned
+     */
+    def tryInclude(vrfVK: Bytes, slot: Slot): (State, Boolean) = {
+      // Note: An entry may already exist in the cache at the provided vrfVK under a different slot.  A future
+      // optimization may be to take the vrfVK instance from the old entry and use it in the new entry as well.
+      // This would avoid a memory penalty of duplicating the same bytes in memory, but would come at the expense of
+      // CPU time to perform the initial search for an existing entry.
+      val newEntry = (slot, vrfVK)
+      if (entries.contains(newEntry)) this         -> false
+      else copy(entries = entries + newEntry).trim -> true
+    }
+
+    /**
+     * Discard old entries to keep the entry-set within the [[maxLength]] bound
+     */
+    private def trim: State =
+      copy(entries = entries.takeRight(maxLength))
+  }
+
+  /**
+   * An implicit ordering based on slot, with a tie-breaker on the VRF VK
+   */
+  implicit private val orderingEntries: Ordering[(Slot, Bytes)] = new Ordering[(Slot, Bytes)] {
+
+    implicit private val bytesOrdering: Ordering[Bytes] =
+      Ordering.comparatorToOrdering(ByteString.unsignedLexicographicalComparator())
+
+    def compare(x: (Slot, Bytes), y: (Slot, Bytes)): Int =
+      if (x._1 > y._1) 1
+      else if (y._1 > x._1) -1
+      else bytesOrdering.compare(x._2, y._2)
+  }
+}

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/EligibilityCacheSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/EligibilityCacheSpec.scala
@@ -1,0 +1,64 @@
+package co.topl.consensus.interpreters
+
+import cats.effect.IO
+import cats.effect.implicits._
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.scalamock.munit.AsyncMockFactory
+import co.topl.models.ModelGenerators._
+import co.topl.models.utility.Lengths
+
+class EligibilityCacheSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+  type F[A] = IO[A]
+
+  test("Eligibility Cache with new entry") {
+    val entry1 = (generateVrfVK(), 1L)
+
+    val resource =
+      for {
+        underTest <- EligibilityCache.make[F](10)
+        _         <- (underTest.tryInclude _).tupled(entry1).assert.toResource
+      } yield ()
+
+    resource.use_
+  }
+
+  test("Eligibility Cache with old entry") {
+    val entry1 = (generateVrfVK(), 1L)
+    val entry2 = (generateVrfVK(), 2L)
+
+    val resource =
+      for {
+        underTest <- EligibilityCache.make[F](10)
+        _         <- (underTest.tryInclude _).tupled(entry1).assert.toResource
+        _         <- (underTest.tryInclude _).tupled(entry1).map(!_).assert.toResource
+        _         <- (underTest.tryInclude _).tupled(entry2).assert.toResource
+      } yield ()
+
+    resource.use_
+  }
+
+  test("Eligibility Cache with new entry and overflow") {
+    val entry1 = (generateVrfVK(), 1L)
+    val entry2 = (generateVrfVK(), 2L)
+    val entry3 = (generateVrfVK(), 3L)
+    val entry3A = (generateVrfVK(), 3L)
+
+    val resource =
+      for {
+        underTest <- EligibilityCache.make[F](2)
+        _         <- (underTest.tryInclude _).tupled(entry1).assert.toResource
+        _         <- (underTest.tryInclude _).tupled(entry2).assert.toResource
+        _         <- (underTest.tryInclude _).tupled(entry3).assert.toResource
+        // NOTE: No way to assert that entry1 was removed.  Attempting to `tryInclude` it again would return "true",
+        // but the entry would be immediately removed because it's at an "older" slot
+        _ <- (underTest.tryInclude _).tupled(entry2).map(!_).assert.toResource
+        _ <- (underTest.tryInclude _).tupled(entry3).map(!_).assert.toResource
+        _ <- (underTest.tryInclude _).tupled(entry3A).assert.toResource
+      } yield ()
+
+    resource.use_
+  }
+
+  private def generateVrfVK() = genSizedStrictBytes[Lengths.`32`.type]().first.data
+}


### PR DESCRIPTION
## Purpose
- Provides a caching mechanism for recently claimed VRF eligibilities
## Approach
- New EligibilityCacheAlgebra which is meant to indicate if an eligibility should be accepted or rejected
- New EligibilityCache interpreter which maintains a state of recent eligibilities (by Slot) and attempts to add new entries to the state.  When a duplicate entry is found, it is rejected
## Testing
- New unit tests for EligibilityCache interpreter
## Tickets
- Part 1 of BN-877
  - Part 2 will follow which _integrates_ the EligibilityCache into BlockHeaderValidation