### PR TITLE
add test fixture for oriend db

### DIFF
--- a/genus-library/src/test/resources/logback-test.xml
+++ b/genus-library/src/test/resources/logback-test.xml
@@ -1,1 +1,16 @@
-<configuration />
+<configuration debug="false">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS}| %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/DbFixtureUtil.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/DbFixtureUtil.scala
@@ -1,0 +1,36 @@
+package co.topl.genusLibrary.orientDb
+
+import cats.effect.{IO, Resource, Sync, SyncIO}
+import com.orientechnologies.orient.core.db.{ODatabaseType, OrientDB, OrientDBConfigBuilder}
+import munit.{CatsEffectSuite, FunSuite, TestOptions}
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+trait DbFixtureUtil { self: FunSuite with CatsEffectSuite =>
+
+  type F[A] = IO[A]
+  implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
+
+  val orientDbFixture: SyncIO[FunFixture[OrientDB]] = {
+    val dbName = "testDb"
+    val dbConfig = new OrientDBConfigBuilder().addGlobalUser("testUser", "testPass", "*").build()
+
+    val factoryR =
+      Resource.make[F, OrientDB](Sync[F].blocking(new OrientDB("memory", "root", "root", dbConfig)))(oDb =>
+        Sync[F].delay(oDb.close())
+      )
+
+    def setup(t: TestOptions, odb: OrientDB): IO[Unit] =
+      Sync[F]
+        .blocking(odb.createIfNotExists(dbName, ODatabaseType.MEMORY))
+        .flatMap(res => logger.info(s"Db Created $res"))
+
+    def teardown(odb: OrientDB): IO[Unit] =
+      Sync[F]
+        .blocking(odb.drop(dbName))
+        .flatTap(_ => logger.info("Teardown, db dropped"))
+
+    ResourceFixture[OrientDB](factoryR, setup _, teardown _)
+  }
+
+}


### PR DESCRIPTION
## Purpose
- Util for testing orient database in memory
- rename files suites -> test

## Testing
> preparePR
## Tickets
* no ticket, tech debt
