### PR TITLE
Align with PB Changes to VerificationKey

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/StakerInitializer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/StakerInitializer.scala
@@ -18,6 +18,7 @@ import co.topl.models.utility.Lengths
 import co.topl.models.utility.Sized
 import com.google.protobuf.ByteString
 import quivr.models._
+import quivr.models.VerificationKey._
 
 /**
  * Represents the data required to initialize a new staking.  This includes the necessary secret keys, plus their
@@ -77,7 +78,7 @@ object StakerInitializers {
                       Challenge().withRevealed(
                         Proposition(
                           Proposition.Value.DigitalSignature(
-                            Proposition.DigitalSignature("ed25519", VerificationKey(spendingVK))
+                            Proposition.DigitalSignature("ed25519", VerificationKey(Vk.Ed25519(Ed25519Vk(spendingVK))))
                           )
                         )
                       )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,9 +11,9 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.6"
   val orientDbVersion = "3.2.17"
-  val protobufSpecsVersion = "ce3282d" // scala-steward:off
-  val bramblScVersion = "93930d1" // scala-steward:off
-  val quivr4sVersion = "69c2605" // scala-steward:off
+  val protobufSpecsVersion = "b745cb1" // scala-steward:off
+  val bramblScVersion = "5eca7c6" // scala-steward:off
+  val quivr4sVersion = "8de3426" // scala-steward:off
 
   val catsSlf4j =
     "org.typelevel" %% "log4cats-slf4j" % "2.5.0"


### PR DESCRIPTION
## Purpose

Recently there was a change to PB specs which changes the definition of VerificationKey and SigningKey. Bifrost should be updated to align.

## Approach

- update dependencies to reference newest changes in protobuf-specs, quivr4s, and BramblSc
- Minor update to a usage of VerificationKey

## Testing

Ran `checkPR` and `checkPRTestQuick`. Ensured they were successful

## Tickets
* Closes TSDK-358