### PR TITLE
Tx ID From Signable Bytes

### DIFF
--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraIdentifiableInstances.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraIdentifiableInstances.scala
@@ -8,6 +8,7 @@ import co.topl.consensus.models.BlockHeader
 import co.topl.consensus.models.BlockId
 import co.topl.crypto.hash.Blake2b256
 
+import co.topl.brambl.common._
 import scala.language.implicitConversions
 
 trait ProtoIdentifiableOps {
@@ -21,16 +22,18 @@ trait ProtoIdentifiableOps {
 
 class IoTransactionIdOps(val transaction: IoTransaction) extends AnyVal {
 
-  import co.topl.brambl.common._
-
   def id: Identifier.IoTransaction32 = {
-    implicit val immutableContainsImmutable: ContainsImmutable[ImmutableBytes] = identity
+    import IoTransactionIdOps._
     val signableBytes = ContainsSignable[IoTransaction].signableBytes(transaction)
     val immutable = ImmutableBytes(signableBytes.value)
     val evidence = ContainsEvidence[ImmutableBytes].sized32Evidence(immutable)
     Identifier.IoTransaction32(evidence)
   }
 
+}
+
+object IoTransactionIdOps {
+  implicit private val immutableContainsImmutable: ContainsImmutable[ImmutableBytes] = identity
 }
 
 class BlockHeaderIdOps(val header: BlockHeader) extends AnyVal {

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraIdentifiableInstances.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraIdentifiableInstances.scala
@@ -1,6 +1,8 @@
 package co.topl.codecs.bytes.tetra
 
+import co.topl.brambl.common.ContainsSignable.instances.ioTransactionSignable
 import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.common.ImmutableBytes
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockHeader
 import co.topl.consensus.models.BlockId
@@ -19,11 +21,15 @@ trait ProtoIdentifiableOps {
 
 class IoTransactionIdOps(val transaction: IoTransaction) extends AnyVal {
 
-  import co.topl.brambl.common.ContainsImmutable.instances.ioTransactionImmutable
   import co.topl.brambl.common._
 
-  def id: Identifier.IoTransaction32 =
-    Identifier.IoTransaction32(ContainsEvidence[IoTransaction].sized32Evidence(transaction))
+  def id: Identifier.IoTransaction32 = {
+    implicit val immutableContainsImmutable: ContainsImmutable[ImmutableBytes] = identity
+    val signableBytes = ContainsSignable[IoTransaction].signableBytes(transaction)
+    val immutable = ImmutableBytes(signableBytes.value)
+    val evidence = ContainsEvidence[ImmutableBytes].sized32Evidence(immutable)
+    Identifier.IoTransaction32(evidence)
+  }
 
 }
 


### PR DESCRIPTION
## Purpose
- Transaction IDs were constructed using `ContainsEvidence[IoTransaction]` which does not strip out the proofs from the Transaction
## Approach
- Update Transaction#id to follow the path: `Signable -> (Immutable) -> Evidence -> Transaction ID`
## Testing
- Implementation of Bifrost-Dart
## Tickets
N/A