### PR TITLE
Move body to header validation right to block body downloader checker

### DIFF
--- a/models/src/test/scala/co/topl/models/generators/consensus/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/generators/consensus/ModelGenerators.scala
@@ -36,6 +36,9 @@ trait ModelGenerators {
   def signatureEd25519Gen: Gen[ByteString] =
     genSizedStrictByteString[Lengths.`64`.type]().map(_.data)
 
+  def txRoot: Gen[Sized.Strict[ByteString, Lengths.`32`.type]] =
+    genSizedStrictByteString[Lengths.`32`.type]()
+
   implicit val arbitraryStakingAddress: Arbitrary[StakingAddress] =
     Arbitrary(genSizedStrictByteString[Lengths.`32`.type]().map(_.data).map(StakingAddress(_)))
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
@@ -21,11 +21,12 @@ import org.typelevel.log4cats.Logger
 trait NetworkAlgebra[F[_]] {
 
   def makePeerManger(
-    networkAlgebra:   NetworkAlgebra[F],
-    localChain:       LocalChainAlgebra[F],
-    slotDataStore:    Store[F, BlockId, SlotData],
-    transactionStore: Store[F, Identifier.IoTransaction32, IoTransaction],
-    blockIdTree:      ParentChildTree[F, BlockId]
+    networkAlgebra:         NetworkAlgebra[F],
+    localChain:             LocalChainAlgebra[F],
+    slotDataStore:          Store[F, BlockId, SlotData],
+    transactionStore:       Store[F, Identifier.IoTransaction32, IoTransaction],
+    blockIdTree:            ParentChildTree[F, BlockId],
+    headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   ): Resource[F, PeersManagerActor[F]]
 
   def makeReputationAggregation(peersManager: PeersManagerActor[F]): Resource[F, ReputationAggregatorActor[F]]
@@ -38,7 +39,6 @@ trait NetworkAlgebra[F[_]] {
     headerStore:                 Store[F, BlockId, BlockHeader],
     bodyStore:                   Store[F, BlockId, BlockBody],
     headerValidation:            BlockHeaderValidationAlgebra[F],
-    headerToBodyValidation:      BlockHeaderToBodyValidationAlgebra[F],
     bodySyntaxValidation:        BodySyntaxValidationAlgebra[F],
     bodySemanticValidation:      BodySemanticValidationAlgebra[F],
     bodyAuthorizationValidation: BodyAuthorizationValidationAlgebra[F],
@@ -56,18 +56,20 @@ trait NetworkAlgebra[F[_]] {
 class NetworkAlgebraImpl[F[_]: Async: Logger] extends NetworkAlgebra[F] {
 
   override def makePeerManger(
-    networkAlgebra:   NetworkAlgebra[F],
-    localChain:       LocalChainAlgebra[F],
-    slotDataStore:    Store[F, BlockId, SlotData],
-    transactionStore: Store[F, Identifier.IoTransaction32, IoTransaction],
-    blockIdTree:      ParentChildTree[F, BlockId]
+    networkAlgebra:         NetworkAlgebra[F],
+    localChain:             LocalChainAlgebra[F],
+    slotDataStore:          Store[F, BlockId, SlotData],
+    transactionStore:       Store[F, Identifier.IoTransaction32, IoTransaction],
+    blockIdTree:            ParentChildTree[F, BlockId],
+    headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   ): Resource[F, PeersManagerActor[F]] =
     PeersManager.makeActor(
       networkAlgebra,
       localChain,
       slotDataStore,
       transactionStore,
-      blockIdTree
+      blockIdTree,
+      headerToBodyValidation
     )
 
   override def makeReputationAggregation(
@@ -83,7 +85,6 @@ class NetworkAlgebraImpl[F[_]: Async: Logger] extends NetworkAlgebra[F] {
     headerStore:                 Store[F, BlockId, BlockHeader],
     bodyStore:                   Store[F, BlockId, BlockBody],
     headerValidation:            BlockHeaderValidationAlgebra[F],
-    headerToBodyValidation:      BlockHeaderToBodyValidationAlgebra[F],
     bodySyntaxValidation:        BodySyntaxValidationAlgebra[F],
     bodySemanticValidation:      BodySemanticValidationAlgebra[F],
     bodyAuthorizationValidation: BodyAuthorizationValidationAlgebra[F],
@@ -97,7 +98,6 @@ class NetworkAlgebraImpl[F[_]: Async: Logger] extends NetworkAlgebra[F] {
       headerStore,
       bodyStore,
       headerValidation,
-      headerToBodyValidation,
       bodySyntaxValidation,
       bodySemanticValidation,
       bodyAuthorizationValidation,

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
@@ -39,7 +39,8 @@ object NetworkManager {
         localChain,
         slotDataStore,
         transactionStore,
-        blockIdTree
+        blockIdTree,
+        headerToBodyValidation
       )
       reputationAggregator <- networkAlgebra.makeReputationAggregation(peerManager)
       requestsProxy <- networkAlgebra.makeRequestsProxy(reputationAggregator, peerManager, headerStore, bodyStore)
@@ -51,7 +52,6 @@ object NetworkManager {
         headerStore,
         bodyStore,
         headerValidation,
-        headerToBodyValidation,
         bodySyntaxValidation,
         bodySemanticValidation,
         bodyAuthorizationValidation,

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -7,16 +7,14 @@ import co.topl.actor.{Actor, Fsm}
 import co.topl.algebras.Store
 import co.topl.brambl.models.Identifier
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.consensus.algebras.LocalChainAlgebra
-import co.topl.consensus.models.BlockId
-import co.topl.consensus.models.SlotData
+import co.topl.consensus.algebras.{BlockHeaderToBodyValidationAlgebra, LocalChainAlgebra}
+import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
 import co.topl.eventtree.ParentChildTree
 import co.topl.networking.blockchain.BlockchainPeerClient
 import co.topl.networking.fsnetwork.BlockChecker.BlockCheckerActor
 import co.topl.networking.fsnetwork.PeerActor.Message.{DownloadBlockBodies, DownloadBlockHeaders, UpdateState}
 import co.topl.networking.fsnetwork.PeerBlockBodyFetcher.PeerBlockBodyFetcherActor
 import co.topl.networking.fsnetwork.PeerBlockHeaderFetcher.PeerBlockHeaderFetcherActor
-import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
 import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
 import org.typelevel.log4cats.Logger
 
@@ -39,17 +37,16 @@ object PeerActor {
 
     /**
      * Request to download block bodies from peer, downloaded bodies will be sent to block checker directly
-     * @param blockIds bodies block id to download
+     * @param blockData bodies block id to download
      */
-    case class DownloadBlockBodies(blockIds: NonEmptyChain[BlockId]) extends Message
+    case class DownloadBlockBodies(blockData: NonEmptyChain[(BlockId, BlockHeader)]) extends Message
   }
 
   case class State[F[_]](
-    hostId:               HostId,
-    client:               BlockchainPeerClient[F],
-    reputationAggregator: ReputationAggregatorActor[F],
-    blockHeaderActor:     PeerBlockHeaderFetcherActor[F],
-    blockBodyActor:       PeerBlockBodyFetcherActor[F]
+    hostId:           HostId,
+    client:           BlockchainPeerClient[F],
+    blockHeaderActor: PeerBlockHeaderFetcherActor[F],
+    blockBodyActor:   PeerBlockBodyFetcherActor[F]
   )
 
   type Response[F[_]] = State[F]
@@ -62,15 +59,15 @@ object PeerActor {
   }
 
   def makeActor[F[_]: Async: Logger](
-    hostId:               HostId,
-    client:               BlockchainPeerClient[F],
-    reputationAggregator: ReputationAggregatorActor[F],
-    blockChecker:         BlockCheckerActor[F],
-    requestsProxy:        RequestsProxyActor[F],
-    localChain:           LocalChainAlgebra[F],
-    slotDataStore:        Store[F, BlockId, SlotData],
-    transactionStore:     Store[F, Identifier.IoTransaction32, IoTransaction],
-    blockIdTree:          ParentChildTree[F, BlockId]
+    hostId:                 HostId,
+    client:                 BlockchainPeerClient[F],
+    blockChecker:           BlockCheckerActor[F],
+    requestsProxy:          RequestsProxyActor[F],
+    localChain:             LocalChainAlgebra[F],
+    slotDataStore:          Store[F, BlockId, SlotData],
+    transactionStore:       Store[F, Identifier.IoTransaction32, IoTransaction],
+    blockIdTree:            ParentChildTree[F, BlockId],
+    headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   ): Resource[F, PeerActor[F]] =
     for {
       header <- PeerBlockHeaderFetcher.makeActor(
@@ -82,8 +79,8 @@ object PeerActor {
         slotDataStore,
         blockIdTree
       )
-      body <- PeerBlockBodyFetcher.makeActor(hostId, client, requestsProxy, transactionStore)
-      initialState = State(hostId, client, reputationAggregator, header, body)
+      body <- PeerBlockBodyFetcher.makeActor(hostId, client, requestsProxy, transactionStore, headerToBodyValidation)
+      initialState = State(hostId, client, header, body)
       actor <- Actor.make(initialState, getFsm[F])
     } yield actor
 
@@ -108,9 +105,9 @@ object PeerActor {
     (state, state).pure[F]
 
   private def downloadBodies[F[_]: Concurrent](
-    state:    State[F],
-    blockIds: NonEmptyChain[BlockId]
+    state:     State[F],
+    blockData: NonEmptyChain[(BlockId, BlockHeader)]
   ): F[(State[F], Response[F])] =
-    state.blockBodyActor.sendNoWait(PeerBlockBodyFetcher.Message.DownloadBlocks(blockIds)) >>
+    state.blockBodyActor.sendNoWait(PeerBlockBodyFetcher.Message.DownloadBlocks(blockData)) >>
     (state, state).pure[F]
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockBodyFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockBodyFetcher.scala
@@ -1,7 +1,7 @@
 package co.topl.networking.fsnetwork
 
 import cats.MonadThrow
-import cats.data.{NonEmptyChain, OptionT}
+import cats.data.{EitherT, NonEmptyChain, OptionT}
 import cats.effect.{Async, Resource}
 import cats.implicits._
 import co.topl.actor.{Actor, Fsm}
@@ -9,11 +9,13 @@ import co.topl.algebras.Store
 import co.topl.brambl.models.Identifier
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.codecs.bytes.tetra.instances._
-import co.topl.consensus.models.BlockId
+import co.topl.consensus.algebras.BlockHeaderToBodyValidationAlgebra
+import co.topl.consensus.models.BlockHeaderToBodyValidationFailure.IncorrectTxRoot
+import co.topl.consensus.models.{BlockHeader, BlockId}
 import co.topl.networking.blockchain.BlockchainPeerClient
 import co.topl.networking.fsnetwork.BlockBodyDownloadError._
 import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
-import co.topl.node.models.BlockBody
+import co.topl.node.models.{Block, BlockBody}
 import co.topl.typeclasses.implicits._
 import fs2.Stream
 import org.typelevel.log4cats.Logger
@@ -29,17 +31,18 @@ object PeerBlockBodyFetcher {
     /**
      * Request to download block bodies from peer, downloaded bodies will be sent to block checker directly
      *
-     * @param blockIds bodies block id to download
+     * @param blockData bodies block id to download
      */
-    case class DownloadBlocks(blockIds: NonEmptyChain[BlockId]) extends Message
+    case class DownloadBlocks(blockData: NonEmptyChain[(BlockId, BlockHeader)]) extends Message
 
   }
 
   case class State[F[_]](
-    hostId:           HostId,
-    client:           BlockchainPeerClient[F],
-    requestsProxy:    RequestsProxyActor[F],
-    transactionStore: Store[F, Identifier.IoTransaction32, IoTransaction]
+    hostId:                 HostId,
+    client:                 BlockchainPeerClient[F],
+    requestsProxy:          RequestsProxyActor[F],
+    transactionStore:       Store[F, Identifier.IoTransaction32, IoTransaction],
+    headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   )
 
   type Response[F[_]] = State[F]
@@ -52,18 +55,19 @@ object PeerBlockBodyFetcher {
   }
 
   def makeActor[F[_]: Async: Logger](
-    hostId:           HostId,
-    client:           BlockchainPeerClient[F],
-    requestsProxy:    RequestsProxyActor[F],
-    transactionStore: Store[F, Identifier.IoTransaction32, IoTransaction]
+    hostId:                 HostId,
+    client:                 BlockchainPeerClient[F],
+    requestsProxy:          RequestsProxyActor[F],
+    transactionStore:       Store[F, Identifier.IoTransaction32, IoTransaction],
+    headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   ): Resource[F, PeerBlockBodyFetcherActor[F]] = {
-    val initialState = State(hostId, client, requestsProxy, transactionStore)
+    val initialState = State(hostId, client, requestsProxy, transactionStore, headerToBodyValidation)
     Actor.make(initialState, getFsm[F])
   }
 
   private def downloadBodies[F[_]: Async: Logger](
     state:            State[F],
-    blocksToDownload: NonEmptyChain[BlockId]
+    blocksToDownload: NonEmptyChain[(BlockId, BlockHeader)]
   ): F[(State[F], Response[F])] =
     for {
       idToBody <- Stream.foldable(blocksToDownload).evalMap(downloadBlockBody(state)).compile.toList
@@ -73,16 +77,19 @@ object PeerBlockBodyFetcher {
 
   private def downloadBlockBody[F[_]: Async: Logger](
     state: State[F]
-  )(blockId: BlockId): F[(BlockId, Either[BlockBodyDownloadError, BlockBody])] = {
-    val bodyEither: F[BlockBody] =
+  )(blockData: (BlockId, BlockHeader)): F[(BlockId, Either[BlockBodyDownloadError, BlockBody])] = {
+    val (blockId, blockHeader) = blockData
+
+    val body: F[BlockBody] =
       for {
         _    <- Logger[F].info(show"Fetching remote body id=$blockId")
         body <- downloadBlockBody(state, blockId)
         _    <- Logger[F].info(show"Fetched remote body id=$blockId")
+        _    <- checkBody(state, Block(blockHeader, body))
         _    <- downloadingMissingTransactions(state, body)
       } yield body
 
-    bodyEither
+    body
       .map(blockBody => Either.right[BlockBodyDownloadError, BlockBody](blockBody))
       .handleError {
         case e: BlockBodyDownloadError => Either.left[BlockBodyDownloadError, BlockBody](e)
@@ -98,11 +105,16 @@ object PeerBlockBodyFetcher {
 
   }
 
-  private def downloadBlockBody[F[_]: Async](
-    state:   State[F],
-    blockId: BlockId
-  ): F[BlockBody] =
+  private def downloadBlockBody[F[_]: Async](state: State[F], blockId: BlockId): F[BlockBody] =
     OptionT(state.client.getRemoteBody(blockId)).getOrElseF(MonadThrow[F].raiseError(BodyNotFoundInPeer))
+
+  private def checkBody[F[_]: Async](state: State[F], block: Block): F[BlockBody] =
+    EitherT(state.headerToBodyValidation.validate(block))
+      .map(_.body)
+      .leftMap { case e: IncorrectTxRoot =>
+        BodyHaveIncorrectTxRoot(e.headerTxRoot, e.bodyTxRoot)
+      }
+      .rethrowT
 
   private def downloadingMissingTransactions[F[_]: Async: Logger](
     state:     State[F],

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
@@ -10,9 +10,8 @@ import co.topl.actor.Fsm
 import co.topl.algebras.Store
 import co.topl.brambl.models.Identifier
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.consensus.algebras.LocalChainAlgebra
-import co.topl.consensus.models.BlockId
-import co.topl.consensus.models.SlotData
+import co.topl.consensus.algebras.{BlockHeaderToBodyValidationAlgebra, LocalChainAlgebra}
+import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
 import co.topl.eventtree.ParentChildTree
 import co.topl.networking.blockchain.BlockchainPeerClient
 import co.topl.networking.fsnetwork.BlockChecker.BlockCheckerActor
@@ -77,9 +76,9 @@ object PeersManager {
     /**
      * @param hostId use hostId as hint for now, later we could have some kind of map of available peer -> blocks
      *               and send requests to many peers
-     * @param blockBodies requested bodies
+     * @param blocks requested bodies
      */
-    case class BlockBodyDownloadRequest(hostId: HostId, blockBodies: NonEmptyChain[BlockId]) extends Message
+    case class BlockBodyDownloadRequest(hostId: HostId, blocks: NonEmptyChain[(BlockId, BlockHeader)]) extends Message
   }
 
   // actor is option, because in future we shall be able to spawn actor without SetupPeer message,
@@ -94,15 +93,16 @@ object PeersManager {
   }
 
   case class State[F[_]](
-    networkAlgebra:       NetworkAlgebra[F],
-    reputationAggregator: Option[ReputationAggregatorActor[F]],
-    blocksChecker:        Option[BlockCheckerActor[F]],
-    requestsProxy:        Option[RequestsProxyActor[F]],
-    peers:                Map[HostId, Peer[F]],
-    localChain:           LocalChainAlgebra[F],
-    slotDataStore:        Store[F, BlockId, SlotData],
-    transactionStore:     Store[F, Identifier.IoTransaction32, IoTransaction],
-    blockIdTree:          ParentChildTree[F, BlockId]
+    networkAlgebra:         NetworkAlgebra[F],
+    reputationAggregator:   Option[ReputationAggregatorActor[F]],
+    blocksChecker:          Option[BlockCheckerActor[F]],
+    requestsProxy:          Option[RequestsProxyActor[F]],
+    peers:                  Map[HostId, Peer[F]],
+    localChain:             LocalChainAlgebra[F],
+    slotDataStore:          Store[F, BlockId, SlotData],
+    transactionStore:       Store[F, Identifier.IoTransaction32, IoTransaction],
+    blockIdTree:            ParentChildTree[F, BlockId],
+    headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   )
 
   type Response[F[_]] = State[F]
@@ -128,11 +128,12 @@ object PeersManager {
       }
 
   def makeActor[F[_]: Async: Logger](
-    networkAlgebra:   NetworkAlgebra[F],
-    localChain:       LocalChainAlgebra[F],
-    slotDataStore:    Store[F, BlockId, SlotData],
-    transactionStore: Store[F, Identifier.IoTransaction32, IoTransaction],
-    blockIdTree:      ParentChildTree[F, BlockId]
+    networkAlgebra:         NetworkAlgebra[F],
+    localChain:             LocalChainAlgebra[F],
+    slotDataStore:          Store[F, BlockId, SlotData],
+    transactionStore:       Store[F, Identifier.IoTransaction32, IoTransaction],
+    blockIdTree:            ParentChildTree[F, BlockId],
+    headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   ): Resource[F, PeersManagerActor[F]] = {
     val initialState =
       PeersManager.State[F](
@@ -144,7 +145,8 @@ object PeersManager {
         localChain,
         slotDataStore,
         transactionStore,
-        blockIdTree
+        blockIdTree,
+        headerToBodyValidation
       )
     Actor.makeFull(initialState, getFsm[F], finalizeActor[F])
   }
@@ -166,13 +168,13 @@ object PeersManager {
         PeerActor.makeActor(
           hostId,
           client,
-          state.reputationAggregator.get,
           state.blocksChecker.get,
           state.requestsProxy.get,
           state.localChain,
           state.slotDataStore,
           state.transactionStore,
-          state.blockIdTree
+          state.blockIdTree,
+          state.headerToBodyValidation
         )
       )
 
@@ -230,7 +232,7 @@ object PeersManager {
   private def blockDownloadRequest[F[_]: Async](
     state:           State[F],
     requestedHostId: HostId,
-    blocks:          NonEmptyChain[BlockId]
+    blocks:          NonEmptyChain[(BlockId, BlockHeader)]
   ): F[(State[F], Response[F])] =
     state.peers.get(requestedHostId) match {
       case Some(peer) =>

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -8,6 +8,7 @@ import co.topl.algebras.Store
 import co.topl.brambl.models.Identifier
 import co.topl.consensus.models._
 import co.topl.ledger.models.{BodyAuthorizationError, BodySemanticError, BodySyntaxError}
+import co.topl.models.TxRoot
 import co.topl.networking.blockchain.BlockchainPeerClient
 import co.topl.typeclasses.implicits._
 import com.github.benmanes.caffeine.cache.Cache
@@ -158,6 +159,10 @@ package object fsnetwork {
 
     case object BodyNotFoundInPeer extends BlockBodyDownloadError {
       override def toString: String = "Block body has not found in peer"
+    }
+
+    case class BodyHaveIncorrectTxRoot(headerTxRoot: TxRoot, bodyTxRoot: TxRoot) extends BlockBodyDownloadError {
+      override def toString: String = show"Peer returns body with bad txRoot: expected $headerTxRoot, got $bodyTxRoot"
     }
 
     case class TransactionNotFoundInPeer(transactionId: Identifier.IoTransaction32) extends BlockBodyDownloadError {

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
@@ -20,7 +20,7 @@ import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
 import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
 import co.topl.networking.fsnetwork.TestHelper._
-import co.topl.node.models.{Block, BlockBody}
+import co.topl.node.models.BlockBody
 import co.topl.quivr.runtime.DynamicContext
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.Gen
@@ -56,7 +56,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -73,7 +72,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -96,7 +94,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -148,7 +145,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -173,7 +169,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -228,7 +223,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -253,7 +247,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -308,7 +301,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -333,7 +325,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -384,7 +375,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -415,7 +405,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -433,7 +422,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -460,7 +448,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -478,7 +465,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -501,7 +487,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -517,6 +502,9 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStoreData = mutable.Map.empty[BlockId, BlockHeader] ++ knownIdAndHeaders.toMap
       (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         headerStoreData.contains(id).pure[F]
+      }
+      (headerStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+        headerStoreData.get(id).pure[F]
       }
       (headerStore
         .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
@@ -557,7 +545,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           slotData.pure[F]
         }
 
-      val expectedIds = NonEmptyChain.fromSeq(idAndHeaders.map(_._1).toList.take(chunkSize)).get
+      val expectedIds = NonEmptyChain.fromSeq(idAndHeaders.toList.take(chunkSize)).get
       val expectedMessage: RequestsProxy.Message = RequestsProxy.Message.DownloadBodiesRequest(hostId, expectedIds)
       (requestsProxy.sendNoWait _).expects(expectedMessage).returning(().pure[F])
 
@@ -570,7 +558,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -594,7 +581,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -610,6 +596,9 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStoreData = mutable.Map.empty[BlockId, BlockHeader] ++ knownIdAndHeaders.toMap
       (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         headerStoreData.contains(id).pure[F]
+      }
+      (headerStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+        headerStoreData.get(id).pure[F]
       }
       (headerStore
         .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
@@ -650,7 +639,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           slotData.pure[F]
         }
 
-      val expectedIds = NonEmptyChain.fromSeq(idAndHeaders.map(_._1).toList.take(chunkSize)).get
+      val expectedIds = NonEmptyChain.fromSeq(idAndHeaders.toList.take(chunkSize)).get
       val expectedMessage: RequestsProxy.Message = RequestsProxy.Message.DownloadBodiesRequest(hostId, expectedIds)
       (requestsProxy.sendNoWait _).expects(expectedMessage).returning(().pure[F])
 
@@ -694,7 +683,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -720,7 +708,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -748,7 +735,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -771,7 +757,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -808,10 +793,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
           headerStorageData(id).pure[F]
         }
-
-      (headerToBodyValidation.validate _).expects(*).rep(newBodiesSize).onCall { b: Block =>
-        Either.right[BlockHeaderToBodyValidationFailure, Block](b).pure[F]
-      }
 
       (bodySyntaxValidation.validate _).expects(*).rep(newBodiesSize).onCall { b: BlockBody =>
         Validated.validNec[BodySyntaxError, BlockBody](b).pure[F]
@@ -855,7 +836,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -878,7 +858,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -915,10 +894,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
           headerStorageData(id).pure[F]
         }
-
-      (headerToBodyValidation.validate _).expects(*).rep(newBodiesSize).onCall { b: Block =>
-        Either.right[BlockHeaderToBodyValidationFailure, Block](b).pure[F]
-      }
 
       (bodySyntaxValidation.validate _).expects(*).rep(newBodiesSize).onCall { b: BlockBody =>
         Validated.validNec[BodySyntaxError, BlockBody](b).pure[F]
@@ -967,7 +942,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -983,7 +957,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     }
   }
 
-  test("RemoteBlockBodies: Verify and save blocks, apply to local chain, send new request die headers exist") {
+  test("RemoteBlockBodies: Verify and save blocks, apply to local chain, send new request due headers exist") {
     withMock {
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
@@ -992,7 +966,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -1026,11 +999,9 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
 
       val expectedNewRequest = allIdSlotDataHeaderBlock.drop(downloadedBodies)
 
-      val messageData =
-        NonEmptyChain.fromSeq(requestIdSlotDataHeaderBlock.map(d => (d._1, d._4))).get
+      val messageData = NonEmptyChain.fromSeq(requestIdSlotDataHeaderBlock.map(d => (d._1, d._4))).get
 
-      val message =
-        BlockChecker.Message.RemoteBlockBodies(hostId, messageData)
+      val message = BlockChecker.Message.RemoteBlockBodies(hostId, messageData)
 
       val knownBodyStorageData: mutable.Map[BlockId, BlockBody] =
         mutable.Map.empty[BlockId, BlockBody] ++ knownBody.toMap
@@ -1050,12 +1021,11 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
           headerStorageData(id).pure[F]
         }
+      (headerStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+        headerStorageData.get(id).pure[F]
+      }
       (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         headerStorageData.contains(id).pure[F]
-      }
-
-      (headerToBodyValidation.validate _).expects(*).rep(requestIdSlotDataHeaderBlockSize).onCall { b: Block =>
-        Either.right[BlockHeaderToBodyValidationFailure, Block](b).pure[F]
       }
 
       (bodySyntaxValidation.validate _).expects(*).rep(requestIdSlotDataHeaderBlockSize).onCall { b: BlockBody =>
@@ -1093,10 +1063,10 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       (localChain.isWorseThan _).expects(lastRequestBlockSlotData).once().returning(true.pure[F])
       (localChain.adopt _).expects(Validated.Valid(lastRequestBlockSlotData)).once().returning(().pure[F])
 
-      val expectedNewRequestMessage /*: RequestsProxy.Message*/ =
+      val expectedNewRequestMessage: RequestsProxy.Message =
         RequestsProxy.Message.DownloadBodiesRequest(
           hostId,
-          NonEmptyChain.fromSeq(expectedNewRequest.map(_._1).take(chunkSize)).get
+          NonEmptyChain.fromSeq(expectedNewRequest.map(d => (d._1, d._3)).take(chunkSize)).get
         )
       (requestsProxy.sendNoWait _).expects(expectedNewRequestMessage).once().returning(().pure[F])
 
@@ -1109,7 +1079,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
@@ -1139,7 +1108,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
       val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
       val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
@@ -1198,9 +1166,8 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         headerStorageData.contains(id).pure[F]
       }
-
-      (headerToBodyValidation.validate _).expects(*).rep(requestIdSlotDataHeaderBlockSize).onCall { b: Block =>
-        Either.right[BlockHeaderToBodyValidationFailure, Block](b).pure[F]
+      (headerStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+        headerStorageData.get(id).pure[F]
       }
 
       (bodySyntaxValidation.validate _).expects(*).rep(requestIdSlotDataHeaderBlockSize).onCall { b: BlockBody =>
@@ -1249,7 +1216,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           headerStore,
           bodyStore,
           headerValidation,
-          headerToBodyValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockBodyFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockBodyFetcherTest.scala
@@ -6,19 +6,24 @@ import co.topl.algebras.Store
 import co.topl.brambl.generators.TransactionGenerator
 import co.topl.brambl.models.Identifier
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.codecs.bytes.tetra.instances.ioTransactionAsIoTransactionOps
-import co.topl.consensus.models.BlockId
+import co.topl.codecs.bytes.tetra.instances.{blockHeaderAsBlockHeaderOps, ioTransactionAsIoTransactionOps}
+import co.topl.consensus.algebras.BlockHeaderToBodyValidationAlgebra
+import co.topl.consensus.models.BlockHeaderToBodyValidationFailure.IncorrectTxRoot
+import co.topl.consensus.models.{BlockHeaderToBodyValidationFailure, BlockId}
 import co.topl.models.ModelGenerators.GenHelper
+import co.topl.models.TxRoot
+import co.topl.models.generators.consensus.ModelGenerators
 import co.topl.models.generators.consensus.ModelGenerators.nonEmptyChainArbOf
 import co.topl.networking.blockchain.BlockchainPeerClient
 import co.topl.networking.fsnetwork.PeerBlockHeaderFetcherTest.F
 import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
 import co.topl.networking.fsnetwork.TestHelper.{CallHandler1Ops, CallHandler2Ops}
-import co.topl.node.models.BlockBody
+import co.topl.node.models.{Block, BlockBody}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import co.topl.typeclasses.implicits._
 
 import scala.collection.mutable
 
@@ -41,6 +46,7 @@ class PeerBlockBodyFetcherTest
       val client = mock[BlockchainPeerClient[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val transactionStore = mock[Store[F, Identifier.IoTransaction32, IoTransaction]]
+      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
 
       val (txs, bodies) =
         nonEmptyChainArbOf(TestHelper.arbitraryTxsAndBlock).arbitrary
@@ -81,6 +87,10 @@ class PeerBlockBodyFetcherTest
           downloadedTxs.put(id, tx).pure[F].void
       }
 
+      (headerToBodyValidation.validate _).expects(*).rep(presentBlockIdAndBodies.size).onCall { block: Block =>
+        Either.right[BlockHeaderToBodyValidationFailure, Block](block).pure[F]
+      }
+
       val wrappedBodies =
         blockIdsAndBodies.map { case (id, body) =>
           if (clientBodiesData.contains(id)) {
@@ -94,21 +104,120 @@ class PeerBlockBodyFetcherTest
       (requestsProxy.sendNoWait _).expects(expectedMessage).once().returning(().pure[F])
 
       PeerBlockBodyFetcher
-        .makeActor(hostId, client, requestsProxy, transactionStore)
+        .makeActor(hostId, client, requestsProxy, transactionStore, headerToBodyValidation)
         .use { actor =>
           for {
-            _ <- actor.send(PeerBlockBodyFetcher.Message.DownloadBlocks(blockIdsAndBodies.unzip._1))
+            _ <- actor.send(
+              PeerBlockBodyFetcher.Message.DownloadBlocks(
+                blockIdsAndBodies
+                  .map { case (id, body) =>
+                    val header = ModelGenerators.arbitraryHeader.arbitrary.first
+                    (id, header.copy(txRoot = body.merkleTreeRootHash.data))
+                  }
+              )
+            )
             _ = assert(downloadedTxs.size <= missedTxs.toMap.size)
           } yield ()
         }
     }
   }
 
-  test("Block bodies shall return error if client has not transaction") {
+  test("Block bodies shall return error if block have incorrect txRoot") {
     withMock {
       val client = mock[BlockchainPeerClient[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val transactionStore = mock[Store[F, Identifier.IoTransaction32, IoTransaction]]
+      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
+
+      val (txs, bodies) =
+        nonEmptyChainArbOf(TestHelper.arbitraryTxsAndBlock).arbitrary
+          .retryUntil(c => c.size > 1 && c.size < maxChainSize)
+          .first
+          .unzip
+
+      val blockIdsBodiesHeaders =
+        bodies.map { body: BlockBody =>
+          val header = ModelGenerators.arbitraryHeader.arbitrary.first.copy(txRoot = body.merkleTreeRootHash.data)
+          val id = header.id
+          (id, body, header)
+        }
+      val blockIdsAndBodies = blockIdsBodiesHeaders.map(d => (d._1, d._2))
+
+      val (correctTxRootBlockIds, _) = blockIdsAndBodies.toList.map(_._1).partition(_.hashCode() % 2 == 0)
+
+      val txIdsAndTxs = txs.toList.flatten.map(tx => (tx.id, tx))
+      val (missedTxs, presentTxs) = txIdsAndTxs.partition { case (id, _) => id.hashCode() % 2 == 0 }
+
+      val clientBodiesData = blockIdsAndBodies.toList.toMap
+      (client.getRemoteBody _).expects(*).rep(blockIdsAndBodies.size.toInt).onCall { id: BlockId =>
+        clientBodiesData.get(id).pure[F]
+      }
+
+      val transactionStoreData = presentTxs.toMap
+      (transactionStore.contains _).expects(*).anyNumberOfTimes().onCall { id: Identifier.IoTransaction32 =>
+        transactionStoreData.contains(id).pure[F]
+      }
+
+      val clientTxsData = missedTxs.toMap
+      (client.getRemoteTransaction _).expects(*).anyNumberOfTimes().onCall { id: Identifier.IoTransaction32 =>
+        clientTxsData.get(id).pure[F]
+      }
+
+      val downloadedTxs =
+        mutable.Map.empty[Identifier.IoTransaction32, IoTransaction]
+      (transactionStore.put _).expects(*, *).anyNumberOfTimes().onCall {
+        case (id: Identifier.IoTransaction32, tx: IoTransaction) =>
+          downloadedTxs.put(id, tx).pure[F].void
+      }
+
+      val incorrectTxRoot: TxRoot = ModelGenerators.txRoot.first
+      (headerToBodyValidation.validate _).expects(*).rep(blockIdsAndBodies.size.toInt).onCall { block: Block =>
+        if (correctTxRootBlockIds.contains(block.header.id)) {
+          Either.right[BlockHeaderToBodyValidationFailure, Block](block).pure[F]
+        } else {
+          Either
+            .left[BlockHeaderToBodyValidationFailure, Block](
+              IncorrectTxRoot(block.body.merkleTreeRootHash, incorrectTxRoot)
+            )
+            .pure[F]
+        }
+      }
+
+      val wrappedBodies =
+        blockIdsAndBodies.map { case (id, body) =>
+          if (correctTxRootBlockIds.contains(id)) {
+            (id, Either.right[BlockBodyDownloadError, BlockBody](body))
+          } else {
+            (
+              id,
+              Either.left[BlockBodyDownloadError, BlockBody](
+                BlockBodyDownloadError.BodyHaveIncorrectTxRoot(body.merkleTreeRootHash, incorrectTxRoot)
+              )
+            )
+          }
+        }
+
+      val expectedMessage = RequestsProxy.Message.DownloadBodiesResponse(hostId, wrappedBodies)
+      (requestsProxy.sendNoWait _).expects(expectedMessage).once().returning(().pure[F])
+
+      val sendMessage = blockIdsBodiesHeaders.map { case (id, _, header) => (id, header) }
+      PeerBlockBodyFetcher
+        .makeActor(hostId, client, requestsProxy, transactionStore, headerToBodyValidation)
+        .use { actor =>
+          for {
+            _ <- actor.send(PeerBlockBodyFetcher.Message.DownloadBlocks(sendMessage))
+            _ = assert(downloadedTxs.size <= missedTxs.toMap.size)
+          } yield ()
+        }
+    }
+  }
+
+  test("Block bodies shall return error if client has no transaction") {
+    withMock {
+      val client = mock[BlockchainPeerClient[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
+      val transactionStore = mock[Store[F, Identifier.IoTransaction32, IoTransaction]]
+      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
 
       val transactionsAndBody =
         nonEmptyChainArbOf(TestHelper.arbitraryTxsAndBlock).arbitrary
@@ -150,6 +259,10 @@ class PeerBlockBodyFetcherTest
 
       (transactionStore.put _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
 
+      (headerToBodyValidation.validate _).expects(*).rep(idAndBody.size.toInt).onCall { block: Block =>
+        Either.right[BlockHeaderToBodyValidationFailure, Block](block).pure[F]
+      }
+
       val wrappedBodies =
         idAndBody.map { case (id, body) =>
           if (!blockIsMissed(body)) {
@@ -168,10 +281,13 @@ class PeerBlockBodyFetcherTest
       (requestsProxy.sendNoWait _).expects(expectedMessage).once().returning(().pure[F])
 
       PeerBlockBodyFetcher
-        .makeActor(hostId, client, requestsProxy, transactionStore)
+        .makeActor(hostId, client, requestsProxy, transactionStore, headerToBodyValidation)
         .use { actor =>
           for {
-            _ <- actor.send(PeerBlockBodyFetcher.Message.DownloadBlocks(idAndBody.map(_._1)))
+            _ <- actor.send(PeerBlockBodyFetcher.Message.DownloadBlocks(idAndBody.map { case (id, body) =>
+              val header = ModelGenerators.arbitraryHeader.arbitrary.first
+              (id, header.copy(txRoot = body.merkleTreeRootHash.data))
+            }))
           } yield ()
         }
     }
@@ -182,6 +298,7 @@ class PeerBlockBodyFetcherTest
       val client = mock[BlockchainPeerClient[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val transactionStore = mock[Store[F, Identifier.IoTransaction32, IoTransaction]]
+      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
 
       val transactionsAndBody =
         nonEmptyChainArbOf(TestHelper.arbitraryTxsAndBlock).arbitrary
@@ -227,6 +344,10 @@ class PeerBlockBodyFetcherTest
 
       (transactionStore.put _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
 
+      (headerToBodyValidation.validate _).expects(*).rep(idAndBody.size.toInt).onCall { block: Block =>
+        Either.right[BlockHeaderToBodyValidationFailure, Block](block).pure[F]
+      }
+
       val wrappedBodies =
         idAndBody.map { case (id, body) =>
           if (!blockIsMissed(body)) {
@@ -247,10 +368,13 @@ class PeerBlockBodyFetcherTest
       (requestsProxy.sendNoWait _).expects(expectedMessage).once().returning(().pure[F])
 
       PeerBlockBodyFetcher
-        .makeActor(hostId, client, requestsProxy, transactionStore)
+        .makeActor(hostId, client, requestsProxy, transactionStore, headerToBodyValidation)
         .use { actor =>
           for {
-            _ <- actor.send(PeerBlockBodyFetcher.Message.DownloadBlocks(idAndBody.map(_._1)))
+            _ <- actor.send(PeerBlockBodyFetcher.Message.DownloadBlocks(idAndBody.map { case (id, body) =>
+              val header = ModelGenerators.arbitraryHeader.arbitrary.first
+              (id, header.copy(txRoot = body.merkleTreeRootHash.data))
+            }))
           } yield ()
         }
     }
@@ -261,6 +385,7 @@ class PeerBlockBodyFetcherTest
       val client = mock[BlockchainPeerClient[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val transactionStore = mock[Store[F, Identifier.IoTransaction32, IoTransaction]]
+      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
 
       val (txs, bodies) =
         nonEmptyChainArbOf(TestHelper.arbitraryTxsAndBlock).arbitrary
@@ -298,16 +423,23 @@ class PeerBlockBodyFetcherTest
           downloadedTxs.put(id, tx).pure[F].void
       }
 
+      (headerToBodyValidation.validate _).expects(*).rep(blockIdsAndBodies.size.toInt).onCall { block: Block =>
+        Either.right[BlockHeaderToBodyValidationFailure, Block](block).pure[F]
+      }
+
       val wrappedBodies =
         blockIdsAndBodies.map { case (id, body) => (id, Either.right[BlockBodyDownloadError, BlockBody](body)) }
       val expectedMessage = RequestsProxy.Message.DownloadBodiesResponse(hostId, wrappedBodies)
       (requestsProxy.sendNoWait _).expects(expectedMessage).once().returning(().pure[F])
 
       PeerBlockBodyFetcher
-        .makeActor(hostId, client, requestsProxy, transactionStore)
+        .makeActor(hostId, client, requestsProxy, transactionStore, headerToBodyValidation)
         .use { actor =>
           for {
-            _ <- actor.send(PeerBlockBodyFetcher.Message.DownloadBlocks(blockIds))
+            _ <- actor.send(PeerBlockBodyFetcher.Message.DownloadBlocks(blockIdsAndBodies.map { case (id, body) =>
+              val header = ModelGenerators.arbitraryHeader.arbitrary.first
+              (id, header.copy(txRoot = body.merkleTreeRootHash.data))
+            }))
             _ = assert(downloadedTxs == missedTxs.toMap)
           } yield ()
         }


### PR DESCRIPTION
## Purpose
Check block body syntax correctness as soon as possible, in that case, check the correctness of transaction Merkle tree root according to the block header. That check will be done immediately after block body downloading

## Approach
Moving checks to PeerBlockBodyFetcher

## Testing
Unit tests + multinode integration test

## Tickets