### PR TITLE
Sync.delay Usage in UnsafeResources

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -214,7 +214,7 @@ object Blockchain {
             headerStore.put(id, block.header) &>
             bodyStore.put(id, block.body) &>
             ed25519VrfResource
-              .use(implicit e => block.header.slotData.pure[F])
+              .use(implicit e => Sync[F].delay(block.header.slotData))
               .flatTap(slotDataStore.put(id, _))
           }
           .map(Validated.Valid(_))

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/ChainSelection.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/ChainSelection.scala
@@ -175,7 +175,7 @@ object ChainSelection {
         xSegment.head === ySegment.head
 
       def comparisonResult: F[Int] =
-        blake2b512Resource.use(implicit blake2b512 => standardOrder.compare(xSegment, ySegment).pure[F])
+        blake2b512Resource.use(implicit blake2b512 => Sync[F].delay(standardOrder.compare(xSegment, ySegment)))
     }
 
     /**

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/LeaderElectionValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/LeaderElectionValidation.scala
@@ -53,13 +53,12 @@ object LeaderElectionValidation {
        * @return true if elected slot leader and false otherwise
        */
       def isSlotLeaderForThreshold(threshold: Ratio)(rho: Rho): F[Boolean] =
-        blake2b512Resource.use(implicit blake2b512 =>
-          Sync[F].delay {
-            val testRhoHashBytes = rhoToRhoTestHash(rho.sizedBytes.data).toByteArray
+        blake2b512Resource
+          .use(implicit blake2b512 => Sync[F].delay(rhoToRhoTestHash(rho.sizedBytes.data).toByteArray))
+          .map { testRhoHashBytes =>
             val test = Ratio(BigInt(Array(0x00.toByte) ++ testRhoHashBytes), NormalizationConstant, BigInt(1))
             (threshold > test)
           }
-        )
     }
 
   def makeCached[F[_]: Sync](alg: LeaderElectionValidationAlgebra[F]): F[LeaderElectionValidationAlgebra[F]] =

--- a/minting/src/main/scala/co/topl/minting/interpreters/VrfCalculator.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/VrfCalculator.scala
@@ -77,8 +77,10 @@ object VrfCalculator {
     def rhoForSlot(slot: Slot, eta: Eta): F[Rho] =
       rhosCache.cachingF((eta.data, slot))(ttl = None)(
         for {
-          proof          <- proofForSlot(slot, eta)
-          proofHashBytes <- ed25519VRFResource.use(_.proofToHash(proof.toByteArray).pure[F])
+          proof <- proofForSlot(slot, eta)
+          proofHashBytes <- ed25519VRFResource.use(ed25519VRF =>
+            Sync[F].delay(ed25519VRF.proofToHash(proof.toByteArray))
+          )
           rho = Rho(Sized.strictUnsafe(ByteString.copyFrom(proofHashBytes)))
         } yield rho
       )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val logback = "1.4.6"
   val orientDbVersion = "3.2.17"
   val protobufSpecsVersion = "ce3282d" // scala-steward:off
-  val bramblScVersion = "8150ea6" // scala-steward:off
+  val bramblScVersion = "93930d1" // scala-steward:off
   val quivr4sVersion = "69c2605" // scala-steward:off
 
   val catsSlf4j =


### PR DESCRIPTION
## Purpose
- A few more places in the codebase still use `.pure` when calling `UnsafeResource.use`, which _could_ lead to issues
- Also updates Brambl dependency to use a more thread-safe version of Ed25519
## Approach
- Search for usages of `UnsafeResource.use`, and update any that still used .pure
## Testing
- preparePR
- NodeAppTest
## Tickets
N/A