### PR TITLE
Density Chain Selection Tie-Breaker

### DIFF
--- a/consensus/src/main/scala/co/topl/consensus/interpreters/ChainSelection.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/ChainSelection.scala
@@ -26,7 +26,7 @@ object ChainSelection {
   import NonEmpty.instances._
   import Prepend.instances._
 
-  private val lengthOrder = Order.by[SlotData, Long](_.height)
+  private val heightOrder = Order.by[SlotData, Long](_.height)
   private val slotOrder = Order.by[SlotData, Slot](-_.slotId.slot)
 
   private def rhoTestHashOrderSlotData(implicit blake2b512: Blake2b512) =
@@ -38,7 +38,7 @@ object ChainSelection {
    * The normal ordering to use between tines with a recent common ancestor
    */
   private def standardOrder(implicit blake2b512: Blake2b512): Order[SlotData] =
-    lengthOrder
+    heightOrder
       .tiebreakWith(slotOrder)
       .tiebreakWith(rhoTestHashOrderSlotData)
 

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/ChainSelection.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/ChainSelection.scala
@@ -26,21 +26,21 @@ object ChainSelection {
   import NonEmpty.instances._
   import Prepend.instances._
 
+  private val lengthOrder = Order.by[SlotData, Long](_.height)
+  private val slotOrder = Order.by[SlotData, Slot](-_.slotId.slot)
+
+  private def rhoTestHashOrderSlotData(implicit blake2b512: Blake2b512) =
+    Order.reverse(
+      Order.by[SlotData, BigInt](h => BigInt(rhoToRhoTestHash(h.rho).toArray))
+    )
+
   /**
    * The normal ordering to use between tines with a recent common ancestor
    */
-  private def standardOrder(implicit blake2b512: Blake2b512): Order[NonEmptyChain[SlotData]] = {
-    val lengthOrder = Order.by[NonEmptyChain[SlotData], Long](_.length)
-    val slotOrder = Order.by[NonEmptyChain[SlotData], Slot](-_.last.slotId.slot)
-    val rhoTestHashOrder =
-      Order.reverse(
-        Order.by[NonEmptyChain[SlotData], BigInt](h => BigInt(rhoToRhoTestHash(h.last.rho).toArray))
-      )
-
+  private def standardOrder(implicit blake2b512: Blake2b512): Order[SlotData] =
     lengthOrder
       .tiebreakWith(slotOrder)
-      .tiebreakWith(rhoTestHashOrder)
-  }
+      .tiebreakWith(rhoTestHashOrderSlotData)
 
   /**
    * Between two tines, determines which one is "better"
@@ -175,7 +175,9 @@ object ChainSelection {
         xSegment.head === ySegment.head
 
       def comparisonResult: F[Int] =
-        blake2b512Resource.use(implicit blake2b512 => Sync[F].delay(standardOrder.compare(xSegment, ySegment)))
+        blake2b512Resource.use(implicit blake2b512 =>
+          Sync[F].delay(standardOrder.compare(xSegment.last, ySegment.last))
+        )
     }
 
     /**
@@ -195,7 +197,14 @@ object ChainSelection {
         xSegment.head === ySegment.head
 
       def comparisonResult: F[Int] =
-        xSegment.length.compare(ySegment.length).pure[F]
+        Sync[F].delay(xSegment.length.compare(ySegment.length)).flatMap {
+          case 0 =>
+            // When the two chains have equal density, fallback to a rhoTestHash comparison on the latest blocks
+            // in the density segments
+            blake2b512Resource
+              .use(implicit blake2b512 => Sync[F].delay(rhoTestHashOrderSlotData.compare(xSegment.last, ySegment.last)))
+          case r => r.pure[F]
+        }
 
       /**
        * In cases where a common-ancestor search traces back more than `kLookback` blocks, we only need to aggregate


### PR DESCRIPTION
## Purpose
- Two blockchain peers may be very out-of-sync, in which case, selecting the "best" chain involves the "Density" Chain Selection Rule
- With the Density Chain Selection Rule, two branches may have equal density, in which case a tie will never be resolved
## Approach
- Modify Density Chain Selection to tie-break on the rhoTestHash value of the "last" slot
## Testing
- New unit test
## Tickets
- #BN-956