### PR TITLE
OrientDb Address schema, Do not merge

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/TransactionFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/TransactionFetcherAlgebra.scala
@@ -1,8 +1,9 @@
 package co.topl.genusLibrary.algebras
 
+import co.topl.brambl.models.Address
 import co.topl.brambl.models.Identifier.IoTransaction32
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.genus.services.TransactionReceipt
+import co.topl.genus.services.{TransactionReceipt, Txo}
 import co.topl.genusLibrary.model.GE
 
 /**
@@ -26,5 +27,14 @@ trait TransactionFetcherAlgebra[F[_]] {
    * @return Optional Transaction, None if it was not found
    */
   def fetchTransactionReceipt(ioTransaction32: IoTransaction32): F[Either[GE, Option[TransactionReceipt]]]
+
+  /**
+   * Retrieve TxOs (spent or unspent) that are associated with any of the specified addresses
+   * TODO: ask about this response Map[String, Txo], it should be Map[Identifier, Seq[]]
+   *
+   * @param addresses sequence of address
+   * @return
+   */
+  def fetchTransactionsByAddress(addresses: Seq[Address]): F[Either[GE, Map[String, Txo]]]
 
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
@@ -58,4 +58,12 @@ trait VertexFetcherAlgebra[F[_]] {
    */
   def fetchTransaction(ioTransaction32: Identifier.IoTransaction32): F[Either[GE, Option[Vertex]]]
 
+  /**
+   * Fetch Address Vertex, using Address Inex
+   *
+   * @param addressId filter by index field
+   * @return Optional Address vertex, None if it was not found
+   */
+  def fetchAddress(addressId: Identifier): F[Either[GE, Option[Vertex]]]
+
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphBlockInserter.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphBlockInserter.scala
@@ -4,9 +4,10 @@ import cats.effect.{Resource, Sync}
 import cats.implicits._
 import co.topl.genus.services.BlockData
 import co.topl.genusLibrary.algebras.BlockInserterAlgebra
-import co.topl.genusLibrary.model.{GE, GEs}
+import co.topl.genusLibrary.model.{AddressUtil, GE, GEs}
 import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances._
-import co.topl.genusLibrary.orientDb.instances.SchemaBlockHeader.Field
+import co.topl.genusLibrary.orientDb.instances.SchemaBlockHeader
+import co.topl.genusLibrary.orientDb.instances.SchemaAddress
 import co.topl.genusLibrary.orientDb.schema.EdgeSchemaInstances._
 import com.tinkerpop.blueprints.impls.orient.OrientGraph
 import scala.util.Try
@@ -31,16 +32,32 @@ object GraphBlockInserter {
                 graph.addEdge(s"class:${blockHeaderBodyEdge.name}", headerVertex, bodyVertex, blockHeaderBodyEdge.label)
 
                 // Relationships between Header <-> TxIOs
-                block.transactions.map { ioTx =>
+                block.transactions.foreach { ioTx =>
                   val txVertex = graph.addIoTx(ioTx)
                   txVertex.setProperty(ioTransactionSchema.links.head.propertyName, headerVertex.getId)
                   graph.addEdge(s"class:${blockHeaderTxIOEdge.name}", headerVertex, txVertex, blockHeaderTxIOEdge.label)
+
+                  // Relationships between TxIOs <-> Address
+                  AddressUtil.getAddresses(ioTx).foreach { address =>
+                    // before adding a new address, check if was not there included by a previous transaction
+                    val addressVertex = {
+                      val addressIterator =
+                        graph.getVertices(SchemaAddress.Field.AddressId, address.id.toByteArray).iterator()
+
+                      if (addressIterator.hasNext) addressIterator.next()
+                      else graph.addAddress(address)
+
+                    }
+                    graph.addEdge(s"class:${addressTxIOEdge.name}", addressVertex, txVertex, addressTxIOEdge.label)
+
+                  }
+
                 }
 
                 // Relationship between Header <-> ParentHeader if Not Genesis block
                 if (block.header.height != 1) {
                   val headerInVertex = graph
-                    .getVertices(Field.BlockId, block.header.parentHeaderId.value.toByteArray)
+                    .getVertices(SchemaBlockHeader.Field.BlockId, block.header.parentHeaderId.value.toByteArray)
                     .iterator()
                     .next()
 

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphTransactionFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphTransactionFetcher.scala
@@ -4,12 +4,13 @@ import cats.data.EitherT
 import cats.effect.Resource
 import cats.effect.kernel.Async
 import cats.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.box.Box
+import co.topl.brambl.models.{Address, Identifier, LockAddress, TransactionOutputAddress}
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
-import co.topl.genus.services.{ChainDistance, ConfidenceFactor, TransactionReceipt}
+import co.topl.genus.services.{ChainDistance, ConfidenceFactor, TransactionReceipt, Txo, TxoState}
 import co.topl.genusLibrary.algebras.{TransactionFetcherAlgebra, VertexFetcherAlgebra}
-import co.topl.genusLibrary.model.GE
+import co.topl.genusLibrary.model.{GE, GEs}
 import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances._
 import com.tinkerpop.blueprints.impls.orient.OrientVertex
 import scala.util.Try
@@ -54,6 +55,26 @@ object GraphTransactionFetcher {
 
         }
 
+        /**
+         * Retrieve TxOs (spent or unspent) that are associated with any of the specifiedaddresses
+         *
+         * @param addresses sequence of address
+         * @return
+         */
+        override def fetchTransactionsByAddress(addresses: Seq[Address]): F[Either[GE, Map[String, Txo]]] = {
+          val box: Box = Box.defaultInstance // TODO Ask how to create a box
+          val state: TxoState = TxoState.PENDING // TODO Ask how to create a state
+          TransactionOutputAddress.defaultInstance // TODO Ask how to create a box
+          LockAddress.defaultInstance // TODO Ask how to create a box
+          EitherT
+            .fromOption[F](
+              Some(Map.from(Seq("foo" -> Txo(box, state, outputAddress = None, lockAddress = None)))),
+              GEs.UnImplemented
+            )
+            .leftWiden[GE]
+            .value
+
+        }
       }
     }
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcher.scala
@@ -8,7 +8,7 @@ import co.topl.brambl.syntax.transactionIdAsIdSyntaxOps
 import co.topl.consensus.models.BlockId
 import co.topl.genusLibrary.algebras.VertexFetcherAlgebra
 import co.topl.genusLibrary.model.{GE, GEs}
-import co.topl.genusLibrary.orientDb.instances.{SchemaBlockHeader, SchemaIoTransaction}
+import co.topl.genusLibrary.orientDb.instances.{SchemaAddress, SchemaBlockHeader, SchemaIoTransaction}
 import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances._
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery
 import com.tinkerpop.blueprints.Vertex
@@ -108,6 +108,20 @@ object GraphVertexFetcher {
             ).toEither
               .map(_.headOption)
               .leftMap[GE](tx => GEs.InternalMessageCause("GraphVertexFetcher:fetchTransaction", tx))
+          )
+
+        def fetchAddress(addressId: Identifier): F[Either[GE, Option[Vertex]]] =
+          Async[F].blocking(
+            Try(
+              orientGraph
+                .getVertices(
+                  SchemaAddress.Field.AddressId,
+                  addressId.toByteArray
+                )
+                .asScala
+            ).toEither
+              .map(_.headOption)
+              .leftMap[GE](tx => GEs.InternalMessageCause("GraphVertexFetcher:fetchAddress", tx))
           )
 
       }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/model/AddressUtil.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/model/AddressUtil.scala
