### PR TITLE
Align Bifrost with recent changes to Crypto/BramblSc

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
@@ -12,7 +12,6 @@ import co.topl.node.models._
 import co.topl.typeclasses.implicits._
 import com.google.protobuf.ByteString
 import quivr.models.SmallData
-import scodec.bits.ByteVector
 
 /**
  * The beginning of everything.  ("everything" of course just means the first block of a blockchain)
@@ -58,7 +57,7 @@ object BigBang {
         new Blake2b256().hash(
           (config.etaPrefix +:
           transactions.map(_.id.evidence.digest.value))
-            .map(v => v: ByteVector): _*
+            .map(v => v: Array[Byte]): _*
         )
       )
 

--- a/blockchain/src/main/scala/co/topl/blockchain/StakerInitializer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/StakerInitializer.scala
@@ -123,19 +123,19 @@ object StakerInitializers {
 
       val operatorSK = new Ed25519()
         .deriveKeyPairFromSeed(
-          blake2b256.hash(seed.data :+ 1).toArray
+          blake2b256.hash(seed.data.toByteArray :+ 1)
         )
         .signingKey
         .bytes
       val walletSK = new Ed25519()
         .deriveKeyPairFromSeed(
-          blake2b256.hash(seed.data :+ 2).toArray
+          blake2b256.hash(seed.data.toByteArray :+ 2)
         )
         .signingKey
         .bytes
       val spendingSK = new Ed25519()
         .deriveKeyPairFromSeed(
-          blake2b256.hash(seed.data :+ 3).toArray
+          blake2b256.hash(seed.data.toByteArray :+ 3)
         )
         .signingKey
         .bytes
@@ -143,10 +143,10 @@ object StakerInitializers {
         Ed25519VRF
           .precomputed()
           .deriveKeyPairFromSeed(
-            blake2b256.hash(seed.data :+ 4).toArray
+            blake2b256.hash(seed.data.toByteArray :+ 4)
           )
       val (kesSK, _) = new KesProduct().createKeyPair(
-        seed = blake2b256.hash(seed.data :+ 5).toArray,
+        seed = blake2b256.hash(seed.data.toByteArray :+ 5),
         height = kesKeyHeight,
         0
       )

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/EtaCalculation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/EtaCalculation.scala
@@ -22,7 +22,6 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scalacache.Entry
 import scalacache.caffeine.CaffeineCache
-import scodec.bits.ByteVector
 
 object EtaCalculation {
 
@@ -151,7 +150,7 @@ object EtaCalculation {
     ): F[Eta] =
       Sync[F]
         .delay(EtaCalculationArgs(previousEta, epoch, rhoNonceHashValues.toIterable).digestMessages)
-        .flatMap(bytes => blake2b256Resource.use(b2b => Sync[F].delay(b2b.hash(bytes.map(v => v: ByteVector): _*))))
+        .flatMap(bytes => blake2b256Resource.use(b2b => Sync[F].delay(b2b.hash(bytes.map(v => v: Array[Byte]): _*))))
         .map(v => v: ByteString)
         .map(Sized.strictUnsafe(_): Eta)
 

--- a/consensus/src/main/scala/co/topl/consensus/package.scala
+++ b/consensus/src/main/scala/co/topl/consensus/package.scala
@@ -11,7 +11,6 @@ import co.topl.models.Bytes
 import co.topl.models.UnsignedBlockHeader
 import co.topl.models.utility._
 import com.google.protobuf.ByteString
-import scodec.bits.ByteVector
 
 package object consensus {
 
@@ -56,7 +55,7 @@ package object consensus {
 
   def thresholdEvidence(threshold: Ratio)(implicit blake2b256: Blake2b256): ByteString =
     blake2b256.hash(
-      ByteVector(threshold.numerator.toByteArray ++ threshold.denominator.toByteArray)
+      threshold.numerator.toByteArray ++ threshold.denominator.toByteArray
     )
 
   /**

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/QuivrContext.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/QuivrContext.scala
@@ -17,6 +17,7 @@ import co.topl.quivr.algebras.SignatureVerifier
 import co.topl.quivr.runtime.DynamicContext
 import co.topl.quivr.runtime.QuivrRuntimeError
 import co.topl.quivr.runtime.QuivrRuntimeErrors
+import co.topl.typeclasses.implicits.arrayEq
 import quivr.models.DigestVerification
 import quivr.models.SignableBytes
 import quivr.models.SignatureVerification

--- a/models/src/main/scala/co/topl/models/utility/package.scala
+++ b/models/src/main/scala/co/topl/models/utility/package.scala
@@ -13,4 +13,8 @@ package object utility {
   implicit def byteVectorToByteString(byteVector: ByteVector): ByteString =
     ByteString.copyFrom(byteVector.toByteBuffer)
 
+  implicit def byteStringToByteArray(byteString: ByteString): Array[Byte] = byteString.toByteArray
+
+  implicit def byteArrayToByteString(byteArray: Array[Byte]): ByteString = ByteString.copyFrom(byteArray)
+
 }

--- a/node-crypto/src/test/scala/co/topl/crypto/signing/KesProductSpec.scala
+++ b/node-crypto/src/test/scala/co/topl/crypto/signing/KesProductSpec.scala
@@ -58,11 +58,11 @@ class KesProductSpec
   }
 
   it should "generate identical keypairs given the same seed" in {
-    forAll(genBytesWithBoundedSize(1, 1024), Gen.choose(1, 12), Gen.choose(1, 12)) {
+    forAll(genByteArrayWithBoundedSize(1, 1024), Gen.choose(1, 12), Gen.choose(1, 12)) {
       (seedBytes, supHeight: Int, subHeight: Int) =>
         val kesProduct = new KesProduct
-        val (_, vk1) = kesProduct.createKeyPair(seedBytes.toArray, (supHeight, subHeight), 0)
-        val (_, vk2) = kesProduct.createKeyPair(seedBytes.toArray, (supHeight, subHeight), 0)
+        val (_, vk1) = kesProduct.createKeyPair(Array.from(seedBytes), (supHeight, subHeight), 0)
+        val (_, vk2) = kesProduct.createKeyPair(Array.from(seedBytes), (supHeight, subHeight), 0)
 
         vk1 shouldBe vk2
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val logback = "1.4.6"
   val orientDbVersion = "3.2.17"
   val protobufSpecsVersion = "b745cb1" // scala-steward:off
-  val bramblScVersion = "9371def" // scala-steward:off
+  val bramblScVersion = "5794d14" // scala-steward:off
   val quivr4sVersion = "8de3426" // scala-steward:off
 
   val catsSlf4j =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val logback = "1.4.6"
   val orientDbVersion = "3.2.17"
   val protobufSpecsVersion = "b745cb1" // scala-steward:off
-  val bramblScVersion = "5eca7c6" // scala-steward:off
+  val bramblScVersion = "9371def" // scala-steward:off
   val quivr4sVersion = "8de3426" // scala-steward:off
 
   val catsSlf4j =

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraIdentifiableInstances.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraIdentifiableInstances.scala
@@ -42,7 +42,7 @@ class BlockHeaderIdOps(val header: BlockHeader) extends AnyVal {
   def id: BlockId =
     BlockId(
       new Blake2b256().hash(
-        TetraScodecCodecs.consensusBlockHeaderCodec.encode(header).require.toByteVector
+        TetraScodecCodecs.consensusBlockHeaderCodec.encode(header).require.toByteVector.toArray
       )
     )
 }


### PR DESCRIPTION
## Purpose

In https://github.com/Topl/BramblSc/pull/40 Scodec (and thus ByteVectors) were removed from Crypto/BramblSc. This caused breaking changes in Bifrost

## Approach

updated any usage of crypto/bramblSc that was affected by the change

## Testing

Ran `checkPR` and `checkPRTestQuick` and ensured everything passed successfully 

## Tickets
* Closes TSDK-413