### PR TITLE
BN-958-implement-the-genus-block-api-step-3-getTxosByAddress

### DIFF
--- a/genus-library/Examples/Queries.md
+++ b/genus-library/Examples/Queries.md
@@ -21,6 +21,12 @@ RETURN $pathelements
 Ex4: Relationship between headers, body, transaction and address, for an existing BlockHeader with id 26:0 (id:cluster)
 
 ```roomsql
-MATCH {Class: LockAddress}-hasAddress-{Class: Transaction}-hasTxIO-{Class: BlockHeader}
+MATCH {Class: LockAddress}-hasLockAddress-{Class: Transaction}-hasTxIO-{Class: BlockHeader}
+RETURN $pathelements
+```
+
+Ex5: Relationship between lockAddress and txo
+```roomsql
+MATCH {Class: LockAddress}-hasTxo-{Class: Txo}
 RETURN $pathelements
 ```

--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/TransactionFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/TransactionFetcherAlgebra.scala
@@ -1,8 +1,8 @@
 package co.topl.genusLibrary.algebras
 
-import co.topl.brambl.models.TransactionId
+import co.topl.brambl.models.{LockAddress, TransactionId}
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.genus.services.TransactionReceipt
+import co.topl.genus.services.{TransactionReceipt, Txo}
 import co.topl.genusLibrary.model.GE
 
 /**
@@ -26,5 +26,13 @@ trait TransactionFetcherAlgebra[F[_]] {
    * @return Optional Transaction, None if it was not found
    */
   def fetchTransactionReceipt(transactionId: TransactionId): F[Either[GE, Option[TransactionReceipt]]]
+
+  /**
+   * Retrieve TxOs (spent or unspent) that are associated with any of the specified addresses
+   *
+   * @param lockAddress the lock address
+   * @return Optional LockAddress, None if it was not found
+   */
+  def fetchTransactionsByAddress(lockAddress: LockAddress): F[Either[GE, Seq[Txo]]]
 
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
@@ -1,6 +1,6 @@
 package co.topl.genusLibrary.algebras
 
-import co.topl.brambl.models.TransactionId
+import co.topl.brambl.models.{LockAddress, TransactionId}
 import co.topl.consensus.models.BlockId
 import co.topl.genusLibrary.model.GE
 import com.tinkerpop.blueprints.Vertex
