### PR TITLE
AddressSchema

### DIFF
--- a/genus-library/Examples/Queries.md
+++ b/genus-library/Examples/Queries.md
@@ -1,4 +1,4 @@
-## Queries 
+## Queries
 
 Ex1: Some block headers ordered
 ```roomsql
@@ -11,9 +11,16 @@ MATCH {Class: BlockHeader}-hasBody-{Class: BlockBody}
 RETURN $pathelements
 ```
 
-Ex3: Relationship between headers and body and transaction, for an existing BlockHeader with id 26:0 (id:cluster)
+Ex3: Relationship between headers , body and transaction, for an existing BlockHeader with id 26:0 (id:cluster)
 
 ```roomsql
 MATCH {Class: Transaction}-hasTxIO-{Class: BlockHeader, where: (@rid=26:0)}-hasBody-{Class: BlockBody}
+RETURN $pathelements
+```
+
+Ex4: Relationship between headers, body, transaction and address, for an existing BlockHeader with id 26:0 (id:cluster)
+
+```roomsql
+MATCH {Class: Address}-hasAddress-{Class: Transaction}-hasTxIO-{Class: BlockHeader, where: (@rid=26:0)}-hasBody-{Class: BlockBody}
 RETURN $pathelements
 ```

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
@@ -5,11 +5,7 @@ import cats.effect.{Resource, Sync, SyncIO}
 import cats.implicits._
 import co.topl.genusLibrary.orientDb.schema.{EdgeSchema, VertexSchema}
 import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances._
-import co.topl.genusLibrary.orientDb.schema.EdgeSchemaInstances.{
-  blockHeaderBodyEdge,
-  blockHeaderEdge,
-  blockHeaderTxIOEdge
-}
+import co.topl.genusLibrary.orientDb.schema.EdgeSchemaInstances._
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal
 import com.orientechnologies.orient.core.metadata.schema.OClass
 import com.orientechnologies.orient.core.metadata.schema.OType
@@ -41,14 +37,14 @@ object OrientDBMetadataFactory {
             _ <- createVertex(db, blockBodySchema)
             _ <- createVertex(db, ioTransactionSchema)
             _ <- createVertex(db, canonicalHeadSchema)
-            _ <- createVertex(db, addressSchema) // Todo add edge when #2923
+            _ <- createVertex(db, lockAddressSchema)
           } yield ()
         )
       )
       _ <- Resource.eval(
         OrientThread[F].defer(
           for {
-            _ <- Seq(blockHeaderEdge, blockHeaderBodyEdge, blockHeaderTxIOEdge)
+            _ <- Seq(blockHeaderEdge, blockHeaderBodyEdge, blockHeaderTxIOEdge, addressTxIOEdge)
               .traverse(e => createEdge(db, e))
               .void
           } yield ()

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
@@ -36,6 +36,7 @@ object OrientDBMetadataFactory {
             _ <- createVertex(db, blockBodySchema)
             _ <- createVertex(db, ioTransactionSchema)
             _ <- createVertex(db, canonicalHeadSchema)
+            _ <- createVertex(db, addressSchema) // Todo add edge when #2923
           } yield ()
         )
       )

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaAddress.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaAddress.scala
@@ -1,0 +1,65 @@
+package co.topl.genusLibrary.orientDb.instances
+
+import co.topl.brambl.models.{Address, Identifier}
+import co.topl.genusLibrary.orientDb.schema.OIndexable.Instances._
+import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
+import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, VertexSchema}
+
+object SchemaAddress {
+
+  /**
+   * Address model:
+   * @see https://github.com/Topl/protobuf-specs/blob/main/proto/brambl/models/address.proto
+   */
+  object Field {
+    val SchemaName = "Address"
+    val Network = "network"
+    val Ledger = "ledger"
+    val Index = "index"
+    // id on proto models, do not use id, Property key is reserved for all elements: id
+    val AddressId = "addressId"
+    val AddressIndex = "addressIndex"
+  }
+
+  def make(): VertexSchema[Address] =
+    VertexSchema.create(
+      Field.SchemaName,
+      GraphDataEncoder[Address]
+        .withProperty(
+          Field.Network,
+          address => java.lang.Integer.valueOf(address.network),
+          mandatory = true,
+          readOnly = true,
+          notNull = true
+        )
+        .withProperty(
+          Field.Ledger,
+          address => java.lang.Integer.valueOf(address.ledger),
+          mandatory = true,
+          readOnly = true,
+          notNull = true
+        )
+        .withProperty(
+          Field.Index,
+          address => java.lang.Integer.valueOf(address.index.getOrElse(0)),
+          mandatory = false,
+          readOnly = true,
+          notNull = false
+        )
+        .withProperty(
+          Field.AddressId,
+          _.id.toByteArray,
+          mandatory = true,
+          readOnly = true,
+          notNull = true
+        )
+        .withIndex[Address](Field.AddressIndex, Field.AddressId),
+      v =>
+        Address(
+          network = v(Field.Network),
+          ledger = v(Field.Ledger),
+          index = v(Field.Index),
+          id = Identifier.parseFrom(v(Field.AddressId): Array[Byte])
+        )
+    )
+}

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaAddress.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaAddress.scala
@@ -49,7 +49,7 @@ object SchemaAddress {
         )
         .withProperty(
           Field.AddressEncodedId,
-          // TODO replace encoder for BramblSc implementation
+          // TODO it should be updated to use the new address encoding scheme.
           lockAddress => BitVector(lockAddress.id.toByteArray).toBase58,
           mandatory = true,
           readOnly = true,

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
@@ -48,7 +48,7 @@ object VertexSchemaInstances {
         }
 
       def addAddress(address: LockAddress): OrientVertex =
-        graph.addVertex(s"class:${addressSchema.name}", addressSchema.encode(address).asJava)
+        graph.addVertex(s"class:${lockAddressSchema.name}", lockAddressSchema.encode(address).asJava)
 
     }
 
