### PR TITLE
Repopulate Eligibility Cache

### DIFF
--- a/consensus/src/main/scala/co/topl/consensus/interpreters/EligibilityCache.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/EligibilityCache.scala
@@ -1,8 +1,11 @@
 package co.topl.consensus.interpreters
 
+import cats.{Applicative, Monad}
 import cats.effect._
 import cats.effect.implicits._
+import cats.implicits._
 import co.topl.consensus.algebras.EligibilityCacheAlgebra
+import co.topl.consensus.models._
 import co.topl.models._
 import com.google.protobuf.ByteString
 
@@ -28,6 +31,31 @@ object EligibilityCache {
 
       def tryInclude(vrfVK: Bytes, slot: Slot): F[Boolean] =
         ref.modify(_.tryInclude(vrfVK, slot))
+    }
+
+  /**
+   * When a node is launched, eligibilities from adopted blocks should be added to the cache.
+   *
+   * @param underlying    The underlying cache to populate
+   * @param maximumLength The maximum number of entries in the underlying cache
+   * @param canonicalHead The current head of the chain
+   * @param fetchHeader   Header lookup function (to traverse ancestors)
+   */
+  def repopulate[F[_]: Monad](
+    underlying:    EligibilityCacheAlgebra[F],
+    maximumLength: Int,
+    canonicalHead: BlockHeader,
+    fetchHeader:   BlockId => F[BlockHeader]
+  ): F[Unit] =
+    if (maximumLength <= 0 || canonicalHead.height < 1)
+      Applicative[F].unit
+    else {
+      underlying.tryInclude(canonicalHead.eligibilityCertificate.vrfVK, canonicalHead.slot) >>
+      (
+        if (canonicalHead.height <= 1) Applicative[F].unit
+        else
+          fetchHeader(canonicalHead.parentHeaderId).flatMap(repopulate(underlying, maximumLength - 1, _, fetchHeader))
+      )
     }
 
   /**

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/EligibilityCacheSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/EligibilityCacheSpec.scala
@@ -2,11 +2,15 @@ package co.topl.consensus.interpreters
 
 import cats.effect.IO
 import cats.effect.implicits._
+import cats.implicits._
 import munit.CatsEffectSuite
 import munit.ScalaCheckEffectSuite
 import org.scalamock.munit.AsyncMockFactory
 import co.topl.models.ModelGenerators._
+import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.models.utility.Lengths
+
+import co.topl.codecs.bytes.tetra.instances._
 
 class EligibilityCacheSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   type F[A] = IO[A]
@@ -58,6 +62,49 @@ class EligibilityCacheSpec extends CatsEffectSuite with ScalaCheckEffectSuite wi
       } yield ()
 
     resource.use_
+  }
+
+  test("EligibilityCache.Repopulate") {
+    val baseHeader = arbitraryHeader.arbitrary.first
+    val h1 =
+      baseHeader
+        .update(_.height := 1L)
+        .update(_.slot := 0L)
+        .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
+    val h1Id = h1.id
+    val h2 =
+      baseHeader
+        .update(_.parentHeaderId := h1Id)
+        .update(_.height := 2L)
+        .update(_.slot := 10L)
+        .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
+    val h2Id = h2.id
+    val h3 =
+      baseHeader
+        .update(_.parentHeaderId := h2Id)
+        .update(_.height := 3L)
+        .update(_.slot := 15L)
+        .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
+    val h3Id = h3.id
+    val h4 =
+      baseHeader
+        .update(_.parentHeaderId := h3Id)
+        .update(_.height := 4L)
+        .update(_.slot := 20L)
+        .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
+    val h4Id = h4.id
+    val headers = Map(h1Id -> h1, h2Id -> h2, h3Id -> h3, h4Id -> h4)
+    val testResource =
+      for {
+        underTest <- EligibilityCache.make[F](10)
+        _         <- EligibilityCache.repopulate[F](underTest, 10, h4, headers(_).pure[F]).toResource
+        _         <- underTest.tryInclude(h1.eligibilityCertificate.vrfVK, h1.slot).map(!_).assert.toResource
+        _         <- underTest.tryInclude(h2.eligibilityCertificate.vrfVK, h2.slot).map(!_).assert.toResource
+        _         <- underTest.tryInclude(h3.eligibilityCertificate.vrfVK, h3.slot).map(!_).assert.toResource
+        _         <- underTest.tryInclude(h4.eligibilityCertificate.vrfVK, h4.slot).map(!_).assert.toResource
+      } yield ()
+
+    testResource.use_
   }
 
   private def generateVrfVK() = genSizedStrictBytes[Lengths.`32`.type]().first.data

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/EligibilityCacheSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/EligibilityCacheSpec.scala
@@ -9,8 +9,8 @@ import org.scalamock.munit.AsyncMockFactory
 import co.topl.models.ModelGenerators._
 import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.models.utility.Lengths
-
 import co.topl.codecs.bytes.tetra.instances._
+import co.topl.consensus.algebras.EligibilityCacheAlgebra
 
 class EligibilityCacheSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   type F[A] = IO[A]
@@ -65,46 +65,77 @@ class EligibilityCacheSpec extends CatsEffectSuite with ScalaCheckEffectSuite wi
   }
 
   test("EligibilityCache.Repopulate") {
-    val baseHeader = arbitraryHeader.arbitrary.first
-    val h1 =
-      baseHeader
-        .update(_.height := 1L)
-        .update(_.slot := 0L)
-        .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
-    val h1Id = h1.id
-    val h2 =
-      baseHeader
-        .update(_.parentHeaderId := h1Id)
-        .update(_.height := 2L)
-        .update(_.slot := 10L)
-        .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
-    val h2Id = h2.id
-    val h3 =
-      baseHeader
-        .update(_.parentHeaderId := h2Id)
-        .update(_.height := 3L)
-        .update(_.slot := 15L)
-        .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
-    val h3Id = h3.id
-    val h4 =
-      baseHeader
-        .update(_.parentHeaderId := h3Id)
-        .update(_.height := 4L)
-        .update(_.slot := 20L)
-        .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
-    val h4Id = h4.id
-    val headers = Map(h1Id -> h1, h2Id -> h2, h3Id -> h3, h4Id -> h4)
-    val testResource =
-      for {
-        underTest <- EligibilityCache.make[F](10)
-        _         <- EligibilityCache.repopulate[F](underTest, 10, h4, headers(_).pure[F]).toResource
-        _         <- underTest.tryInclude(h1.eligibilityCertificate.vrfVK, h1.slot).map(!_).assert.toResource
-        _         <- underTest.tryInclude(h2.eligibilityCertificate.vrfVK, h2.slot).map(!_).assert.toResource
-        _         <- underTest.tryInclude(h3.eligibilityCertificate.vrfVK, h3.slot).map(!_).assert.toResource
-        _         <- underTest.tryInclude(h4.eligibilityCertificate.vrfVK, h4.slot).map(!_).assert.toResource
-      } yield ()
+    withMock {
+      val baseHeader = arbitraryHeader.arbitrary.first
+      // Genesis "parent"
+      val h0 =
+        baseHeader
+          .update(_.height := 0L)
+          .update(_.slot := -1L)
+          .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
+      val h0Id = h0.id
+      // Genesis
+      val h1 =
+        baseHeader
+          .update(_.height := 1L)
+          .update(_.slot := 0L)
+          .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
+      val h1Id = h1.id
+      val h2 =
+        baseHeader
+          .update(_.parentHeaderId := h1Id)
+          .update(_.height := 2L)
+          .update(_.slot := 10L)
+          .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
+      val h2Id = h2.id
+      val h3 =
+        baseHeader
+          .update(_.parentHeaderId := h2Id)
+          .update(_.height := 3L)
+          .update(_.slot := 15L)
+          .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
+      val h3Id = h3.id
+      val h4 =
+        baseHeader
+          .update(_.parentHeaderId := h3Id)
+          .update(_.height := 4L)
+          .update(_.slot := 20L)
+          .update(_.eligibilityCertificate.vrfVK := generateVrfVK())
+      val h4Id = h4.id
+      val headers = Map(h0Id -> h0, h1Id -> h1, h2Id -> h2, h3Id -> h3, h4Id -> h4)
+      val underlying = mock[EligibilityCacheAlgebra[F]]
+      (underlying
+        .tryInclude(_, _))
+        .expects(h4.eligibilityCertificate.vrfVK, h4.slot)
+        .once()
+        .returning(true.pure[F])
+      (underlying
+        .tryInclude(_, _))
+        .expects(h3.eligibilityCertificate.vrfVK, h3.slot)
+        .once()
+        .returning(true.pure[F])
+      (underlying
+        .tryInclude(_, _))
+        .expects(h2.eligibilityCertificate.vrfVK, h2.slot)
+        .once()
+        .returning(true.pure[F])
+      (underlying
+        .tryInclude(_, _))
+        .expects(h1.eligibilityCertificate.vrfVK, h1.slot)
+        .once()
+        .returning(true.pure[F])
+      // The genesis parent should never be called
+      (underlying
+        .tryInclude(_, _))
+        .expects(h0.eligibilityCertificate.vrfVK, h0.slot)
+        .never()
+      val testResource =
+        for {
+          _ <- EligibilityCache.repopulate[F](underlying, 10, h4, headers(_).pure[F]).toResource
+        } yield ()
 
-    testResource.use_
+      testResource.use_
+    }
   }
 
   private def generateVrfVK() = genSizedStrictBytes[Lengths.`32`.type]().first.data

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -105,6 +105,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig)(implicit syste
 
       canonicalHeadId       <- Resource.eval(currentEventIdGetterSetters.canonicalHead.get())
       canonicalHeadSlotData <- Resource.eval(dataStores.slotData.getOrRaise(canonicalHeadId))
+      canonicalHead         <- Resource.eval(dataStores.headers.getOrRaise(canonicalHeadId))
       _                     <- Resource.eval(Logger[F].info(show"Canonical head id=$canonicalHeadId"))
 
       blockIdTree <- Resource.eval(
@@ -215,7 +216,17 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig)(implicit syste
           ).map(_.some)
         )
 
-      eligibilityCache <- EligibilityCache.make[F](appConfig.bifrost.cache.eligibilities.maximumEntries.toInt)
+      eligibilityCache <-
+        EligibilityCache
+          .make[F](appConfig.bifrost.cache.eligibilities.maximumEntries.toInt)
+          .evalTap(
+            EligibilityCache.repopulate(
+              _,
+              appConfig.bifrost.cache.eligibilities.maximumEntries.toInt,
+              canonicalHead,
+              dataStores.headers.getOrRaise
+            )
+          )
       validators <- Resource.eval(
         Validators.make[F](
           cryptoResources,


### PR DESCRIPTION
## Purpose
- When a node launches, its eligibility cache is initially empty which would allow previous eligibilities along the canonical chain to be re-used
## Approach
- Adds a function which repopulates the Eligibility Cache with recent blocks on the canonical chain
## Testing
- New unit test
- preparePR
## Tickets
- #BN-877