### PR TITLE
BN-996 Process get new best chain after error

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/interpreters/BlockchainPeerServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/interpreters/BlockchainPeerServer.scala
@@ -88,7 +88,8 @@ object BlockchainPeerServer {
               blockIdOpt <- blockHeights.useStateAt(head.slotId.blockId)(_.apply(height))
             } yield blockIdOpt
 
-          def getCurrentTip: F[Option[SlotData]] = localChain.head.map(Option.apply)
+          def getLocalBlockAtDepth(depth: Long): F[Option[BlockId]] =
+            localChain.head.flatMap(s => getLocalBlockAtHeight(s.height - depth))
         }
       )
 }

--- a/blockchain/src/main/scala/co/topl/blockchain/interpreters/BlockchainPeerServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/interpreters/BlockchainPeerServer.scala
@@ -87,6 +87,8 @@ object BlockchainPeerServer {
               head       <- localChain.head
               blockIdOpt <- blockHeights.useStateAt(head.slotId.blockId)(_.apply(height))
             } yield blockIdOpt
+
+          def getCurrentTip: F[Option[SlotData]] = localChain.head.map(Option.apply)
         }
       )
 }

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
@@ -37,10 +37,14 @@ trait BlockchainPeerClient[F[_]] {
   def remoteTransactionNotifications: F[Stream[F, TransactionId]]
 
   /**
-   * A lookup to retrieve a remote best slot data for block
-   * @return
+   * A lookup to retrieve a remote block at depth, where depth=0 is the best tip, and depth=1 is the parent of best tip
    */
-  def remoteCurrentTip(): F[Option[SlotData]]
+  def getRemoteBlockIdAtDepth(depth: Long): F[Option[BlockId]]
+
+  /**
+   * A lookup to retrieve a remote best block id
+   */
+  def remoteCurrentTip(): F[Option[BlockId]] = getRemoteBlockIdAtDepth(0)
 
   /**
    * A Lookup to retrieve a remote SlotData by ID

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
@@ -37,6 +37,12 @@ trait BlockchainPeerClient[F[_]] {
   def remoteTransactionNotifications: F[Stream[F, TransactionId]]
 
   /**
+   * A lookup to retrieve a remote best slot data for block
+   * @return
+   */
+  def remoteCurrentTip(): F[Option[SlotData]]
+
+  /**
    * A Lookup to retrieve a remote SlotData by ID
    */
   def getRemoteSlotData(id: BlockId): F[Option[SlotData]]

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactory.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactory.scala
@@ -94,6 +94,15 @@ object BlockchainPeerConnectionFlowFactory {
           14: Byte
         )
 
+    val currentTipRecipF =
+      TypedProtocolSetFactory.CommonProtocols
+        .requestResponseReciprocated[F, Unit, SlotData](
+          BlockchainProtocols.CurrentTip,
+          _ => protocolServer.getCurrentTip,
+          15: Byte,
+          16: Byte
+        )
+
     (connectedPeer: ConnectedPeer, connectionLeader: ConnectionLeader) =>
       for {
         (adoptionTypedSubHandlers, remoteBlockIdsSource) <- blockAdoptionRecipF.ap(connectionLeader.pure[F])
@@ -105,6 +114,7 @@ object BlockchainPeerConnectionFlowFactory {
         (bodyTypedSubHandlers, bodyReceivedCallback)               <- bodyRecipF.ap(connectionLeader.pure[F])
         (transactionTypedSubHandlers, transactionReceivedCallback) <- transactionRecipF.ap(connectionLeader.pure[F])
         (idAtHeightTypedSubHandlers, heightIdReceivedCallback)     <- idAtHeightRecipF.ap(connectionLeader.pure[F])
+        (currentTipTypedSubHandlers, currentTipReceivedCallback)   <- currentTipRecipF.ap(connectionLeader.pure[F])
         blockchainProtocolClient = new BlockchainPeerClient[F] {
           val remotePeer: F[ConnectedPeer] = connectedPeer.pure[F]
           val remotePeerAdoptions: F[Stream[F, BlockId]] = remoteBlockIdsSource.pure[F]
@@ -115,11 +125,9 @@ object BlockchainPeerConnectionFlowFactory {
           def getRemoteBody(id:     BlockId): F[Option[BlockBody]] = bodyReceivedCallback(id)
           def getRemoteTransaction(id: TransactionId): F[Option[IoTransaction]] =
             transactionReceivedCallback(id)
-          def getRemoteBlockIdAtHeight(
-            height:       Long,
-            localBlockId: Option[BlockId]
-          ): F[Option[BlockId]] =
+          def getRemoteBlockIdAtHeight(height: Long, localBlockId: Option[BlockId]): F[Option[BlockId]] =
             heightIdReceivedCallback((height, localBlockId))
+          def remoteCurrentTip(): F[Option[SlotData]] = currentTipReceivedCallback(())
         }
         subHandlers =
           adoptionTypedSubHandlers ++
@@ -128,7 +136,8 @@ object BlockchainPeerConnectionFlowFactory {
             headerTypedSubHandlers ++
             bodyTypedSubHandlers ++
             transactionTypedSubHandlers ++
-            idAtHeightTypedSubHandlers
+            idAtHeightTypedSubHandlers ++
+            currentTipTypedSubHandlers
       } yield subHandlers -> blockchainProtocolClient
   }
 

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServerAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServerAlgebra.scala
@@ -19,4 +19,5 @@ trait BlockchainPeerServerAlgebra[F[_]] {
   def getLocalBody(id:              BlockId): F[Option[BlockBody]]
   def getLocalTransaction(id:       TransactionId): F[Option[IoTransaction]]
   def getLocalBlockAtHeight(height: Long): F[Option[BlockId]]
+  def getCurrentTip: F[Option[SlotData]]
 }

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServerAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServerAlgebra.scala
@@ -19,5 +19,5 @@ trait BlockchainPeerServerAlgebra[F[_]] {
   def getLocalBody(id:              BlockId): F[Option[BlockBody]]
   def getLocalTransaction(id:       TransactionId): F[Option[IoTransaction]]
   def getLocalBlockAtHeight(height: Long): F[Option[BlockId]]
-  def getCurrentTip: F[Option[SlotData]]
+  def getLocalBlockAtDepth(depth:   Long): F[Option[BlockId]]
 }

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainProtocols.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainProtocols.scala
@@ -59,6 +59,11 @@ object BlockchainProtocols {
   object BlockIdAtHeight extends RequestResponseProtocol[(Long, Option[BlockId]), BlockId]
 
   /**
+   * Request current best tip from remote Node
+   */
+  object CurrentTip extends RequestResponseProtocol[Unit, SlotData]
+
+  /**
    * Notifies a client node every time the server adopts a new Block
    *
    * This protocol runs a server and client in parallel for each connection.

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainProtocols.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainProtocols.scala
@@ -61,7 +61,7 @@ object BlockchainProtocols {
   /**
    * Request current best tip from remote Node
    */
-  object CurrentTip extends RequestResponseProtocol[Unit, SlotData]
+  object BlockIdAtDepth extends RequestResponseProtocol[Long, BlockId]
 
   /**
    * Notifies a client node every time the server adopts a new Block

--- a/networking/src/main/scala/co/topl/networking/blockchain/NetworkTypeTags.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/NetworkTypeTags.scala
@@ -37,6 +37,9 @@ object NetworkTypeTags {
     : NetworkTypeTag[TypedProtocol.CommonMessages.Get[(Long, Option[BlockId])]] =
     NetworkTypeTag.create("TypedProtocol.CommonMessages.Get[(Long, BlockId)]")
 
+  implicit val commonMessagesGetUnitTypedCurrentTipTypeTag: NetworkTypeTag[TypedProtocol.CommonMessages.Get[Unit]] =
+    NetworkTypeTag.create("TypedProtocol.CommonMessages.Get[Unit]")
+
   implicit val commonMessagesResponseSlotDataNetworkTypeTag
     : NetworkTypeTag[TypedProtocol.CommonMessages.Response[SlotData]] =
     NetworkTypeTag.create("TypedProtocol.CommonMessages.Response[SlotData]")

--- a/networking/src/main/scala/co/topl/networking/blockchain/NetworkTypeTags.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/NetworkTypeTags.scala
@@ -37,8 +37,8 @@ object NetworkTypeTags {
     : NetworkTypeTag[TypedProtocol.CommonMessages.Get[(Long, Option[BlockId])]] =
     NetworkTypeTag.create("TypedProtocol.CommonMessages.Get[(Long, BlockId)]")
 
-  implicit val commonMessagesGetUnitTypedCurrentTipTypeTag: NetworkTypeTag[TypedProtocol.CommonMessages.Get[Unit]] =
-    NetworkTypeTag.create("TypedProtocol.CommonMessages.Get[Unit]")
+  implicit val commonMessagesGetLongTypedCurrentTipTypeTag: NetworkTypeTag[TypedProtocol.CommonMessages.Get[Long]] =
+    NetworkTypeTag.create("TypedProtocol.CommonMessages.Get[Long]")
 
   implicit val commonMessagesResponseSlotDataNetworkTypeTag
     : NetworkTypeTag[TypedProtocol.CommonMessages.Response[SlotData]] =

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -63,6 +63,7 @@ object ActorPeerHandlerBridgeAlgebra {
         hostId <- client.remotePeer.map(_.remoteAddress.host)
         _      <- peersManager.sendNoWait(PeersManager.Message.SetupPeer(hostId, client))
         _      <- peersManager.sendNoWait(PeersManager.Message.UpdatePeerStatus(hostId, PeerState.Hot))
+        _      <- peersManager.sendNoWait(PeersManager.Message.GetCurrentTip(hostId))
       } yield ()
   }
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
@@ -447,6 +447,7 @@ object BlockChecker {
     if (invalidBlockOnCurrentBestChain) {
       val newState = state.copy(bestKnownRemoteSlotDataOpt = None, bestKnownRemoteSlotDataHost = None)
       Logger[F].error("clean current best chain due error in validation") >>
+      state.requestsProxy.sendNoWait(RequestsProxy.Message.GetCurrentTips) >>
       newState.pure[F]
     } else {
       state.pure[F]

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -192,8 +192,8 @@ object PeerBlockHeaderFetcher {
     for {
       _   <- OptionT.liftF(Logger[F].info(s"Requested current tip from host ${state.hostId}"))
       tip <- OptionT(state.client.remoteCurrentTip())
-      _   <- buildAndAdoptSlotDataForBlockId(state, tip.slotId.blockId)
-      _   <- OptionT.liftF(Logger[F].info(show"Send tip ${tip.slotId.blockId} from host ${state.hostId}"))
+      _   <- buildAndAdoptSlotDataForBlockId(state, tip)
+      _   <- OptionT.liftF(Logger[F].info(show"Send tip $tip from host ${state.hostId}"))
     } yield (state, state)
   }.getOrElse((state, state))
     .handleErrorWith(Logger[F].error(_)("Get tip from remote host return error") >> (state, state).pure[F])

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -33,6 +33,11 @@ object PeerBlockHeaderFetcher {
      * @param blockIds headers block id to download
      */
     case class DownloadBlockHeaders(blockIds: NonEmptyChain[BlockId]) extends Message
+
+    /**
+     * Get current tip from remote peer
+     */
+    case object GetCurrentTip extends Message
   }
 
   case class State[F[_]](
@@ -53,6 +58,7 @@ object PeerBlockHeaderFetcher {
     case (state, Message.StartActor)               => startActor(state)
     case (state, Message.StopActor)                => stopActor(state)
     case (state, Message.DownloadBlockHeaders(id)) => downloadHeaders(state, id)
+    case (state, Message.GetCurrentTip)            => getCurrentTip(state)
   }
 
   def makeActor[F[_]: Async: Logger](
@@ -86,19 +92,26 @@ object PeerBlockHeaderFetcher {
     newBlockIdsStream.evalMap { blockId =>
       {
         for {
-          _              <- OptionT.liftF(Logger[F].info(show"Got slot for $blockId from remote host ${state.hostId}"))
-          newBlockId     <- isUnknownBlockOpt(state, blockId)
-          remoteSlotData <- adoptRemoteSlotData(state, newBlockId)
-          betterSlotData <- compareWithLocalChain(remoteSlotData, state)
-          _              <- OptionT.liftF(sendProposalToBlockChecker(state, betterSlotData))
+          _          <- OptionT.liftF(Logger[F].info(show"Got slot for $blockId from remote host ${state.hostId}"))
+          newBlockId <- isUnknownBlockOpt(state, blockId)
+          _          <- buildAndAdoptSlotDataForBlockId(state, newBlockId)
         } yield ()
       }.value.void.handleErrorWith(Logger[F].error(_)("Fetching slot data from remote host return error"))
     }
 
-  private def isUnknownBlockOpt[F[_]: Async: Logger](
-    state:   State[F],
-    blockId: BlockId
-  ): OptionT[F, BlockId] =
+  private def buildAndAdoptSlotDataForBlockId[F[_]: Async: Logger](
+    state:      State[F],
+    newBlockId: BlockId
+  ): OptionT[F, Unit] =
+    for {
+      slotDataChain  <- buildSlotDataChain(state.slotDataStore, state.client, newBlockId)
+      _              <- OptionT.liftF(Logger[F].info(show"Retrieved remote tine length=${slotDataChain.length}"))
+      savedSlotData  <- OptionT.liftF(saveSlotDataChain(state, slotDataChain))
+      betterSlotData <- compareWithLocalChain(savedSlotData, state)
+      _              <- OptionT.liftF(sendProposalToBlockChecker(state, betterSlotData))
+    } yield ()
+
+  private def isUnknownBlockOpt[F[_]: Async: Logger](state: State[F], blockId: BlockId): OptionT[F, BlockId] =
     OptionT(
       state.slotDataStore
         .contains(blockId)
@@ -109,10 +122,10 @@ object PeerBlockHeaderFetcher {
         .map(Option.unless(_)(blockId))
     )
 
-  private def adoptRemoteSlotData[F[_]: Async: Logger](
-    state:   State[F],
-    blockId: BlockId
-  ): OptionT[F, NonEmptyChain[SlotData]] = {
+  private def saveSlotDataChain[F[_]: Async: Logger](
+    state: State[F],
+    tine:  NonEmptyChain[SlotData]
+  ): F[NonEmptyChain[SlotData]] = {
     def adoptSlotData(slotData: SlotData) = {
       val slotBlockId = slotData.slotId.blockId
       val parentBlockId = slotData.parentSlotId.blockId
@@ -123,15 +136,11 @@ object PeerBlockHeaderFetcher {
       state.slotDataStore.put(slotBlockId, slotData)
     }
 
-    for {
-      tine <- buildTine(state.slotDataStore, state.client, blockId)
-      _    <- OptionT.liftF(Logger[F].info(show"Retrieved remote tine length=${tine.length}"))
-      _    <- OptionT.liftF(tine.traverse(adoptSlotData))
-    } yield tine
+    tine.traverse(adoptSlotData) >> tine.pure[F]
   }
 
   // return: recent (current) block is the last
-  private def buildTine[F[_]: Async: Logger](
+  private def buildSlotDataChain[F[_]: Async: Logger](
     store:  Store[F, BlockId, SlotData],
     client: BlockchainPeerClient[F],
     from:   BlockId
@@ -167,8 +176,8 @@ object PeerBlockHeaderFetcher {
       state.localChain
         .isWorseThan(bestBlockInChain)
         .flatTap {
-          case true  => Logger[F].debug(show"Received header ${bestBlockInChain.slotId} is better than current block")
-          case false => Logger[F].info(show"Ignoring weaker (or equal) block header id=${bestBlockInChain.slotId}")
+          case true  => Logger[F].debug(show"Received tip ${bestBlockInChain.slotId} is better than current block")
+          case false => Logger[F].info(show"Ignoring weaker (or equal) block tip id=${bestBlockInChain.slotId}")
         }
         .map(Option.when(_)(blockIds))
     )
@@ -178,6 +187,16 @@ object PeerBlockHeaderFetcher {
     val message = BlockChecker.Message.RemoteSlotData(state.hostId, slotData)
     state.blockChecker.sendNoWait(message)
   }
+
+  private def getCurrentTip[F[_]: Async: Logger](state: State[F]): F[(State[F], Response[F])] = {
+    for {
+      _   <- OptionT.liftF(Logger[F].info(s"Requested current tip from host ${state.hostId}"))
+      tip <- OptionT(state.client.remoteCurrentTip())
+      _   <- buildAndAdoptSlotDataForBlockId(state, tip.slotId.blockId)
+      _   <- OptionT.liftF(Logger[F].info(show"Send tip ${tip.slotId.blockId} from host ${state.hostId}"))
+    } yield (state, state)
+  }.getOrElse((state, state))
+    .handleErrorWith(Logger[F].error(_)("Get tip from remote host return error") >> (state, state).pure[F])
 
   private def downloadHeaders[F[_]: Async: Logger](
     state:    State[F],

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
@@ -50,6 +50,8 @@ class BlockchainClientSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
           ): F[Option[BlockId]] =
             (height.toString + (if (height > ancestorHeight) "remote" else "")).typedId.some
               .pure[F]
+
+          override def remoteCurrentTip(): F[Option[SlotData]] = ???
         }
 
         val blockHeights =

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
@@ -51,7 +51,7 @@ class BlockchainClientSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
             (height.toString + (if (height > ancestorHeight) "remote" else "")).typedId.some
               .pure[F]
 
-          override def remoteCurrentTip(): F[Option[SlotData]] = ???
+          override def getRemoteBlockIdAtDepth(depth: Long): F[Option[BlockId]] = ???
         }
 
         val blockHeights =

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactorySpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainPeerConnectionFlowFactorySpec.scala
@@ -51,9 +51,9 @@ class BlockchainPeerConnectionFlowFactorySpec
 
       val (protocols, _) = factory.protocolsForPeer(connectedPeer, connectionLeader).unsafeRunSync()
 
-      protocols.length shouldBe 14L
+      protocols.length shouldBe 16L
       protocols.map(_.sessionId).toNes[Byte].toSortedSet shouldBe SortedSet[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
-        13, 14)
+        13, 14, 15, 16)
     }
   }
 }

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
@@ -328,7 +328,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       val client = mock[BlockchainPeerClient[F]]
       (client.remoteCurrentTip _)
         .expects()
-        .returns(Option(bestTip).pure[F])
+        .returns(Option(bestTip.slotId.blockId).pure[F])
       (client.remotePeerAdoptions _).expects().once().onCall { () =>
         Stream.fromOption[F](Option.empty[BlockId]).pure[F]
       }
@@ -393,7 +393,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       val client = mock[BlockchainPeerClient[F]]
       (client.remoteCurrentTip _)
         .expects()
-        .returns(Option(bestTip).pure[F])
+        .returns(Option(bestTip.slotId.blockId).pure[F])
       (client.remotePeerAdoptions _).expects().once().onCall { () =>
         Stream.fromOption[F](Option.empty[BlockId]).pure[F]
       }

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
@@ -312,4 +312,135 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
     }
   }
+
+  test("Requested tip shall be sent if local chain is better") {
+    withMock {
+      val slotData: NonEmptyChain[SlotData] =
+        arbitraryLinkedSlotDataChain.arbitrary.retryUntil(c => c.size > 1 && c.size < 5).first
+      val idAndSlotData: NonEmptyChain[(BlockId, SlotData)] = slotData.map(s => (s.slotId.blockId, s))
+      val (knownId, knownSlotData) = idAndSlotData.head
+      val remoteSlotData = NonEmptyChain.fromChain(idAndSlotData.tail).get
+
+      val remoteIdToSlotData: Map[BlockId, SlotData] = remoteSlotData.toList.toMap
+
+      val bestTip = idAndSlotData.last._2
+
+      val client = mock[BlockchainPeerClient[F]]
+      (client.remoteCurrentTip _)
+        .expects()
+        .returns(Option(bestTip).pure[F])
+      (client.remotePeerAdoptions _).expects().once().onCall { () =>
+        Stream.fromOption[F](Option.empty[BlockId]).pure[F]
+      }
+      (client
+        .getSlotDataOrError(_: BlockId, _: Throwable)(_: MonadThrow[F]))
+        .expects(*, *, *)
+        .anyNumberOfTimes()
+        .onCall { case (id: BlockId, e: BlockHeaderDownloadErrorByName, _: MonadThrow[F]) =>
+          OptionT(remoteIdToSlotData.get(id).pure[F]).getOrRaise(e.apply())
+        }
+
+      val blockChecker = mock[BlockCheckerActor[F]]
+      val expectedMessage: BlockChecker.Message = BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData.map(_._2))
+      (blockChecker.sendNoWait _).expects(expectedMessage).returns(().pure[F])
+
+      val requestsProxy = mock[RequestsProxyActor[F]]
+
+      val localChain = mock[LocalChainAlgebra[F]]
+      (localChain.isWorseThan _).expects(bestTip).once().returning(true.pure[F])
+
+      val slotDataStoreMap = mutable.Map.empty[BlockId, SlotData]
+      slotDataStoreMap.put(knownId, knownSlotData)
+      val slotDataStore = mock[Store[F, BlockId, SlotData]]
+      (slotDataStore.get _).expects(*).rep(idAndSlotData.size.toInt).onCall { id: BlockId =>
+        slotDataStoreMap.get(id).pure[F]
+      }
+      (slotDataStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+        slotDataStoreMap.contains(id).pure[F]
+      }
+      (slotDataStore.put _).expects(*, *).anyNumberOfTimes().onCall { case (id: BlockId, slotData: SlotData) =>
+        slotDataStoreMap.put(id, slotData).pure[F].void
+      }
+
+      val blockIdTree = mock[ParentChildTree[F, BlockId]]
+      (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
+
+      PeerBlockHeaderFetcher
+        .makeActor(hostId, client, blockChecker, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .use { actor =>
+          for {
+            _     <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)
+            state <- actor.send(PeerBlockHeaderFetcher.Message.GetCurrentTip)
+            _     <- actor.send(PeerBlockHeaderFetcher.Message.StopActor)
+            _     <- state.fetchingFiber.get.join
+          } yield ()
+        }
+    }
+  }
+
+  test("Requested tip shall not be sent if local chain is worse") {
+    withMock {
+      val slotData: NonEmptyChain[SlotData] =
+        arbitraryLinkedSlotDataChain.arbitrary.retryUntil(c => c.size > 1 && c.size < 5).first
+      val idAndSlotData: NonEmptyChain[(BlockId, SlotData)] = slotData.map(s => (s.slotId.blockId, s))
+      val (knownId, knownSlotData) = idAndSlotData.head
+      val remoteSlotData = NonEmptyChain.fromChain(idAndSlotData.tail).get
+
+      val remoteIdToSlotData: Map[BlockId, SlotData] = remoteSlotData.toList.toMap
+
+      val bestTip = idAndSlotData.last._2
+
+      val client = mock[BlockchainPeerClient[F]]
+      (client.remoteCurrentTip _)
+        .expects()
+        .returns(Option(bestTip).pure[F])
+      (client.remotePeerAdoptions _).expects().once().onCall { () =>
+        Stream.fromOption[F](Option.empty[BlockId]).pure[F]
+      }
+      (client
+        .getSlotDataOrError(_: BlockId, _: Throwable)(_: MonadThrow[F]))
+        .expects(*, *, *)
+        .anyNumberOfTimes()
+        .onCall { case (id: BlockId, e: BlockHeaderDownloadErrorByName, _: MonadThrow[F]) =>
+          OptionT(remoteIdToSlotData.get(id).pure[F]).getOrRaise(e.apply())
+        }
+
+      val blockChecker = mock[BlockCheckerActor[F]]
+      val expectedMessage: BlockChecker.Message = BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData.map(_._2))
+      (blockChecker.sendNoWait _).expects(expectedMessage).never()
+
+      val requestsProxy = mock[RequestsProxyActor[F]]
+
+      val localChain = mock[LocalChainAlgebra[F]]
+      (localChain.isWorseThan _).expects(bestTip).once().returning(false.pure[F])
+
+      val slotDataStoreMap = mutable.Map.empty[BlockId, SlotData]
+      slotDataStoreMap.put(knownId, knownSlotData)
+      val slotDataStore = mock[Store[F, BlockId, SlotData]]
+      (slotDataStore.get _).expects(*).rep(idAndSlotData.size.toInt).onCall { id: BlockId =>
+        slotDataStoreMap.get(id).pure[F]
+      }
+      (slotDataStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+        slotDataStoreMap.contains(id).pure[F]
+      }
+      (slotDataStore.put _).expects(*, *).anyNumberOfTimes().onCall { case (id: BlockId, slotData: SlotData) =>
+        slotDataStoreMap.put(id, slotData).pure[F].void
+      }
+
+      val blockIdTree = mock[ParentChildTree[F, BlockId]]
+      (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
+
+      PeerBlockHeaderFetcher
+        .makeActor(hostId, client, blockChecker, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .use { actor =>
+          for {
+            _     <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)
+            state <- actor.send(PeerBlockHeaderFetcher.Message.GetCurrentTip)
+            _     <- actor.send(PeerBlockHeaderFetcher.Message.StopActor)
+            _     <- state.fetchingFiber.get.join
+          } yield ()
+        }
+
+    }
+  }
 }

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
@@ -359,4 +359,26 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
         }
     }
   }
