### PR TITLE
BN-973 Insert canonical head vertex, partial Pr

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/BlockFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/BlockFetcherAlgebra.scala
@@ -13,6 +13,13 @@ import co.topl.node.models.BlockBody
 trait BlockFetcherAlgebra[F[_]] {
 
   /**
+   * Fetch Canonical head vertex on the stored Ledger
+   *
+   * @return Optional header vertex, None if it was not found
+   */
+  def fetchCanonicalHead(): F[Either[GE, Option[BlockHeader]]]
+
+  /**
    * Fetch a BlockHeader on the stored Ledger
    * @param blockId  blockId filter by field
    * @return Optional BlockHeader, None if it was not found

--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/NodeBlockFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/NodeBlockFetcherAlgebra.scala
@@ -26,4 +26,11 @@ trait NodeBlockFetcherAlgebra[F[_], G[_]] {
    */
   def fetch(height: Long): F[Either[GE, Option[BlockData]]]
 
+  /**
+   * Look-up up to the node's current head height
+   *
+   * @return height
+   */
+  def fetchHeight(): F[Either[GE, Long]]
+
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/NodeBlockFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/NodeBlockFetcherAlgebra.scala
@@ -31,6 +31,6 @@ trait NodeBlockFetcherAlgebra[F[_], G[_]] {
    *
    * @return height
    */
-  def fetchHeight(): F[Either[GE, Long]]
+  def fetchHeight(): F[Option[Long]]
 
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
@@ -12,6 +12,13 @@ import com.tinkerpop.blueprints.Vertex
 trait VertexFetcherAlgebra[F[_]] {
 
   /**
+   * Fetch Canonical head vertex on the stored Ledger
+   *
+   * @return Optional header vertex, None if it was not found
+   */
+  def fetchCanonicalHead(): F[Either[GE, Option[Vertex]]]
+
+  /**
    * Fetch a BlockHeader vertex on the stored Ledger
    * @param blockId  blockId filter by field
    * @return Optional header vertex, None if it was not found

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphBlockInserter.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphBlockInserter.scala
@@ -24,6 +24,8 @@ object GraphBlockInserter {
               Try {
                 val headerVertex = graph.addHeader(block.header)
 
+                graph.addCanonicalHead(headerVertex)
+
                 val bodyVertex = graph.addBody(block.body)
                 bodyVertex.setProperty(blockBodySchema.links.head.propertyName, headerVertex.getId)
 

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcher.scala
@@ -22,6 +22,13 @@ object GraphVertexFetcher {
     Resource.pure {
       new VertexFetcherAlgebra[F] {
 
+        override def fetchCanonicalHead(): F[Either[GE, Option[Vertex]]] =
+          Async[F].blocking(
+            Try(orientGraph.getVerticesOfClass(s"${canonicalHeadSchema.name}").asScala).toEither
+              .map(_.headOption)
+              .leftMap[GE](tx => GEs.InternalMessageCause("GraphVertexFetcher:fetchCanonicalHead", tx))
+          )
+
         override def fetchHeader(blockId: BlockId): F[Either[GE, Option[Vertex]]] =
           Async[F].blocking(
             Try(orientGraph.getVertices(SchemaBlockHeader.Field.BlockId, blockId.value.toByteArray).asScala).toEither

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
@@ -4,7 +4,7 @@ import cats.data.{Chain, EitherT, OptionT}
 import cats.effect.Resource
 import cats.effect.kernel.Async
 import cats.implicits._
-import co.topl.algebras.ToplRpc
+import co.topl.algebras.{SynchronizationTraversalSteps, ToplRpc}
 import co.topl.brambl.models.Identifier
 import co.topl.brambl.models.transaction._
 import co.topl.consensus.models.BlockId
@@ -14,6 +14,7 @@ import co.topl.genusLibrary.model.{GE, GEs}
 import co.topl.node.models.BlockBody
 import fs2.Stream
 import org.typelevel.log4cats.Logger
+
 import scala.collection.immutable.ListSet
 
 object NodeBlockFetcher {
@@ -88,6 +89,33 @@ object NodeBlockFetcher {
           } map [Either[GE, Chain[IoTransaction]]] (_.left.map(
             GEs.TransactionsNotFound
           ))
+
+        def fetchHeight(): F[Either[GE, Long]] =
+          for {
+            adoptionsStream <- toplRpc.synchronizationTraversal()
+            latestApplied <- adoptionsStream
+              .collectFirst { case SynchronizationTraversalSteps.Applied(blockId) =>
+                blockId
+              }
+              .last
+              .compile
+              .toList
+              .map(_.flatten)
+              .map(_.headOption)
+            latest <-
+              EitherT
+                .fromOptionF(latestApplied.pure[F], GEs.InternalMessage("Unable to fetch height Latest applied step"))
+                .flatMapF(blockId =>
+                  EitherT
+                    .fromOptionF(
+                      toplRpc.fetchBlockHeader(blockId),
+                      GEs.InternalMessage("Unable to fetch latest applied header"): GE
+                    )
+                    .map(_.height)
+                    .value
+                )
+                .value
+          } yield latest
 
       }
     }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
@@ -32,6 +32,16 @@ object VertexSchemaInstances {
 
       def addIoTx(ioTx: IoTransaction): OrientVertex =
         graph.addVertex(s"class:${ioTransactionSchema.name}", ioTransactionSchema.encode(ioTx).asJava)
+
+      def addCanonicalHead(blockHeaderVertex: OrientVertex): OrientVertex = {
+        // Is expected that Canonical head schema only contains 1 vertex, the head of the chain
+        graph.getVerticesOfClass(s"${canonicalHeadSchema.name}").asScala.foreach(graph.removeVertex)
+        val v = graph
+          .addVertex(s"class:${canonicalHeadSchema.name}", canonicalHeadSchema.encode(CanonicalHead).asJava)
+        v.setProperty(canonicalHeadSchema.links.head.propertyName, blockHeaderVertex.getId)
+        v
+      }
+
     }
 
     private[genusLibrary] val blockHeaderSchema: VertexSchema[BlockHeader] = SchemaBlockHeader.make()

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
@@ -10,6 +10,7 @@ import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
 import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, VertexSchema}
 import co.topl.node.models.BlockBody
 import com.google.protobuf.ByteString
+import com.tinkerpop.blueprints.Vertex
 import com.tinkerpop.blueprints.impls.orient.{OrientGraph, OrientVertex}
 import quivr.models.Digest
 
@@ -33,14 +34,18 @@ object VertexSchemaInstances {
       def addIoTx(ioTx: IoTransaction): OrientVertex =
         graph.addVertex(s"class:${ioTransactionSchema.name}", ioTransactionSchema.encode(ioTx).asJava)
 
-      def addCanonicalHead(blockHeaderVertex: OrientVertex): OrientVertex = {
+      def addCanonicalHead(blockHeaderVertex: OrientVertex): Vertex =
         // Is expected that Canonical head schema only contains 1 vertex, the head of the chain
-        graph.getVerticesOfClass(s"${canonicalHeadSchema.name}").asScala.foreach(graph.removeVertex)
-        val v = graph
-          .addVertex(s"class:${canonicalHeadSchema.name}", canonicalHeadSchema.encode(CanonicalHead).asJava)
-        v.setProperty(canonicalHeadSchema.links.head.propertyName, blockHeaderVertex.getId)
-        v
-      }
+        graph.getVerticesOfClass(s"${canonicalHeadSchema.name}").asScala.headOption match {
+          case Some(v) =>
+            v.setProperty(canonicalHeadSchema.links.head.propertyName, blockHeaderVertex.getId)
+            v
+          case None =>
+            val v =
+              graph.addVertex(s"class:${canonicalHeadSchema.name}", canonicalHeadSchema.encode(CanonicalHead).asJava)
+            v.setProperty(canonicalHeadSchema.links.head.propertyName, blockHeaderVertex.getId)
+            v
+        }
 
     }
 

--- a/genus-server/src/main/resources/environment.conf
+++ b/genus-server/src/main/resources/environment.conf
@@ -9,7 +9,8 @@ genus {
   // The _base_ directory in which genus_db data is stored
   // optionally if OrientDB Studio was previously installed required, the genus_db storage should be a child of ¨database¨ folder
   // Example = "../../orientdb-community-3.2.18/databases/genus_db"
-  orient-db-directory = "/tmp/genus_db"
+  orient-db-directory = "../../orientdb-community-3.2.18/databases/genus_db"
+;   orient-db-directory = "/tmp/genus_db"
   orient-db-user = "admin"
   orient-db-password = "admin"
 }

--- a/genus-server/src/main/resources/environment.conf
+++ b/genus-server/src/main/resources/environment.conf
@@ -7,10 +7,9 @@ genus {
   rpc-node-tls = false
 
   // The _base_ directory in which genus_db data is stored
-  // optionally if OrientDB Studio was previously installed required, the genus_db storage should be a child of ¨database¨ folder
+  // optionally if OrientDB Studio was previously installed, the genus_db storage should be a child of ¨database¨ folder
   // Example = "../../orientdb-community-3.2.18/databases/genus_db"
-  orient-db-directory = "../../orientdb-community-3.2.18/databases/genus_db"
-;   orient-db-directory = "/tmp/genus_db"
+  orient-db-directory = "/tmp/genus_db"
   orient-db-user = "admin"
   orient-db-password = "admin"
 }

--- a/genus-server/src/main/scala/co/topl/genusServer/GenusServerApp.scala
+++ b/genus-server/src/main/scala/co/topl/genusServer/GenusServerApp.scala
@@ -3,12 +3,15 @@ package co.topl.genusServer
 import cats.effect._
 import cats.effect.implicits.effectResourceOps
 import cats.syntax.all._
+import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.common.application.IOBaseApp
 import co.topl.genusLibrary.interpreter._
 import co.topl.genusLibrary.orientDb.OrientDBFactory
 import co.topl.grpc.ToplGrpc
+import co.topl.typeclasses.implicits.showBlockId
 import org.typelevel.log4cats._
 import org.typelevel.log4cats.slf4j._
+
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
 
@@ -41,12 +44,32 @@ object GenusServerApp
       nodeBlockFetcher <- NodeBlockFetcher.make(rpcInterpreter)
 
       // TODO this is just proof of concept, we need to add a lot of logic here, related to retries and handling errors
-      nodeEnabled <- Resource.pure(false) // maybe we can use a config
+      nodeEnabled <- Resource.pure(true) // maybe we can use a config
+
+      nodeLatestHeight <- nodeBlockFetcher
+        .fetchHeight()
+        .map(_.getOrElse(Integer.MAX_VALUE: Long))
+        .toResource
+
+      graphCurrentHead <-
+        blockFetcher
+          .fetchCanonicalHead()
+          .map(_.map(_.map(_.height)))
+          .map(
+            _.getOrElse(Some(1L))
+          )
+          .map(_.getOrElse(1L))
+          .toResource
+
+      _ <- Logger[F].info(s"Node height: $nodeLatestHeight").toResource
       inserter <- nodeBlockFetcher
-        .fetch(startHeight = 1, endHeight = 300)
+        .fetch(startHeight = graphCurrentHead + 1, endHeight = nodeLatestHeight)
         .map(_.spaced(50 millis))
         .map(
-          _.evalMap(graphBlockInserter.insert)
+          _.evalMap { blockData =>
+            Logger[F].info(s"Inserting block data ${blockData.header.id.show}") >>
+            graphBlockInserter.insert(blockData)
+          }
             .evalTap(res => Logger[F].info(res.leftMap(_.toString).swap.getOrElse("OK")))
         )
         .toResource
@@ -54,7 +77,7 @@ object GenusServerApp
       _ <-
         if (nodeEnabled)
           inserter
-            .take(300)
+            .take(Integer.MAX_VALUE)
             .compile
             .toList
             .void


### PR DESCRIPTION
## Purpose
update canonical head vertex during Genus insert block task 

## Approach

- Canonical head vertex, was implemented in a previous or #2913 
- This PR, update this vertex (delete and create a new vertex) with a link to the Block header head of the chain. (no edges was created, just a link)
- When genus server start, get the latest canonical head changes from the Node, and then fetch the head on the graph.
- With this information, the two heights, we fetch blocks the missing blocks and insert them into the graph.

## Testing
Start an stop multiple times the Genus app, and validate that we only have 1 canonical head vertex, liked to the head

## Tickets
Partial Pr BN-973
![Screenshot from 2023-04-19 13-32-54](https://user-images.githubusercontent.com/8540107/233087740-67c52aaa-dca6-4ced-a9a9-1c6bdb252ba4.png)
