### PR TITLE
Extend NodeAppTest Genesis Timestamp

### DIFF
--- a/node/src/it/scala/co/topl/node/NodeAppTest.scala
+++ b/node/src/it/scala/co/topl/node/NodeAppTest.scala
@@ -37,14 +37,14 @@ class NodeAppTest extends CatsEffectSuite {
 
   type RpcClient = ToplRpc[F, Stream[F, *]]
 
-  override val munitTimeout: Duration = 2.minutes
+  override val munitTimeout: Duration = 3.minutes
 
   test("Two block-producing nodes that maintain consensus") {
     // Allow the nodes to produce/adopt blocks until reaching this height
     val targetProductionHeight = 10
     // All of the nodes should agree on the same block at this height
     val targetConsensusHeight = 8
-    val startTimestamp = System.currentTimeMillis() + 10_000L
+    val startTimestamp = System.currentTimeMillis() + 20_000L
     val configNodeA =
       s"""
         |bifrost:


### PR DESCRIPTION
## Purpose
- NodeAppTest launches two nodes (in the local JVM); one node launches Genus
- Launching Genus takes extra time, especially on the 2-core GitHub Actions machines.  If it takes _too_ long, the P2P layer may not bind in time thus failing the test
## Approach
- Double the NodeAppTest genesis timestamp delay
## Testing
- NodeAppTest locally
## Tickets
- #BN-994