+
+  test("Get all tips shall be forwarded to requests proxy") {
+    withMock {
+      val reputationAggregator = mock[ReputationAggregatorActor[F]]
+      val peersManager = mock[PeersManagerActor[F]]
+      val headerStore = mock[Store[F, BlockId, BlockHeader]]
+      val bodyStore = mock[Store[F, BlockId, BlockBody]]
+
+      (peersManager.sendNoWait _)
+        .expects(PeersManager.Message.GetCurrentTips)
+        .returns(().pure[F])
+
+      RequestsProxy
+        .makeActor(reputationAggregator, peersManager, headerStore, bodyStore)
+        .use { actor =>
+          for {
+            _ <- actor.send(RequestsProxy.Message.GetCurrentTips)
+          } yield ()
+        }
+
+    }
+  }
 }

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraTransmittableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraTransmittableCodecs.scala
@@ -26,6 +26,11 @@ trait TetraTransmittableCodecs {
 
   implicit val ratioTransmittable: Transmittable[Ratio] = Transmittable.instanceFromCodec
 
+  implicit val unitTransmittable: Transmittable[Unit] = new Transmittable[Unit] {
+    override def transmittableBytes(value:     Unit): ByteString = ByteString.EMPTY
+    override def fromTransmittableBytes(bytes: ByteString): Either[String, Unit] = Right(())
+  }
+
   implicit val longBlockIdOptTransmittable: Transmittable[(Long, Option[BlockId])] =
     Transmittable.instanceFromCodec(
       (longCodec :: optionCodec[BlockId])

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraTransmittableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraTransmittableCodecs.scala
@@ -31,6 +31,8 @@ trait TetraTransmittableCodecs {
     override def fromTransmittableBytes(bytes: ByteString): Either[String, Unit] = Right(())
   }
 
+  implicit val longTransmittable: Transmittable[Long] = Transmittable.instanceFromCodec(longCodec)
+
   implicit val longBlockIdOptTransmittable: Transmittable[(Long, Option[BlockId])] =
     Transmittable.instanceFromCodec(
       (longCodec :: optionCodec[BlockId])


### PR DESCRIPTION
## Purpose
Correctly process state where block in current best chain became invalid, but new tip(s) from remote host is not received yet
 
## Approach
 * Extend typed protocol / blockchain client with remoteBestTip request
 * After block invalidation new best tips are requested from all remote hosts
 * Appropriate unit tests had been added as well

## Testing
Unit tests + multinode integration test

## Tickets
*