@@ -1,0 +1,35 @@
+package co.topl.genusLibrary.model
+
+import co.topl.brambl.models._
+import co.topl.brambl.models.transaction.IoTransaction
+
+object AddressUtil {
+
+  def getAddresses(ioTx: IoTransaction): Seq[Address] =
+    ioTx.inputs.map(_.address).map(addressFromOutput) ++
+    ioTx.outputs.map(_.address).map(addressFromLock)
+
+  private def addressFromOutput(address: TransactionOutputAddress): Address =
+    Address(
+      address.network,
+      address.ledger,
+      address.index,
+      id = address.id match {
+        case TransactionOutputAddress.Id.Empty                   => Identifier(Identifier.Value.Empty)
+        case TransactionOutputAddress.Id.IoTransaction32(ioTx32) => Identifier(Identifier.Value.IoTransaction32(ioTx32))
+        case TransactionOutputAddress.Id.IoTransaction64(ioTx64) => Identifier(Identifier.Value.IoTransaction64(ioTx64))
+      }
+    )
+
+  private def addressFromLock(address: LockAddress): Address =
+    Address(
+      address.network,
+      address.ledger,
+      index = 0, // TODO, should be None
+      id = address.id match {
+        case LockAddress.Id.Empty          => Identifier(Identifier.Value.Empty)
+        case LockAddress.Id.Lock32(lock32) => Identifier(Identifier.Value.Lock32(lock32))
+        case LockAddress.Id.Lock64(lock64) => Identifier(Identifier.Value.Lock64(lock64))
+      }
+    )
+}

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaAddress.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaAddress.scala
@@ -1,0 +1,66 @@
+package co.topl.genusLibrary.orientDb.instances
+
+import co.topl.brambl.models.{Address, Identifier}
+import co.topl.genusLibrary.orientDb.schema.OIndexable.Instances._
+import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
+import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, VertexSchema}
+
+object SchemaAddress {
+
+  /**
+   * Address model:
+   * @see https://github.com/Topl/protobuf-specs/blob/main/proto/brambl/models/address.proto
+   */
+  object Field {
+    val SchemaName = "Address"
+    val Network = "network"
+    val Ledger = "ledger"
+    val Index = "index"
+    // id on proto models, do not use id, Property key is reserved for all elements: id
+    val AddressId = "addressId"
+    val AddressIndex = "addressIndex"
+  }
+
+  def make(): VertexSchema[Address] =
+    VertexSchema.create(
+      Field.SchemaName,
+      GraphDataEncoder[Address]
+        .withProperty(
+          Field.Network,
+          address => java.lang.Integer.valueOf(address.network),
+          mandatory = true,
+          readOnly = true,
+          notNull = true
+        )
+        .withProperty(
+          Field.Ledger,
+          address => java.lang.Integer.valueOf(address.ledger),
+          mandatory = true,
+          readOnly = true,
+          notNull = true
+        )
+        .withProperty(
+          Field.Index,
+          address => java.lang.Integer.valueOf(address.index),
+          mandatory = false,
+          readOnly = true,
+          notNull = false
+        )
+        .withProperty(
+          Field.AddressId,
+          _.id.toByteArray,
+          mandatory = true,
+          readOnly = true,
+          notNull = true
+        )
+        .withIndex[Address](Field.AddressIndex, Field.AddressId),
+      v =>
+        Address(
+          network = v(Field.Network),
+          ledger = v(Field.Ledger),
+          index = v(Field.Index),
+          id = Identifier.parseFrom(v(Field.AddressId): Array[Byte])
+        )
+    )
+
+}

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/EdgeSchema.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/EdgeSchema.scala
@@ -30,4 +30,8 @@ object EdgeSchemaInstances {
     override def label: String = "hasTxIO"
   }
 