@@ -56,7 +56,7 @@ object VertexSchemaInstances {
     private[genusLibrary] val blockBodySchema: VertexSchema[BlockBody] = SchemaBlockBody.make()
     private[genusLibrary] val ioTransactionSchema: VertexSchema[IoTransaction] = SchemaIoTransaction.make()
     private[genusLibrary] val canonicalHeadSchema: VertexSchema[CanonicalHead.type] = SchemaCanonicalHead.make()
-    private[genusLibrary] val addressSchema: VertexSchema[LockAddress] = SchemaAddress.make()
+    private[genusLibrary] val lockAddressSchema: VertexSchema[LockAddress] = SchemaAddress.make()
 
     // Note, From here to the end, VertexSchemas not tested
     /**

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
@@ -2,7 +2,7 @@ package co.topl.genusLibrary.orientDb.instances
 
 import co.topl.brambl.models.box.Box
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.models.{Evidence, Identifier, LockAddress, TransactionOutputAddress}
+import co.topl.brambl.models.{Address, Evidence, Identifier, TransactionOutputAddress}
 import co.topl.consensus.models.BlockHeader
 import co.topl.genus.services.{Txo, TxoState}
 import co.topl.genusLibrary.orientDb.instances.SchemaCanonicalHead.CanonicalHead
@@ -47,55 +47,18 @@ object VertexSchemaInstances {
             v
         }
 
+      def addAddress(address: Address): OrientVertex =
+        graph.addVertex(s"class:${addressSchema.name}", addressSchema.encode(address).asJava)
+
     }
 
     private[genusLibrary] val blockHeaderSchema: VertexSchema[BlockHeader] = SchemaBlockHeader.make()
     private[genusLibrary] val blockBodySchema: VertexSchema[BlockBody] = SchemaBlockBody.make()
     private[genusLibrary] val ioTransactionSchema: VertexSchema[IoTransaction] = SchemaIoTransaction.make()
     private[genusLibrary] val canonicalHeadSchema: VertexSchema[CanonicalHead.type] = SchemaCanonicalHead.make()
+    private[genusLibrary] val addressSchema: VertexSchema[Address] = SchemaAddress.make()
 
     // Note, From here to the end, VertexSchemas not tested
-    /**
-     * Schema for Address nodes
-     */
-    implicit private[genusLibrary] val addressVertexSchema: VertexSchema[LockAddress] =
-      VertexSchema.create(
-        "LockAddress",
-        GraphDataEncoder[LockAddress]
-          .withProperty(
-            "network",
-            v => java.lang.Integer.valueOf(v.network),
-            mandatory = false,
-            readOnly = false,
-            notNull = true
-          )
-          .withProperty(
-            "ledger",
-            v => java.lang.Integer.valueOf(v.ledger),
-            mandatory = false,
-            readOnly = false,
-            notNull = true
-          )
-          .withProperty(
-            "id",
-            _.id match {
-              case v: LockAddress.Id.Lock32 => Array[Byte](0) ++ v.value.toByteArray
-              case v: LockAddress.Id.Lock64 => Array[Byte](1) ++ v.value.toByteArray
-            },
-            mandatory = false,
-            readOnly = false,
-            notNull = true
-          ),
-        v => {
-          val idData: Array[Byte] = v("id")
-          val id = idData(0) match {
-            case 0 => LockAddress.Id.Lock32(Identifier.Lock32.parseFrom(idData.tail))
-            case 1 => LockAddress.Id.Lock64(Identifier.Lock64.parseFrom(idData.tail))
-          }
-          LockAddress(v("network"), v("ledger"), id)
-        }
-      )
-
     /**
      * Schema for TxO state vertexes
      * <p>

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/EdgeSchema.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/EdgeSchema.scala
@@ -30,4 +30,8 @@ object EdgeSchemaInstances {
     override def label: String = "hasTxIO"
   }
 
+  // Edge: address <--> transactionIO
+  val addressTxIOEdge: EdgeSchema = new EdgeSchema {
+    override def label: String = "hasAddress"
+  }
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/OIndexable.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/OIndexable.scala
@@ -1,6 +1,7 @@
 package co.topl.genusLibrary.orientDb.schema
 
 import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.models.Address
 import co.topl.consensus.models.BlockHeader
 import com.orientechnologies.orient.core.metadata.schema.OClass
 import com.orientechnologies.orient.core.metadata.schema.OClass.INDEX_TYPE
@@ -19,6 +20,10 @@ object OIndexable {
     }
 
     implicit val ioTransaction: OIndexable[IoTransaction] = new OIndexable[IoTransaction] {
+      override def indexType: OClass.INDEX_TYPE = INDEX_TYPE.UNIQUE
+    }
+
+    implicit val address: OIndexable[Address] = new OIndexable[Address] {
       override def indexType: OClass.INDEX_TYPE = INDEX_TYPE.UNIQUE
     }
   }

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaAddressTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaAddressTest.scala
@@ -1,0 +1,211 @@
+package co.topl.genusLibrary.orientDb.instances
+
+import cats.effect.implicits.effectResourceOps
+import cats.implicits._
+import co.topl.genusLibrary.orientDb.instances.SchemaAddress.Field
+import co.topl.genusLibrary.orientDb.{DbFixtureUtil, OrientDBMetadataFactory}
+import co.topl.models.ModelGenerators.GenHelper
+import co.topl.brambl.generators.{ModelGenerators => BramblGens}
+import co.topl.brambl.models.{Address, Identifier}
+import com.orientechnologies.orient.core.metadata.schema.OType
+import com.tinkerpop.blueprints.impls.orient.OrientGraphFactoryV2
+import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalamock.munit.AsyncMockFactory
+import scala.jdk.CollectionConverters._
+import scodec.bits.ByteVector
+
+class SchemaAddressTest
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with AsyncMockFactory
+    with CatsEffectFunFixtures
+    with DbFixtureUtil {
+
+  orientDbFixture.test("Address Schema Metadata") { case (odb, oThread) =>
+    val res = for {
+      odbFactory <- oThread.delay(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
+      dbNoTx     <- oThread.delay(odbFactory.getNoTx).toResource
+      _          <- oThread.delay(dbNoTx.makeActive()).toResource
+
+      databaseDocumentTx <- oThread.delay(odbFactory.getNoTx.getRawGraph).toResource
+      schema = SchemaAddress.make()
+      _ <- OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, schema).toResource
+
+      oClass <- oThread.delay(databaseDocumentTx.getClass(schema.name)).toResource
+
+      _ <- assertIO(oClass.getName.pure[F], schema.name, s"${schema.name} Class was not created").toResource
+
+      networkProperty <- oClass.getProperty(Field.Network).pure[F].toResource
+      _ <- (
+        assertIO(networkProperty.getName.pure[F], Field.Network) &>
+        assertIO(networkProperty.isMandatory.pure[F], true) &>
+        assertIO(networkProperty.isReadonly.pure[F], true) &>
+        assertIO(networkProperty.isNotNull.pure[F], true) &>
+        assertIO(networkProperty.getType.pure[F], OType.INTEGER)
+      ).toResource
+
+      ledgerProperty <- oClass.getProperty(Field.Ledger).pure[F].toResource
+      _ <- (
+        assertIO(ledgerProperty.getName.pure[F], Field.Ledger) &>
+        assertIO(ledgerProperty.isMandatory.pure[F], true) &>
+        assertIO(ledgerProperty.isReadonly.pure[F], true) &>
+        assertIO(ledgerProperty.isNotNull.pure[F], true) &>
+        assertIO(ledgerProperty.getType.pure[F], OType.INTEGER)
+      ).toResource
+
+      indexProperty <- oClass.getProperty(Field.Index).pure[F].toResource
+      _ <- (
+        assertIO(indexProperty.getName.pure[F], Field.Index) &>
+        assertIO(indexProperty.isMandatory.pure[F], false) &>
+        assertIO(indexProperty.isReadonly.pure[F], true) &>
+        assertIO(indexProperty.isNotNull.pure[F], false) &>
+        assertIO(indexProperty.getType.pure[F], OType.INTEGER)
+      ).toResource
+
+      idProperty <- oClass.getProperty(Field.AddressId).pure[F].toResource
+      _ <- (
+        assertIO(idProperty.getName.pure[F], Field.AddressId) &>
+        assertIO(idProperty.isMandatory.pure[F], true) &>
+        assertIO(idProperty.isReadonly.pure[F], true) &>
+        assertIO(idProperty.isNotNull.pure[F], true) &>
+        assertIO(idProperty.getType.pure[F], OType.BINARY)
+      ).toResource
+
+    } yield ()
+
+    res.use_
+
+  }
+
+  orientDbFixture.test("Address Schema Add vertex Lock Address") { case (odb, oThread) =>
+    val res = for {
+      odbFactory <- oThread.delay(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
+
+      dbNoTx <- oThread.delay(odbFactory.getNoTx).toResource
+      _      <- oThread.delay(dbNoTx.makeActive()).toResource
+
+      schema = SchemaAddress.make()
+      _ <- OrientDBMetadataFactory.createVertex[F](dbNoTx.getRawGraph, schema).toResource
+
+      dbTx <- oThread.delay(odbFactory.getTx).toResource
+      _    <- oThread.delay(dbTx.makeActive()).toResource
+
+      address <- BramblGens.arbitraryLockAddress.arbitrary
+        .map(lockAddress =>
+          Address(
+            lockAddress.network,
+            lockAddress.ledger,
+            None,
+            id = Identifier.of(Identifier.Value.Lock32(lockAddress.id.lock32.get))
+          )
+        )
+        .first
+        .pure[F]
+        .toResource
+
+      vertex <- oThread
+        .delay(
+          dbTx
+            .addVertex(s"class:${schema.name}", schema.encode(address).asJava)
+        )
+        .toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Int](schema.properties.filter(_.name == Field.Network).head.name).pure[F],
+        address.network
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Int](schema.properties.filter(_.name == Field.Ledger).head.name).pure[F],
+        address.ledger
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Int](schema.properties.filter(_.name == Field.Index).head.name).pure[F],
+        0
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Array[Byte]](schema.properties.filter(_.name == Field.AddressId).head.name).toSeq.pure[F],
+        address.id.toByteArray.toSeq
+      ).toResource
+
+      _ <- logger.info(ByteVector(vertex.getProperty[Array[Byte]](Field.AddressId)).toBase64).toResource
+      _ <- logger.info(ByteVector(address.id.toByteArray).toBase64).toResource
+
+      _ <- assertIO(
+        oThread.delay(
+          dbTx
+            .getVertices(SchemaAddress.Field.AddressId, address.id.toByteArray)
+            .iterator()
+            .next()
+            .getProperty[Array[Byte]](Field.AddressId)
+            .toSeq
+        ),
+        address.id.toByteArray.toSeq
+      ).toResource
+
+    } yield ()
+    res.use_
+
+  }
+
+  orientDbFixture.test("Address Schema Add vertex Transaction Output Address") { case (odb, oThread) =>
+    val res = for {
+      odbFactory <- oThread.delay(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
+
+      dbNoTx <- oThread.delay(odbFactory.getNoTx).toResource
+      _      <- oThread.delay(dbNoTx.makeActive()).toResource
+
+      schema = SchemaAddress.make()
+      _ <- OrientDBMetadataFactory.createVertex[F](dbNoTx.getRawGraph, schema).toResource
+
+      dbTx <- oThread.delay(odbFactory.getTx).toResource
+      _    <- oThread.delay(dbTx.makeActive()).toResource
+
+      address <- BramblGens.arbitraryTransactionOutputAddress.arbitrary
+        .map(outputAddress =>
+          Address(
+            outputAddress.network,
+            outputAddress.ledger,
+            Some(outputAddress.index),
+            id = Identifier.of(Identifier.Value.IoTransaction32(outputAddress.id.ioTransaction32.get))
+          )
+        )
+        .first
+        .pure[F]
+        .toResource
+
+      vertex <- oThread
+        .delay(
+          dbTx
+            .addVertex(s"class:${schema.name}", schema.encode(address).asJava)
+        )
+        .toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Int](schema.properties.filter(_.name == Field.Network).head.name).pure[F],
+        address.network
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Int](schema.properties.filter(_.name == Field.Ledger).head.name).pure[F],
+        address.ledger
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Int](schema.properties.filter(_.name == Field.Index).head.name).pure[F],
+        address.index.getOrElse(0)
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Array[Byte]](schema.properties.filter(_.name == Field.AddressId).head.name).toSeq.pure[F],
+        address.id.toByteArray.toSeq
+      ).toResource
+
+    } yield ()
+    res.use_
+
+  }
+
+}

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaLockAddressTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaLockAddressTest.scala
@@ -127,6 +127,7 @@ class SchemaLockAddressTest
 
       _ <- assertIO(
         vertex.getProperty[String](schema.properties.filter(_.name == Field.AddressEncodedId).head.name).pure[F],
+        // TODO it should be updated to use the new address encoding scheme.
         BitVector(address.id.toByteArray).toBase58
       ).toResource
 


### PR DESCRIPTION
## Purpose
Address Schema implementation
## Approach

- each time we process a TxIO, a new address Vertex will be created and liked using edges

## Testing
PROPERTIES

|#   |NAME     |TYPE   |LINKED-TYPE/CLASS|MANDATORY|READONLY|NOT-NULL|
|--------|--------|--------|--------|--------|--------|--------|
|0   |ledger   |INTEGER|                 |true     |true    |true    |   
|2   |network  |INTEGER|                 |true     |true    |true    | 
|3   |addressId|BINARY |                 |true     |true    |true    | 
|4   |addressEncodedId    |STRING|                 |false    |true    |false   |    


![image](https://user-images.githubusercontent.com/8540107/233782134-d0897eff-b8f4-491d-831b-87ce3bc39bde.png)


## Tickets
* this work is required to implement `getTxosByAddress`  which is a Transaction service endpoint Api part-2 BN-958 