@@ -64,5 +64,13 @@ trait VertexFetcherAlgebra[F[_]] {
    * @return Optional transaction vertex, None if it was not found
    */
   def fetchTransaction(transactionId: TransactionId): F[Either[GE, Option[Vertex]]]
+
+  /**
+   * Fetch LockAddress Vertex, using Address Index
+   *
+   * @param lockAddress filter by index field
+   * @return Optional Address vertex, None if it was not found
+   */
+  def fetchLockAddress(lockAddress: LockAddress): F[Either[GE, Option[Vertex]]]
 
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphBlockInserter.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphBlockInserter.scala
@@ -2,7 +2,9 @@ package co.topl.genusLibrary.interpreter
 
 import cats.effect._
 import cats.implicits._
-import co.topl.genus.services.BlockData
+import co.topl.brambl.models.TransactionOutputAddress
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.genus.services.{BlockData, Txo, TxoState}
 import co.topl.genusLibrary.algebras.BlockInserterAlgebra
 import co.topl.genusLibrary.model.{GE, GEs}
 import co.topl.genusLibrary.orientDb.OrientThread
@@ -12,7 +14,6 @@ import co.topl.genusLibrary.orientDb.instances.SchemaBlockHeader.Field
 import co.topl.genusLibrary.orientDb.schema.EdgeSchemaInstances._
 import com.tinkerpop.blueprints.impls.orient.OrientGraph
 import org.typelevel.log4cats.Logger
-
 import scala.util.Try
 
 object GraphBlockInserter {
@@ -33,24 +34,38 @@ object GraphBlockInserter {
 
               // Relationships between Header <-> TxIOs
               block.transactions.foreach { ioTx =>
-                val txVertex = graph.addIoTx(ioTx)
-                txVertex.setProperty(ioTransactionSchema.links.head.propertyName, headerVertex.getId)
-                graph.addEdge(s"class:${blockHeaderTxIOEdge.name}", headerVertex, txVertex, blockHeaderTxIOEdge.label)
+                val ioTxVertex = graph.addIoTx(ioTx)
+                ioTxVertex.setProperty(ioTransactionSchema.links.head.propertyName, headerVertex.getId)
+                graph.addEdge(s"class:${blockHeaderTxIOEdge.name}", headerVertex, ioTxVertex, blockHeaderTxIOEdge.label)
+
+                // TODO question
+                //  ioTx.outputs.inputs.address.TransactionOutputAddress foreach, fetch the txo, and change the status to SPENT?
+                // if, yes the Txo model should have the transactionId.
+                // when a txo is spent, is fully spent or partially spent?
 
                 // Relationships between TxIOs <-> LockAddress
-                ioTx.outputs.map(_.address).foreach { lockAddress =>
+                ioTx.outputs.zipWithIndex.foreach { case (utxo, index) =>
                   // before adding a new address, check if was not there included by a previous transaction
                   val lockAddressVertex = {
                     val addressIterator =
-                      graph.getVertices(SchemaLockAddress.Field.AddressId, lockAddress.id.toByteArray).iterator()
+                      graph.getVertices(SchemaLockAddress.Field.AddressId, utxo.address.id.value.toByteArray).iterator()
 
                     if (addressIterator.hasNext) addressIterator.next()
-                    else graph.addAddress(lockAddress)
+                    else graph.addAddress(utxo.address)
 
                   }
-                  graph.addEdge(s"class:${addressTxIOEdge.name}", lockAddressVertex, txVertex, addressTxIOEdge.label)
+                  graph.addEdge(s"class:${addressTxIOEdge.name}", lockAddressVertex, ioTxVertex, addressTxIOEdge.label)
 
+                  val txoVertex = graph.addTxo(
+                    Txo(
+                      utxo,
+                      TxoState.UNSPENT,
+                      TransactionOutputAddress(utxo.address.network, utxo.address.ledger, index, ioTx.id)
+                    )
+                  )
+                  graph.addEdge(s"class:${addressTxoEdge.name}", lockAddressVertex, txoVertex, addressTxoEdge.label)
                 }
+
               }
 
               // Relationship between Header <-> ParentHeader if Not Genesis block

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
@@ -33,18 +33,23 @@ object OrientDBMetadataFactory {
       _ <- Resource.eval(
         OrientThread[F].defer(
           for {
-            _ <- createVertex(db, blockHeaderSchema)
-            _ <- createVertex(db, blockBodySchema)
-            _ <- createVertex(db, ioTransactionSchema)
-            _ <- createVertex(db, canonicalHeadSchema)
-            _ <- createVertex(db, lockAddressSchema)
+            _ <- Seq(
+              blockHeaderSchema,
+              blockBodySchema,
+              ioTransactionSchema,
+              canonicalHeadSchema,
+              lockAddressSchema,
+              txoSchema
+            )
+              .traverse(createVertex(db, _))
+              .void
           } yield ()
         )
       )
       _ <- Resource.eval(
         OrientThread[F].defer(
           for {
-            _ <- Seq(blockHeaderEdge, blockHeaderBodyEdge, blockHeaderTxIOEdge, addressTxIOEdge)
+            _ <- Seq(blockHeaderEdge, blockHeaderBodyEdge, blockHeaderTxIOEdge, addressTxIOEdge, addressTxoEdge)
               .traverse(e => createEdge(db, e))
               .void
           } yield ()

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaLockAddress.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaLockAddress.scala
@@ -42,7 +42,7 @@ object SchemaLockAddress {
         )
         .withProperty(
           Field.AddressId,
-          _.id.toByteArray,
+          _.id.value.toByteArray,
           mandatory = true,
           readOnly = true,
           notNull = true

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaTxo.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaTxo.scala
@@ -1,0 +1,55 @@
+package co.topl.genusLibrary.orientDb.instances
+
+import co.topl.brambl.models.TransactionOutputAddress
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
+import co.topl.genus.services.{Txo, TxoState}
+import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
+import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, VertexSchema}
+
+object SchemaTxo {
+
+  /**
+   * Txo model:
+   * @see https://github.com/Topl/protobuf-specs/blob/main/proto/genus/genus_models.proto#L28
+   */
+  object Field {
+    val SchemaName = "Txo"
+    val TransactionOutput = "transactionOutput"
+    val State = "state"
+    val OutputAddress = "outputAddress"
+  }
+
+  def make(): VertexSchema[Txo] =
+    VertexSchema.create(
+      Field.SchemaName,
+      GraphDataEncoder[Txo]
+        .withProperty(
+          Field.TransactionOutput,
+          _.transactionOutput.toByteArray,
+          mandatory = true,
+          readOnly = true,
+          notNull = true
+        )
+        .withProperty(
+          Field.State,
+          txo => java.lang.Integer.valueOf(txo.state.value),
+          mandatory = true,
+          readOnly = true,
+          notNull = true
+        )
+        .withProperty(
+          Field.OutputAddress,
+          _.outputAddress.toByteArray,
+          mandatory = true,
+          readOnly = true,
+          notNull = true
+        ),
+      v =>
+        Txo(
+          transactionOutput = UnspentTransactionOutput.parseFrom(v(Field.TransactionOutput): Array[Byte]),
+          state = TxoState.fromValue(v(Field.State): Int),
+          outputAddress = TransactionOutputAddress.parseFrom(v(Field.OutputAddress): Array[Byte])
+        )
+    )
+
+}

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
@@ -3,12 +3,12 @@ package co.topl.genusLibrary.orientDb.instances
 import co.topl.brambl.models.LockAddress
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockHeader
+import co.topl.genus.services.Txo
 import co.topl.genusLibrary.orientDb.instances.SchemaCanonicalHead.CanonicalHead
 import co.topl.genusLibrary.orientDb.schema.VertexSchema
 import co.topl.node.models.BlockBody
 import com.tinkerpop.blueprints.Vertex
 import com.tinkerpop.blueprints.impls.orient.{OrientGraph, OrientVertex}
-
 import scala.jdk.CollectionConverters._
 
 /**
@@ -45,6 +45,8 @@ object VertexSchemaInstances {
       def addAddress(address: LockAddress): OrientVertex =
         graph.addVertex(s"class:${lockAddressSchema.name}", lockAddressSchema.encode(address).asJava)
 
+      def addTxo(txo: Txo): OrientVertex =
+        graph.addVertex(s"class:${txoSchema.name}", txoSchema.encode(txo).asJava)
     }
 
     private[genusLibrary] val blockHeaderSchema: VertexSchema[BlockHeader] = SchemaBlockHeader.make()
@@ -52,6 +54,7 @@ object VertexSchemaInstances {
     private[genusLibrary] val ioTransactionSchema: VertexSchema[IoTransaction] = SchemaIoTransaction.make()
     private[genusLibrary] val canonicalHeadSchema: VertexSchema[CanonicalHead.type] = SchemaCanonicalHead.make()
     private[genusLibrary] val lockAddressSchema: VertexSchema[LockAddress] = SchemaLockAddress.make()
+    private[genusLibrary] val txoSchema: VertexSchema[Txo] = SchemaTxo.make()
 
   }
   object instances extends Instances

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/EdgeSchema.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/EdgeSchema.scala
@@ -30,8 +30,13 @@ object EdgeSchemaInstances {
     override def label: String = "hasTxIO"
   }
 
-  // Edge: address <--> transactionIO
+  // Edge: lockAddress <--> transactionIO
   val addressTxIOEdge: EdgeSchema = new EdgeSchema {
-    override def label: String = "hasAddress"
+    override def label: String = "hasLockAddress"
+  }
+
+  // Edge: lockAddress <--> txo
+  val addressTxoEdge: EdgeSchema = new EdgeSchema {
+    override def label: String = "hasTxo"
   }
 }

--- a/node/src/it/scala/co/topl/node/NodeAppTest.scala
+++ b/node/src/it/scala/co/topl/node/NodeAppTest.scala
@@ -13,7 +13,6 @@ import co.topl.brambl.models._
 import co.topl.brambl.models.box.Attestation
 import co.topl.brambl.models.transaction._
 import co.topl.brambl.syntax._
-import co.topl.codecs.bytes.tetra.instances._
 import co.topl.consensus.models.BlockId
 import co.topl.grpc.ToplGrpc
 import co.topl.quivr.api.Prover

--- a/node/src/main/scala/co/topl/genus/GrpcTransactionService.scala
+++ b/node/src/main/scala/co/topl/genus/GrpcTransactionService.scala
@@ -34,7 +34,10 @@ class GrpcTransactionService[F[_]: Async](transactionFetcher: TransactionFetcher
     Stream.raiseError[F](GEs.UnImplemented).adaptErrorsToGrpc
 
   override def getTxosByAddress(request: QueryByAddressRequest, ctx: Metadata): F[TxoAddressResponse] =
-    Async[F].raiseError[TxoAddressResponse](GEs.UnImplemented).adaptErrorsToGrpc
+    EitherT(transactionFetcher.fetchTransactionsByAddress(request.address))
+      .map(TxoAddressResponse(_))
+      .rethrowT
+      .adaptErrorsToGrpc
 
   override def getTxosByAddressStream(request: QueryByAddressRequest, ctx: Metadata): Stream[F, TxoAddressResponse] =
     Stream.raiseError[F](GEs.UnImplemented).adaptErrorsToGrpc


### PR DESCRIPTION
## Purpose
BN-958-implement-the-genus-block-api-step-3-getTxosByAddress
## Approach
- a new Schema Txo was created. 
  + fields: transactionOutput, state, outputAddress
  + TODO: Pending question for transactionId, and txoIndex
- the block inserter takes an `iotx`, and for each output creates Txo
  + TODO: Pending question for inputs, and changing the state

- Implement  Transaction Service-getTxosByAddress

## Testing
preparePR, some unit test,  local testing

## Tickets
BN-958


![image](https://user-images.githubusercontent.com/8540107/236216812-f0765270-fda5-4077-815c-e92ef62cde11.png)

[BN-958.txt](https://github.com/Topl/Bifrost/files/11397852/BN-958.txt)
![lockAddressTxo](https://user-images.githubusercontent.com/8540107/236215980-ad29c141-8bcf-4dcf-8af6-c51ce35ce3ac.png)