+  // Edge: address <--> transactionIO
+  val addressTxIOEdge: EdgeSchema = new EdgeSchema {
+    override def label: String = "hasAddress"
+  }
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/OIndexable.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/OIndexable.scala
@@ -1,5 +1,6 @@
 package co.topl.genusLibrary.orientDb.schema
 
+import co.topl.brambl.models.Address
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockHeader
 import com.orientechnologies.orient.core.metadata.schema.OClass
@@ -19,6 +20,10 @@ object OIndexable {
     }
 
     implicit val ioTransaction: OIndexable[IoTransaction] = new OIndexable[IoTransaction] {
+      override def indexType: OClass.INDEX_TYPE = INDEX_TYPE.UNIQUE
+    }
+
+    implicit val address: OIndexable[Address] = new OIndexable[Address] {
       override def indexType: OClass.INDEX_TYPE = INDEX_TYPE.UNIQUE
     }
   }

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphBlockInserterSuite.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphBlockInserterSuite.scala
@@ -31,10 +31,10 @@ class GraphBlockInserterSuite extends CatsEffectSuite with ScalaCheckEffectSuite
 
     PropF.forAllF { blockHeader: BlockHeader =>
       val res = for {
-        blockData           <- Resource.pure(BlockData(blockHeader.copy(height = 1), null, null))
-        graphHeaderInserter <- GraphBlockInserter.make[F](orientGraph)
+        blockData     <- Resource.pure(BlockData(blockHeader.copy(height = 1), null, null))
+        blockInserter <- GraphBlockInserter.make[F](orientGraph)
         _ <- assertIO(
-          graphHeaderInserter.insert(blockData),
+          blockInserter.insert(blockData),
           (GEs.InternalMessage("boom!"): GE).asLeft[Unit]
         ).toResource
       } yield ()
@@ -52,10 +52,10 @@ class GraphBlockInserterSuite extends CatsEffectSuite with ScalaCheckEffectSuite
 
     PropF.forAllF { blockHeader: BlockHeader =>
       val res = for {
-        blockData           <- Resource.pure(BlockData(blockHeader.copy(height = 1), null, null))
-        graphHeaderInserter <- GraphBlockInserter.make[F](orientGraph)
+        blockData     <- Resource.pure(BlockData(blockHeader.copy(height = 1), null, null))
+        blockInserter <- GraphBlockInserter.make[F](orientGraph)
         _ <- assertIO(
-          graphHeaderInserter.insert(blockData),
+          blockInserter.insert(blockData),
           ().asRight[GE]
         ).toResource
       } yield ()
@@ -73,10 +73,10 @@ class GraphBlockInserterSuite extends CatsEffectSuite with ScalaCheckEffectSuite
     PropF.forAllF { blockHeader: BlockHeader =>
       withMock {
         val res = for {
-          blockData           <- Resource.pure(BlockData(blockHeader.copy(height = 2), null, null))
-          graphHeaderInserter <- GraphBlockInserter.make[F](orientGraph)
+          blockData     <- Resource.pure(BlockData(blockHeader.copy(height = 2), null, null))
+          blockInserter <- GraphBlockInserter.make[F](orientGraph)
           _ <- assertIO(
-            graphHeaderInserter.insert(blockData),
+            blockInserter.insert(blockData),
             (GEs.InternalMessage("boom!"): GE).asLeft[Unit]
           ).toResource
         } yield ()
@@ -103,10 +103,10 @@ class GraphBlockInserterSuite extends CatsEffectSuite with ScalaCheckEffectSuite
     PropF.forAllF { blockHeader: BlockHeader =>
       withMock {
         val res = for {
-          blockData           <- Resource.pure(BlockData(blockHeader.copy(height = 2), null, null))
-          graphHeaderInserter <- GraphBlockInserter.make[F](orientGraph)
+          blockData     <- Resource.pure(BlockData(blockHeader.copy(height = 2), null, null))
+          blockInserter <- GraphBlockInserter.make[F](orientGraph)
           _ <- assertIO(
-            graphHeaderInserter.insert(blockData),
+            blockInserter.insert(blockData),
             ().asRight[GE]
           ).toResource
         } yield ()
@@ -131,10 +131,10 @@ class GraphBlockInserterSuite extends CatsEffectSuite with ScalaCheckEffectSuite
     PropF.forAllF { blockHeader: BlockHeader =>
       withMock {
         val res = for {
-          blockData           <- Resource.pure(BlockData(blockHeader.copy(height = 2), null, null))
-          graphHeaderInserter <- GraphBlockInserter.make[F](orientGraph)
+          blockData     <- Resource.pure(BlockData(blockHeader.copy(height = 2), null, null))
+          blockInserter <- GraphBlockInserter.make[F](orientGraph)
           _ <- assertIO(
-            graphHeaderInserter.insert(blockData),
+            blockInserter.insert(blockData),
             (GEs.InternalMessage("boom!"): GE).asLeft[Unit]
           ).toResource
         } yield ()

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaAddressTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaAddressTest.scala
@@ -1,0 +1,213 @@
+package co.topl.genusLibrary.orientDb.instances
+
+import cats.effect.implicits.effectResourceOps
+import cats.effect.kernel.Async
+import cats.effect.{Resource, Sync}
+import cats.implicits._
+import co.topl.genusLibrary.orientDb.instances.SchemaAddress.Field
+import co.topl.genusLibrary.orientDb.{DbFixtureUtil, OrientDBMetadataFactory}
+import co.topl.models.ModelGenerators.GenHelper
+import co.topl.brambl.generators.{ModelGenerators => BramblGens}
+import co.topl.brambl.models.{Address, Identifier}
+import com.orientechnologies.orient.core.metadata.schema.OType
+import com.tinkerpop.blueprints.impls.orient.OrientGraphFactoryV2
+import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalamock.munit.AsyncMockFactory
+import scala.jdk.CollectionConverters._
+import scodec.bits.ByteVector
+
+class SchemaAddressTest
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with AsyncMockFactory
+    with CatsEffectFunFixtures
+    with DbFixtureUtil {
+
+  orientDbFixture.test("Address Schema Metadata") { odb =>
+    val res = for {
+      odbFactory <- Sync[F].blocking(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
+      dbNoTx     <- Sync[F].blocking(odbFactory.getNoTx).toResource
+      _          <- Sync[F].blocking(dbNoTx.makeActive()).toResource
+
+      databaseDocumentTx <- Resource.pure(odbFactory.getNoTx.getRawGraph)
+      schema             <- SchemaAddress.make().pure[F].toResource
+      _                  <- OrientDBMetadataFactory.createSchema[F](databaseDocumentTx, schema).toResource
+
+      oClass <- Async[F].delay(databaseDocumentTx.getClass(schema.name)).toResource
+
+      _ <- assertIO(oClass.getName.pure[F], schema.name, s"${schema.name} Class was not created").toResource
+
+      networkProperty <- oClass.getProperty(Field.Network).pure[F].toResource
+      _ <- (
+        assertIO(networkProperty.getName.pure[F], Field.Network) &>
+        assertIO(networkProperty.isMandatory.pure[F], true) &>
+        assertIO(networkProperty.isReadonly.pure[F], true) &>
+        assertIO(networkProperty.isNotNull.pure[F], true) &>
+        assertIO(networkProperty.getType.pure[F], OType.INTEGER)
+      ).toResource
+
+      ledgerProperty <- oClass.getProperty(Field.Ledger).pure[F].toResource
+      _ <- (
+        assertIO(ledgerProperty.getName.pure[F], Field.Ledger) &>
+        assertIO(ledgerProperty.isMandatory.pure[F], true) &>
+        assertIO(ledgerProperty.isReadonly.pure[F], true) &>
+        assertIO(ledgerProperty.isNotNull.pure[F], true) &>
+        assertIO(ledgerProperty.getType.pure[F], OType.INTEGER)
+      ).toResource
+
+      indexProperty <- oClass.getProperty(Field.Index).pure[F].toResource
+      _ <- (
+        assertIO(indexProperty.getName.pure[F], Field.Index) &>
+        assertIO(indexProperty.isMandatory.pure[F], false) &>
+        assertIO(indexProperty.isReadonly.pure[F], true) &>
+        assertIO(indexProperty.isNotNull.pure[F], false) &>
+        assertIO(indexProperty.getType.pure[F], OType.INTEGER)
+      ).toResource
+
+      idProperty <- oClass.getProperty(Field.AddressId).pure[F].toResource
+      _ <- (
+        assertIO(idProperty.getName.pure[F], Field.AddressId) &>
+        assertIO(idProperty.isMandatory.pure[F], true) &>
+        assertIO(idProperty.isReadonly.pure[F], true) &>
+        assertIO(idProperty.isNotNull.pure[F], true) &>
+        assertIO(idProperty.getType.pure[F], OType.BINARY)
+      ).toResource
+
+    } yield ()
+
+    res.use_
+
+  }
+
+  orientDbFixture.test("Address Schema Add vertex Lock Address") { odb =>
+    val res = for {
+      odbFactory <- Sync[F].blocking(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
+
+      dbNoTx <- Sync[F].blocking(odbFactory.getNoTx).toResource
+      _      <- Sync[F].blocking(dbNoTx.makeActive()).toResource
+
+      schema <- SchemaAddress.make().pure[F].toResource
+      _      <- OrientDBMetadataFactory.createSchema[F](dbNoTx.getRawGraph, schema).toResource
+
+      dbTx <- Sync[F].blocking(odbFactory.getTx).toResource
+      _    <- Sync[F].blocking(dbTx.makeActive()).toResource
+
+      address <- BramblGens.arbitraryLockAddress.arbitrary
+        .map(lockAddress =>
+          Address(
+            lockAddress.network,
+            lockAddress.ledger,
+            0, // None when https://github.com/Topl/protobuf-specs/pull/49
+            id = Identifier.of(Identifier.Value.Lock32(lockAddress.id.lock32.get))
+          )
+        )
+        .first
+        .pure[F]
+        .toResource
+
+      vertex <- Sync[F]
+        .blocking(
+          dbTx
+            .addVertex(s"class:${schema.name}", schema.encode(address).asJava)
+        )
+        .toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Int](schema.properties.filter(_.name == Field.Network).head.name).pure[F],
+        address.network
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Int](schema.properties.filter(_.name == Field.Ledger).head.name).pure[F],
+        address.ledger
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Int](schema.properties.filter(_.name == Field.Index).head.name).pure[F],
+        address.index
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Array[Byte]](schema.properties.filter(_.name == Field.AddressId).head.name).toSeq.pure[F],
+        address.id.toByteArray.toSeq
+      ).toResource
+
+      _ <- logger.info(ByteVector(vertex.getProperty[Array[Byte]](Field.AddressId)).toBase64).toResource
+      _ <- logger.info(ByteVector(address.id.toByteArray).toBase64).toResource
+
+      _ <- assertIO(
+        Sync[F].blocking(
+          dbTx
+            .getVertices(SchemaAddress.Field.AddressId, address.id.toByteArray)
+            .iterator()
+            .next()
+            .getProperty[Array[Byte]](Field.AddressId)
+            .toSeq
+        ),
+        address.id.toByteArray.toSeq
+      ).toResource
+
+    } yield ()
+    res.use_
+
+  }
+
+  orientDbFixture.test("Address Schema Add vertex Transaction Output Address") { odb =>
+    val res = for {
+      odbFactory <- Sync[F].blocking(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
+
+      dbNoTx <- Sync[F].blocking(odbFactory.getNoTx).toResource
+      _      <- Sync[F].blocking(dbNoTx.makeActive()).toResource
+
+      schema <- SchemaAddress.make().pure[F].toResource
+      _      <- OrientDBMetadataFactory.createSchema[F](dbNoTx.getRawGraph, schema).toResource
+
+      dbTx <- Sync[F].blocking(odbFactory.getTx).toResource
+      _    <- Sync[F].blocking(dbTx.makeActive()).toResource
+
+      address <- BramblGens.arbitraryTransactionOutputAddress.arbitrary
+        .map(outputAddress =>
+          Address(
+            outputAddress.network,
+            outputAddress.ledger,
+            outputAddress.index,
+            id = Identifier.of(Identifier.Value.IoTransaction32(outputAddress.id.ioTransaction32.get))
+          )
+        )
+        .first
+        .pure[F]
+        .toResource
+
+      vertex <- Sync[F]
+        .blocking(
+          dbTx
+            .addVertex(s"class:${schema.name}", schema.encode(address).asJava)
+        )
+        .toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Int](schema.properties.filter(_.name == Field.Network).head.name).pure[F],
+        address.network
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Int](schema.properties.filter(_.name == Field.Ledger).head.name).pure[F],
+        address.ledger
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Int](schema.properties.filter(_.name == Field.Index).head.name).pure[F],
+        address.index
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Array[Byte]](schema.properties.filter(_.name == Field.AddressId).head.name).toSeq.pure[F],
+        address.id.toByteArray.toSeq
+      ).toResource
+
+    } yield ()
+    res.use_
+
+  }
+
+}

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeaderTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeaderTest.scala
@@ -30,7 +30,7 @@ class SchemaBlockHeaderTest
 
       databaseDocumentTx <- Resource.pure(odbFactory.getNoTx.getRawGraph)
       schema             <- SchemaBlockHeader.make().pure[F].toResource
-      _                  <- OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, schema)
+      _                  <- OrientDBMetadataFactory.createSchema[F](databaseDocumentTx, schema).toResource
 
       oClass <- Async[F].delay(databaseDocumentTx.getClass(schema.name)).toResource
 
