### PR TITLE
Update Node Config Defaults

### DIFF
--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
@@ -185,6 +185,9 @@ case class TestNodeConfig(
        |    local-staker-index: $localStakerIndex
        |    timestamp: ${bigBangTimestamp.toEpochMilli}
        |    $stakesStr
+       |  protocols:
+       |    0:
+       |      slot-duration: 200 milli
        |""".stripMargin
   }
 

--- a/node/src/it/scala/co/topl/node/NodeAppTest.scala
+++ b/node/src/it/scala/co/topl/node/NodeAppTest.scala
@@ -96,8 +96,8 @@ class NodeAppTest extends CatsEffectSuite {
         (utxoAddress, utxo) <- bigBangSpendableUtxo(rpcClientA).toResource
         newTransaction      <- spendUtxo(rpcClientB)(utxoAddress, utxo).toResource
         _ <- (
-          Async[F].timeout(confirmTransaction(rpcClientA)(newTransaction.id), 15.seconds).toResource,
-          Async[F].timeout(confirmTransaction(rpcClientB)(newTransaction.id), 15.seconds).toResource
+          Async[F].timeout(confirmTransaction(rpcClientA)(newTransaction.id), 30.seconds).toResource,
+          Async[F].timeout(confirmTransaction(rpcClientB)(newTransaction.id), 30.seconds).toResource
         ).parTupled
         _ <- (
           fetchUntilHeight(rpcClientA, targetProductionHeight).toResource,

--- a/node/src/it/scala/co/topl/node/NodeAppTest.scala
+++ b/node/src/it/scala/co/topl/node/NodeAppTest.scala
@@ -60,6 +60,9 @@ class NodeAppTest extends CatsEffectSuite {
         |  big-bang:
         |    staker-count: 2
         |    timestamp: $startTimestamp
+        |  protocols:
+        |    0:
+        |      slot-duration: 500 milli
         |""".stripMargin
     val configNodeB =
       s"""
@@ -78,6 +81,9 @@ class NodeAppTest extends CatsEffectSuite {
          |    staker-count: 2
          |    local-staker-index: 1
          |    timestamp: $startTimestamp
+         |  protocols:
+         |    0:
+         |      slot-duration: 500 milli
          |""".stripMargin
 
     val resource =
@@ -96,8 +102,8 @@ class NodeAppTest extends CatsEffectSuite {
         (utxoAddress, utxo) <- bigBangSpendableUtxo(rpcClientA).toResource
         newTransaction      <- spendUtxo(rpcClientB)(utxoAddress, utxo).toResource
         _ <- (
-          Async[F].timeout(confirmTransaction(rpcClientA)(newTransaction.id), 30.seconds).toResource,
-          Async[F].timeout(confirmTransaction(rpcClientB)(newTransaction.id), 30.seconds).toResource
+          Async[F].timeout(confirmTransaction(rpcClientA)(newTransaction.id), 60.seconds).toResource,
+          Async[F].timeout(confirmTransaction(rpcClientB)(newTransaction.id), 60.seconds).toResource
         ).parTupled
         _ <- (
           fetchUntilHeight(rpcClientA, targetProductionHeight).toResource,
@@ -219,7 +225,7 @@ class NodeAppTest extends CatsEffectSuite {
 
   private def confirmTransaction(
     client: RpcClient
-  )(id: Identifier.IoTransaction32, confirmationDepth: Int = 4): F[Unit] = {
+  )(id: Identifier.IoTransaction32, confirmationDepth: Int = 3): F[Unit] = {
     def containsTransaction(targetBlock: BlockId): F[Boolean] =
       client
         .fetchBlockBody(targetBlock)

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -12,7 +12,7 @@ bifrost {
   // Settings for P2P networking
   p2p {
     // The local host/IP for binding at the OS-level to allow outside P2P connections
-    bind-host = "localhost"
+    bind-host = "0.0.0.0"
     // The local port for binding at the OS-level to allow outside P2P connections
     bind-port = 9085
     // The hostname to tell _other_ peers for inbound connections
@@ -27,7 +27,7 @@ bifrost {
   // Settings for RPC/gRPC
   rpc {
     // The local host/IP for binding at the OS-level to allow outside gRPC connections
-    bind-host = "localhost"
+    bind-host = "0.0.0.0"
     // The local port for binding at the OS-level to allow outside gRPC connections
     bind-port = 9084
   }
@@ -61,7 +61,7 @@ bifrost {
       vrf-baseline-difficulty = "1/20"
       vrf-amplitude = "1/2"
       chain-selection-k-lookback = 50
-      slot-duration = 200 milli
+      slot-duration = 1000 milli
       forward-biased-slot-window = 50
       operational-periods-per-epoch = 2
       kes-key-hours = 9

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -56,7 +56,7 @@ bifrost {
     // The _slot_ at which this protocol begins
     0 {
       f-effective = "15/100"
-      vrf-ldd-cutoff = 15
+      vrf-ldd-cutoff = 50
       vrf-precision = 40
       vrf-baseline-difficulty = "1/20"
       vrf-amplitude = "1/2"


### PR DESCRIPTION
## Purpose
- When running the node in Docker, the RPC bind host (localhost) is inaccessible from the host machine
- The current default configuration is unrealistic in the real-world (too fast)
## Approach
- Set default bind host to 0.0.0.0
- Set default slot duration to 1000ms
- Set ldd-cutoff to 50
## Testing
- NodeAppTest locally
## Tickets
N/A