### PR TITLE
Delay Block Producer

### DIFF
--- a/minting/src/main/scala/co/topl/minting/interpreters/OperationalKeyMaker.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/OperationalKeyMaker.scala
@@ -196,45 +196,31 @@ object OperationalKeyMaker {
       kesParent: SecretKeyKesProduct,
       slots:     Vector[Slot]
     ): F[Vector[OperationalKeyOut]] =
-      Sync[F]
-        .delay(List.fill(slots.size)(()))
-        .flatMap(
-          _.parTraverse(_ =>
-            ed25519Resource
-              .use(ed =>
-                Sync[F].delay(
-                  ed.deriveKeyPairFromEntropy(Entropy.fromUuid(UUID.randomUUID()), None)
-                )
-              )
-              .map { keyPair =>
-                (
-                  ByteString.copyFrom(keyPair.signingKey.bytes),
-                  ByteString.copyFrom(keyPair.verificationKey.bytes)
-                )
-              }
-          )
-        )
-        .flatMap(children =>
-          kesProductResource
-            .use(kesProduct => Sync[F].delay(kesProduct.getVerificationKey(kesParent)))
-            .flatMap(parentVK =>
-              slots
-                .zip(children)
-                .parTraverse { case (slot, (childSK, childVK)) =>
-                  kesProductResource
-                    .use(kesProductScheme =>
-                      Sync[F]
-                        .delay(
-                          kesProductScheme.sign(
-                            kesParent,
-                            childVK.concat(ByteString.copyFrom(Longs.toByteArray(slot))).toByteArray
-                          )
-                        )
-                    )
-                    .map(parentSignature => OperationalKeyOut(slot, childVK, childSK, parentSignature, parentVK))
-                }
-            )
-        )
+      kesProductResource
+        .use(kesProduct => Sync[F].delay(kesProduct.getVerificationKey(kesParent)))
+        .flatMap(parentVK => slots.parTraverse(prepareOperationalPeriodKey(kesParent, parentVK, _)))
+
+    /**
+     * From some "parent" KES keypair, create a single child key for the given slot
+     */
+    private def prepareOperationalPeriodKey(
+      kesParentSK: SecretKeyKesProduct,
+      kesParentVK: VerificationKeyKesProduct,
+      slot:        Slot
+    ) =
+      for {
+        entropy <- Sync[F].delay(Entropy.fromUuid(UUID.randomUUID()))
+        keyPair <- ed25519Resource.use(ed => Sync[F].delay(ed.deriveKeyPairFromEntropy(entropy, None)))
+        message = keyPair.verificationKey.bytes ++ Longs.toByteArray(slot)
+        parentSignature <- kesProductResource
+          .use(kesProductScheme => Sync[F].delay(kesProductScheme.sign(kesParentSK, message)))
+      } yield OperationalKeyOut(
+        slot,
+        ByteString.copyFrom(keyPair.verificationKey.bytes),
+        ByteString.copyFrom(keyPair.signingKey.bytes),
+        parentSignature,
+        kesParentVK
+      )
   }
 
 }

--- a/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
@@ -47,7 +47,8 @@ class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
           .returning(outputHeader.some.pure[F])
 
         val clock = mock[ClockAlgebra[F]]
-        (() => clock.globalSlot).expects().once().returning(parentSlotData.slotId.slot.pure[F])
+        (() => clock.slotsPerEpoch).expects().once().returning(300L.pure[F])
+        (() => clock.globalSlot).expects().twice().returning((parentSlotData.slotId.slot + 1).pure[F])
         (clock.slotToTimestamps(_)).expects(vrfHit.slot).once().returning(NumericRange.inclusive(50L, 99L, 1L).pure[F])
 
         val blockPacker = mock[BlockPackerAlgebra[F]]


### PR DESCRIPTION
## Purpose
- If a node launches and it is de-synced from the network, block production will fail
  - It is impossible to compute an eta value for an epoch if there are 0 blocks
## Approach
- OperationalKeyMaker remove "initialization" step and allow it to happen naturally from block production
- BlockProducer filter parent blocks that are too far in the past
## Testing
- Launch Node A.  Wait an epoch.  Launch Node B (same genesis timestamp).  Node B logs a warning and synchronizes with Node A before producing new blocks.
- Also updated ChainSelectionTest.  Only two (disconnected) nodes are launched at first.  After 2 epochs, the 2 nodes are restarted (connected) with a 3rd node also launched.  All 3 nodes achieve consensus.
## Tickets
- BN-854
  - Note: I'll make a follow-up PR with some changes to BlockHeaderValidation caching