### PR TITLE
Remove BlockHeaderValidation Cached Recursion

### DIFF
--- a/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
@@ -335,7 +335,11 @@ object BlockHeaderValidation {
     /**
      * Wraps an existing BlockHeaderValidation with a cache.  Valid block IDs are saved in the cache to avoid recomputing
      * when switching branches.
-     * @param underlying The base cache
+     *
+     * Invalid block IDs are not saved, but this is subject to change.  This is to avoid an adversary flooding the
+     * cache with invalid block IDs, but this comes at the risk of the adversary flooding compute resources.
+     *
+     * @param underlying The base header validation implementation
      * @param cacheSize The maximum number of header IDs to store
      */
     def make[F[_]: Sync](

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
@@ -18,8 +18,10 @@ import co.topl.models.utility.HasLength.instances._
 import co.topl.models.utility.Lengths._
 import co.topl.models.utility._
 import co.topl.typeclasses.implicits._
+import com.github.benmanes.caffeine.cache.Caffeine
 import com.google.common.primitives.Longs
 import com.google.protobuf.ByteString
+import scalacache.Entry
 import scalacache.caffeine.CaffeineCache
 
 /**
@@ -330,31 +332,32 @@ object BlockHeaderValidation {
 
   object WithCache {
 
+    /**
+     * Wraps an existing BlockHeaderValidation with a cache.  Valid block IDs are saved in the cache to avoid recomputing
+     * when switching branches.
+     * @param underlying The base cache
+     * @param cacheSize The maximum number of header IDs to store
+     */
     def make[F[_]: Sync](
-      underlying:       BlockHeaderValidationAlgebra[F],
-      blockHeaderStore: Store[F, BlockId, BlockHeader],
-      bigBangBlockId:   BlockId
+      underlying: BlockHeaderValidationAlgebra[F],
+      cacheSize:  Int = 512
     ): F[BlockHeaderValidationAlgebra[F]] =
-      CaffeineCache[F, BlockId, Unit].map(implicit cache =>
-        new BlockHeaderValidationAlgebra[F] {
+      Sync[F]
+        .delay(CaffeineCache[F, BlockId, Unit](Caffeine.newBuilder.maximumSize(cacheSize).build[BlockId, Entry[Unit]]))
+        .map(implicit cache =>
+          new BlockHeaderValidationAlgebra[F] {
 
-          def validate(header: BlockHeader): F[Either[BlockHeaderValidationFailure, BlockHeader]] =
-            if (header.id === bigBangBlockId) header.asRight[BlockHeaderValidationFailure].pure[F]
-            else
+            def validate(header: BlockHeader): F[Either[BlockHeaderValidationFailure, BlockHeader]] =
               cache
                 .cachingF(header.id)(ttl = None)(
-                  EitherT
-                    .liftF(Sync[F].defer(blockHeaderStore.getOrRaise(header.parentHeaderId)))
-                    .flatMapF(validate)
-                    .flatMapF(_ => underlying.validate(header))
-                    .void
+                  EitherT(Sync[F].defer(underlying.validate(header))).void
                     .leftMap(new WrappedFailure(_))
                     .rethrowT
                 )
                 .as(header.asRight[BlockHeaderValidationFailure])
                 .recover { case w: WrappedFailure => w.failure.asLeft[BlockHeader] }
-        }
-      )
+          }
+        )
 
     private class WrappedFailure(val failure: BlockHeaderValidationFailure) extends Exception
   }

--- a/node/src/main/scala/co/topl/node/Validators.scala
+++ b/node/src/main/scala/co/topl/node/Validators.scala
@@ -64,7 +64,7 @@ object Validators {
           cryptoResources.ed25519,
           cryptoResources.blake2b256
         )
-        .flatMap(BlockHeaderValidation.WithCache.make[F](_, dataStores.headers, bigBangBlockId))
+        .flatMap(BlockHeaderValidation.WithCache.make[F](_))
       headerToBody <- BlockHeaderToBodyValidation.make()
       boxState <- BoxState.make(
         currentEventIdGetterSetters.boxState.get(),


### PR DESCRIPTION
## Purpose
- BlockHeaderValidation.WithCache recursively validates all ancestor headers before validating the current headers
- This is an expensive and unnecessary computation, especially on node restart which would re-validate the entire chain
## Approach
- Remove the recursive call from BlockHeaderValidation.WithCache
- Add a cache size limit
## Testing
- preparePR and NodeAppTest
## Tickets
- #BN-854