### PR TITLE
TransactionId, Remove 32/64 Types

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
@@ -1,6 +1,6 @@
 package co.topl.algebras
 
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockHeader
 import co.topl.consensus.models.BlockId
@@ -15,13 +15,13 @@ import co.topl.node.models.BlockBody
 trait ToplRpc[F[_], S[_]] {
   def broadcastTransaction(transaction: IoTransaction): F[Unit]
 
-  def currentMempool(): F[Set[Identifier.IoTransaction32]]
+  def currentMempool(): F[Set[TransactionId]]
 
   def fetchBlockHeader(blockId: BlockId): F[Option[BlockHeader]]
 
   def fetchBlockBody(blockId: BlockId): F[Option[BlockBody]]
 
-  def fetchTransaction(transactionId: Identifier.IoTransaction32): F[Option[IoTransaction]]
+  def fetchTransaction(transactionId: TransactionId): F[Option[IoTransaction]]
 
   def blockIdAtHeight(height: Long): F[Option[BlockId]]
 

--- a/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
@@ -56,8 +56,7 @@ object BigBang {
       Sized.strictUnsafe(
         new Blake2b256().hash(
           (config.etaPrefix +:
-          transactions.map(_.id.evidence.digest.value))
-            .map(v => v: Array[Byte]): _*
+          transactions.map(_.id.value)).map(v => v: Array[Byte]): _*
         )
       )
 

--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -22,7 +22,7 @@ import co.topl.typeclasses.implicits._
 import org.typelevel.log4cats.{Logger, SelfAwareStructuredLogger}
 import BlockchainPeerHandler.monoidBlockchainPeerHandler
 import co.topl.blockchain.interpreters.BlockchainPeerServer
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.validation.algebras.TransactionSyntaxVerifier
 import co.topl.consensus.models.BlockId
@@ -46,7 +46,7 @@ object Blockchain {
     slotDataStore:               Store[F, BlockId, SlotData],
     headerStore:                 Store[F, BlockId, BlockHeader],
     bodyStore:                   Store[F, BlockId, BlockBody],
-    transactionStore:            Store[F, Identifier.IoTransaction32, IoTransaction],
+    transactionStore:            Store[F, TransactionId, IoTransaction],
     _localChain:                 LocalChainAlgebra[F],
     chainSelectionAlgebra:       ChainSelectionAlgebra[F, SlotData],
     blockIdTree:                 ParentChildTree[F, BlockId],

--- a/blockchain/src/main/scala/co/topl/blockchain/MempoolBroadcaster.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/MempoolBroadcaster.scala
@@ -4,7 +4,7 @@ import cats.data.EitherT
 import cats.effect.Resource
 import cats.effect.kernel.Async
 import cats.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.consensus.models.BlockId
 import co.topl.ledger.algebras.MempoolAlgebra
 import fs2.concurrent.Topic
@@ -13,21 +13,21 @@ object MempoolBroadcaster {
 
   def make[F[_]: Async](
     mempool: MempoolAlgebra[F]
-  ): Resource[F, (MempoolAlgebra[F], Topic[F, Identifier.IoTransaction32])] =
+  ): Resource[F, (MempoolAlgebra[F], Topic[F, TransactionId])] =
     Resource
-      .make(Topic[F, Identifier.IoTransaction32])(_.close.void)
+      .make(Topic[F, TransactionId])(_.close.void)
       .map { topic =>
         val interpreter =
           new MempoolAlgebra[F] {
-            def read(blockId: BlockId): F[Set[Identifier.IoTransaction32]] = mempool.read(blockId)
+            def read(blockId: BlockId): F[Set[TransactionId]] = mempool.read(blockId)
 
-            def add(transactionId: Identifier.IoTransaction32): F[Unit] =
+            def add(transactionId: TransactionId): F[Unit] =
               mempool.add(transactionId) >>
               EitherT(topic.publish1(transactionId))
                 .leftMap(_ => new IllegalStateException("MempoolBroadcaster topic unexpectedly closed"))
                 .rethrowT
 
-            def remove(transactionId: Identifier.IoTransaction32): F[Unit] = mempool.remove(transactionId)
+            def remove(transactionId: TransactionId): F[Unit] = mempool.remove(transactionId)
           }
 
         (interpreter, topic)

--- a/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
@@ -1,13 +1,11 @@
 package co.topl.blockchain
 
-import co.topl.brambl.common.ContainsEvidence
-import co.topl.brambl.common.ContainsImmutable.instances.lockImmutable
-import co.topl.brambl.models.Identifier
 import co.topl.brambl.models.LockAddress
 import co.topl.brambl.models.box.Challenge
 import co.topl.brambl.models.box.Lock
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
+import co.topl.brambl.syntax.lockAsLockSyntaxOps
 import co.topl.crypto.hash.Blake2b256
 import co.topl.models._
 import co.topl.models.utility.HasLength.instances._
@@ -90,15 +88,6 @@ object PrivateTestnet {
       )
     )
 
-  val HeightLockOneSpendingAddress: LockAddress =
-    LockAddress(
-      0,
-      0,
-      LockAddress.Id.Lock32(
-        Identifier.Lock32(
-          ContainsEvidence[Lock].sized32Evidence(HeightLockOneLock)
-        )
-      )
-    )
+  val HeightLockOneSpendingAddress: LockAddress = HeightLockOneLock.lockAddress(0, 0)
 
 }

--- a/blockchain/src/main/scala/co/topl/blockchain/StakerInitializer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/StakerInitializer.scala
@@ -1,11 +1,10 @@
 package co.topl.blockchain
 
 import cats.implicits._
-import co.topl.brambl.common.ContainsEvidence
-import co.topl.brambl.common.ContainsImmutable.instances.lockImmutable
 import co.topl.brambl.models._
 import co.topl.brambl.models.box._
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
+import co.topl.brambl.syntax.lockAsLockSyntaxOps
 import co.topl.consensus.models._
 import co.topl.crypto.hash.Blake2b256
 import co.topl.crypto.models.SecretKeyKesProduct
@@ -65,32 +64,22 @@ object StakerInitializers {
     )
 
     val lockAddress: LockAddress =
-      LockAddress(
-        0,
-        0,
-        LockAddress.Id.Lock32(
-          Identifier.Lock32(
-            ContainsEvidence[Lock].sized32Evidence(
-              Lock(
-                Lock.Value.Predicate(
-                  Lock.Predicate(
-                    List(
-                      Challenge().withRevealed(
-                        Proposition(
-                          Proposition.Value.DigitalSignature(
-                            Proposition.DigitalSignature("ed25519", VerificationKey(Vk.Ed25519(Ed25519Vk(spendingVK))))
-                          )
-                        )
-                      )
-                    ),
-                    1
+      Lock(
+        Lock.Value.Predicate(
+          Lock.Predicate(
+            List(
+              Challenge().withRevealed(
+                Proposition(
+                  Proposition.Value.DigitalSignature(
+                    Proposition.DigitalSignature("ed25519", VerificationKey(Vk.Ed25519(Ed25519Vk(spendingVK))))
                   )
                 )
               )
-            )
+            ),
+            1
           )
         )
-      )
+      ).lockAddress(0, 0)
 
     /**
      * This staker's initial stake in the network

--- a/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import cats.effect.Async
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.algebras.{Store, SynchronizationTraversalStep, ToplRpc}
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.validation.TransactionSyntaxError
 import co.topl.brambl.validation.algebras.TransactionSyntaxVerifier
@@ -43,7 +43,7 @@ object ToplRpcServer {
   def make[F[_]: Async](
     headerStore:               Store[F, BlockId, BlockHeader],
     bodyStore:                 Store[F, BlockId, BlockBody],
-    transactionStore:          Store[F, Identifier.IoTransaction32, IoTransaction],
+    transactionStore:          Store[F, TransactionId, IoTransaction],
     mempool:                   MempoolAlgebra[F],
     syntacticValidation:       TransactionSyntaxVerifier[F],
     localChain:                LocalChainAlgebra[F],
@@ -70,7 +70,7 @@ object ToplRpcServer {
             )
         }
 
-        def currentMempool(): F[Set[Identifier.IoTransaction32]] =
+        def currentMempool(): F[Set[TransactionId]] =
           localChain.head.map(_.slotId.blockId).flatMap(blockId => mempool.read(blockId))
 
         def fetchBlockHeader(blockId: BlockId): F[Option[BlockHeader]] =
@@ -79,7 +79,7 @@ object ToplRpcServer {
         def fetchBlockBody(blockId: BlockId): F[Option[BlockBody]] =
           bodyStore.get(blockId)
 
-        def fetchTransaction(transactionId: Identifier.IoTransaction32): F[Option[IoTransaction]] =
+        def fetchTransaction(transactionId: TransactionId): F[Option[IoTransaction]] =
           transactionStore
             .get(transactionId)
 
@@ -135,7 +135,7 @@ object ToplRpcServer {
     }
 
   private def processValidTransaction[F[_]: Monad: Logger](
-    transactionStore: Store[F, Identifier.IoTransaction32, IoTransaction],
+    transactionStore: Store[F, TransactionId, IoTransaction],
     mempool:          MempoolAlgebra[F]
   )(transaction: IoTransaction) =
     for {

--- a/blockchain/src/test/scala/co/topl/blockchain/MempoolBroadcasterSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/MempoolBroadcasterSpec.scala
@@ -3,7 +3,7 @@ package co.topl.blockchain
 import cats.effect.IO
 import cats.implicits._
 import co.topl.brambl.generators.ModelGenerators._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.ledger.algebras.MempoolAlgebra
 import co.topl.typeclasses.implicits._
 import fs2._
@@ -19,7 +19,7 @@ class MempoolBroadcasterSpec extends CatsEffectSuite with ScalaCheckEffectSuite 
   type F[A] = IO[A]
 
   test("Transactions should be produced in a stream whenever they are added to the mempool") {
-    PropF.forAllF { transactionId: Identifier.IoTransaction32 =>
+    PropF.forAllF { transactionId: TransactionId =>
       withMock {
         for {
           delegate <- mock[MempoolAlgebra[F]].pure[F]

--- a/blockchain/src/test/scala/co/topl/blockchain/ToplRpcServerSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/ToplRpcServerSpec.scala
@@ -3,7 +3,7 @@ package co.topl.blockchain
 import cats.effect.IO
 import cats.implicits._
 import co.topl.algebras.Store
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.validation.algebras.TransactionSyntaxVerifier
 import co.topl.consensus.algebras.LocalChainAlgebra
@@ -58,7 +58,7 @@ class ToplRpcServerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
           underTest <- ToplRpcServer.make[F](
             mock[Store[F, BlockId, BlockHeader]],
             mock[Store[F, BlockId, BlockBody]],
-            mock[Store[F, Identifier.IoTransaction32, IoTransaction]],
+            mock[Store[F, TransactionId, IoTransaction]],
             mock[MempoolAlgebra[F]],
             mock[TransactionSyntaxVerifier[F]],
             localChain,
@@ -80,7 +80,7 @@ class ToplRpcServerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
           underTest <- ToplRpcServer.make[F](
             mock[Store[F, BlockId, BlockHeader]],
             mock[Store[F, BlockId, BlockBody]],
-            mock[Store[F, Identifier.IoTransaction32, IoTransaction]],
+            mock[Store[F, TransactionId, IoTransaction]],
             mock[MempoolAlgebra[F]],
             mock[TransactionSyntaxVerifier[F]],
             localChain,
@@ -99,7 +99,7 @@ class ToplRpcServerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
           underTest <- ToplRpcServer.make[F](
             mock[Store[F, BlockId, BlockHeader]],
             mock[Store[F, BlockId, BlockBody]],
-            mock[Store[F, Identifier.IoTransaction32, IoTransaction]],
+            mock[Store[F, TransactionId, IoTransaction]],
             mock[MempoolAlgebra[F]],
             mock[TransactionSyntaxVerifier[F]],
             localChain,
@@ -203,10 +203,9 @@ class ToplRpcServerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
   }
 
   private def createServer(
-    headerStore: Store[F, BlockId, BlockHeader] = mock[Store[F, BlockId, BlockHeader]],
-    bodyStore:   Store[F, BlockId, BlockBody] = mock[Store[F, BlockId, BlockBody]],
-    transactionStore: Store[F, Identifier.IoTransaction32, IoTransaction] =
-      mock[Store[F, Identifier.IoTransaction32, IoTransaction]],
+    headerStore:         Store[F, BlockId, BlockHeader] = mock[Store[F, BlockId, BlockHeader]],
+    bodyStore:           Store[F, BlockId, BlockBody] = mock[Store[F, BlockId, BlockBody]],
+    transactionStore:    Store[F, TransactionId, IoTransaction] = mock[Store[F, TransactionId, IoTransaction]],
     mempool:             MempoolAlgebra[F] = mock[MempoolAlgebra[F]],
     syntacticValidation: TransactionSyntaxVerifier[F] = mock[TransactionSyntaxVerifier[F]],
     localChain:          LocalChainAlgebra[F] = mock[LocalChainAlgebra[F]],

--- a/common-interpreters/src/main/scala/co/topl/interpreters/MultiToplRpc.scala
+++ b/common-interpreters/src/main/scala/co/topl/interpreters/MultiToplRpc.scala
@@ -5,7 +5,7 @@ import cats.effect.Async
 import cats.effect.std.Random
 import cats.implicits._
 import co.topl.algebras.{SynchronizationTraversalStep, ToplRpc}
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockHeader
 import co.topl.consensus.models.BlockId
@@ -38,7 +38,7 @@ object MultiToplRpc {
       def broadcastTransaction(transaction: IoTransaction): F[Unit] =
         randomDelegate.flatMap(_.broadcastTransaction(transaction))
 
-      def currentMempool(): F[Set[Identifier.IoTransaction32]] =
+      def currentMempool(): F[Set[TransactionId]] =
         randomDelegate.flatMap(_.currentMempool())
 
       def fetchBlockHeader(blockId: BlockId): F[Option[BlockHeader]] =
@@ -47,7 +47,7 @@ object MultiToplRpc {
       def fetchBlockBody(blockId: BlockId): F[Option[BlockBody]] =
         randomDelegate.flatMap(_.fetchBlockBody(blockId))
 
-      def fetchTransaction(transactionId: Identifier.IoTransaction32): F[Option[IoTransaction]] =
+      def fetchTransaction(transactionId: TransactionId): F[Option[IoTransaction]] =
         randomDelegate.flatMap(_.fetchTransaction(transactionId))
 
       def blockIdAtHeight(height: Long): F[Option[BlockId]] =

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusDataEventSourcedState.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusDataEventSourcedState.scala
@@ -6,7 +6,7 @@ import cats.data.OptionT
 import cats.effect.Async
 import cats.implicits._
 import co.topl.algebras._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockId
 import co.topl.consensus.models.SignatureKesProduct
@@ -41,7 +41,7 @@ object ConsensusDataEventSourcedState {
     currentEventChanged: BlockId => F[Unit],
     initialState:        F[ConsensusData[F]],
     fetchBlockBody:      BlockId => F[BlockBody],
-    fetchTransaction:    Identifier.IoTransaction32 => F[IoTransaction]
+    fetchTransaction:    TransactionId => F[IoTransaction]
   ): F[EventSourcedState[F, ConsensusData[F], BlockId]] =
     EventSourcedState.OfTree.make(
       initialState = initialState,
@@ -54,7 +54,7 @@ object ConsensusDataEventSourcedState {
 
   private class ApplyBlock[F[_]: MonadThrow](
     fetchBlockBody:   BlockId => F[BlockBody],
-    fetchTransaction: Identifier.IoTransaction32 => F[IoTransaction]
+    fetchTransaction: TransactionId => F[IoTransaction]
   ) extends ((ConsensusData[F], BlockId) => F[ConsensusData[F]]) {
 
     def apply(state: ConsensusData[F], blockId: BlockId): F[ConsensusData[F]] =
@@ -112,7 +112,7 @@ object ConsensusDataEventSourcedState {
 
   private class UnapplyBlock[F[_]: MonadThrow](
     fetchBlockBody:   BlockId => F[BlockBody],
-    fetchTransaction: Identifier.IoTransaction32 => F[IoTransaction]
+    fetchTransaction: TransactionId => F[IoTransaction]
   ) extends ((ConsensusData[F], BlockId) => F[ConsensusData[F]]) {
 
     def apply(state: ConsensusData[F], blockId: BlockId): F[ConsensusData[F]] =

--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/TransactionFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/TransactionFetcherAlgebra.scala
@@ -1,6 +1,6 @@
 package co.topl.genusLibrary.algebras
 
-import co.topl.brambl.models.Identifier.IoTransaction32
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.genus.services.TransactionReceipt
 import co.topl.genusLibrary.model.GE
@@ -17,7 +17,7 @@ trait TransactionFetcherAlgebra[F[_]] {
    * @param ioTransaction32  Transaction Identifier filter by field
    * @return Optional Transaction, None if it was not found
    */
-  def fetchTransaction(ioTransaction32: IoTransaction32): F[Either[GE, Option[IoTransaction]]]
+  def fetchTransaction(transactionId: TransactionId): F[Either[GE, Option[IoTransaction]]]
 
   /**
    * Fetch a Transaction TransactionReceipt (includes ioTx, blockId, chain distance,...) on the stored Ledger
@@ -25,6 +25,6 @@ trait TransactionFetcherAlgebra[F[_]] {
    * @param ioTransaction32 Transaction Identifier filter by field
    * @return Optional Transaction, None if it was not found
    */
-  def fetchTransactionReceipt(ioTransaction32: IoTransaction32): F[Either[GE, Option[TransactionReceipt]]]
+  def fetchTransactionReceipt(transactionId: TransactionId): F[Either[GE, Option[TransactionReceipt]]]
 
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
@@ -1,6 +1,6 @@
 package co.topl.genusLibrary.algebras
 
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.consensus.models.BlockId
 import co.topl.genusLibrary.model.GE
 import com.tinkerpop.blueprints.Vertex
@@ -63,6 +63,6 @@ trait VertexFetcherAlgebra[F[_]] {
    * @param ioTransaction32 filter by index field
    * @return Optional transaction vertex, None if it was not found
    */
-  def fetchTransaction(ioTransaction32: Identifier.IoTransaction32): F[Either[GE, Option[Vertex]]]
+  def fetchTransaction(transactionId: TransactionId): F[Either[GE, Option[Vertex]]]
 
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcher.scala
@@ -2,7 +2,7 @@ package co.topl.genusLibrary.interpreter
 
 import cats.effect.Resource
 import cats.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.syntax.transactionIdAsIdSyntaxOps
 import co.topl.consensus.models.BlockId
 import co.topl.genusLibrary.algebras.VertexFetcherAlgebra
@@ -106,13 +106,13 @@ object GraphVertexFetcher {
               .leftMap[GE](tx => GEs.InternalMessageCause("GraphVertexFetcher:fetchTransactions", tx))
           )
 
-        def fetchTransaction(ioTransaction32: Identifier.IoTransaction32): F[Either[GE, Option[Vertex]]] =
+        def fetchTransaction(ioTransaction32: TransactionId): F[Either[GE, Option[Vertex]]] =
           OrientThread[F].delay(
             Try(
               orientGraph
                 .getVertices(
                   SchemaIoTransaction.Field.TransactionId,
-                  ioTransaction32.id.evidence.digest.value.toByteArray
+                  ioTransaction32.id.value.toByteArray
                 )
                 .asScala
             ).toEither

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
@@ -5,7 +5,7 @@ import cats.effect.Resource
 import cats.effect.kernel.Async
 import cats.implicits._
 import co.topl.algebras.ToplRpc
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction._
 import co.topl.consensus.models.BlockId
 import co.topl.genus.services.BlockData
@@ -80,7 +80,7 @@ object NodeBlockFetcher {
               .fetchTransaction(ioTx32)
               .map(maybeTransaction => (ioTx32, maybeTransaction))
           ) map { e =>
-            e.foldLeft(Chain.empty[IoTransaction].asRight[ListSet[Identifier.IoTransaction32]]) {
+            e.foldLeft(Chain.empty[IoTransaction].asRight[ListSet[TransactionId]]) {
               case (Right(transactions), (_, Some(transaction)))     => (transactions :+ transaction).asRight
               case (Right(_), (ioTx32, None))                        => ListSet(ioTx32).asLeft
               case (nonExistentTransactions @ Left(_), (_, Some(_))) => nonExistentTransactions

--- a/genus-library/src/main/scala/co/topl/genusLibrary/model/GE.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/model/GE.scala
@@ -2,7 +2,7 @@ package co.topl.genusLibrary.model
 
 import cats.implicits._
 import co.topl.typeclasses.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.consensus.models.BlockId
 import scala.collection.immutable.ListSet
 
@@ -19,7 +19,7 @@ object GEs {
 
   case class BodyNotFound(blockId: BlockId) extends GE(s"Block body wasn't found. BlockId=[${blockId.show}]")
 
-  case class TransactionsNotFound(ioTx32s: ListSet[Identifier.IoTransaction32])
+  case class TransactionsNotFound(ioTx32s: ListSet[TransactionId])
       extends GE(s"Transactions weren't found. Transactions=[${ioTx32s.map(_.show)}]")
 
   case class NotFound(msg: String) extends GE(msg)

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransaction.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransaction.scala
@@ -27,7 +27,7 @@ object SchemaIoTransaction {
         // transactionID is not stored in a transaction, but computed
         .withProperty(
           Field.TransactionId,
-          _.id.evidence.digest.value.toByteArray,
+          _.id.value.toByteArray,
           mandatory = false,
           readOnly = true,
           notNull = true

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcherSuite.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcherSuite.scala
@@ -5,7 +5,7 @@ import cats.effect.implicits.effectResourceOps
 import cats.implicits._
 import co.topl.algebras.ToplRpc
 import co.topl.brambl.generators.ModelGenerators._
-import co.topl.brambl.models.Identifier.IoTransaction32
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.consensus.models.BlockHeader
@@ -21,6 +21,7 @@ import org.scalamock.munit.AsyncMockFactory
 import fs2._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+
 import scala.collection.immutable.ListSet
 
 class NodeBlockFetcherSuite extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
@@ -124,7 +125,7 @@ class NodeBlockFetcherSuite extends CatsEffectSuite with ScalaCheckEffectSuite w
         height:        Long,
         blockId:       BlockId,
         blockHeader:   BlockHeader,
-        transactionId: IoTransaction32
+        transactionId: TransactionId
       ) =>
         withMock {
 
@@ -173,9 +174,9 @@ class NodeBlockFetcherSuite extends CatsEffectSuite with ScalaCheckEffectSuite w
         height:           Long,
         blockId:          BlockId,
         blockHeader:      BlockHeader,
-        transactionId_01: IoTransaction32,
-        transactionId_02: IoTransaction32,
-        transactionId_03: IoTransaction32,
+        transactionId_01: TransactionId,
+        transactionId_02: TransactionId,
+        transactionId_03: TransactionId,
         transaction_01:   IoTransaction
       ) =>
         withMock {
@@ -246,9 +247,9 @@ class NodeBlockFetcherSuite extends CatsEffectSuite with ScalaCheckEffectSuite w
         height:           Long,
         blockId:          BlockId,
         blockHeader:      BlockHeader,
-        transactionId_01: IoTransaction32,
-        transactionId_02: IoTransaction32,
-        transactionId_03: IoTransaction32
+        transactionId_01: TransactionId,
+        transactionId_02: TransactionId,
+        transactionId_03: TransactionId
       ) =>
         withMock {
 

--- a/genus-library/src/test/scala/co/topl/genusLibrary/model/GESuite.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/model/GESuite.scala
@@ -1,9 +1,9 @@
 package co.topl.genusLibrary.model
 
-import co.topl.brambl.models.{Evidence, Identifier}
+import co.topl.brambl.models.TransactionId
 import co.topl.consensus.models.BlockId
 import com.google.protobuf.ByteString
-import quivr.models.Digest
+
 import scala.collection.immutable.ListSet
 
 class GESuite extends munit.FunSuite {
@@ -58,14 +58,10 @@ class GESuite extends munit.FunSuite {
 
   test("Genus Exception TransactionsNotFound") {
     val ioTxId_1 =
-      Identifier.IoTransaction32.of(
-        Evidence.Sized32.of(Digest.Digest32.of(value = ByteString.copyFrom(Array.fill[Byte](32)(1))))
-      )
+      TransactionId(ByteString.copyFrom(Array.fill[Byte](32)(1)))
 
     val ioTxId_2 =
-      Identifier.IoTransaction32.of(
-        Evidence.Sized32.of(Digest.Digest32.of(value = ByteString.copyFrom(Array.fill[Byte](32)(2))))
-      )
+      TransactionId(ByteString.copyFrom(Array.fill[Byte](32)(2)))
 
     val ioTx32s = ListSet.from(ListSet(ioTxId_1, ioTxId_2))
 

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransactionSuite.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransactionSuite.scala
@@ -122,7 +122,7 @@ class SchemaIoTransactionSuite extends CatsEffectSuite with ScalaCheckEffectSuit
           )
           .toSeq
           .pure[F],
-        transaction.id.evidence.digest.value.toByteArray.toSeq
+        transaction.id.value.toByteArray.toSeq
       ).toResource
 
       _ <- assertIO(

--- a/ledger/src/main/scala/co/topl/ledger/algebras/MempoolAlgebra.scala
+++ b/ledger/src/main/scala/co/topl/ledger/algebras/MempoolAlgebra.scala
@@ -1,6 +1,6 @@
 package co.topl.ledger.algebras
 
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.consensus.models.BlockId
 
 trait MempoolAlgebra[F[_]] {
@@ -8,16 +8,16 @@ trait MempoolAlgebra[F[_]] {
   /**
    * Read the set of unconfirmed Transaction IDs at the given block ID
    */
-  def read(blockId: BlockId): F[Set[Identifier.IoTransaction32]]
+  def read(blockId: BlockId): F[Set[TransactionId]]
 
   /**
    * Inserts an externally sourced Transaction ID into the Mempool
    */
-  def add(transactionId: Identifier.IoTransaction32): F[Unit]
+  def add(transactionId: TransactionId): F[Unit]
 
   /**
    * Remove/evict the given Transaction ID from the Mempool
    */
-  def remove(transactionId: Identifier.IoTransaction32): F[Unit]
+  def remove(transactionId: TransactionId): F[Unit]
 
 }

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/AugmentedBoxState.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/AugmentedBoxState.scala
@@ -4,6 +4,7 @@ import cats.effect.Sync
 import cats.implicits._
 import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.consensus.models.BlockId
 import co.topl.ledger.algebras.BoxStateAlgebra
@@ -45,9 +46,7 @@ object AugmentedBoxState {
       val transactionId = transaction.id
       val transactionNewBoxIds =
         transaction.outputs
-          .mapWithIndex((_, idx) =>
-            TransactionOutputAddress(0, 0, idx, TransactionOutputAddress.Id.IoTransaction32(transactionId))
-          )
+          .mapWithIndex((_, idx) => transactionId.outputAddress(0, 0, idx))
           .toSet
       StateAugmentation(
         spentBoxIds ++ transactionSpentBoxIds,

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BodyAuthorizationValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BodyAuthorizationValidation.scala
@@ -4,7 +4,7 @@ import cats.data.ValidatedNec
 import cats.effect.Sync
 import cats.implicits._
 import co.topl.brambl.models.Datum
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.validation.algebras.TransactionAuthorizationVerifier
 import co.topl.ledger.algebras._
@@ -15,7 +15,7 @@ import co.topl.quivr.runtime.DynamicContext
 object BodyAuthorizationValidation {
 
   def make[F[_]: Sync](
-    fetchTransaction:                   Identifier.IoTransaction32 => F[IoTransaction],
+    fetchTransaction:                   TransactionId => F[IoTransaction],
     transactionAuthorizationValidation: TransactionAuthorizationVerifier[F]
   ): F[BodyAuthorizationValidationAlgebra[F]] =
     Sync[F].delay {

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BodySemanticValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BodySemanticValidation.scala
@@ -3,7 +3,7 @@ package co.topl.ledger.interpreters
 import cats.data.{NonEmptyChain, Validated, ValidatedNec}
 import cats.effect.Sync
 import cats.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.ledger.algebras._
 import co.topl.ledger.models._
@@ -12,7 +12,7 @@ import co.topl.node.models.BlockBody
 object BodySemanticValidation {
 
   def make[F[_]: Sync](
-    fetchTransaction:              Identifier.IoTransaction32 => F[IoTransaction],
+    fetchTransaction:              TransactionId => F[IoTransaction],
     transactionSemanticValidation: TransactionSemanticValidationAlgebra[F]
   ): F[BodySemanticValidationAlgebra[F]] =
     Sync[F].delay {
@@ -40,7 +40,7 @@ object BodySemanticValidation {
         private def validateTransaction(
           context: BodyValidationContext,
           prefix:  Seq[IoTransaction]
-        )(transactionId: Identifier.IoTransaction32) =
+        )(transactionId: TransactionId) =
           for {
             transaction <- fetchTransaction(transactionId)
             transactionValidationContext = StaticTransactionValidationContext(

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BodySyntaxValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BodySyntaxValidation.scala
@@ -6,7 +6,7 @@ import cats.effect.Sync
 import cats.implicits._
 import cats.Foldable
 import cats.Order
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.validation.algebras.TransactionSyntaxVerifier
@@ -20,18 +20,18 @@ import scala.collection.immutable.SortedSet
 object BodySyntaxValidation {
 
   implicit private val orderBoxId: Order[TransactionOutputAddress] = {
-    implicit val orderTypedIdentifier: Order[Identifier.IoTransaction32] =
-      Order.by[Identifier.IoTransaction32, ByteString](_.evidence.digest.value)(
+    implicit val orderTypedIdentifier: Order[TransactionId] =
+      Order.by[TransactionId, ByteString](_.value)(
         Order.from(ByteString.unsignedLexicographicalComparator().compare)
       )
     Order.whenEqual(
-      Order.by(_.id.asInstanceOf[TransactionOutputAddress.Id.IoTransaction32].value),
+      Order.by(_.id),
       Order.by(_.index)
     )
   }
 
   def make[F[_]: Sync](
-    fetchTransaction:               Identifier.IoTransaction32 => F[IoTransaction],
+    fetchTransaction:               TransactionId => F[IoTransaction],
     transactionSyntacticValidation: TransactionSyntaxVerifier[F]
   ): F[BodySyntaxValidationAlgebra[F]] =
     Sync[F].delay {

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/QuivrContext.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/QuivrContext.scala
@@ -77,7 +77,7 @@ object QuivrContext {
       def validate(t: DigestVerification): F[Either[QuivrRuntimeError, DigestVerification]] =
         Sync[F].delay(
           Either.cond(
-            blake2b256.hash(t.preimage.input.concat(t.preimage.salt)) === t.digest.getDigest32.value,
+            blake2b256.hash(t.preimage.input.concat(t.preimage.salt)) === t.digest.value,
             t,
             QuivrRuntimeErrors.ValidationError.UserProvidedInterfaceFailure // TODO
           )

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/AugmentedBoxStateSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/AugmentedBoxStateSpec.scala
@@ -7,6 +7,7 @@ import co.topl.algebras.testInterpreters.TestStore
 import co.topl.brambl.models._
 import co.topl.brambl.models.transaction._
 import co.topl.brambl.generators.ModelGenerators._
+import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.consensus.models.BlockId
@@ -30,18 +31,8 @@ class AugmentedBoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
         blockId1:         BlockId
       ) =>
         val transaction1 = txBase1.addOutputs(txOutput10, txOutput11)
-        val outputBoxId10 = TransactionOutputAddress(
-          0,
-          0,
-          transaction1.outputs.length - 2,
-          TransactionOutputAddress.Id.IoTransaction32(transaction1.id)
-        )
-        val outputBoxId11 = TransactionOutputAddress(
-          0,
-          0,
-          transaction1.outputs.length - 1,
-          TransactionOutputAddress.Id.IoTransaction32(transaction1.id)
-        )
+        val outputBoxId10 = transaction1.id.outputAddress(0, 0, transaction1.outputs.length - 2)
+        val outputBoxId11 = transaction1.id.outputAddress(0, 0, transaction1.outputs.length - 1)
         val transaction2 = transaction2Base.addInputs(input.copy(address = outputBoxId11))
 
         for {
@@ -59,7 +50,7 @@ class AugmentedBoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
             ),
             parentChildTree,
             _ => IO.unit,
-            TestStore.make[IO, Identifier.IoTransaction32, NonEmptySet[Short]].widen
+            TestStore.make[IO, TransactionId, NonEmptySet[Short]].widen
           )
 
           stateAugmentation <-

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BodySemanticValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BodySemanticValidationSpec.scala
@@ -3,7 +3,7 @@ package co.topl.ledger.interpreters
 import cats.effect.IO
 import cats.implicits._
 import co.topl.brambl.generators.ModelGenerators._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.models.transaction.SpentTransactionOutput
 import co.topl.codecs.bytes.tetra.instances._
@@ -28,7 +28,7 @@ class BodySemanticValidationSpec extends CatsEffectSuite with ScalaCheckEffectSu
         withMock {
           val body = BlockBody(List(transaction.id))
           for {
-            fetchTransaction <- mockFunction[Identifier.IoTransaction32, F[IoTransaction]].pure[F]
+            fetchTransaction <- mockFunction[TransactionId, F[IoTransaction]].pure[F]
             _ = fetchTransaction.expects(transaction.id).once().returning(transaction.pure[F])
             transactionSemanticValidation = mock[TransactionSemanticValidationAlgebra[F]]
             _ = (transactionSemanticValidation
@@ -62,7 +62,7 @@ class BodySemanticValidationSpec extends CatsEffectSuite with ScalaCheckEffectSu
         withMock {
           val body = BlockBody(List(transactionA.id, transactionB.id))
           for {
-            fetchTransaction <- mockFunction[Identifier.IoTransaction32, F[IoTransaction]].pure[F]
+            fetchTransaction <- mockFunction[TransactionId, F[IoTransaction]].pure[F]
             _ = fetchTransaction
               .expects(transactionA.id)
               .anyNumberOfTimes()

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BodySyntaxValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BodySyntaxValidationSpec.scala
@@ -2,7 +2,7 @@ package co.topl.ledger.interpreters
 
 import cats.effect.IO
 import cats.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.generators.ModelGenerators._
 import co.topl.brambl.validation.TransactionSyntaxError
@@ -22,7 +22,7 @@ class BodySyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEffectSuit
       withMock {
         val body = BlockBody(List(transaction.id))
         for {
-          fetchTransaction <- mockFunction[Identifier.IoTransaction32, F[IoTransaction]].pure[F]
+          fetchTransaction <- mockFunction[TransactionId, F[IoTransaction]].pure[F]
           _ = fetchTransaction.expects(transaction.id).once().returning(transaction.pure[F])
           transactionSyntaxValidation = mock[TransactionSyntaxVerifier[F]]
           _ = (transactionSyntaxValidation.validate _)

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
@@ -7,6 +7,7 @@ import co.topl.algebras.testInterpreters.TestStore
 import co.topl.brambl.generators.ModelGenerators._
 import co.topl.brambl.models._
 import co.topl.brambl.models.transaction._
+import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.consensus.models.BlockId
 import co.topl.eventtree.ParentChildTree
@@ -29,13 +30,7 @@ class BoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
         blockId2: BlockId
       ) =>
         val transaction1 = IoTransaction.defaultInstance.withOutputs(List(output))
-        val outputBoxId =
-          TransactionOutputAddress(
-            0,
-            0,
-            transaction1.outputs.length - 1,
-            TransactionOutputAddress.Id.IoTransaction32(transaction1.id)
-          )
+        val outputBoxId = transaction1.id.outputAddress(0, 0, transaction1.outputs.length - 1)
 
         val transaction2 = IoTransaction.defaultInstance.withInputs(List(input.copy(address = outputBoxId)))
 
@@ -55,7 +50,7 @@ class BoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
             ),
             parentChildTree,
             _ => IO.unit,
-            TestStore.make[IO, Identifier.IoTransaction32, NonEmptySet[Short]].widen
+            TestStore.make[IO, TransactionId, NonEmptySet[Short]].widen
           )
           _ <- underTest.boxExistsAt(blockId1)(outputBoxId).assert
           _ <- underTest.boxExistsAt(blockId2)(outputBoxId).map(!_).assert

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSemanticValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionSemanticValidationSpec.scala
@@ -26,14 +26,12 @@ class TransactionSemanticValidationSpec extends CatsEffectSuite with ScalaCheckE
         withMock {
           val transactionB = _transactionB.clearInputs
             .addInputs(
-              input.copy(address =
-                TransactionOutputAddress(0, 0, 0, TransactionOutputAddress.Id.IoTransaction32(transactionA.id))
-              )
+              input.copy(address = transactionA.id.outputAddress(0, 0, 0))
             )
             .update(_.datum.event.schedule.min.set(0))
             .update(_.datum.event.schedule.max.set(4))
           for {
-            fetchTransaction <- mockFunction[Identifier.IoTransaction32, F[IoTransaction]].pure[F]
+            fetchTransaction <- mockFunction[TransactionId, F[IoTransaction]].pure[F]
             boxState         <- mock[BoxStateAlgebra[F]].pure[F]
             underTest        <- TransactionSemanticValidation.make[F](fetchTransaction, boxState)
             _ <- underTest
@@ -50,17 +48,10 @@ class TransactionSemanticValidationSpec extends CatsEffectSuite with ScalaCheckE
       (blockId: BlockId, transactionA: IoTransaction, _transactionB: IoTransaction, input: SpentTransactionOutput) =>
         withMock {
           val transactionB = _transactionB.clearInputs.addInputs(
-            input.copy(
-              TransactionOutputAddress(
-                0,
-                0,
-                Short.MaxValue,
-                TransactionOutputAddress.Id.IoTransaction32(transactionA.id)
-              )
-            )
+            input.copy(transactionA.id.outputAddress(0, 0, Short.MaxValue))
           )
           for {
-            fetchTransaction <- mockFunction[Identifier.IoTransaction32, F[IoTransaction]].pure[F]
+            fetchTransaction <- mockFunction[TransactionId, F[IoTransaction]].pure[F]
             boxState         <- mock[BoxStateAlgebra[F]].pure[F]
             _ = fetchTransaction.expects(transactionA.id).once().returning(transactionA.pure[F])
             _ = (boxState
@@ -90,7 +81,7 @@ class TransactionSemanticValidationSpec extends CatsEffectSuite with ScalaCheckE
         input:         SpentTransactionOutput
       ) =>
         withMock {
-          val lockAddress = input.attestation.getPredicate.lock.address(0, 0)
+          val lockAddress = input.attestation.getPredicate.lock.lockAddress(0, 0)
           val transactionA = _transactionA.update(
             _.outputs.set(
               List(
@@ -102,15 +93,13 @@ class TransactionSemanticValidationSpec extends CatsEffectSuite with ScalaCheckE
             _.inputs.set(
               List(
                 input.update(
-                  _.address.set(
-                    TransactionOutputAddress(0, 0, 0, TransactionOutputAddress.Id.IoTransaction32(transactionA.id))
-                  )
+                  _.address.set(transactionA.id.outputAddress(0, 0, 0))
                 )
               )
             )
           )
           for {
-            fetchTransaction <- mockFunction[Identifier.IoTransaction32, F[IoTransaction]].pure[F]
+            fetchTransaction <- mockFunction[TransactionId, F[IoTransaction]].pure[F]
             boxState         <- mock[BoxStateAlgebra[F]].pure[F]
             _ = fetchTransaction.expects(transactionA.id).once().returning(transactionA.pure[F])
             _ = (boxState
@@ -149,13 +138,12 @@ class TransactionSemanticValidationSpec extends CatsEffectSuite with ScalaCheckE
             List(
               input.copy(
                 value = Value.defaultInstance,
-                address =
-                  TransactionOutputAddress(0, 0, 0, TransactionOutputAddress.Id.IoTransaction32(transactionA.id))
+                address = transactionA.id.outputAddress(0, 0, 0)
               )
             )
           )
           for {
-            fetchTransaction <- mockFunction[Identifier.IoTransaction32, F[IoTransaction]].pure[F]
+            fetchTransaction <- mockFunction[TransactionId, F[IoTransaction]].pure[F]
             boxState         <- mock[BoxStateAlgebra[F]].pure[F]
             _ = fetchTransaction.expects(transactionA.id).once().returning(transactionA.pure[F])
             _ = (boxState
@@ -189,7 +177,7 @@ class TransactionSemanticValidationSpec extends CatsEffectSuite with ScalaCheckE
             outputs = List(
               output.copy(
                 value = Value.defaultInstance,
-                address = input.attestation.getPredicate.lock.address(0, 0)
+                address = input.attestation.getPredicate.lock.lockAddress(0, 0)
               )
             )
           )
@@ -197,13 +185,12 @@ class TransactionSemanticValidationSpec extends CatsEffectSuite with ScalaCheckE
             List(
               input.copy(
                 value = Value.defaultInstance,
-                address =
-                  TransactionOutputAddress(0, 0, 0, TransactionOutputAddress.Id.IoTransaction32(transactionA.id))
+                address = transactionA.id.outputAddress(0, 0, 0)
               )
             )
           )
           for {
-            fetchTransaction <- mockFunction[Identifier.IoTransaction32, F[IoTransaction]].pure[F]
+            fetchTransaction <- mockFunction[TransactionId, F[IoTransaction]].pure[F]
             boxState         <- mock[BoxStateAlgebra[F]].pure[F]
             _ = fetchTransaction.expects(transactionA.id).once().returning(transactionA.pure[F])
             _ = (boxState

--- a/models/src/test/scala/co/topl/models/generators/node/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/generators/node/ModelGenerators.scala
@@ -1,6 +1,6 @@
 package co.topl.models.generators.node
 
-import co.topl.brambl.generators.ModelGenerators.arbitraryIoTransaction32
+import co.topl.brambl.generators.ModelGenerators._
 import co.topl.models.generators.consensus.ModelGenerators.arbitraryHeader
 import co.topl.node.models._
 import org.scalacheck.{Arbitrary, Gen}
@@ -10,7 +10,7 @@ trait ModelGenerators {
   implicit val arbitraryNodeBody: Arbitrary[BlockBody] =
     Arbitrary(
       for {
-        ioTx32 <- Gen.listOf(arbitraryIoTransaction32.arbitrary)
+        ioTx32 <- Gen.listOf(arbitraryTransactionId.arbitrary)
       } yield BlockBody.of(ioTx32)
     )
 

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
@@ -4,7 +4,7 @@ import cats._
 import cats.data.OptionT
 import cats.effect.kernel.Sync
 import cats.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockId
 import co.topl.consensus.models.{BlockHeader, SlotData}
@@ -34,7 +34,7 @@ trait BlockchainPeerClient[F[_]] {
   /**
    * A Source of transaction IDs that were observed by the remote node
    */
-  def remoteTransactionNotifications: F[Stream[F, Identifier.IoTransaction32]]
+  def remoteTransactionNotifications: F[Stream[F, TransactionId]]
 
   /**
    * A Lookup to retrieve a remote SlotData by ID
@@ -66,7 +66,7 @@ trait BlockchainPeerClient[F[_]] {
   /**
    * A lookup to retrieve a remote transaction by ID
    */
-  def getRemoteTransaction(id: Identifier.IoTransaction32): F[Option[IoTransaction]]
+  def getRemoteTransaction(id: TransactionId): F[Option[IoTransaction]]
 
   /**
    * A lookup to retrieve the remote node's block ID associated with the given height.

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactory.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactory.scala
@@ -4,7 +4,7 @@ import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import cats.effect.{Async, Resource}
 import cats.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.catsakka._
 import co.topl.codecs.bytes.tetra.instances._
@@ -108,12 +108,12 @@ object BlockchainPeerConnectionFlowFactory {
         blockchainProtocolClient = new BlockchainPeerClient[F] {
           val remotePeer: F[ConnectedPeer] = connectedPeer.pure[F]
           val remotePeerAdoptions: F[Stream[F, BlockId]] = remoteBlockIdsSource.pure[F]
-          val remoteTransactionNotifications: F[Stream[F, Identifier.IoTransaction32]] =
+          val remoteTransactionNotifications: F[Stream[F, TransactionId]] =
             remoteTransactionIdsSource.pure[F]
           def getRemoteSlotData(id: BlockId): F[Option[SlotData]] = slotDataReceivedCallback(id)
           def getRemoteHeader(id:   BlockId): F[Option[BlockHeader]] = headerReceivedCallback(id)
           def getRemoteBody(id:     BlockId): F[Option[BlockBody]] = bodyReceivedCallback(id)
-          def getRemoteTransaction(id: Identifier.IoTransaction32): F[Option[IoTransaction]] =
+          def getRemoteTransaction(id: TransactionId): F[Option[IoTransaction]] =
             transactionReceivedCallback(id)
           def getRemoteBlockIdAtHeight(
             height:       Long,

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServerAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServerAlgebra.scala
@@ -1,6 +1,6 @@
 package co.topl.networking.blockchain
 
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockHeader
 import co.topl.consensus.models.BlockId
@@ -13,10 +13,10 @@ import fs2._
  */
 trait BlockchainPeerServerAlgebra[F[_]] {
   def localBlockAdoptions: F[Stream[F, BlockId]]
-  def localTransactionNotifications: F[Stream[F, Identifier.IoTransaction32]]
+  def localTransactionNotifications: F[Stream[F, TransactionId]]
   def getLocalSlotData(id:          BlockId): F[Option[SlotData]]
   def getLocalHeader(id:            BlockId): F[Option[BlockHeader]]
   def getLocalBody(id:              BlockId): F[Option[BlockBody]]
-  def getLocalTransaction(id:       Identifier.IoTransaction32): F[Option[IoTransaction]]
+  def getLocalTransaction(id:       TransactionId): F[Option[IoTransaction]]
   def getLocalBlockAtHeight(height: Long): F[Option[BlockId]]
 }

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainProtocols.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainProtocols.scala
@@ -1,6 +1,6 @@
 package co.topl.networking.blockchain
 
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockId
 import co.topl.consensus.models.BlockHeader
@@ -49,7 +49,7 @@ object BlockchainProtocols {
    *
    * This protocol runs a server and client in parallel for each connection.
    */
-  object Transaction extends RequestResponseProtocol[Identifier.IoTransaction32, IoTransaction]
+  object Transaction extends RequestResponseProtocol[TransactionId, IoTransaction]
 
   /**
    * Request the Block ID at some height.  The request also includes the client node's Block ID at the given height.
@@ -70,6 +70,6 @@ object BlockchainProtocols {
    *
    * This protocol runs a server and client in parallel for each connection.
    */
-  object TransactionBroadcasts extends NotificationProtocol[Identifier.IoTransaction32]
+  object TransactionBroadcasts extends NotificationProtocol[TransactionId]
 
 }

--- a/networking/src/main/scala/co/topl/networking/blockchain/NetworkTypeTags.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/NetworkTypeTags.scala
@@ -1,6 +1,6 @@
 package co.topl.networking.blockchain
 
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockHeader
 import co.topl.consensus.models.BlockId
@@ -30,8 +30,8 @@ object NetworkTypeTags {
     NetworkTypeTag.create("TypedProtocol.CommonMessages.Get[BlockId]")
 
   implicit val commonMessagesGetTransactionIdNetworkTypeTag
-    : NetworkTypeTag[TypedProtocol.CommonMessages.Get[Identifier.IoTransaction32]] =
-    NetworkTypeTag.create("TypedProtocol.CommonMessages.Get[Identifier.IoTransaction32]")
+    : NetworkTypeTag[TypedProtocol.CommonMessages.Get[TransactionId]] =
+    NetworkTypeTag.create("TypedProtocol.CommonMessages.Get[TransactionId]")
 
   implicit val commonMessagesGetLongTypedIdentifierOptNetworkTypeTag
     : NetworkTypeTag[TypedProtocol.CommonMessages.Get[(Long, Option[BlockId])]] =
@@ -63,8 +63,8 @@ object NetworkTypeTags {
     NetworkTypeTag.create("TypedProtocol.CommonMessages.Push[BlockId]")
 
   implicit val commonMessagesPushTransactionIdNetworkTypeTag
-    : NetworkTypeTag[TypedProtocol.CommonMessages.Push[Identifier.IoTransaction32]] =
-    NetworkTypeTag.create("TypedProtocol.CommonMessages.Push[Identifier.IoTransaction32]")
+    : NetworkTypeTag[TypedProtocol.CommonMessages.Push[TransactionId]] =
+    NetworkTypeTag.create("TypedProtocol.CommonMessages.Push[TransactionId]")
 
   implicit val commonMessagesDoneNetworkTypeTag: NetworkTypeTag[TypedProtocol.CommonMessages.Done.type] =
     NetworkTypeTag.create("TypedProtocol.CommonMessages.Done")

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -5,7 +5,7 @@ import cats.effect.Resource
 import cats.effect.kernel.Concurrent
 import cats.implicits._
 import co.topl.algebras.Store
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.algebras._
 import co.topl.consensus.models.BlockHeader
@@ -32,7 +32,7 @@ object ActorPeerHandlerBridgeAlgebra {
     slotDataStore:               Store[F, BlockId, SlotData],
     headerStore:                 Store[F, BlockId, BlockHeader],
     bodyStore:                   Store[F, BlockId, BlockBody],
-    transactionStore:            Store[F, Identifier.IoTransaction32, IoTransaction],
+    transactionStore:            Store[F, TransactionId, IoTransaction],
     blockIdTree:                 ParentChildTree[F, BlockId]
   ): Resource[F, BlockchainPeerHandlerAlgebra[F]] = {
     val networkAlgebra = new NetworkAlgebraImpl[F]()

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockDownloadError.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockDownloadError.scala
@@ -1,7 +1,7 @@
 package co.topl.networking.fsnetwork
 
 import cats.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.consensus.models.BlockId
 import co.topl.models.TxRoot
 import co.topl.typeclasses.implicits._
@@ -44,11 +44,11 @@ object BlockDownloadError {
       override def toString: String = show"Peer returns body with bad txRoot: expected $headerTxRoot, got $bodyTxRoot"
     }
 
-    case class TransactionNotFoundInPeer(transactionId: Identifier.IoTransaction32) extends BlockBodyDownloadError {
+    case class TransactionNotFoundInPeer(transactionId: TransactionId) extends BlockBodyDownloadError {
       override def toString: String = show"Peer have no transaction $transactionId despite having appropriate block"
     }
 
-    case class TransactionHaveIncorrectId(expected: Identifier.IoTransaction32, actual: Identifier.IoTransaction32)
+    case class TransactionHaveIncorrectId(expected: TransactionId, actual: TransactionId)
         extends BlockBodyDownloadError {
       override def toString: String = show"Peer returns transaction with bad id: expected $expected, actual $actual"
     }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
@@ -3,7 +3,7 @@ package co.topl.networking.fsnetwork
 import cats.effect.Async
 import cats.effect.Resource
 import co.topl.algebras.Store
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.algebras._
 import co.topl.consensus.models.BlockId
@@ -24,7 +24,7 @@ trait NetworkAlgebra[F[_]] {
     networkAlgebra:         NetworkAlgebra[F],
     localChain:             LocalChainAlgebra[F],
     slotDataStore:          Store[F, BlockId, SlotData],
-    transactionStore:       Store[F, Identifier.IoTransaction32, IoTransaction],
+    transactionStore:       Store[F, TransactionId, IoTransaction],
     blockIdTree:            ParentChildTree[F, BlockId],
     headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   ): Resource[F, PeersManagerActor[F]]
@@ -59,7 +59,7 @@ class NetworkAlgebraImpl[F[_]: Async: Logger] extends NetworkAlgebra[F] {
     networkAlgebra:         NetworkAlgebra[F],
     localChain:             LocalChainAlgebra[F],
     slotDataStore:          Store[F, BlockId, SlotData],
-    transactionStore:       Store[F, Identifier.IoTransaction32, IoTransaction],
+    transactionStore:       Store[F, TransactionId, IoTransaction],
     blockIdTree:            ParentChildTree[F, BlockId],
     headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   ): Resource[F, PeersManagerActor[F]] =

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
@@ -2,7 +2,7 @@ package co.topl.networking.fsnetwork
 
 import cats.effect.kernel.Resource
 import co.topl.algebras.Store
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.algebras._
 import co.topl.consensus.models.BlockId
@@ -27,7 +27,7 @@ object NetworkManager {
     slotDataStore:               Store[F, BlockId, SlotData],
     headerStore:                 Store[F, BlockId, BlockHeader],
     bodyStore:                   Store[F, BlockId, BlockBody],
-    transactionStore:            Store[F, Identifier.IoTransaction32, IoTransaction],
+    transactionStore:            Store[F, TransactionId, IoTransaction],
     blockIdTree:                 ParentChildTree[F, BlockId],
     networkAlgebra:              NetworkAlgebra[F],
     initialHosts:                List[HostId]

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -5,7 +5,7 @@ import cats.effect.{Async, Concurrent, Resource}
 import cats.implicits._
 import co.topl.actor.{Actor, Fsm}
 import co.topl.algebras.Store
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.algebras.{BlockHeaderToBodyValidationAlgebra, LocalChainAlgebra}
 import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
@@ -65,7 +65,7 @@ object PeerActor {
     requestsProxy:          RequestsProxyActor[F],
     localChain:             LocalChainAlgebra[F],
     slotDataStore:          Store[F, BlockId, SlotData],
-    transactionStore:       Store[F, Identifier.IoTransaction32, IoTransaction],
+    transactionStore:       Store[F, TransactionId, IoTransaction],
     blockIdTree:            ParentChildTree[F, BlockId],
     headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   ): Resource[F, PeerActor[F]] =

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import co.topl.actor.Actor
 import co.topl.actor.Fsm
 import co.topl.algebras.Store
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.algebras.{BlockHeaderToBodyValidationAlgebra, LocalChainAlgebra}
 import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
@@ -100,7 +100,7 @@ object PeersManager {
     peers:                  Map[HostId, Peer[F]],
     localChain:             LocalChainAlgebra[F],
     slotDataStore:          Store[F, BlockId, SlotData],
-    transactionStore:       Store[F, Identifier.IoTransaction32, IoTransaction],
+    transactionStore:       Store[F, TransactionId, IoTransaction],
     blockIdTree:            ParentChildTree[F, BlockId],
     headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   )
@@ -131,7 +131,7 @@ object PeersManager {
     networkAlgebra:         NetworkAlgebra[F],
     localChain:             LocalChainAlgebra[F],
     slotDataStore:          Store[F, BlockId, SlotData],
-    transactionStore:       Store[F, Identifier.IoTransaction32, IoTransaction],
+    transactionStore:       Store[F, TransactionId, IoTransaction],
     blockIdTree:            ParentChildTree[F, BlockId],
     headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   ): Resource[F, PeersManagerActor[F]] = {

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
@@ -1,49 +1,40 @@
 package co.topl.networking.blockchain
 
 import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import cats.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockId
 import co.topl.consensus.models.{BlockHeader, SlotData}
+import co.topl.crypto.hash.Blake2b256
 import co.topl.node.models.BlockBody
 import co.topl.networking.p2p.ConnectedPeer
 import com.google.protobuf.ByteString
 import fs2._
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
 import org.scalacheck.Gen
-import org.scalamock.scalatest.MockFactory
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.{BeforeAndAfterAll, EitherValues}
-import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}
+import org.scalacheck.effect.PropF
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-class BlockchainClientSpec
-    extends AnyFlatSpec
-    with BeforeAndAfterAll
-    with MockFactory
-    with Matchers
-    with EitherValues
-    with ScalaCheckPropertyChecks
-    with ScalaCheckDrivenPropertyChecks {
+import java.nio.charset.StandardCharsets
 
-  behavior of "BlockchainClient"
+class BlockchainClientSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   implicit private val logger: Logger[F] = Slf4jLogger.getLogger[F]
 
   type F[A] = IO[A]
 
-  it should "trace a common ancestor" in {
-    forAll(Gen.posNum[Long]) { headHeight =>
-      forAll(Gen.chooseNum[Long](1, headHeight)) { ancestorHeight =>
+  test("trace a common ancestor") {
+    PropF.forAllF(Gen.posNum[Long]) { headHeight =>
+      PropF.forAllF(Gen.chooseNum[Long](1, headHeight)) { ancestorHeight =>
         val client = new BlockchainPeerClient[F] {
           def remotePeer: F[ConnectedPeer] = ???
 
           def remotePeerAdoptions: F[Stream[F, BlockId]] = ???
 
-          def remoteTransactionNotifications: F[Stream[F, Identifier.IoTransaction32]] = ???
+          def remoteTransactionNotifications: F[Stream[F, TransactionId]] = ???
 
           def getRemoteSlotData(id: BlockId): F[Option[SlotData]] = ???
 
@@ -51,7 +42,7 @@ class BlockchainClientSpec
 
           def getRemoteBody(id: BlockId): F[Option[BlockBody]] = ???
 
-          def getRemoteTransaction(id: Identifier.IoTransaction32): F[Option[IoTransaction]] = ???
+          def getRemoteTransaction(id: TransactionId): F[Option[IoTransaction]] = ???
 
           def getRemoteBlockIdAtHeight(
             height:       Long,
@@ -66,15 +57,13 @@ class BlockchainClientSpec
             (height.toString + (if (height > ancestorHeight) "local" else "")).typedId
               .pure[F]
 
-        val ancestor = client.findCommonAncestor(blockHeights, () => headHeight.pure[F]).unsafeRunSync()
-
-        ancestor shouldBe ancestorHeight.toString.typedId
+        client.findCommonAncestor(blockHeights, () => headHeight.pure[F]).assertEquals(ancestorHeight.toString.typedId)
       }
     }
   }
 
   implicit private class StringToBlockId(string: String) {
-    def typedId: BlockId = BlockId(ByteString.copyFromUtf8(string))
+    def typedId: BlockId = BlockId(ByteString.copyFrom(new Blake2b256().hash(string.getBytes(StandardCharsets.UTF_8))))
   }
 
 }

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactorySpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactorySpec.scala
@@ -3,7 +3,7 @@ package co.topl.networking.blockchain
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.consensus.models.BlockId
 import co.topl.networking.NetworkGen._
 import co.topl.networking.p2p.{ConnectedPeer, ConnectionLeader}
@@ -45,7 +45,7 @@ class BlockchainPeerConnectionFlowFactorySpec
       (() => server.localTransactionNotifications)
         .expects()
         .once()
-        .returning(Stream.never[F].pure[F]: F[Stream[F, Identifier.IoTransaction32]])
+        .returning(Stream.never[F].pure[F]: F[Stream[F, TransactionId]])
 
       val factory = BlockchainPeerConnectionFlowFactory.createFactory[F](server)
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockBodyFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockBodyFetcherTest.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import cats.implicits._
 import co.topl.algebras.Store
 import co.topl.brambl.generators.TransactionGenerator
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.codecs.bytes.tetra.instances.{blockHeaderAsBlockHeaderOps, ioTransactionAsIoTransactionOps}
 import co.topl.consensus.algebras.BlockHeaderToBodyValidationAlgebra
@@ -46,7 +46,7 @@ class PeerBlockBodyFetcherTest
     withMock {
       val client = mock[BlockchainPeerClient[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
-      val transactionStore = mock[Store[F, Identifier.IoTransaction32, IoTransaction]]
+      val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
 
       val (txs, bodies) =
@@ -72,20 +72,19 @@ class PeerBlockBodyFetcherTest
       }
 
       val transactionStoreData = presentTxs.toMap
-      (transactionStore.contains _).expects(*).anyNumberOfTimes().onCall { id: Identifier.IoTransaction32 =>
+      (transactionStore.contains _).expects(*).anyNumberOfTimes().onCall { id: TransactionId =>
         transactionStoreData.contains(id).pure[F]
       }
 
       val clientTxsData = missedTxs.toMap
-      (client.getRemoteTransaction _).expects(*).anyNumberOfTimes().onCall { id: Identifier.IoTransaction32 =>
+      (client.getRemoteTransaction _).expects(*).anyNumberOfTimes().onCall { id: TransactionId =>
         clientTxsData.get(id).pure[F]
       }
 
       val downloadedTxs =
-        mutable.Map.empty[Identifier.IoTransaction32, IoTransaction]
-      (transactionStore.put _).expects(*, *).anyNumberOfTimes().onCall {
-        case (id: Identifier.IoTransaction32, tx: IoTransaction) =>
-          downloadedTxs.put(id, tx).pure[F].void
+        mutable.Map.empty[TransactionId, IoTransaction]
+      (transactionStore.put _).expects(*, *).anyNumberOfTimes().onCall { case (id: TransactionId, tx: IoTransaction) =>
+        downloadedTxs.put(id, tx).pure[F].void
       }
 
       (headerToBodyValidation.validate _).expects(*).rep(presentBlockIdAndBodies.size).onCall { block: Block =>
@@ -127,7 +126,7 @@ class PeerBlockBodyFetcherTest
     withMock {
       val client = mock[BlockchainPeerClient[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
-      val transactionStore = mock[Store[F, Identifier.IoTransaction32, IoTransaction]]
+      val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
 
       val (txs, bodies) =
@@ -155,20 +154,19 @@ class PeerBlockBodyFetcherTest
       }
 
       val transactionStoreData = presentTxs.toMap
-      (transactionStore.contains _).expects(*).anyNumberOfTimes().onCall { id: Identifier.IoTransaction32 =>
+      (transactionStore.contains _).expects(*).anyNumberOfTimes().onCall { id: TransactionId =>
         transactionStoreData.contains(id).pure[F]
       }
 
       val clientTxsData = missedTxs.toMap
-      (client.getRemoteTransaction _).expects(*).anyNumberOfTimes().onCall { id: Identifier.IoTransaction32 =>
+      (client.getRemoteTransaction _).expects(*).anyNumberOfTimes().onCall { id: TransactionId =>
         clientTxsData.get(id).pure[F]
       }
 
       val downloadedTxs =
-        mutable.Map.empty[Identifier.IoTransaction32, IoTransaction]
-      (transactionStore.put _).expects(*, *).anyNumberOfTimes().onCall {
-        case (id: Identifier.IoTransaction32, tx: IoTransaction) =>
-          downloadedTxs.put(id, tx).pure[F].void
+        mutable.Map.empty[TransactionId, IoTransaction]
+      (transactionStore.put _).expects(*, *).anyNumberOfTimes().onCall { case (id: TransactionId, tx: IoTransaction) =>
+        downloadedTxs.put(id, tx).pure[F].void
       }
 
       val incorrectTxRoot: TxRoot = ModelGenerators.txRoot.first
@@ -217,7 +215,7 @@ class PeerBlockBodyFetcherTest
     withMock {
       val client = mock[BlockchainPeerClient[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
-      val transactionStore = mock[Store[F, Identifier.IoTransaction32, IoTransaction]]
+      val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
 
       val transactionsAndBody =
@@ -234,7 +232,7 @@ class PeerBlockBodyFetcherTest
 
       val idAndBody = idBodyTxIdTx.map(d => (d._1, d._2))
 
-      def transactionIsMissed(id:  Identifier.IoTransaction32): Boolean = id.hashCode() % 7 == 0
+      def transactionIsMissed(id:  TransactionId): Boolean = id.hashCode() % 7 == 0
       def blockIsMissed(blockBody: BlockBody): Boolean = blockBody.transactionIds.exists(transactionIsMissed)
 
       val presentBlockIdAndBodies = idAndBody.toList
@@ -250,7 +248,7 @@ class PeerBlockBodyFetcherTest
       (transactionStore.contains _).expects(*).anyNumberOfTimes().returning(false.pure[F])
 
       val clientTxsData = txIdsAndTxs.toMap
-      (client.getRemoteTransaction _).expects(*).anyNumberOfTimes().onCall { id: Identifier.IoTransaction32 =>
+      (client.getRemoteTransaction _).expects(*).anyNumberOfTimes().onCall { id: TransactionId =>
         if (transactionIsMissed(id)) {
           Option.empty[IoTransaction].pure[F]
         } else {
@@ -298,7 +296,7 @@ class PeerBlockBodyFetcherTest
     withMock {
       val client = mock[BlockchainPeerClient[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
-      val transactionStore = mock[Store[F, Identifier.IoTransaction32, IoTransaction]]
+      val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
 
       val transactionsAndBody =
@@ -313,7 +311,7 @@ class PeerBlockBodyFetcherTest
             (id, body, txs.map(tx => (tx.id, tx)))
           }
 
-      def transactionHaveIncorrectId(id: Identifier.IoTransaction32): Boolean = id.hashCode() % 7 == 0
+      def transactionHaveIncorrectId(id: TransactionId): Boolean = id.hashCode() % 7 == 0
 
       def blockIsMissed(blockBody: BlockBody): Boolean = blockBody.transactionIds.exists(transactionHaveIncorrectId)
 
@@ -335,7 +333,7 @@ class PeerBlockBodyFetcherTest
       (transactionStore.contains _).expects(*).anyNumberOfTimes().returning(false.pure[F])
 
       val clientTxsData = txIdsAndTxs.toMap
-      (client.getRemoteTransaction _).expects(*).anyNumberOfTimes().onCall { id: Identifier.IoTransaction32 =>
+      (client.getRemoteTransaction _).expects(*).anyNumberOfTimes().onCall { id: TransactionId =>
         if (transactionHaveIncorrectId(id)) {
           Option(incorrectTransaction).pure[F]
         } else {
@@ -385,7 +383,7 @@ class PeerBlockBodyFetcherTest
     withMock {
       val client = mock[BlockchainPeerClient[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
-      val transactionStore = mock[Store[F, Identifier.IoTransaction32, IoTransaction]]
+      val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
 
       val (txs, bodies) =
@@ -408,20 +406,19 @@ class PeerBlockBodyFetcherTest
       }
 
       val transactionStoreData = presentTxs.toMap
-      (transactionStore.contains _).expects(*).rep(txIdsAndTxs.size).onCall { id: Identifier.IoTransaction32 =>
+      (transactionStore.contains _).expects(*).rep(txIdsAndTxs.size).onCall { id: TransactionId =>
         transactionStoreData.contains(id).pure[F]
       }
 
       val clientTxsData = missedTxs.toMap
-      (client.getRemoteTransaction _).expects(*).rep(missedTxs.size).onCall { id: Identifier.IoTransaction32 =>
+      (client.getRemoteTransaction _).expects(*).rep(missedTxs.size).onCall { id: TransactionId =>
         clientTxsData.get(id).pure[F]
       }
 
       val downloadedTxs =
-        mutable.Map.empty[Identifier.IoTransaction32, IoTransaction]
-      (transactionStore.put _).expects(*, *).rep(missedTxs.size).onCall {
-        case (id: Identifier.IoTransaction32, tx: IoTransaction) =>
-          downloadedTxs.put(id, tx).pure[F].void
+        mutable.Map.empty[TransactionId, IoTransaction]
+      (transactionStore.put _).expects(*, *).rep(missedTxs.size).onCall { case (id: TransactionId, tx: IoTransaction) =>
+        downloadedTxs.put(id, tx).pure[F].void
       }
 
       (headerToBodyValidation.validate _).expects(*).rep(blockIdsAndBodies.size.toInt).onCall { block: Block =>

--- a/node/src/it/scala/co/topl/node/NodeAppTest.scala
+++ b/node/src/it/scala/co/topl/node/NodeAppTest.scala
@@ -9,16 +9,11 @@ import co.topl.algebras.{SynchronizationTraversalSteps, ToplRpc}
 import co.topl.blockchain.PrivateTestnet
 import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
 import co.topl.brambl.common.ContainsSignable.instances.ioTransactionSignable
-import co.topl.brambl.models.Datum
-import co.topl.brambl.models.Event
-import co.topl.brambl.models.Identifier
-import co.topl.brambl.models.TransactionOutputAddress
+import co.topl.brambl.models._
 import co.topl.brambl.models.box.Attestation
-import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.models.transaction.Schedule
-import co.topl.brambl.models.transaction.SpentTransactionOutput
-import co.topl.brambl.models.transaction.UnspentTransactionOutput
-import co.topl.codecs.bytes.tetra.instances.ioTransactionAsIoTransactionOps
+import co.topl.brambl.models.transaction._
+import co.topl.brambl.syntax._
+import co.topl.codecs.bytes.tetra.instances._
 import co.topl.consensus.models.BlockId
 import co.topl.grpc.ToplGrpc
 import co.topl.quivr.api.Prover
@@ -185,7 +180,7 @@ class NodeAppTest extends CatsEffectSuite {
       .map(_.get)
       .map { t =>
         val index = t.outputs.indexWhere(_.address == PrivateTestnet.HeightLockOneSpendingAddress)
-        val address = TransactionOutputAddress(0, 0, index, TransactionOutputAddress.Id.IoTransaction32(t.id))
+        val address = t.id.outputAddress(0, 0, index)
         (address, t.outputs(index))
       }
 
@@ -229,7 +224,7 @@ class NodeAppTest extends CatsEffectSuite {
 
   private def confirmTransaction(
     client: RpcClient
-  )(id: Identifier.IoTransaction32, confirmationDepth: Int = 3): F[Unit] = {
+  )(id: TransactionId, confirmationDepth: Int = 3): F[Unit] = {
     def containsTransaction(targetBlock: BlockId): F[Boolean] =
       client
         .fetchBlockBody(targetBlock)

--- a/node/src/main/scala/co/topl/genus/GenusGrpc.scala
+++ b/node/src/main/scala/co/topl/genus/GenusGrpc.scala
@@ -23,7 +23,7 @@ object GenusGrpc {
       transactionFetcherAlgebra: TransactionFetcherAlgebra[F]
     ): Resource[F, Server] =
       for {
-        fullBlockService <- GenusFullBlockServiceFs2Grpc.bindServiceResource(
+        fullBlockService <- BlockServiceFs2Grpc.bindServiceResource(
           new GrpcGenusFullBlockService(blockFetcher)
         )
         transactionService <- TransactionServiceFs2Grpc.bindServiceResource(

--- a/node/src/main/scala/co/topl/genus/GrpcGenusFullBlockService.scala
+++ b/node/src/main/scala/co/topl/genus/GrpcGenusFullBlockService.scala
@@ -12,7 +12,7 @@ import co.topl.typeclasses.implicits._
 import io.grpc.Metadata
 
 class GrpcGenusFullBlockService[F[_]: Async](blockFetcher: BlockFetcherAlgebra[F])
-    extends GenusFullBlockServiceFs2Grpc[F, Metadata] {
+    extends BlockServiceFs2Grpc[F, Metadata] {
 
   override def getBlockById(request: GetBlockByIdRequest, ctx: Metadata): F[BlockResponse] =
     EitherT(blockFetcher.fetchBlock(request.blockId))

--- a/node/src/main/scala/co/topl/node/DataStores.scala
+++ b/node/src/main/scala/co/topl/node/DataStores.scala
@@ -8,7 +8,7 @@ import cats.Applicative
 import cats.Monad
 import cats.MonadThrow
 import co.topl.algebras.Store
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.Persistable
@@ -35,8 +35,8 @@ case class DataStores[F[_]](
   slotData:        Store[F, BlockId, SlotData],
   headers:         Store[F, BlockId, BlockHeader],
   bodies:          Store[F, BlockId, BlockBody],
-  transactions:    Store[F, Identifier.IoTransaction32, IoTransaction], // TODO replace old Transaction model
-  spendableBoxIds: Store[F, Identifier.IoTransaction32, NonEmptySet[Short]],
+  transactions:    Store[F, TransactionId, IoTransaction], // TODO replace old Transaction model
+  spendableBoxIds: Store[F, TransactionId, NonEmptySet[Short]],
   epochBoundaries: Store[F, Long, BlockId],
   operatorStakes:  Store[F, StakingAddress, BigInt],
   activeStake:     Store[F, Unit, BigInt],
@@ -74,15 +74,15 @@ object DataStores {
         appConfig.bifrost.cache.bodies,
         _.value
       )
-      transactionStore <- makeCachedDb[F, Identifier.IoTransaction32, ByteString, IoTransaction](dataDir)(
+      transactionStore <- makeCachedDb[F, TransactionId, ByteString, IoTransaction](dataDir)(
         "transactions",
         appConfig.bifrost.cache.transactions,
-        _.evidence.digest.value
+        _.value
       )
-      spendableBoxIdsStore <- makeCachedDb[F, Identifier.IoTransaction32, ByteString, NonEmptySet[Short]](dataDir)(
+      spendableBoxIdsStore <- makeCachedDb[F, TransactionId, ByteString, NonEmptySet[Short]](dataDir)(
         "spendable-box-ids",
         appConfig.bifrost.cache.spendableBoxIds,
-        _.evidence.digest.value
+        _.value
       )
       epochBoundariesStore <- makeCachedDb[F, Long, java.lang.Long, BlockId](dataDir)(
         "epoch-boundaries",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,9 +11,9 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.18"
-  val protobufSpecsVersion = "b745cb1" // scala-steward:off
-  val bramblScVersion = "5794d14" // scala-steward:off
-  val quivr4sVersion = "8de3426" // scala-steward:off
+  val protobufSpecsVersion = "110e109" // scala-steward:off
+  val bramblScVersion = "244c88f" // scala-steward:off
+  val quivr4sVersion = "ef50d78" // scala-steward:off
 
   val catsSlf4j =
     "org.typelevel" %% "log4cats-slf4j" % "2.6.0"
@@ -124,7 +124,7 @@ object Dependencies {
   val quivr4s = "com.github.Topl"                  % "quivr4s"    % quivr4sVersion
 
   val protobufSpecs: Seq[ModuleID] = Seq(
-    "com.github.Topl" % "protobuf-specs" % protobufSpecsVersion
+    "com.github.Topl.protobuf-specs" %% "protobuf-fs2" % protobufSpecsVersion
   )
 
   // For NTP-UDP

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,9 +11,9 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.18"
-  val protobufSpecsVersion = "110e109" // scala-steward:off
-  val bramblScVersion = "244c88f" // scala-steward:off
-  val quivr4sVersion = "ef50d78" // scala-steward:off
+  val protobufSpecsVersion = "ba616f0" // scala-steward:off
+  val bramblScVersion = "ddc8bd1" // scala-steward:off
+  val quivr4sVersion = "30bb9d2" // scala-steward:off
 
   val catsSlf4j =
     "org.typelevel" %% "log4cats-slf4j" % "2.6.0"

--- a/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/app/Orchestrator.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/app/Orchestrator.scala
@@ -6,7 +6,7 @@ import cats.effect._
 import cats.effect.std.Random
 import cats.implicits._
 import co.topl.algebras.{SynchronizationTraversalSteps, ToplRpc}
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.common.application.IOBaseApp
 import co.topl.grpc.ToplGrpc
 import co.topl.interpreters.MultiToplRpc
@@ -189,7 +189,7 @@ object Orchestrator
 
   private def publishBlockBodiesAndAssignTransactions(publisher: Publisher, nodes: NodeRpcs)(
     blockAssignments: List[(NodeName, BlockId, BlockHeader)]
-  ): F[Map[Identifier.IoTransaction32, NodeName]] =
+  ): F[Map[TransactionId, NodeName]] =
     for {
       // Create a topic which is expected to contain two subscribers
       blockDatumTopic <- Topic[F, (NodeName, BlockDatum)]
@@ -206,7 +206,7 @@ object Orchestrator
       assignTransactionsStream =
         blockDatumTopic
           .subscribe(128)
-          .fold(Map.empty[Identifier.IoTransaction32, NodeName]) { case (assignments, (node, datum)) =>
+          .fold(Map.empty[TransactionId, NodeName]) { case (assignments, (node, datum)) =>
             assignments ++ datum.body.transactionIds.tupleRight(node)
           }
       // Publish the block data results

--- a/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/interpreters/GcpCsvDataPublisher.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/interpreters/GcpCsvDataPublisher.scala
@@ -123,7 +123,7 @@ object GcpCsvDataPublisher {
       datum.transaction.inputs
         .map(input =>
           List(
-            s"${input.address.getIoTransaction32.show}[${input.address.index}]",
+            s"${input.address.id.show}[${input.address.index}]",
             ByteString.EMPTY,
             ByteString.EMPTY,
             input.value.value match {
@@ -139,7 +139,7 @@ object GcpCsvDataPublisher {
       datum.transaction.outputs
         .map(output =>
           List(
-            output.address.getLock32.evidence.digest.value.show,
+            output.address.id.value.show,
             output.value.value match {
               case Value.Value.Empty    => "E"
               case v: Value.Value.Lvl   => s"L(${v.value.quantity: BigInt})"

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraIdentifiableInstances.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraIdentifiableInstances.scala
@@ -1,14 +1,14 @@
 package co.topl.codecs.bytes.tetra
 
 import co.topl.brambl.common.ContainsSignable.instances.ioTransactionSignable
-import co.topl.brambl.models.Identifier
 import co.topl.brambl.models.common.ImmutableBytes
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockHeader
 import co.topl.consensus.models.BlockId
 import co.topl.crypto.hash.Blake2b256
-
 import co.topl.brambl.common._
+import co.topl.brambl.models.TransactionId
+
 import scala.language.implicitConversions
 
 trait ProtoIdentifiableOps {
@@ -22,12 +22,12 @@ trait ProtoIdentifiableOps {
 
 class IoTransactionIdOps(val transaction: IoTransaction) extends AnyVal {
 
-  def id: Identifier.IoTransaction32 = {
+  def id: TransactionId = {
     import IoTransactionIdOps._
     val signableBytes = ContainsSignable[IoTransaction].signableBytes(transaction)
     val immutable = ImmutableBytes(signableBytes.value)
-    val evidence = ContainsEvidence[ImmutableBytes].sized32Evidence(immutable)
-    Identifier.IoTransaction32(evidence)
+    val evidence = ContainsEvidence[ImmutableBytes].sizedEvidence(immutable)
+    TransactionId(evidence.digest.value)
   }
 
 }

--- a/topl-grpc/src/main/scala/co/topl/grpc/ToplGrpc.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/ToplGrpc.scala
@@ -9,7 +9,7 @@ import cats.Now
 import co.topl.algebras.SynchronizationTraversalStep
 import co.topl.algebras.SynchronizationTraversalSteps
 import co.topl.algebras.ToplRpc
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models._
 import co.topl.node.models.BlockBody
@@ -58,7 +58,7 @@ object ToplGrpc {
                 )
                 .void
 
-            def currentMempool(): F[Set[Identifier.IoTransaction32]] =
+            def currentMempool(): F[Set[TransactionId]] =
               client
                 .currentMempool(
                   CurrentMempoolReq(),
@@ -66,9 +66,7 @@ object ToplGrpc {
                 )
                 .map(_.transactionIds.toSet)
 
-            def fetchBlockHeader(
-              blockId: BlockId
-            ): F[Option[BlockHeader]] =
+            def fetchBlockHeader(blockId: BlockId): F[Option[BlockHeader]] =
               client
                 .fetchBlockHeader(
                   FetchBlockHeaderReq(blockId),
@@ -84,9 +82,7 @@ object ToplGrpc {
                 )
                 .map(_.body)
 
-            def fetchTransaction(
-              transactionId: Identifier.IoTransaction32
-            ): F[Option[IoTransaction]] =
+            def fetchTransaction(transactionId: TransactionId): F[Option[IoTransaction]] =
               client
                 .fetchTransaction(FetchTransactionReq(transactionId), new Metadata())
                 .map(_.transaction)

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/TransactionGeneratorApp.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/TransactionGeneratorApp.scala
@@ -6,7 +6,7 @@ import cats.effect._
 import cats.effect.std.Random
 import cats.implicits._
 import co.topl.algebras.ToplRpc
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.common.application._
@@ -122,8 +122,8 @@ object TransactionGeneratorApp
       .compile
       .drain
 
-  implicit private val showMempool: Show[Set[Identifier.IoTransaction32]] =
-    catsStdShowForSet(showIoTransaction32Id)
+  implicit private val showMempool: Show[Set[TransactionId]] =
+    catsStdShowForSet(showIoTransactionId)
 
   /**
    * Periodically poll and log the state of the mempool.

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/package.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/package.scala
@@ -1,10 +1,9 @@
 package co.topl.transactiongenerator
 
-import co.topl.brambl.common.ContainsEvidence
-import co.topl.brambl.common.ContainsImmutable.instances.lockImmutable
 import co.topl.brambl.models._
 import co.topl.brambl.models.box._
 import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.transactiongenerator.models.Wallet
 import quivr.models._
@@ -32,18 +31,7 @@ package object interpreters {
     )
 
   val HeightLockOneSpendingAddress: LockAddress =
-    lockAddressOf(HeightLockOneLock)
-
-  def lockAddressOf(lock: Lock): LockAddress =
-    LockAddress(
-      0,
-      0,
-      LockAddress.Id.Lock32(
-        Identifier.Lock32(
-          ContainsEvidence[Lock].sized32Evidence(lock)
-        )
-      )
-    )
+    HeightLockOneLock.lockAddress(0, 0)
 
   val emptyWallet: Wallet =
     Wallet(
@@ -63,7 +51,7 @@ package object interpreters {
         .get(output.address)
         .map(lock =>
           (
-            TransactionOutputAddress(0, 0, index, TransactionOutputAddress.Id.IoTransaction32(transactionId)),
+            transactionId.outputAddress(0, 0, index),
             Box(lock, output.value)
           )
         )

--- a/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTransactions.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ContainsTransactions.scala
@@ -3,7 +3,7 @@ package co.topl.typeclasses
 import cats.Foldable
 import cats.data.ValidatedNec
 import cats.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.codecs.bytes.tetra.instances.ioTransactionAsIoTransactionOps
 import co.topl.crypto.accumulators.LeafData
@@ -23,7 +23,7 @@ import simulacrum.op
 import simulacrum.typeclass
 
 @typeclass trait ContainsTransactionIds[T] {
-  @op("transactionIds") def transactionIds(t: T): Seq[Identifier.IoTransaction32]
+  @op("transactionIds") def transactionIds(t: T): Seq[TransactionId]
 
   @op("merkleTree") def merkleTreeOf(t: T): MerkleTree[Blake2b, Digest32] = {
     // The current MerkleTree implementation will, by default, use a shared digest and hash instance,
@@ -36,7 +36,7 @@ import simulacrum.typeclass
       override def bytes(d: Digest32): Array[Byte] = d.value
     }
     implicit val hash: Blake2bHash[Digest32] = new Blake2bHash[Digest32] {}
-    MerkleTree[Blake2b, Digest32](transactionIds(t).map(id => LeafData(id.evidence.digest.value.toByteArray)))
+    MerkleTree[Blake2b, Digest32](transactionIds(t).map(id => LeafData(id.value.toByteArray)))
   }
 
   @op("merkleTreeRootHash") def merkleTreeRootHashOf(t: T): TxRoot =

--- a/typeclasses/src/main/scala/co/topl/typeclasses/EqInstances.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/EqInstances.scala
@@ -2,7 +2,7 @@ package co.topl.typeclasses
 
 import cats.Eq
 import cats.implicits._
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.crypto.generation.mnemonic.Entropy
 import co.topl.models._
 import co.topl.models.utility.Sized
@@ -32,8 +32,8 @@ trait EqInstances {
   implicit val blockIdEq: Eq[BlockId] =
     (a, b) => a.value === b.value
 
-  implicit val transactionIdEq: Eq[Identifier.IoTransaction32] =
-    (a, b) => a.evidence.digest.value === b.evidence.digest.value
+  implicit val transactionIdEq: Eq[TransactionId] =
+    (a, b) => a.value === b.value
 
   implicit val eqSlotData: Eq[SlotData] =
     Eq.fromUniversalEquals

--- a/typeclasses/src/main/scala/co/topl/typeclasses/ShowInstances.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ShowInstances.scala
@@ -2,6 +2,7 @@ package co.topl.typeclasses
 
 import cats.Show
 import cats.implicits._
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.consensus.models.BlockHeader
@@ -22,8 +23,8 @@ trait ShowInstances {
   implicit def showSizedBytes[Data: Show, L <: Length](implicit l: L): Show[Sized.Strict[Data, L]] =
     sized => show"[${l.value}](${sized.data})"
 
-  implicit val showIoTransaction32Id: Show[co.topl.brambl.models.Identifier.IoTransaction32] =
-    t => show"t_${t.evidence.digest.value: Bytes}"
+  implicit val showIoTransactionId: Show[TransactionId] =
+    t => show"t_${t.value: Bytes}"
 
   implicit val showBlockId: Show[co.topl.consensus.models.BlockId] =
     b => show"b_${b.value: Bytes}"
@@ -55,11 +56,6 @@ trait ShowInstances {
 
   implicit val showNodeBlockBody: Show[BlockBody] =
     body => show"${body.transactionIds}"
-
-  implicit val showTransactionOutputAddressId: Show[TransactionOutputAddress.Id] = {
-    case TransactionOutputAddress.Id.IoTransaction32(value) => value.show
-    case t                                                  => throw new MatchError(t)
-  }
 
   implicit val showBoxId: Show[TransactionOutputAddress] =
     boxId => show"${boxId.id}.outputs[${boxId.index}]"


### PR DESCRIPTION
## Purpose
- protobuf-specs [introduces](https://github.com/Topl/protobuf-specs/pull/54) TransactionId type to replace Identifier.IoTransaction32
- protobuf-specs removes 32/64 distinctions in types
- Updates to [BramblSc](https://github.com/Topl/BramblSc/pull/47) and [quivr](https://github.com/Topl/quivr4s/pull/38)
## Approach
- Update all broken code references
## Testing
- preparePR, NodeAppTest
## Tickets
- #BN-963