### PR TITLE
canonical head schema

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
@@ -26,6 +26,7 @@ package co.topl.genusLibrary.orientDb {
         _ <- createVertex(db, blockHeaderSchema)
         _ <- createVertex(db, blockBodySchema)
         _ <- createVertex(db, ioTransactionSchema)
+        _ <- createVertex(db, canonicalHeadSchema)
 
       } yield ()
 

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaCanonicalHead.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaCanonicalHead.scala
@@ -1,0 +1,24 @@
+package co.topl.genusLibrary.orientDb.instances
+
+import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, VertexSchema}
+import com.orientechnologies.orient.core.metadata.schema.OType
+
+object SchemaCanonicalHead {
+
+  case object CanonicalHead
+
+  /**
+   * CanonicalHead is represented by 1 vertex, and it is not associated with any mapping model
+   */
+  object Field {
+    val SchemaName = "CanonicalHead"
+
+  }
+
+  def make(): VertexSchema[CanonicalHead.type] = VertexSchema.create(
+    Field.SchemaName,
+    GraphDataEncoder[CanonicalHead.type]
+      .withLink(SchemaBlockHeader.Field.BlockId, OType.LINK, SchemaBlockHeader.Field.SchemaName),
+    _ => CanonicalHead
+  )
+}

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
@@ -5,12 +5,14 @@ import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.models.{Evidence, Identifier, LockAddress, TransactionOutputAddress}
 import co.topl.consensus.models.BlockHeader
 import co.topl.genus.services.{Txo, TxoState}
+import co.topl.genusLibrary.orientDb.instances.SchemaCanonicalHead.CanonicalHead
 import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
 import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, VertexSchema}
 import co.topl.node.models.BlockBody
 import com.google.protobuf.ByteString
 import com.tinkerpop.blueprints.impls.orient.{OrientGraph, OrientVertex}
 import quivr.models.Digest
