### PR TITLE
EligibilityCache Allow BlockId Re-Use

### DIFF
--- a/consensus/src/main/scala/co/topl/consensus/algebras/EligibilityCacheAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/EligibilityCacheAlgebra.scala
@@ -1,5 +1,6 @@
 package co.topl.consensus.algebras
 
+import co.topl.consensus.models.BlockId
 import co.topl.models.Bytes
 import co.topl.models.Slot
 
@@ -14,6 +15,6 @@ trait EligibilityCacheAlgebra[F[_]] {
    * @param slot The slot for which the eligibility was generated
    * @return true if the eligibility was inserted, false if it was already in the cache
    */
-  def tryInclude(vrfVK: Bytes, slot: Slot): F[Boolean]
+  def tryInclude(blockId: BlockId, vrfVK: Bytes, slot: Slot): F[Boolean]
 
 }

--- a/consensus/src/main/scala/co/topl/consensus/algebras/EligibilityCacheAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/EligibilityCacheAlgebra.scala
@@ -11,6 +11,7 @@ trait EligibilityCacheAlgebra[F[_]] {
 
   /**
    * Attempt to include the given eligibility in the cache
+   * @param blockId the block ID associated with the eligibility
    * @param vrfVK The staker's VRF VK
    * @param slot The slot for which the eligibility was generated
    * @return true if the eligibility was inserted, false if it was already in the cache

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
@@ -274,7 +274,9 @@ object BlockHeaderValidation {
           )
           .leftWiden[BlockHeaderValidationFailure]
         // Warning: This is most likely a side effecting operation
-        isNewEligibility <- EitherT.liftF(eligibilityCache.tryInclude(header.eligibilityCertificate.vrfVK, header.slot))
+        isNewEligibility <- EitherT.liftF(
+          eligibilityCache.tryInclude(header.id, header.eligibilityCertificate.vrfVK, header.slot)
+        )
         _ <- EitherT
           .cond[F](
             isNewEligibility,

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/EligibilityCache.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/EligibilityCache.scala
@@ -3,12 +3,14 @@ package co.topl.consensus.interpreters
 import cats.effect._
 import cats.effect.implicits._
 import cats.implicits._
+import co.topl.codecs.bytes.tetra.instances._
 import co.topl.consensus.algebras.EligibilityCacheAlgebra
 import co.topl.consensus.models._
 import co.topl.models._
+import co.topl.typeclasses.implicits._
 import com.google.protobuf.ByteString
 
-import scala.collection.immutable.SortedSet
+import scala.collection.immutable.SortedMap
 
 object EligibilityCache {
 
@@ -28,8 +30,8 @@ object EligibilityCache {
       ref <- Ref.of(State(maximumLength)).toResource
     } yield new EligibilityCacheAlgebra[F] {
 
-      def tryInclude(vrfVK: Bytes, slot: Slot): F[Boolean] =
-        ref.modify(_.tryInclude(vrfVK, slot))
+      def tryInclude(blockId: BlockId, vrfVK: Bytes, slot: Slot): F[Boolean] =
+        ref.modify(_.tryInclude(blockId, vrfVK, slot))
     }
 
   /**
@@ -56,7 +58,7 @@ object EligibilityCache {
       )
     (Stream(canonicalHead) ++ ancestors)
       .take(maximumLength)
-      .evalMap(header => underlying.tryInclude(header.eligibilityCertificate.vrfVK, header.slot))
+      .evalMap(header => underlying.tryInclude(header.id, header.eligibilityCertificate.vrfVK, header.slot))
       .compile
       .drain
   }
@@ -65,22 +67,25 @@ object EligibilityCache {
    * The internal state of the cache
    * @param maxLength The maximum number of entries allowed in the cache.  If the cache is full and a new
    *                  entry is provided, the oldest entry (by slot) will be removed
-   * @param entries A set of entries in the cache, sorted by Slot
+   * @param entries A sorted map of entries in the cache, sorted by Slot
    */
-  private case class State(maxLength: Int, entries: SortedSet[(Slot, Bytes)] = SortedSet.empty) {
+  private case class State(maxLength: Int, entries: SortedMap[(Slot, Bytes), BlockId] = SortedMap.empty) {
 
     /**
      * Attempt to include the entry.  If the entry already existed, the state remains unchanged, and "false" is returned.
      * Otherwise, a new state and "true" is returned
      */
-    def tryInclude(vrfVK: Bytes, slot: Slot): (State, Boolean) = {
+    def tryInclude(blockId: BlockId, vrfVK: Bytes, slot: Slot): (State, Boolean) = {
       // Note: An entry may already exist in the cache at the provided vrfVK under a different slot.  A future
       // optimization may be to take the vrfVK instance from the old entry and use it in the new entry as well.
       // This would avoid a memory penalty of duplicating the same bytes in memory, but would come at the expense of
       // CPU time to perform the initial search for an existing entry.
       val newEntry = (slot, vrfVK)
-      if (entries.contains(newEntry)) this         -> false
-      else copy(entries = entries + newEntry).trim -> true
+      entries.get(newEntry) match {
+        // An entry already exists, so check if the entry corresponds to the provided block
+        case Some(entry) => this                                                 -> (entry === blockId)
+        case _           => copy(entries = entries + (newEntry -> blockId)).trim -> true
+      }
     }
 
     /**

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/BlockHeaderValidationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/BlockHeaderValidationSpec.scala
@@ -434,8 +434,8 @@ class BlockHeaderValidationSpec extends CatsEffectSuite with ScalaCheckEffectSui
             .returning(relativeStake.some.pure[F])
 
           (eligibilityCache
-            .tryInclude(_: Bytes, _: Slot))
-            .expects(*, *)
+            .tryInclude(_: BlockId, _: Bytes, _: Slot))
+            .expects(*, *, *)
             .once()
             .returning(false.pure[F])
 
@@ -489,8 +489,8 @@ class BlockHeaderValidationSpec extends CatsEffectSuite with ScalaCheckEffectSui
             .returning(relativeStake.some.pure[F])
 
           (eligibilityCache
-            .tryInclude(_: Bytes, _: Slot))
-            .expects(*, *)
+            .tryInclude(_: BlockId, _: Bytes, _: Slot))
+            .expects(*, *, *)
             .anyNumberOfTimes()
             .returning(true.pure[F])
 


### PR DESCRIPTION
## Purpose
- After restarting a node, a new block will result in re-validating the chain (for now, PR to follow to change this a bit)
- Re-validating the chain of headers will attempt to re-deduplicate the eligibilities from those headers
- Because the EligibilityCache is repopulated with headers on launch, the re-validation of them will fail because the eligibility appears to have been used already
## Approach
- When running EligibilityCache.tryInclude, provide the block ID corresponding to the validation.  If it matches the existing entry, return true
## Testing
- Update unit test for EligibilityCache
- Run 2 local nodes.  Stop 2nd node.  Start 2nd node.  Observed it was able to sync without validation failure
## Tickets
- #BN-877