@@ -158,7 +158,7 @@ class SchemaBlockHeaderTest
       _      <- Sync[F].blocking(dbNoTx.makeActive()).toResource
 
       schema <- SchemaBlockHeader.make().pure[F].toResource
-      _      <- OrientDBMetadataFactory.createVertex[F](dbNoTx.getRawGraph, schema)
+      _      <- OrientDBMetadataFactory.createSchema[F](dbNoTx.getRawGraph, schema).toResource
 
       dbTx <- Sync[F].blocking(odbFactory.getTx).toResource
       _    <- Sync[F].blocking(dbTx.makeActive()).toResource

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransactionSuite.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransactionSuite.scala
@@ -35,9 +35,9 @@ class SchemaIoTransactionSuite extends CatsEffectSuite with ScalaCheckEffectSuit
       )
 
       blockHeaderSchema <- SchemaBlockHeader.make().pure[F].toResource
-      _                 <- OrientDBMetadataFactory.createVertex[F](db, blockHeaderSchema)
+      _                 <- OrientDBMetadataFactory.createSchema[F](db, blockHeaderSchema).toResource
       transactionSchema <- SchemaIoTransaction.make().pure[F].toResource
-      _                 <- OrientDBMetadataFactory.createVertex[F](db, transactionSchema)
+      _                 <- OrientDBMetadataFactory.createSchema[F](db, transactionSchema).toResource
 
       oClass <- Async[F].delay(db.getClass(transactionSchema.name)).toResource
 