+
 import scala.jdk.CollectionConverters._
 
 /**
@@ -35,6 +37,7 @@ object VertexSchemaInstances {
     private[genusLibrary] val blockHeaderSchema: VertexSchema[BlockHeader] = SchemaBlockHeader.make()
     private[genusLibrary] val blockBodySchema: VertexSchema[BlockBody] = SchemaBlockBody.make()
     private[genusLibrary] val ioTransactionSchema: VertexSchema[IoTransaction] = SchemaIoTransaction.make()
+    private[genusLibrary] val canonicalHeadSchema: VertexSchema[CanonicalHead.type] = SchemaCanonicalHead.make()
 
     // Note, From here to the end, VertexSchemas not tested
     /**

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaCanonicalHeadTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaCanonicalHeadTest.scala
@@ -1,0 +1,118 @@
+package co.topl.genusLibrary.orientDb.instances
+
+import cats.effect.implicits.effectResourceOps
+import cats.effect.kernel.Async
+import cats.effect.{Resource, Sync}
+import cats.implicits._
+import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
+import co.topl.genusLibrary.orientDb.instances.SchemaBlockHeader.Field
+import co.topl.genusLibrary.orientDb.instances.SchemaCanonicalHead.CanonicalHead
+import co.topl.genusLibrary.orientDb.{DbFixtureUtil, OrientDBMetadataFactory}
+import co.topl.models.ModelGenerators.GenHelper
+import co.topl.models.generators.consensus.ModelGenerators
+import com.orientechnologies.orient.core.metadata.schema.OType
+import com.tinkerpop.blueprints.impls.orient.{OrientGraphFactoryV2, OrientVertex}
+import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalamock.munit.AsyncMockFactory
+
+import scala.jdk.CollectionConverters._
+
+class SchemaCanonicalHeadTest
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with AsyncMockFactory
+    with CatsEffectFunFixtures
+    with DbFixtureUtil {
+
+  orientDbFixture.test("Canonical Head Schema Metadata") { odb =>
+    val res = for {
+      odbFactory <- Sync[F].blocking(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
+      dbNoTx     <- Sync[F].blocking(odbFactory.getNoTx).toResource
+      _          <- Sync[F].blocking(dbNoTx.makeActive()).toResource
+
+      databaseDocumentTx <- Resource.pure(odbFactory.getNoTx.getRawGraph)
+
+      blockHeaderSchema   <- SchemaBlockHeader.make().pure[F].toResource
+      _                   <- OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, blockHeaderSchema)
+      canonicalHeadSchema <- SchemaCanonicalHead.make().pure[F].toResource
+      _                   <- OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, canonicalHeadSchema)
+
+      oClass <- Async[F].delay(databaseDocumentTx.getClass(canonicalHeadSchema.name)).toResource
+
+      _ <- assertIO(
+        oClass.getName.pure[F],
+        canonicalHeadSchema.name,
+        s"${canonicalHeadSchema.name} Class was not created"
+      ).toResource
+
+      canonicalHeadLink <- oClass.getProperty(SchemaBlockHeader.Field.BlockId).pure[F].toResource
+      _ <- (
+        assertIO(canonicalHeadLink.getName.pure[F], SchemaBlockHeader.Field.BlockId) &>
+        assertIO(canonicalHeadLink.getType.pure[F], OType.LINK) &>
+        assertIO(canonicalHeadLink.getLinkedClass.getName.pure[F], SchemaBlockHeader.Field.SchemaName)
+      ).toResource
+
+    } yield ()
+
+    res.use_
+
+  }
+
+  orientDbFixture.test("Canonical Header Schema Add vertex") { odb =>
+    val res = for {
+      odbFactory <- Sync[F].blocking(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
+
+      dbNoTx <- Sync[F].blocking(odbFactory.getNoTx).toResource
+      _      <- Sync[F].blocking(dbNoTx.makeActive()).toResource
+
+      blockHeaderSchema <- SchemaBlockHeader.make().pure[F].toResource
+      _                 <- OrientDBMetadataFactory.createVertex[F](dbNoTx.getRawGraph, blockHeaderSchema)
+
+      canonicalHeadSchema <- SchemaCanonicalHead.make().pure[F].toResource
+      _                   <- OrientDBMetadataFactory.createVertex[F](dbNoTx.getRawGraph, canonicalHeadSchema)
+
+      dbTx <- Sync[F].blocking(odbFactory.getTx).toResource
+      _    <- Sync[F].blocking(dbTx.makeActive()).toResource
+
+      blockHeader <- ModelGenerators.arbitraryHeader.arbitrary.first.pure[F].toResource
+
+      blockHeaderVertex <- Sync[F]
+        .blocking(
+          dbTx
+            .addVertex(s"class:${blockHeaderSchema.name}", blockHeaderSchema.encode(blockHeader).asJava)
+        )
+        .toResource
+
+      _ <- assertIO(
+        blockHeaderVertex
+          .getProperty[Array[Byte]](blockHeaderSchema.properties.filter(_.name == Field.BlockId).head.name)
+          .toSeq
+          .pure[F],
+        blockHeader.id.value.toByteArray.toSeq
+      ).toResource
+
+      canonicalHeadVertex <- Sync[F].blocking {
+        val v = dbTx
+          .addVertex(s"class:${canonicalHeadSchema.name}", canonicalHeadSchema.encode(CanonicalHead).asJava)
+        v.setProperty(canonicalHeadSchema.links.head.propertyName, blockHeaderVertex.getId)
+        v
+      }.toResource
+
+      blockHeaderFromCanonicalHead <- Sync[F].blocking {
+        canonicalHeadVertex.getProperty[OrientVertex](SchemaBlockHeader.Field.BlockId)
+      }.toResource
+
+      _ <- assertIO(
+        blockHeaderFromCanonicalHead.pure[F],
+        blockHeaderVertex
+      ).toResource
+
+      blockHeaderDecoded = blockHeaderSchema.decodeVertex(blockHeaderFromCanonicalHead)
+      _ <- assertIOBoolean((blockHeader == blockHeaderDecoded).pure[F]).toResource
+
+    } yield ()
+    res.use_
+
+  }
+
+}

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransactionSuite.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransactionSuite.scala
@@ -7,7 +7,6 @@ import cats.implicits._
 import co.topl.brambl.generators.{ModelGenerators => BramblGenerator}
 import co.topl.codecs.bytes.tetra.instances.ioTransactionAsIoTransactionOps
 import co.topl.genusLibrary.orientDb.OrientDBMetadataFactory
-import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.ioTransactionSchema
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.models.generators.consensus.ModelGenerators
 import com.orientechnologies.orient.core.metadata.schema.OType
@@ -108,7 +107,7 @@ class SchemaIoTransactionSuite extends CatsEffectSuite with ScalaCheckEffectSuit
       transactionVertex <- Sync[F].blocking {
         val v = orientGraph
           .addVertex(s"class:${transactionSchema.name}", transactionSchema.encode(transaction).asJava)
-        v.setProperty(ioTransactionSchema.links.head.propertyName, blockHeaderVertex.getId)
+        v.setProperty(transactionSchema.links.head.propertyName, blockHeaderVertex.getId)
         v
       }.toResource
 

--- a/genus-server/src/main/resources/environment.conf
+++ b/genus-server/src/main/resources/environment.conf
@@ -8,7 +8,8 @@ genus {
 
   // The _base_ directory in which genus_db data is stored
   // optionally if OrientDB Studio was previously installed required, the genus_db storage should be a child of ¨database¨ folder
-  orient-db-directory = "../../orientdb-community-3.2.17/databases/genus_db"
+  // Example = "../../orientdb-community-3.2.18/databases/genus_db"
+  orient-db-directory = "/tmp/genus_db"
   orient-db-user = "admin"
   orient-db-password = "admin"
 }


### PR DESCRIPTION
## Purpose
- Canonical head vertex is 1 vertex (linked to the some block Header vertex), which represent the head of chain.
- Idea was taken from Sean's implementation, OrientDB chain replicator, https://github.com/Topl/Bifrost/blob/flutter-admin-ui-genus/genus/src/main/scala/co/topl/genus/interpreters/orientdb/OrientDbChainReplicator.scala 
- this unique Vertex will help to know the head of the chain, without traverse all vertices looking the last adoptions

## Tickets
* partial ticker of Node replicator