### PR TITLE
Multi-RPC Stream Subscribers Fix

### DIFF
--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/ChainSelectionTest.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/ChainSelectionTest.scala
@@ -23,7 +23,7 @@ class ChainSelectionTest extends IntegrationSuite {
   override def munitTimeout: Duration = 12.minutes
 
   test("Disconnected nodes can forge independently and later sync up to a proper chain") {
-    val epochSlotLength = 500 // (50/4) * (100/15) * 6
+    val epochSlotLength: Long = 6 * 50 // See co.topl.node.ApplicationConfig.Bifrost.Protocol
     val bigBang = Instant.now().plusSeconds(30)
     val stakes = List(BigInt(500), BigInt(400), BigInt(300)).some
     val config0 =

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/MultiNodeTest.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/MultiNodeTest.scala
@@ -15,7 +15,7 @@ class MultiNodeTest extends IntegrationSuite {
   override def munitTimeout: Duration = 15.minutes
 
   test("Multiple nodes launch and maintain consensus for three epochs") {
-    val epochSlotLength = 500 // (50/4) * (100/15) * 6
+    val epochSlotLength: Long = 6 * 50 // See co.topl.node.ApplicationConfig.Bifrost.Protocol
     val bigBang = Instant.now().plusSeconds(30)
     val config0 = TestNodeConfig(bigBang, 3, 0, Nil)
     val config1 = TestNodeConfig(bigBang, 3, 1, List("MultiNodeTest-node0"))

--- a/node/src/it/scala/co/topl/node/NodeAppTest.scala
+++ b/node/src/it/scala/co/topl/node/NodeAppTest.scala
@@ -59,7 +59,7 @@ class NodeAppTest extends CatsEffectSuite {
         |    0:
         |      slot-duration: 500 milli
         |genus:
-        |  enable: false
+        |  enable: true
         |  rpc-node-port: 9151
         |""".stripMargin
     val configNodeB =


### PR DESCRIPTION
## Purpose
- Two subscribers to the gRPC Block Adoptions stream cause some sort of conflict
## Approach
- Don't pre-emptively subscribeAwait on the local adoptions topic when constructing the gRPC Server
- Also fix byzantine tests epoch length
## Testing
- Ad-hoc test [success](https://github.com/Topl/Bifrost/actions/runs/4800364773)
## Tickets
N/A