@@ -90,9 +90,9 @@ class SchemaIoTransactionSuite extends CatsEffectSuite with ScalaCheckEffectSuit
       )
 
       blockHeaderSchema <- SchemaBlockHeader.make().pure[F].toResource
-      _                 <- OrientDBMetadataFactory.createVertex[F](db, blockHeaderSchema)
+      _                 <- OrientDBMetadataFactory.createSchema[F](db, blockHeaderSchema).toResource
       transactionSchema <- SchemaIoTransaction.make().pure[F].toResource
-      _                 <- OrientDBMetadataFactory.createVertex[F](db, transactionSchema)
+      _                 <- OrientDBMetadataFactory.createSchema[F](db, transactionSchema).toResource
 
       orientGraph <- Sync[F].blocking(orientGraphFactory.getTx).toResource
       blockHeader <- ModelGenerators.arbitraryHeader.arbitrary.first.pure[F].toResource

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/schema/VertexSchemaTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/schema/VertexSchemaTest.scala
@@ -30,7 +30,7 @@ class VertexSchemaTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     val res = for {
       odbFactory         <- Sync[F].blocking(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
       databaseDocumentTx <- Resource.pure(odbFactory.getNoTx.getRawGraph)
-      _                  <- OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, testSchema)
+      _                  <- OrientDBMetadataFactory.createSchema[F](databaseDocumentTx, testSchema).toResource
 
       oClass <- Async[F].delay(databaseDocumentTx.getClass(testSchema.name)).toResource
 
@@ -50,7 +50,7 @@ class VertexSchemaTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     val res = for {
       odbFactory         <- Sync[F].blocking(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
       databaseDocumentTx <- Resource.pure(odbFactory.getNoTx.getRawGraph)
-      _                  <- OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, testSchema)
+      _                  <- OrientDBMetadataFactory.createSchema[F](databaseDocumentTx, testSchema).toResource
 
       dbTx <- Sync[F].blocking(odbFactory.getTx).toResource
       _    <- Sync[F].blocking(dbTx.makeActive()).toResource

--- a/genus-server/Examples/Queries.md
+++ b/genus-server/Examples/Queries.md
@@ -11,9 +11,16 @@ MATCH {Class: BlockHeader}-hasBody-{Class: BlockBody}
 RETURN $pathelements
 ```
 
-Ex3: Relationship between headers and body and transaction, for an existing BlockHeader with id 26:0 (id:cluster)
+Ex3: Relationship between headers , body and transaction, for an existing BlockHeader with id 26:0 (id:cluster)
 
 ```roomsql
 MATCH {Class: Transaction}-hasTxIO-{Class: BlockHeader, where: (@rid=26:0)}-hasBody-{Class: BlockBody}
+RETURN $pathelements
+```
+
+Ex4: Relationship between headers, body, transaction and address, for an existing BlockHeader with id 26:0 (id:cluster)
+
+```roomsql
+MATCH {Class: Address}-hasAddress-{Class: Transaction}-hasTxIO-{Class: BlockHeader, where: (@rid=26:0)}-hasBody-{Class: BlockBody}
 RETURN $pathelements
 ```

--- a/genus-server/src/main/scala/co/topl/genusServer/GenusServerApp.scala
+++ b/genus-server/src/main/scala/co/topl/genusServer/GenusServerApp.scala
@@ -41,13 +41,13 @@ object GenusServerApp
       nodeBlockFetcher <- NodeBlockFetcher.make(rpcInterpreter)
 
       // TODO this is just proof of concept, we need to add a lot of logic here, related to retries and handling errors
-      nodeEnabled <- Resource.pure(false) // maybe we can use a config
+      nodeEnabled <- Resource.pure(true) // maybe we can use a config
       inserter <- nodeBlockFetcher
-        .fetch(startHeight = 1, endHeight = 300)
+        .fetch(startHeight = 1, endHeight = 10)
         .map(_.spaced(50 millis))
         .map(
           _.evalMap(graphBlockInserter.insert)
-            .evalTap(res => Logger[F].info(res.leftMap(_.toString).swap.getOrElse("OK")))
+            .evalTap(res => Logger[F].info(res.leftMap(_.getMessage).swap.getOrElse("OK")))
         )
         .toResource
 

--- a/genus-server/src/main/scala/co/topl/genusServer/GrpcTransactionService.scala
+++ b/genus-server/src/main/scala/co/topl/genusServer/GrpcTransactionService.scala
@@ -34,7 +34,10 @@ private[genusServer] class GrpcTransactionService[F[_]: Async](transactionFetche
     Stream.raiseError[F](GEs.UnImplemented).adaptErrorsToGrpc
 
   override def getTxosByAddress(request: QueryByAddressRequest, ctx: Metadata): F[TxoAddressResponse] =
-    Async[F].raiseError[TxoAddressResponse](GEs.UnImplemented).adaptErrorsToGrpc
+    EitherT(transactionFetcher.fetchTransactionsByAddress(request.addresses))
+      .map(TxoAddressResponse(_))
+      .rethrowT
+      .adaptErrorsToGrpc
 
   override def getTxosByAddressStream(request: QueryByAddressRequest, ctx: Metadata): Stream[F, TxoAddressResponse] =
     Stream.raiseError[F](GEs.UnImplemented).adaptErrorsToGrpc


### PR DESCRIPTION
## Purpose
Address Schema implementation

## Approach
- each time we process a TxIO, a new address Vertex will be created and liked using edge

PROPERTIES

|#   |NAME     |TYPE   |LINKED-TYPE/CLASS|MANDATORY|READONLY|NOT-NULL|
|--------|--------|--------|--------|--------|--------|--------|
|0   |ledger   |INTEGER|                 |true     |true    |true    |   
|1   |index    |INTEGER|                 |false    |true    |false   |    
|2   |network  |INTEGER|                 |true     |true    |true    | 
|3   |addressId|BINARY |                 |true     |true    |true    | 


![header_body_txio_address](https://user-images.githubusercontent.com/8540107/229932283-f8be9f76-4613-40ac-a311-ddf25a002e8c.png)


## Questions
The genesis block contains (26), contains 1 Txio (42), and this Txio is related to 3 Addresses (LockAddress, or OutputAddress)
- why is connected with the same address twice, is it correct? if yes, should we represent this information, or if an edge exists between (Txio-Address), do not create a new one? 

## Tickets
* this work is required to implement `getTxosByAddress`  which is a Transaction service endpoint Api part-2 BN-958 


