### PR TITLE
BN-1017-P2P-RemoveRedundantBlockId

### DIFF
--- a/models/src/test/scala/co/topl/models/generators/consensus/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/generators/consensus/ModelGenerators.scala
@@ -193,16 +193,22 @@ trait ModelGenerators {
         addSlotDataToChain(slotData.append(gen.sample.get.copy(parentSlotId = slotData.last.slotId)), gen, count - 1)
     }
 
-  implicit val arbitraryLinkedSlotDataChain: Arbitrary[NonEmptyChain[SlotData]] =
+  def arbitraryLinkedSlotDataChainFor(sizeGen: Gen[Long]): Arbitrary[NonEmptyChain[SlotData]] =
     Arbitrary(
       for {
-        size <- Gen.posNum[Long]
+        size <- sizeGen
         root <- arbitrarySlotData.arbitrary
       } yield addSlotDataToChain(NonEmptyChain.one(root), arbitrarySlotData.arbitrary, size)
     )
 
+  implicit val arbitraryLinkedSlotDataChain: Arbitrary[NonEmptyChain[SlotData]] =
+    arbitraryLinkedSlotDataChainFor(Gen.posNum[Long])
+
   implicit def chainArbOf[T](implicit a: Arbitrary[T]): Arbitrary[Chain[T]] =
     Arbitrary(Gen.listOf[T](a.arbitrary).map(Chain.apply))
+
+  def nonEmptyChainArbOfLen[T](a: Arbitrary[T], size: Int): Arbitrary[NonEmptyChain[T]] =
+    Arbitrary(Gen.listOfN[T](size, a.arbitrary).map(NonEmptyChain.fromSeq(_).get))
 
   implicit def nonEmptyChainArbOf[T](implicit a: Arbitrary[T]): Arbitrary[NonEmptyChain[T]] =
     Arbitrary(Gen.nonEmptyListOf[T](a.arbitrary).map(NonEmptyChain.fromSeq(_).get))

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
@@ -312,13 +312,13 @@ object BlockChecker {
   }
 
   private def processRemoteBodies[F[_]: Async: Logger](
-    state:       State[F],
-    hostId:      HostId,
-    blockBodies: NonEmptyChain[Block]
+    state:  State[F],
+    hostId: HostId,
+    blocks: NonEmptyChain[Block]
   ): F[(State[F], Response[F])] = {
     val processedBlocksAndError =
       Stream
-        .foldable(blockBodies)
+        .foldable(blocks)
         .covaryAll[F, Block]
         .evalDropWhile(knownBlockBodyPredicate(state))
         .evalMap(verifyOneBlockBody(state))

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -39,7 +39,7 @@ object PeerActor {
      * Request to download block bodies from peer, downloaded bodies will be sent to block checker directly
      * @param blockData bodies block id to download
      */
-    case class DownloadBlockBodies(blockData: NonEmptyChain[(BlockId, BlockHeader)]) extends Message
+    case class DownloadBlockBodies(blockData: NonEmptyChain[BlockHeader]) extends Message
 
     /**
      * Request current tip from remote peer
@@ -58,10 +58,10 @@ object PeerActor {
   type PeerActor[F[_]] = Actor[F, Message, Response[F]]
 
   def getFsm[F[_]: Concurrent]: Fsm[F, State[F], Message, Response[F]] = Fsm {
-    case (state, UpdateState(newState))          => updateState(state, newState)
-    case (state, DownloadBlockHeaders(blockIds)) => downloadHeaders(state, blockIds)
-    case (state, DownloadBlockBodies(blockIds))  => downloadBodies(state, blockIds)
-    case (state, GetCurrentTip)                  => getCurrentTip(state)
+    case (state, UpdateState(newState))             => updateState(state, newState)
+    case (state, DownloadBlockHeaders(blockIds))    => downloadHeaders(state, blockIds)
+    case (state, DownloadBlockBodies(blockHeaders)) => downloadBodies(state, blockHeaders)
+    case (state, GetCurrentTip)                     => getCurrentTip(state)
   }
 
   def makeActor[F[_]: Async: Logger](
@@ -112,7 +112,7 @@ object PeerActor {
 
   private def downloadBodies[F[_]: Concurrent](
     state:     State[F],
-    blockData: NonEmptyChain[(BlockId, BlockHeader)]
+    blockData: NonEmptyChain[BlockHeader]
   ): F[(State[F], Response[F])] =
     state.blockBodyActor.sendNoWait(PeerBlockBodyFetcher.Message.DownloadBlocks(blockData)) >>
     (state, state).pure[F]

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
@@ -69,7 +69,7 @@ object PeersManager {
 
     /**
      * @param hostId use hostId as hint for now, later we could have some kind of map of available peer -> headers
-     * @param blockIds requested headers
+     * @param blockIds list of block's id of headers to be requested from peer
      */
     case class BlockHeadersRequest(hostId: HostId, blockIds: NonEmptyChain[BlockId]) extends Message
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -125,9 +125,8 @@ package object fsnetwork {
         .map(NonEmptyChain.fromSeq)
     )
 
-  def dropKnownPrefix[F[_]: Async, T](
-    data:  Seq[(BlockId, T)],
-    store: Store[F, BlockId, T]
-  ): F[Option[NonEmptyChain[(BlockId, T)]]] =
-    data.dropWhileF(idAndBody => store.contains(idAndBody._1)).map(NonEmptyChain.fromSeq)
+  def dropKnownPrefix[F[_]: Async, I, T](data: Seq[(I, T)], store: Store[F, BlockId, T])(
+    iToId: I => BlockId
+  ): F[Option[NonEmptyChain[(I, T)]]] =
+    data.dropWhileF(d => store.contains(iToId(d._1))).map(NonEmptyChain.fromSeq)
 }

--- a/networking/src/test/resources/logback-test.xml
+++ b/networking/src/test/resources/logback-test.xml
@@ -13,7 +13,7 @@
     </appender>
 
     <logger name="co.topl" level="INFO" />
-    <logger name="co.topl.networking" level="ERROR" />
+    <logger name="co.topl.networking" level="OFF" />
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
@@ -6,7 +6,6 @@ import cats.implicits._
 import cats.MonadThrow
 import cats.Show
 import co.topl.algebras.Store
-import co.topl.algebras.testInterpreters.NoOpLogger
 import co.topl.brambl.models.Datum
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.codecs.bytes.tetra.instances._
@@ -25,14 +24,16 @@ import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
 import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
 import co.topl.networking.fsnetwork.TestHelper._
-import co.topl.node.models.BlockBody
+import co.topl.node.models.{Block, BlockBody}
 import co.topl.quivr.runtime.DynamicContext
 import co.topl.typeclasses.implicits._
 import munit.CatsEffectSuite
 import munit.ScalaCheckEffectSuite
 import org.scalacheck.Gen
+import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.collection.mutable
 
@@ -41,1047 +42,1055 @@ object BlockCheckerTest {
 }
 
 class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
-  implicit val logger: Logger[F] = new NoOpLogger[F]
+  implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
   val hostId: HostId = "127.0.0.1"
   val maxChainSize = 99
 
   test("RemoteSlotData: Request no headers if new slot data is worse") {
-    withMock {
-      val slotData: NonEmptyChain[SlotData] =
-        arbitraryLinkedSlotDataChain.arbitrary.retryUntil(c => c.size < maxChainSize).first
+    PropF.forAllF(arbitraryLinkedSlotDataChainFor(Gen.choose(1, maxChainSize)).arbitrary) {
+      slotData: NonEmptyChain[SlotData] =>
+        withMock {
+          val reputationAggregator = mock[ReputationAggregatorActor[F]]
 
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
+          val requestsProxy = mock[RequestsProxyActor[F]]
 
-      val requestsProxy = mock[RequestsProxyActor[F]]
+          val localChain = mock[LocalChainAlgebra[F]]
+          val currentSlotDataHead = arbitrarySlotData.arbitrary.first
+          (() => localChain.head).expects().once().onCall(() => currentSlotDataHead.pure[F])
 
-      val localChain = mock[LocalChainAlgebra[F]]
-      val currentSlotDataHead = arbitrarySlotData.arbitrary.first
-      (() => localChain.head).expects().once().onCall(() => currentSlotDataHead.pure[F])
+          val slotDataStore = mock[Store[F, BlockId, SlotData]]
+          val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val bodyStore = mock[Store[F, BlockId, BlockBody]]
+          val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+          val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+          val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+          val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+          val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+          (chainSelectionAlgebra.compare _).expects(slotData.last, currentSlotDataHead).returning((-1).pure[F])
 
-      (chainSelectionAlgebra.compare _).expects(slotData.last, currentSlotDataHead).returning((-1).pure[F])
-
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra
-        )
-        .use { actor =>
-          for {
-            _ <- actor.sendNoWait(BlockChecker.Message.RemoteSlotData(hostId, slotData))
-          } yield ()
+          BlockChecker
+            .makeActor(
+              reputationAggregator,
+              requestsProxy,
+              localChain,
+              slotDataStore,
+              headerStore,
+              bodyStore,
+              headerValidation,
+              bodySyntaxValidation,
+              bodySemanticValidation,
+              bodyAuthorizationValidation,
+              chainSelectionAlgebra
+            )
+            .use { actor =>
+              for {
+                _ <- actor.sendNoWait(BlockChecker.Message.RemoteSlotData(hostId, slotData))
+              } yield ()
+            }
         }
     }
   }
 
   test("RemoteSlotData: Request headers if new slot data is better and is extension of current chain") {
-    withMock {
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
-      val requestsProxy = mock[RequestsProxyActor[F]]
-      val localChain = mock[LocalChainAlgebra[F]]
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+    PropF.forAllF(arbitraryLinkedSlotDataChainFor(Gen.choose(3, maxChainSize)).arbitrary) {
+      slotData: NonEmptyChain[SlotData] =>
+        withMock {
+          val reputationAggregator = mock[ReputationAggregatorActor[F]]
+          val requestsProxy = mock[RequestsProxyActor[F]]
+          val localChain = mock[LocalChainAlgebra[F]]
+          val slotDataStore = mock[Store[F, BlockId, SlotData]]
+          val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val bodyStore = mock[Store[F, BlockId, BlockBody]]
+          val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+          val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+          val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+          val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+          val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val slotData: NonEmptyChain[SlotData] =
-        arbitraryLinkedSlotDataChain.arbitrary.retryUntil(c => c.size > 2 && c.size < maxChainSize).first
-      val idAndSlotData: NonEmptyChain[(BlockId, SlotData)] = slotData.map(s => (s.slotId.blockId, s))
+          val idAndSlotData: NonEmptyChain[(BlockId, SlotData)] = slotData.map(s => (s.slotId.blockId, s))
 
-      // local is known data which are stored in stores
-      val (localId, localSlotData) = idAndSlotData.head
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(localId, *, *)
-        .once()
-        .returning(localSlotData.pure[F])
-      (headerStore.contains _).expects(localId).once().returning(true.pure[F])
+          // local is known data which are stored in stores
+          val (localId, localSlotData) = idAndSlotData.head
+          (slotDataStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(localId, *, *)
+            .once()
+            .returning(localSlotData.pure[F])
+          (headerStore.contains _).expects(localId).once().returning(true.pure[F])
 
-      // slot data from peer
-      val remoteSlotDataAndId = NonEmptyChain.fromChain(idAndSlotData.tail).get
-      val (_, remoteSlotData) = remoteSlotDataAndId.unzip
+          // slot data from peer
+          val remoteSlotDataAndId = NonEmptyChain.fromChain(idAndSlotData.tail).get
+          val (_, remoteSlotData) = remoteSlotDataAndId.unzip
 
-      (chainSelectionAlgebra.compare _).expects(slotData.last, localSlotData).returning(1.pure[F])
+          (chainSelectionAlgebra.compare _).expects(slotData.last, localSlotData).returning(1.pure[F])
 
-      val localSlotDataStore = idAndSlotData.toList.toMap
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          localSlotDataStore(id).pure[F]
-        }
+          val localSlotDataStore = idAndSlotData.toList.toMap
+          (slotDataStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(*, *, *)
+            .anyNumberOfTimes()
+            .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+              localSlotDataStore(id).pure[F]
+            }
 
-      (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId => (id == localId).pure[F] }
+          (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId => (id == localId).pure[F] }
 
-      val expectedRequest =
-        RequestsProxy.Message.DownloadHeadersRequest(
-          hostId,
-          NonEmptyChain.fromSeq(remoteSlotDataAndId.toChain.toList.take(chunkSize).map(_._1)).get
-        ): RequestsProxy.Message
-      (requestsProxy.sendNoWait _).expects(expectedRequest).once().returning(().pure[F])
+          val expectedRequest =
+            RequestsProxy.Message.DownloadHeadersRequest(
+              hostId,
+              NonEmptyChain.fromSeq(remoteSlotDataAndId.toChain.toList.take(chunkSize).map(_._1)).get
+            ): RequestsProxy.Message
+          (requestsProxy.sendNoWait _).expects(expectedRequest).once().returning(().pure[F])
 
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra,
-          Option(BestChain(NonEmptyChain.one(localSlotData)))
-        )
-        .use { actor =>
-          for {
-            updatedState <- actor.send(BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData))
-            _ = assert(updatedState.bestKnownRemoteSlotDataOpt == Option(BestChain(remoteSlotData)))
-          } yield ()
+          BlockChecker
+            .makeActor(
+              reputationAggregator,
+              requestsProxy,
+              localChain,
+              slotDataStore,
+              headerStore,
+              bodyStore,
+              headerValidation,
+              bodySyntaxValidation,
+              bodySemanticValidation,
+              bodyAuthorizationValidation,
+              chainSelectionAlgebra,
+              Option(BestChain(NonEmptyChain.one(localSlotData)))
+            )
+            .use { actor =>
+              for {
+                updatedState <- actor.send(BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData))
+                _ = assert(updatedState.bestKnownRemoteSlotDataOpt == Option(BestChain(remoteSlotData)))
+              } yield ()
+            }
         }
     }
   }
 
   test("RemoteSlotData: Request headers if new slot data is better and is overlapped of current chain") {
-    withMock {
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
-      val requestsProxy = mock[RequestsProxyActor[F]]
-      val localChain = mock[LocalChainAlgebra[F]]
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+    PropF.forAllF(arbitraryLinkedSlotDataChainFor(Gen.choose(3, maxChainSize)).arbitrary) {
+      slotData: NonEmptyChain[SlotData] =>
+        withMock {
+          val reputationAggregator = mock[ReputationAggregatorActor[F]]
+          val requestsProxy = mock[RequestsProxyActor[F]]
+          val localChain = mock[LocalChainAlgebra[F]]
+          val slotDataStore = mock[Store[F, BlockId, SlotData]]
+          val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val bodyStore = mock[Store[F, BlockId, BlockBody]]
+          val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+          val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+          val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+          val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+          val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val slotData: NonEmptyChain[SlotData] =
-        arbitraryLinkedSlotDataChain.arbitrary.retryUntil(c => c.size > 2 && c.size < maxChainSize).first
-      val idAndSlotData: NonEmptyChain[(BlockId, SlotData)] = slotData.map(s => (s.slotId.blockId, s))
+          val idAndSlotData: NonEmptyChain[(BlockId, SlotData)] = slotData.map(s => (s.slotId.blockId, s))
 
-      // local is known data which are stored in stores
-      val (localId, localSlotData) = idAndSlotData.head
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(localId, *, *)
-        .once()
-        .returning(localSlotData.pure[F])
-      (headerStore.contains _).expects(localId).once().returning(true.pure[F])
+          // local is known data which are stored in stores
+          val (localId, localSlotData) = idAndSlotData.head
+          (slotDataStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(localId, *, *)
+            .once()
+            .returning(localSlotData.pure[F])
+          (headerStore.contains _).expects(localId).once().returning(true.pure[F])
 
-      // slot data from peer
-      val remoteSlotDataAndId = NonEmptyChain.fromChain(idAndSlotData.tail).get
-      val (_, remoteSlotData) = remoteSlotDataAndId.unzip
+          // slot data from peer
+          val remoteSlotDataAndId = NonEmptyChain.fromChain(idAndSlotData.tail).get
+          val (_, remoteSlotData) = remoteSlotDataAndId.unzip
 
-      // known but not accepted yet data
-      val knownSlotData = NonEmptyChain.fromSeq(slotData.toChain.toList.take(2)).get
+          // known but not accepted yet data
+          val knownSlotData = NonEmptyChain.fromSeq(slotData.toChain.toList.take(2)).get
 
-      (chainSelectionAlgebra.compare _).expects(slotData.last, knownSlotData.last).returning(1.pure[F])
+          (chainSelectionAlgebra.compare _).expects(slotData.last, knownSlotData.last).returning(1.pure[F])
 
-      val localSlotDataStore = idAndSlotData.toList.toMap
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          localSlotDataStore(id).pure[F]
-        }
+          val localSlotDataStore = idAndSlotData.toList.toMap
+          (slotDataStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(*, *, *)
+            .anyNumberOfTimes()
+            .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+              localSlotDataStore(id).pure[F]
+            }
 
-      (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId => (id == localId).pure[F] }
+          (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId => (id == localId).pure[F] }
 
-      val expectedRequest =
-        RequestsProxy.Message.DownloadHeadersRequest(
-          hostId,
-          NonEmptyChain.fromSeq(remoteSlotDataAndId.toChain.toList.take(chunkSize).map(_._1)).get
-        ): RequestsProxy.Message
-      (requestsProxy.sendNoWait _).expects(expectedRequest).once().returning(().pure[F])
+          val expectedRequest =
+            RequestsProxy.Message.DownloadHeadersRequest(
+              hostId,
+              NonEmptyChain.fromSeq(remoteSlotDataAndId.toChain.toList.take(chunkSize).map(_._1)).get
+            ): RequestsProxy.Message
+          (requestsProxy.sendNoWait _).expects(expectedRequest).once().returning(().pure[F])
 
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra,
-          Option(BestChain(NonEmptyChain.one(remoteSlotData.head)))
-        )
-        .use { actor =>
-          for {
-            updatedState <- actor.send(BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData))
-            _ = assert(updatedState.bestKnownRemoteSlotDataOpt == Option(BestChain(remoteSlotData)))
-          } yield ()
+          BlockChecker
+            .makeActor(
+              reputationAggregator,
+              requestsProxy,
+              localChain,
+              slotDataStore,
+              headerStore,
+              bodyStore,
+              headerValidation,
+              bodySyntaxValidation,
+              bodySemanticValidation,
+              bodyAuthorizationValidation,
+              chainSelectionAlgebra,
+              Option(BestChain(NonEmptyChain.one(remoteSlotData.head)))
+            )
+            .use { actor =>
+              for {
+                updatedState <- actor.send(BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData))
+                _ = assert(updatedState.bestKnownRemoteSlotDataOpt == Option(BestChain(remoteSlotData)))
+              } yield ()
+            }
         }
     }
   }
 
   test("RemoteSlotData: Request headers if new slot data is better and is not extension of current chain") {
-    withMock {
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
-      val requestsProxy = mock[RequestsProxyActor[F]]
-      val localChain = mock[LocalChainAlgebra[F]]
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+    PropF.forAllF(arbitraryLinkedSlotDataChainFor(Gen.choose(3, maxChainSize)).arbitrary) {
+      slotData: NonEmptyChain[SlotData] =>
+        withMock {
+          val reputationAggregator = mock[ReputationAggregatorActor[F]]
+          val requestsProxy = mock[RequestsProxyActor[F]]
+          val localChain = mock[LocalChainAlgebra[F]]
+          val slotDataStore = mock[Store[F, BlockId, SlotData]]
+          val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val bodyStore = mock[Store[F, BlockId, BlockBody]]
+          val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+          val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+          val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+          val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+          val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val slotData: NonEmptyChain[SlotData] =
-        arbitraryLinkedSlotDataChain.arbitrary.retryUntil(c => c.size > 2 && c.size < maxChainSize).first
-      val idAndSlotData: NonEmptyChain[(BlockId, SlotData)] = slotData.map(s => (s.slotId.blockId, s))
+          val idAndSlotData: NonEmptyChain[(BlockId, SlotData)] = slotData.map(s => (s.slotId.blockId, s))
 
-      // local is known data which are stored in stores
-      val (localId, localSlotData) = idAndSlotData.head
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(localId, *, *)
-        .once()
-        .returning(localSlotData.pure[F])
+          // local is known data which are stored in stores
+          val (localId, localSlotData) = idAndSlotData.head
+          (slotDataStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(localId, *, *)
+            .once()
+            .returning(localSlotData.pure[F])
 
-      // slot data from peer
-      val remoteSlotDataAndId = NonEmptyChain.fromChain(idAndSlotData.tail).get
-      val (_, remoteSlotData) = remoteSlotDataAndId.unzip
+          // slot data from peer
+          val remoteSlotDataAndId = NonEmptyChain.fromChain(idAndSlotData.tail).get
+          val (_, remoteSlotData) = remoteSlotDataAndId.unzip
 
-      (() => localChain.head).expects().once().returning(localSlotData.pure[F])
+          (() => localChain.head).expects().once().returning(localSlotData.pure[F])
 
-      (chainSelectionAlgebra.compare _).expects(slotData.last, localSlotData).returning(1.pure[F])
+          (chainSelectionAlgebra.compare _).expects(slotData.last, localSlotData).returning(1.pure[F])
 
-      val localSlotDataStore = idAndSlotData.toList.toMap
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          localSlotDataStore(id).pure[F]
-        }
+          val localSlotDataStore = idAndSlotData.toList.toMap
+          (slotDataStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(*, *, *)
+            .anyNumberOfTimes()
+            .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+              localSlotDataStore(id).pure[F]
+            }
 
-      (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId => (id == localId).pure[F] }
+          (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId => (id == localId).pure[F] }
 
-      val expectedRequest =
-        RequestsProxy.Message.DownloadHeadersRequest(
-          hostId,
-          NonEmptyChain.fromSeq(remoteSlotDataAndId.toChain.toList.take(chunkSize).map(_._1)).get
-        ): RequestsProxy.Message
-      (requestsProxy.sendNoWait _).expects(expectedRequest).once().returning(().pure[F])
+          val expectedRequest =
+            RequestsProxy.Message.DownloadHeadersRequest(
+              hostId,
+              NonEmptyChain.fromSeq(remoteSlotDataAndId.toChain.toList.take(chunkSize).map(_._1)).get
+            ): RequestsProxy.Message
+          (requestsProxy.sendNoWait _).expects(expectedRequest).once().returning(().pure[F])
 
-      val expectedBestChain = Option(BestChain(NonEmptyChain.fromChain(slotData.tail).get))
+          val expectedBestChain = Option(BestChain(NonEmptyChain.fromChain(slotData.tail).get))
 
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra
-        )
-        .use { actor =>
-          for {
-            updatedState <- actor.send(BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData))
-            _ = assert(updatedState.bestKnownRemoteSlotDataOpt == expectedBestChain)
-          } yield ()
+          BlockChecker
+            .makeActor(
+              reputationAggregator,
+              requestsProxy,
+              localChain,
+              slotDataStore,
+              headerStore,
+              bodyStore,
+              headerValidation,
+              bodySyntaxValidation,
+              bodySemanticValidation,
+              bodyAuthorizationValidation,
+              chainSelectionAlgebra
+            )
+            .use { actor =>
+              for {
+                updatedState <- actor.send(BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData))
+                _ = assert(updatedState.bestKnownRemoteSlotDataOpt == expectedBestChain)
+              } yield ()
+            }
         }
     }
   }
 
   test("RemoteSlotData: Request headers if new slot data is better, building full chain") {
-    withMock {
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
-      mock[PeersManagerActor[F]]
-      val requestsProxy = mock[RequestsProxyActor[F]]
-      val localChain = mock[LocalChainAlgebra[F]]
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+    PropF.forAllF(arbitraryLinkedSlotDataChainFor(Gen.choose(3, maxChainSize)).arbitrary) {
+      slotData: NonEmptyChain[SlotData] =>
+        withMock {
+          val reputationAggregator = mock[ReputationAggregatorActor[F]]
+          mock[PeersManagerActor[F]]
+          val requestsProxy = mock[RequestsProxyActor[F]]
+          val localChain = mock[LocalChainAlgebra[F]]
+          val slotDataStore = mock[Store[F, BlockId, SlotData]]
+          val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val bodyStore = mock[Store[F, BlockId, BlockBody]]
+          val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+          val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+          val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+          val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+          val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val slotData: NonEmptyChain[SlotData] =
-        arbitraryLinkedSlotDataChain.arbitrary.retryUntil(c => c.size > 3 && c.size < maxChainSize).first
-      val idAndSlotData: NonEmptyChain[(BlockId, SlotData)] = slotData.map(s => (s.slotId.blockId, s))
+          val idAndSlotData: NonEmptyChain[(BlockId, SlotData)] = slotData.map(s => (s.slotId.blockId, s))
 
-      // local is known data which are stored in stores
-      val (localId, _) = idAndSlotData.head
-      (headerStore.contains _).expects(localId).once().returning(true.pure[F])
+          // local is known data which are stored in stores
+          val (localId, _) = idAndSlotData.head
+          (headerStore.contains _).expects(localId).once().returning(true.pure[F])
 
-      // slot data from peer
-      val remoteSize = Gen.choose[Int](2, idAndSlotData.tail.size.toInt - 1).first
-      val (missedInChainData, remoteIdAndSlotData) = idAndSlotData.tail.toList.splitAt(remoteSize)
-      val (_, peerSlotData) = remoteIdAndSlotData.unzip
+          // slot data from peer
+          val remoteSize = Gen.choose[Int](2, idAndSlotData.tail.size.toInt - 1).first
+          val (missedInChainData, remoteIdAndSlotData) = idAndSlotData.tail.toList.splitAt(remoteSize)
+          val (_, peerSlotData) = remoteIdAndSlotData.unzip
 
-      val localSlotDataStore = idAndSlotData.toList.toMap
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          localSlotDataStore(id).pure[F]
-        }
+          val localSlotDataStore = idAndSlotData.toList.toMap
+          (slotDataStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(*, *, *)
+            .anyNumberOfTimes()
+            .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+              localSlotDataStore(id).pure[F]
+            }
 
-      (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId => (id == localId).pure[F] }
+          (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId => (id == localId).pure[F] }
 
-      val currentBestChain = NonEmptyChain.fromSeq(slotData.toList.take(2)).get
-      (chainSelectionAlgebra.compare _).expects(slotData.last, currentBestChain.last).returning(1.pure[F])
+          val currentBestChain = NonEmptyChain.fromSeq(slotData.toList.take(2)).get
+          (chainSelectionAlgebra.compare _).expects(slotData.last, currentBestChain.last).returning(1.pure[F])
 
-      val expectedRequest =
-        RequestsProxy.Message.DownloadHeadersRequest(
-          hostId,
-          NonEmptyChain.fromSeq(missedInChainData.take(chunkSize).map(_._1)).get
-        ): RequestsProxy.Message
-      (requestsProxy.sendNoWait _).expects(expectedRequest).once().returning(().pure[F])
+          val expectedRequest =
+            RequestsProxy.Message.DownloadHeadersRequest(
+              hostId,
+              NonEmptyChain.fromSeq(missedInChainData.take(chunkSize).map(_._1)).get
+            ): RequestsProxy.Message
+          (requestsProxy.sendNoWait _).expects(expectedRequest).once().returning(().pure[F])
 
-      val expectedBestChain = Option(BestChain(NonEmptyChain.fromChain(slotData.tail).get))
+          val expectedBestChain = Option(BestChain(NonEmptyChain.fromChain(slotData.tail).get))
 
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra,
-          Option(BestChain(currentBestChain))
-        )
-        .use { actor =>
-          for {
-            updatedState <- actor.send(
-              BlockChecker.Message.RemoteSlotData(hostId, NonEmptyChain.fromSeq(peerSlotData).get)
+          BlockChecker
+            .makeActor(
+              reputationAggregator,
+              requestsProxy,
+              localChain,
+              slotDataStore,
+              headerStore,
+              bodyStore,
+              headerValidation,
+              bodySyntaxValidation,
+              bodySemanticValidation,
+              bodyAuthorizationValidation,
+              chainSelectionAlgebra,
+              Option(BestChain(currentBestChain))
             )
-            _ = assert(updatedState.bestKnownRemoteSlotDataOpt == expectedBestChain)
-          } yield ()
+            .use { actor =>
+              for {
+                updatedState <- actor.send(
+                  BlockChecker.Message.RemoteSlotData(hostId, NonEmptyChain.fromSeq(peerSlotData).get)
+                )
+                _ = assert(updatedState.bestKnownRemoteSlotDataOpt == expectedBestChain)
+              } yield ()
+            }
         }
     }
   }
 
   test("RemoteBlockHeader: Do not verify already known headers") {
-    withMock {
-      val headers: NonEmptyChain[BlockHeader] =
-        nonEmptyChainArbOf(arbitraryHeader).arbitrary.retryUntil(c => c.size > 0 && c.size < maxChainSize).first
-      val idAndHeaders = headers.map(h => (h.id, h))
+    PropF.forAllF(nonEmptyChainArbOfLen(arbitraryHeader, maxChainSize).arbitrary) {
+      headers: NonEmptyChain[BlockHeader] =>
+        withMock {
+          val reputationAggregator = mock[ReputationAggregatorActor[F]]
+          val requestsProxy = mock[RequestsProxyActor[F]]
+          val localChain = mock[LocalChainAlgebra[F]]
+          val slotDataStore = mock[Store[F, BlockId, SlotData]]
+          val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val bodyStore = mock[Store[F, BlockId, BlockBody]]
+          val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+          val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+          val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+          val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+          val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
-      val requestsProxy = mock[RequestsProxyActor[F]]
-      val localChain = mock[LocalChainAlgebra[F]]
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+          (headerStore.contains _).expects(*).rep(headers.size.toInt).returning(true.pure[F])
+          (headerValidation.validate _).expects(*).never()
 
-      (headerStore.contains _).expects(*).rep(headers.size.toInt).returning(true.pure[F])
-      (headerValidation.validate _).expects(*).never()
-
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra
-        )
-        .use { actor =>
-          for {
-            _ <- actor.sendNoWait(BlockChecker.Message.RemoteBlockHeaders(hostId, idAndHeaders))
-          } yield ()
+          BlockChecker
+            .makeActor(
+              reputationAggregator,
+              requestsProxy,
+              localChain,
+              slotDataStore,
+              headerStore,
+              bodyStore,
+              headerValidation,
+              bodySyntaxValidation,
+              bodySemanticValidation,
+              bodyAuthorizationValidation,
+              chainSelectionAlgebra
+            )
+            .use { actor =>
+              for {
+                _ <- actor.sendNoWait(BlockChecker.Message.RemoteBlockHeaders(hostId, headers))
+              } yield ()
+            }
         }
     }
   }
 
   test("RemoteBlockHeader: Do not verify already known headers, stop processing if all headers are known") {
-    withMock {
-      val headers: NonEmptyChain[BlockHeader] =
-        arbitraryLinkedBlockHeaderChain(Gen.choose(2, maxChainSize)).arbitrary.first
-      val idAndHeaders = headers.map(h => (h.id, h))
+    PropF.forAllF(arbitraryLinkedBlockHeaderChain(Gen.choose(2, maxChainSize)).arbitrary) {
+      headers: NonEmptyChain[BlockHeader] =>
+        withMock {
+          val reputationAggregator = mock[ReputationAggregatorActor[F]]
+          val requestsProxy = mock[RequestsProxyActor[F]]
+          val localChain = mock[LocalChainAlgebra[F]]
+          val slotDataStore = mock[Store[F, BlockId, SlotData]]
+          val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val bodyStore = mock[Store[F, BlockId, BlockBody]]
+          val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+          val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+          val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+          val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+          val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
-      val requestsProxy = mock[RequestsProxyActor[F]]
-      val localChain = mock[LocalChainAlgebra[F]]
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+          (headerStore.contains _).expects(*).rep(headers.size.toInt).returning(true.pure[F])
+          (headerValidation.validate _).expects(*).never()
 
-      (headerStore.contains _).expects(*).rep(headers.size.toInt).returning(true.pure[F])
-      (headerValidation.validate _).expects(*).never()
-
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra
-        )
-        .use { actor =>
-          for {
-            _ <- actor.sendNoWait(BlockChecker.Message.RemoteBlockHeaders(hostId, idAndHeaders))
-          } yield ()
+          BlockChecker
+            .makeActor(
+              reputationAggregator,
+              requestsProxy,
+              localChain,
+              slotDataStore,
+              headerStore,
+              bodyStore,
+              headerValidation,
+              bodySyntaxValidation,
+              bodySemanticValidation,
+              bodyAuthorizationValidation,
+              chainSelectionAlgebra
+            )
+            .use { actor =>
+              for {
+                _ <- actor.sendNoWait(BlockChecker.Message.RemoteBlockHeaders(hostId, headers))
+              } yield ()
+            }
         }
     }
   }
 
   test("RemoteBlockHeader: Do not verify already known headers, request bodies, do not request next headers") {
-    withMock {
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
-      val requestsProxy = mock[RequestsProxyActor[F]]
-      val localChain = mock[LocalChainAlgebra[F]]
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+    PropF.forAllF(arbitraryLinkedBlockHeaderChain(Gen.choose(2, maxChainSize)).arbitrary) {
+      headers: NonEmptyChain[BlockHeader] =>
+        withMock {
+          val reputationAggregator = mock[ReputationAggregatorActor[F]]
+          val requestsProxy = mock[RequestsProxyActor[F]]
+          val localChain = mock[LocalChainAlgebra[F]]
+          val slotDataStore = mock[Store[F, BlockId, SlotData]]
+          val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val bodyStore = mock[Store[F, BlockId, BlockBody]]
+          val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+          val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+          val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+          val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+          val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val headers: NonEmptyChain[BlockHeader] =
-        arbitraryLinkedBlockHeaderChain(Gen.choose(2, maxChainSize)).arbitrary.first
-      val idAndHeaders = headers.map(h => (h.id, h))
+          val idAndHeaders = headers.map(h => (h.id, h))
 
-      val knownHeadersSize = Gen.choose[Int](1, headers.size.toInt - 1).first
-      val (knownIdAndHeaders, newIdAndHeaders) = idAndHeaders.toList.splitAt(knownHeadersSize)
+          val knownHeadersSize = Gen.choose[Int](1, headers.size.toInt - 1).first
+          val (knownIdAndHeaders, newIdAndHeaders) = idAndHeaders.toList.splitAt(knownHeadersSize)
 
-      val headerStoreData = mutable.Map.empty[BlockId, BlockHeader] ++ knownIdAndHeaders.toMap
-      (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
-        headerStoreData.contains(id).pure[F]
-      }
-      (headerStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
-        headerStoreData.get(id).pure[F]
-      }
-      (headerStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          headerStoreData(id).pure[F]
-        }
-      val addedHeader = mutable.Map.empty[BlockId, BlockHeader]
-      (headerStore.put _).expects(*, *).rep(newIdAndHeaders.size).onCall { case (id: BlockId, header: BlockHeader) =>
-        addedHeader.put(id, header)
-        headerStoreData.put(id, header)
-        ().pure[F]
-      }
+          val headerStoreData = mutable.Map.empty[BlockId, BlockHeader] ++ knownIdAndHeaders.toMap
+          (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+            headerStoreData.contains(id).pure[F]
+          }
+          (headerStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+            headerStoreData.get(id).pure[F]
+          }
+          (headerStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(*, *, *)
+            .anyNumberOfTimes()
+            .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+              headerStoreData(id).pure[F]
+            }
+          val addedHeader = mutable.Map.empty[BlockId, BlockHeader]
+          (headerStore.put _).expects(*, *).rep(newIdAndHeaders.size).onCall {
+            case (id: BlockId, header: BlockHeader) =>
+              addedHeader.put(id, header)
+              headerStoreData.put(id, header)
+              ().pure[F]
+          }
 
-      (headerValidation.validate _)
-        .expects(*)
-        .rep(newIdAndHeaders.size)
-        .onCall((header: BlockHeader) => Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F])
+          (headerValidation.validate _)
+            .expects(*)
+            .rep(newIdAndHeaders.size)
+            .onCall((header: BlockHeader) => Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F])
 
-      val bodyStoreData = idAndHeaders.toList.toMap
-      (bodyStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
-        (!bodyStoreData.contains(id)).pure[F]
-      }
+          val bodyStoreData = idAndHeaders.toList.toMap
+          (bodyStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+            (!bodyStoreData.contains(id)).pure[F]
+          }
 
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .rep(idAndHeaders.size.toInt)
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          val header = headerStoreData(id)
-          val arbSlotData = arbitrarySlotData.arbitrary.first
-          val slotData =
-            arbSlotData.copy(
-              slotId = arbSlotData.slotId.copy(blockId = header.id),
-              parentSlotId = arbSlotData.parentSlotId.copy(blockId = header.parentHeaderId)
+          (slotDataStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(*, *, *)
+            .rep(idAndHeaders.size.toInt)
+            .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+              val header = headerStoreData(id)
+              val arbSlotData = arbitrarySlotData.arbitrary.first
+              val slotData =
+                arbSlotData.copy(
+                  slotId = arbSlotData.slotId.copy(blockId = header.id),
+                  parentSlotId = arbSlotData.parentSlotId.copy(blockId = header.parentHeaderId)
+                )
+              slotData.pure[F]
+            }
+
+          val expectedHeaders = NonEmptyChain.fromSeq(idAndHeaders.toList.take(chunkSize).map(_._2)).get
+          val expectedMessage: RequestsProxy.Message =
+            RequestsProxy.Message.DownloadBodiesRequest(hostId, expectedHeaders)
+          (requestsProxy.sendNoWait _).expects(expectedMessage).returning(().pure[F])
+
+          BlockChecker
+            .makeActor(
+              reputationAggregator,
+              requestsProxy,
+              localChain,
+              slotDataStore,
+              headerStore,
+              bodyStore,
+              headerValidation,
+              bodySyntaxValidation,
+              bodySemanticValidation,
+              bodyAuthorizationValidation,
+              chainSelectionAlgebra
             )
-          slotData.pure[F]
-        }
-
-      val expectedIds = NonEmptyChain.fromSeq(idAndHeaders.toList.take(chunkSize)).get
-      val expectedMessage: RequestsProxy.Message = RequestsProxy.Message.DownloadBodiesRequest(hostId, expectedIds)
-      (requestsProxy.sendNoWait _).expects(expectedMessage).returning(().pure[F])
-
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra
-        )
-        .use { actor =>
-          for {
-            _ <- actor.send(BlockChecker.Message.RemoteBlockHeaders(hostId, idAndHeaders))
-            _ = assert(newIdAndHeaders.map(_._1).forall(k => addedHeader.contains(k)))
-          } yield ()
+            .use { actor =>
+              for {
+                _ <- actor.send(BlockChecker.Message.RemoteBlockHeaders(hostId, headers))
+                _ = assert(newIdAndHeaders.map(_._1).forall(k => addedHeader.contains(k)))
+              } yield ()
+            }
         }
     }
   }
 
   test("RemoteBlockHeader: Do not verify known headers, request bodies, request next headers because best chain") {
-    withMock {
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
-      val requestsProxy = mock[RequestsProxyActor[F]]
-      val localChain = mock[LocalChainAlgebra[F]]
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+    PropF.forAllF(arbitraryLinkedBlockHeaderChain(Gen.choose(2, maxChainSize)).arbitrary) {
+      headers: NonEmptyChain[BlockHeader] =>
+        withMock {
+          val reputationAggregator = mock[ReputationAggregatorActor[F]]
+          val requestsProxy = mock[RequestsProxyActor[F]]
+          val localChain = mock[LocalChainAlgebra[F]]
+          val slotDataStore = mock[Store[F, BlockId, SlotData]]
+          val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val bodyStore = mock[Store[F, BlockId, BlockBody]]
+          val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+          val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+          val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+          val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+          val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val headers: NonEmptyChain[BlockHeader] =
-        arbitraryLinkedBlockHeaderChain(Gen.choose(2, maxChainSize)).arbitrary.first
-      val idAndHeaders = headers.map(h => (h.id, h))
+          val idAndHeaders = headers.map(h => (h.id, h))
 
-      val knownHeadersSize = Gen.choose[Int](1, headers.size.toInt - 1).first
-      val (knownIdAndHeaders, newIdAndHeaders) = idAndHeaders.toList.splitAt(knownHeadersSize)
+          val knownHeadersSize = Gen.choose[Int](1, headers.size.toInt - 1).first
+          val (knownIdAndHeaders, newIdAndHeaders) = idAndHeaders.toList.splitAt(knownHeadersSize)
 
-      val headerStoreData = mutable.Map.empty[BlockId, BlockHeader] ++ knownIdAndHeaders.toMap
-      (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
-        headerStoreData.contains(id).pure[F]
-      }
-      (headerStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
-        headerStoreData.get(id).pure[F]
-      }
-      (headerStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          headerStoreData(id).pure[F]
-        }
-      val addedHeader = mutable.Map.empty[BlockId, BlockHeader]
-      (headerStore.put _).expects(*, *).rep(newIdAndHeaders.size).onCall { case (id: BlockId, header: BlockHeader) =>
-        addedHeader.put(id, header)
-        headerStoreData.put(id, header)
-        ().pure[F]
-      }
+          val headerStoreData = mutable.Map.empty[BlockId, BlockHeader] ++ knownIdAndHeaders.toMap
+          (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+            headerStoreData.contains(id).pure[F]
+          }
+          (headerStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+            headerStoreData.get(id).pure[F]
+          }
+          (headerStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(*, *, *)
+            .anyNumberOfTimes()
+            .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+              headerStoreData(id).pure[F]
+            }
+          val addedHeader = mutable.Map.empty[BlockId, BlockHeader]
+          (headerStore.put _).expects(*, *).rep(newIdAndHeaders.size).onCall {
+            case (id: BlockId, header: BlockHeader) =>
+              addedHeader.put(id, header)
+              headerStoreData.put(id, header)
+              ().pure[F]
+          }
 
-      (headerValidation.validate _)
-        .expects(*)
-        .rep(newIdAndHeaders.size)
-        .onCall((header: BlockHeader) => Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F])
+          (headerValidation.validate _)
+            .expects(*)
+            .rep(newIdAndHeaders.size)
+            .onCall((header: BlockHeader) => Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F])
 
-      val bodyStoreData = idAndHeaders.toList.toMap
-      (bodyStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
-        (!bodyStoreData.contains(id)).pure[F]
-      }
+          val bodyStoreData = idAndHeaders.toList.toMap
+          (bodyStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+            (!bodyStoreData.contains(id)).pure[F]
+          }
 
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .rep(idAndHeaders.size.toInt)
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          val header = headerStoreData(id)
-          val arbSlotData = arbitrarySlotData.arbitrary.first
-          val slotData =
-            arbSlotData.copy(
-              slotId = arbSlotData.slotId.copy(blockId = header.id),
-              parentSlotId = arbSlotData.parentSlotId.copy(blockId = header.parentHeaderId)
+          (slotDataStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(*, *, *)
+            .rep(idAndHeaders.size.toInt)
+            .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+              val header = headerStoreData(id)
+              val arbSlotData = arbitrarySlotData.arbitrary.first
+              val slotData =
+                arbSlotData.copy(
+                  slotId = arbSlotData.slotId.copy(blockId = header.id),
+                  parentSlotId = arbSlotData.parentSlotId.copy(blockId = header.parentHeaderId)
+                )
+              slotData.pure[F]
+            }
+
+          val expectedHeaders = NonEmptyChain.fromSeq(idAndHeaders.toList.take(chunkSize).map(_._2)).get
+          val expectedMessage: RequestsProxy.Message =
+            RequestsProxy.Message.DownloadBodiesRequest(hostId, expectedHeaders)
+          (requestsProxy.sendNoWait _).expects(expectedMessage).returning(().pure[F])
+
+          val bestChainForKnownAndNewIds: NonEmptyChain[SlotData] =
+            idAndHeaders.map { case (id, header) =>
+              val parentId = header.parentHeaderId
+              val slotId = SlotId(blockId = id)
+              val parentSlotId = SlotId(blockId = parentId)
+              arbitrarySlotData.arbitrary.first.copy(slotId = slotId, parentSlotId = parentSlotId)
+            }
+
+          val newSlotData: Chain[SlotData] = {
+            val arSlot = arbitraryLinkedSlotDataChain.arbitrary.retryUntil(c => c.size > 1 && c.size < 10).first
+            arSlot.head.copy(parentSlotId = bestChainForKnownAndNewIds.last.slotId) +: arSlot.tail
+          }
+
+          val bestChain = bestChainForKnownAndNewIds.appendChain(newSlotData)
+
+          val idAndSlotData = bestChain.map(s => (s.slotId.blockId, s))
+          val localSlotDataStore = idAndSlotData.toList.toMap
+          (slotDataStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(*, *, *)
+            .anyNumberOfTimes()
+            .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+              localSlotDataStore(id).pure[F]
+            }
+
+          val nextHeaders = newSlotData.toList.take(chunkSize).map(s => s.slotId.blockId)
+
+          val nextHeaderMessage: RequestsProxy.Message =
+            RequestsProxy.Message.DownloadHeadersRequest(hostId, NonEmptyChain.fromSeq(nextHeaders).get)
+          (requestsProxy.sendNoWait _).expects(nextHeaderMessage).once().returning(().pure[F])
+
+          BlockChecker
+            .makeActor(
+              reputationAggregator,
+              requestsProxy,
+              localChain,
+              slotDataStore,
+              headerStore,
+              bodyStore,
+              headerValidation,
+              bodySyntaxValidation,
+              bodySemanticValidation,
+              bodyAuthorizationValidation,
+              chainSelectionAlgebra,
+              Option(BestChain(bestChain)),
+              Option(hostId)
             )
-          slotData.pure[F]
-        }
-
-      val expectedIds = NonEmptyChain.fromSeq(idAndHeaders.toList.take(chunkSize)).get
-      val expectedMessage: RequestsProxy.Message = RequestsProxy.Message.DownloadBodiesRequest(hostId, expectedIds)
-      (requestsProxy.sendNoWait _).expects(expectedMessage).returning(().pure[F])
-
-      val bestChainForKnownAndNewIds: NonEmptyChain[SlotData] =
-        idAndHeaders.map { case (id, header) =>
-          val parentId = header.parentHeaderId
-          val slotId = SlotId(blockId = id)
-          val parentSlotId = SlotId(blockId = parentId)
-          arbitrarySlotData.arbitrary.first.copy(slotId = slotId, parentSlotId = parentSlotId)
-        }
-
-      val newSlotData: Chain[SlotData] = {
-        val arSlot = arbitraryLinkedSlotDataChain.arbitrary.retryUntil(c => c.size > 1 && c.size < 10).first
-        arSlot.head.copy(parentSlotId = bestChainForKnownAndNewIds.last.slotId) +: arSlot.tail
-      }
-
-      val bestChain = bestChainForKnownAndNewIds.appendChain(newSlotData)
-
-      val idAndSlotData = bestChain.map(s => (s.slotId.blockId, s))
-      val localSlotDataStore = idAndSlotData.toList.toMap
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          localSlotDataStore(id).pure[F]
-        }
-
-      val nextHeaders = newSlotData.toList.take(chunkSize).map(s => s.slotId.blockId)
-
-      val nextHeaderMessage: RequestsProxy.Message =
-        RequestsProxy.Message.DownloadHeadersRequest(hostId, NonEmptyChain.fromSeq(nextHeaders).get)
-      (requestsProxy.sendNoWait _).expects(nextHeaderMessage).once().returning(().pure[F])
-
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra,
-          Option(BestChain(bestChain)),
-          Option(hostId)
-        )
-        .use { actor =>
-          for {
-            _ <- actor.send(BlockChecker.Message.RemoteBlockHeaders(hostId, idAndHeaders))
-            _ = assert(newIdAndHeaders.map(_._1).forall(k => addedHeader.contains(k)))
-          } yield ()
+            .use { actor =>
+              for {
+                _ <- actor.send(BlockChecker.Message.RemoteBlockHeaders(hostId, headers))
+                _ = assert(newIdAndHeaders.map(_._1).forall(k => addedHeader.contains(k)))
+              } yield ()
+            }
         }
     }
   }
 
   test("RemoteBlockHeader: Do not verify already known headers, apply only first header, second is not correct") {
-    withMock {
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
-      val requestsProxy = mock[RequestsProxyActor[F]]
-      val localChain = mock[LocalChainAlgebra[F]]
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+    PropF.forAllF(arbitraryLinkedBlockHeaderChain(Gen.choose(3, maxChainSize)).arbitrary) {
+      headers: NonEmptyChain[BlockHeader] =>
+        withMock {
+          val reputationAggregator = mock[ReputationAggregatorActor[F]]
+          val requestsProxy = mock[RequestsProxyActor[F]]
+          val localChain = mock[LocalChainAlgebra[F]]
+          val slotDataStore = mock[Store[F, BlockId, SlotData]]
+          val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val bodyStore = mock[Store[F, BlockId, BlockBody]]
+          val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+          val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+          val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+          val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+          val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val headers: NonEmptyChain[BlockHeader] =
-        arbitraryLinkedBlockHeaderChain(Gen.choose(3, maxChainSize)).arbitrary.first
-      val idAndHeaders = headers.map(h => (h.id, h))
+          val idAndHeaders = headers.map(h => (h.id, h))
 
-      val knownHeadersSize = Gen.choose[Int](1, headers.size.toInt - 1).first
-      val (knownIdAndHeaders, newIdAndHeaders) = idAndHeaders.toList.splitAt(knownHeadersSize)
+          val knownHeadersSize = Gen.choose[Int](1, headers.size.toInt - 2).first
+          val (knownIdAndHeaders, newIdAndHeaders) = idAndHeaders.toList.splitAt(knownHeadersSize)
 
-      val headerStoreData = mutable.Map.empty[BlockId, BlockHeader] ++ knownIdAndHeaders.toMap
-      (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
-        headerStoreData.contains(id).pure[F]
-      }
-      (headerStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
-        headerStoreData.get(id).pure[F]
-      }
-      (headerStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          headerStoreData(id).pure[F]
-        }
-      val addedHeader = mutable.Map.empty[BlockId, BlockHeader]
-      (headerStore.put _).expects(*, *).rep(1).onCall { case (id: BlockId, header: BlockHeader) =>
-        addedHeader.put(id, header)
-        headerStoreData.put(id, header)
-        ().pure[F]
-      }
+          val headerStoreData = mutable.Map.empty[BlockId, BlockHeader] ++ knownIdAndHeaders.toMap
+          (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+            headerStoreData.contains(id).pure[F]
+          }
+          (headerStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+            headerStoreData.get(id).pure[F]
+          }
+          (headerStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(*, *, *)
+            .anyNumberOfTimes()
+            .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+              headerStoreData(id).pure[F]
+            }
+          val addedHeader = mutable.Map.empty[BlockId, BlockHeader]
+          (headerStore.put _).expects(*, *).rep(1).onCall { case (id: BlockId, header: BlockHeader) =>
+            addedHeader.put(id, header)
+            headerStoreData.put(id, header)
+            ().pure[F]
+          }
 
-      (headerValidation.validate _)
-        .expects(*)
-        .once()
-        .onCall((header: BlockHeader) => Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F])
-      (headerValidation.validate _)
-        .expects(*)
-        .once()
-        .onCall((_: BlockHeader) =>
-          Either.left[BlockHeaderValidationFailure, BlockHeader](NonForwardSlot(0, 1)).pure[F]
-        )
-
-      val bodyStoreData = idAndHeaders.toList.toMap
-      (bodyStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
-        (!bodyStoreData.contains(id)).pure[F]
-      }
-
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          val header = headerStoreData(id)
-          val arbSlotData = arbitrarySlotData.arbitrary.first
-          val slotData =
-            arbSlotData.copy(
-              slotId = arbSlotData.slotId.copy(blockId = header.id),
-              parentSlotId = arbSlotData.parentSlotId.copy(blockId = header.parentHeaderId)
+          (headerValidation.validate _)
+            .expects(*)
+            .once()
+            .onCall((header: BlockHeader) => Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F])
+          (headerValidation.validate _)
+            .expects(*)
+            .once()
+            .onCall((_: BlockHeader) =>
+              Either.left[BlockHeaderValidationFailure, BlockHeader](NonForwardSlot(0, 1)).pure[F]
             )
-          slotData.pure[F]
-        }
 
-      val expectedIds = NonEmptyChain.fromSeq(idAndHeaders.toList.take(chunkSize)).get
-      val expectedMessage: RequestsProxy.Message = RequestsProxy.Message.DownloadBodiesRequest(hostId, expectedIds)
-      (requestsProxy.sendNoWait _).expects(expectedMessage).returning(().pure[F])
-      (requestsProxy.sendNoWait _).expects(RequestsProxy.Message.GetCurrentTips).returns(().pure[F])
+          val bodyStoreData = idAndHeaders.toList.toMap
+          (bodyStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+            (!bodyStoreData.contains(id)).pure[F]
+          }
 
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra,
-          bestChain = Option(BestChain(NonEmptyChain.fromSeq(newIdAndHeaders.map(d => headerToSlotData(d._2))).get))
-        )
-        .use { actor =>
-          for {
-            state <- actor.send(BlockChecker.Message.RemoteBlockHeaders(hostId, idAndHeaders))
-            _ = assert(addedHeader.contains(newIdAndHeaders.head._1))
-            _ = assert(state.bestKnownRemoteSlotDataOpt.isEmpty)
-            _ = assert(state.bestKnownRemoteSlotDataHost.isEmpty)
-          } yield ()
+          (slotDataStore
+            .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+            .expects(*, *, *)
+            .anyNumberOfTimes()
+            .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+              val header = headerStoreData(id)
+              val arbSlotData = arbitrarySlotData.arbitrary.first
+              val slotData =
+                arbSlotData.copy(
+                  slotId = arbSlotData.slotId.copy(blockId = header.id),
+                  parentSlotId = arbSlotData.parentSlotId.copy(blockId = header.parentHeaderId)
+                )
+              slotData.pure[F]
+            }
+
+          val expectedHeaders = NonEmptyChain.fromSeq(idAndHeaders.toList.take(chunkSize).map(_._2)).get
+          val expectedMessage: RequestsProxy.Message =
+            RequestsProxy.Message.DownloadBodiesRequest(hostId, expectedHeaders)
+          (requestsProxy.sendNoWait _).expects(expectedMessage).returning(().pure[F])
+          (requestsProxy.sendNoWait _).expects(RequestsProxy.Message.GetCurrentTips).returns(().pure[F])
+
+          BlockChecker
+            .makeActor(
+              reputationAggregator,
+              requestsProxy,
+              localChain,
+              slotDataStore,
+              headerStore,
+              bodyStore,
+              headerValidation,
+              bodySyntaxValidation,
+              bodySemanticValidation,
+              bodyAuthorizationValidation,
+              chainSelectionAlgebra,
+              bestChain = Option(BestChain(NonEmptyChain.fromSeq(newIdAndHeaders.map(d => headerToSlotData(d._2))).get))
+            )
+            .use { actor =>
+              for {
+                state <- actor.send(BlockChecker.Message.RemoteBlockHeaders(hostId, headers))
+                _ = assert(addedHeader.contains(newIdAndHeaders.head._1))
+                _ = assert(state.bestKnownRemoteSlotDataOpt.isEmpty)
+                _ = assert(state.bestKnownRemoteSlotDataHost.isEmpty)
+              } yield ()
+            }
         }
     }
   }
 
   test("RemoteBlockBodies: Skip verification already known bodies") {
-    withMock {
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
-      val requestsProxy = mock[RequestsProxyActor[F]]
-      val localChain = mock[LocalChainAlgebra[F]]
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+    PropF.forAllF(
+      nonEmptyChainArbOfLen(ModelGenerators.arbitraryNodeBody, Gen.choose(2, maxChainSize).first).arbitrary
+    ) { bodies: NonEmptyChain[BlockBody] =>
+      withMock {
+        val reputationAggregator = mock[ReputationAggregatorActor[F]]
+        val requestsProxy = mock[RequestsProxyActor[F]]
+        val localChain = mock[LocalChainAlgebra[F]]
+        val slotDataStore = mock[Store[F, BlockId, SlotData]]
+        val headerStore = mock[Store[F, BlockId, BlockHeader]]
+        val bodyStore = mock[Store[F, BlockId, BlockBody]]
+        val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+        val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+        val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+        val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+        val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val bodies =
-        nonEmptyChainArbOf(ModelGenerators.arbitraryNodeBody).arbitrary
-          .retryUntil(c => c.size > 1 && c.size < maxChainSize)
-          .sample
-          .get
-      val ids: NonEmptyChain[BlockId] = bodies.map(_ => arbitraryHeader.arbitrary.first.id)
+        val ids: NonEmptyChain[BlockHeader] = bodies.map(_ => arbitraryHeader.arbitrary.first)
 
-      val idAndBody: NonEmptyChain[(BlockId, BlockBody)] = ids.zipWith(bodies)((_, _))
+        val blocks: NonEmptyChain[Block] =
+          ids.zipWith(bodies)((_, _)).map { case (header, body) => Block(header, body) }
 
-      val message = BlockChecker.Message.RemoteBlockBodies(hostId, idAndBody)
+        val message = BlockChecker.Message.RemoteBlockBodies(hostId, blocks)
 
-      (bodyStore.contains _).expects(*).rep(bodies.size.toInt).returning(true.pure[F])
+        (bodyStore.contains _).expects(*).rep(bodies.size.toInt).returning(true.pure[F])
 
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra
-        )
-        .use { actor =>
-          for {
-            _ <- actor.send(message)
-          } yield ()
-        }
+        BlockChecker
+          .makeActor(
+            reputationAggregator,
+            requestsProxy,
+            localChain,
+            slotDataStore,
+            headerStore,
+            bodyStore,
+            headerValidation,
+            bodySyntaxValidation,
+            bodySemanticValidation,
+            bodyAuthorizationValidation,
+            chainSelectionAlgebra
+          )
+          .use { actor =>
+            for {
+              _ <- actor.send(message)
+            } yield ()
+          }
+      }
     }
   }
 
   test("RemoteBlockBodies: Verify and save new blocks, but not apply to local chain because it worse") {
-    withMock {
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
-      val requestsProxy = mock[RequestsProxyActor[F]]
-      val localChain = mock[LocalChainAlgebra[F]]
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+    PropF.forAllF(
+      nonEmptyChainArbOfLen(ModelGenerators.arbitraryNodeBody, Gen.choose(2, maxChainSize).first).arbitrary
+    ) { bodies: NonEmptyChain[BlockBody] =>
+      withMock {
+        val reputationAggregator = mock[ReputationAggregatorActor[F]]
+        val requestsProxy = mock[RequestsProxyActor[F]]
+        val localChain = mock[LocalChainAlgebra[F]]
+        val slotDataStore = mock[Store[F, BlockId, SlotData]]
+        val headerStore = mock[Store[F, BlockId, BlockHeader]]
+        val bodyStore = mock[Store[F, BlockId, BlockBody]]
+        val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+        val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+        val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+        val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+        val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val bodies =
-        nonEmptyChainArbOf(ModelGenerators.arbitraryNodeBody).arbitrary
-          .retryUntil(c => c.size > 1 && c.size < maxChainSize)
-          .sample
-          .get
-      val ids: NonEmptyChain[BlockId] = bodies.map(_ => arbitraryHeader.arbitrary.first.id)
+        val headers: NonEmptyChain[BlockHeader] = bodies.map(_ => arbitraryHeader.arbitrary.first).map(_.embedId)
 
-      val idAndBody: NonEmptyChain[(BlockId, BlockBody)] = ids.zipWith(bodies)((_, _))
-      val idAndHeader: NonEmptyChain[(BlockId, BlockHeader)] =
-        ids.map(id => (id, arbitraryHeader.arbitrary.first))
+        val blocks: NonEmptyChain[Block] =
+          headers.zipWith(bodies)((_, _)).map { case (header, body) => Block(header, body) }
+        val idAndHeader: NonEmptyChain[(BlockId, BlockHeader)] = headers.map(h => (h.id, h))
+        val idAndBody = blocks.map(block => (block.header.id, block.body))
 
-      val message = BlockChecker.Message.RemoteBlockBodies(hostId, idAndBody)
+        val message = BlockChecker.Message.RemoteBlockBodies(hostId, blocks)
 
-      val knownBodiesSize = Gen.choose[Int](1, bodies.size.toInt - 1).first
-      val (knownIdAndHeaders, newIdAndHeaders) = idAndBody.toList.splitAt(knownBodiesSize)
+        val knownBodiesSize = Gen.choose[Int](1, bodies.size.toInt - 1).first
+        val (knownIdAndHeaders, newIdAndHeaders) = idAndBody.toList.splitAt(knownBodiesSize)
 
-      val newBodiesSize = newIdAndHeaders.size
+        val newBodiesSize = newIdAndHeaders.size
 
-      val knownBodyStorageData = knownIdAndHeaders.toMap
-      (bodyStore.contains _).expects(*).rep(bodies.size.toInt).onCall { id: BlockId =>
-        knownBodyStorageData.contains(id).pure[F]
+        val knownBodyStorageData = knownIdAndHeaders.toMap
+        (bodyStore.contains _).expects(*).rep(bodies.size.toInt).onCall { id: BlockId =>
+          knownBodyStorageData.contains(id).pure[F]
+        }
+
+        val headerStorageData = idAndHeader.toChain.toList.toMap
+        (headerStore
+          .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+          .expects(*, *, *)
+          .anyNumberOfTimes()
+          .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+            headerStorageData(id).pure[F]
+          }
+
+        (bodySyntaxValidation.validate _).expects(*).rep(newBodiesSize).onCall { b: BlockBody =>
+          Validated.validNec[BodySyntaxError, BlockBody](b).pure[F]
+        }
+
+        (bodySemanticValidation
+          .validate(_: BodyValidationContext)(_: BlockBody))
+          .expects(*, *)
+          .rep(newBodiesSize)
+          .onCall { case (_: BodyValidationContext, b: BlockBody) =>
+            Validated.validNec[BodySemanticError, BlockBody](b).pure[F]
+          }
+
+        type AuthContext = IoTransaction => DynamicContext[F, String, Datum]
+        (bodyAuthorizationValidation
+          .validate(_: AuthContext)(_: BlockBody))
+          .expects(*, *)
+          .rep(newBodiesSize)
+          .onCall { case (_: AuthContext @unchecked, b: BlockBody) =>
+            Validated.validNec[BodyAuthorizationError, BlockBody](b).pure[F]
+          }
+
+        val storedBodies = mutable.Map.empty[BlockId, BlockBody]
+        (bodyStore.put _).expects(*, *).rep(newBodiesSize).onCall { case (id: BlockId, block: BlockBody) =>
+          storedBodies.put(id, block).pure[F].void
+        }
+
+        val slotsStorageData = idAndHeader.map { case (id, header) => (id, headerToSlotData(header)) }.toList.toMap
+        (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId => slotsStorageData.get(id).pure[F] }
+        (slotDataStore
+          .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+          .expects(*, *, *)
+          .anyNumberOfTimes()
+          .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+            slotsStorageData(id).pure[F]
+          }
+
+        (localChain.isWorseThan _).expects(*).anyNumberOfTimes().returning(false.pure[F])
+
+        BlockChecker
+          .makeActor(
+            reputationAggregator,
+            requestsProxy,
+            localChain,
+            slotDataStore,
+            headerStore,
+            bodyStore,
+            headerValidation,
+            bodySyntaxValidation,
+            bodySemanticValidation,
+            bodyAuthorizationValidation,
+            chainSelectionAlgebra
+          )
+          .use { actor =>
+            for {
+              _ <- actor.send(message)
+            } yield ()
+          }
       }
-
-      val headerStorageData = idAndHeader.toChain.toList.toMap
-      (headerStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          headerStorageData(id).pure[F]
-        }
-
-      (bodySyntaxValidation.validate _).expects(*).rep(newBodiesSize).onCall { b: BlockBody =>
-        Validated.validNec[BodySyntaxError, BlockBody](b).pure[F]
-      }
-
-      (bodySemanticValidation
-        .validate(_: BodyValidationContext)(_: BlockBody))
-        .expects(*, *)
-        .rep(newBodiesSize)
-        .onCall { case (_: BodyValidationContext, b: BlockBody) =>
-          Validated.validNec[BodySemanticError, BlockBody](b).pure[F]
-        }
-
-      type AuthContext = IoTransaction => DynamicContext[F, String, Datum]
-      (bodyAuthorizationValidation
-        .validate(_: AuthContext)(_: BlockBody))
-        .expects(*, *)
-        .rep(newBodiesSize)
-        .onCall { case (_: AuthContext, b: BlockBody) =>
-          Validated.validNec[BodyAuthorizationError, BlockBody](b).pure[F]
-        }
-
-      val storedBodies = mutable.Map.empty[BlockId, BlockBody]
-      (bodyStore.put _).expects(*, *).rep(newBodiesSize).onCall { case (id: BlockId, block: BlockBody) =>
-        storedBodies.put(id, block).pure[F].void
-      }
-
-      val slotsStorageData = idAndHeader.map { case (id, header) => (id, headerToSlotData(header)) }.toList.toMap
-      (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId => slotsStorageData.get(id).pure[F] }
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          slotsStorageData(id).pure[F]
-        }
-
-      (localChain.isWorseThan _).expects(*).anyNumberOfTimes().returning(false.pure[F])
-
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra
-        )
-        .use { actor =>
-          for {
-            _ <- actor.send(message)
-          } yield ()
-        }
     }
   }
 
   test("RemoteBlockBodies: Verify and save blocks, apply to local chain, send no new request") {
-    withMock {
-      val reputationAggregator = mock[ReputationAggregatorActor[F]]
-      val requestsProxy = mock[RequestsProxyActor[F]]
-      val localChain = mock[LocalChainAlgebra[F]]
-      val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      val headerStore = mock[Store[F, BlockId, BlockHeader]]
-      val bodyStore = mock[Store[F, BlockId, BlockBody]]
-      val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
-      val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
-      val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
-      val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
-      val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
+    PropF.forAllF(
+      nonEmptyChainArbOfLen(ModelGenerators.arbitraryNodeBody, Gen.choose(2, maxChainSize).first).arbitrary
+    ) { bodies: NonEmptyChain[BlockBody] =>
+      withMock {
+        val reputationAggregator = mock[ReputationAggregatorActor[F]]
+        val requestsProxy = mock[RequestsProxyActor[F]]
+        val localChain = mock[LocalChainAlgebra[F]]
+        val slotDataStore = mock[Store[F, BlockId, SlotData]]
+        val headerStore = mock[Store[F, BlockId, BlockHeader]]
+        val bodyStore = mock[Store[F, BlockId, BlockBody]]
+        val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
+        val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
+        val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
+        val bodyAuthorizationValidation = mock[BodyAuthorizationValidationAlgebra[F]]
+        val chainSelectionAlgebra = mock[ChainSelectionAlgebra[F, SlotData]]
 
-      val bodies =
-        nonEmptyChainArbOf(ModelGenerators.arbitraryNodeBody).arbitrary
-          .retryUntil(c => c.size > 1 && c.size < maxChainSize)
-          .sample
-          .get
-      val idAndHeader: NonEmptyChain[(BlockId, BlockHeader)] = bodies.map { _ =>
-        val header = arbitraryHeader.arbitrary.first
-        val id = header.id
-        (id, header)
-      }
+        val headers: NonEmptyChain[BlockHeader] = bodies.map(_ => arbitraryHeader.arbitrary.first).map(_.embedId)
 
-      val idAndBody: NonEmptyChain[(BlockId, BlockBody)] = idAndHeader.map(_._1).zipWith(bodies)((_, _))
+        val blocks: NonEmptyChain[Block] =
+          headers.zipWith(bodies)((_, _)).map { case (header, body) => Block(header, body) }
+        val idAndHeader: NonEmptyChain[(BlockId, BlockHeader)] = headers.map(h => (h.id, h))
+        val idAndBody = blocks.map(block => (block.header.id, block.body))
 
-      val message = BlockChecker.Message.RemoteBlockBodies(hostId, idAndBody)
+        val message = BlockChecker.Message.RemoteBlockBodies(hostId, blocks)
 
-      val knownBodiesSize = Gen.choose[Int](1, bodies.size.toInt - 1).first
-      val (knownIdAndHeaders, newIdAndHeaders) = idAndBody.toList.splitAt(knownBodiesSize)
+        val knownBodiesSize = Gen.choose[Int](1, bodies.size.toInt - 1).first
+        val (knownIdAndHeaders, newIdAndHeaders) = idAndBody.toList.splitAt(knownBodiesSize)
 
-      val newBodiesSize = newIdAndHeaders.size
+        val newBodiesSize = newIdAndHeaders.size
 
-      val knownBodyStorageData = knownIdAndHeaders.toMap
-      (bodyStore.contains _).expects(*).rep(bodies.size.toInt).onCall { id: BlockId =>
-        knownBodyStorageData.contains(id).pure[F]
-      }
-
-      val headerStorageData = idAndHeader.toChain.toList.toMap
-      (headerStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          headerStorageData(id).pure[F]
+        val knownBodyStorageData = knownIdAndHeaders.toMap
+        (bodyStore.contains _).expects(*).rep(bodies.size.toInt).onCall { id: BlockId =>
+          knownBodyStorageData.contains(id).pure[F]
         }
 
-      (bodySyntaxValidation.validate _).expects(*).rep(newBodiesSize).onCall { b: BlockBody =>
-        Validated.validNec[BodySyntaxError, BlockBody](b).pure[F]
+        val headerStorageData = idAndHeader.toChain.toList.toMap
+        (headerStore
+          .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+          .expects(*, *, *)
+          .anyNumberOfTimes()
+          .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+            headerStorageData(id).pure[F]
+          }
+
+        (bodySyntaxValidation.validate _).expects(*).rep(newBodiesSize).onCall { b: BlockBody =>
+          Validated.validNec[BodySyntaxError, BlockBody](b).pure[F]
+        }
+
+        (bodySemanticValidation
+          .validate(_: BodyValidationContext)(_: BlockBody))
+          .expects(*, *)
+          .rep(newBodiesSize)
+          .onCall { case (_: BodyValidationContext, b: BlockBody) =>
+            Validated.validNec[BodySemanticError, BlockBody](b).pure[F]
+          }
+
+        type AuthContext = IoTransaction => DynamicContext[F, String, Datum]
+        (bodyAuthorizationValidation
+          .validate(_: AuthContext)(_: BlockBody))
+          .expects(*, *)
+          .rep(newBodiesSize)
+          .onCall { case (_: AuthContext @unchecked, b: BlockBody) =>
+            Validated.validNec[BodyAuthorizationError, BlockBody](b).pure[F]
+          }
+
+        val storedBodies = mutable.Map.empty[BlockId, BlockBody]
+        (bodyStore.put _).expects(*, *).rep(newBodiesSize).onCall { case (id: BlockId, block: BlockBody) =>
+          storedBodies.put(id, block).pure[F].void
+        }
+
+        val idAndSlotData = idAndHeader.map { case (id, header) => (id, headerToSlotData(header)) }.toList
+        val slotsStorageData = idAndSlotData.toMap
+        (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId => slotsStorageData.get(id).pure[F] }
+        (slotDataStore
+          .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+          .expects(*, *, *)
+          .anyNumberOfTimes()
+          .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
+            slotsStorageData(id).pure[F]
+          }
+
+        val lastBlockSlotData = idAndSlotData.last._2
+
+        (localChain.isWorseThan _).expects(*).anyNumberOfTimes().onCall { id: SlotData =>
+          (lastBlockSlotData === id).pure[F]
+        }
+
+        (localChain.adopt _).expects(Validated.Valid(lastBlockSlotData)).once().returning(().pure[F])
+
+        (bodyStore.contains _).expects(*).once().returning(true.pure[F])
+
+        (requestsProxy.sendNoWait _).expects(*).never()
+
+        BlockChecker
+          .makeActor(
+            reputationAggregator,
+            requestsProxy,
+            localChain,
+            slotDataStore,
+            headerStore,
+            bodyStore,
+            headerValidation,
+            bodySyntaxValidation,
+            bodySemanticValidation,
+            bodyAuthorizationValidation,
+            chainSelectionAlgebra,
+            Option(BestChain(NonEmptyChain.one(lastBlockSlotData)))
+          )
+          .use { actor =>
+            for {
+              newState <- actor.send(message)
+              _ = assert(newState.bestKnownRemoteSlotDataOpt.isEmpty)
+            } yield ()
+          }
       }
-
-      (bodySemanticValidation
-        .validate(_: BodyValidationContext)(_: BlockBody))
-        .expects(*, *)
-        .rep(newBodiesSize)
-        .onCall { case (_: BodyValidationContext, b: BlockBody) =>
-          Validated.validNec[BodySemanticError, BlockBody](b).pure[F]
-        }
-
-      type AuthContext = IoTransaction => DynamicContext[F, String, Datum]
-      (bodyAuthorizationValidation
-        .validate(_: AuthContext)(_: BlockBody))
-        .expects(*, *)
-        .rep(newBodiesSize)
-        .onCall { case (_: AuthContext, b: BlockBody) =>
-          Validated.validNec[BodyAuthorizationError, BlockBody](b).pure[F]
-        }
-
-      val storedBodies = mutable.Map.empty[BlockId, BlockBody]
-      (bodyStore.put _).expects(*, *).rep(newBodiesSize).onCall { case (id: BlockId, block: BlockBody) =>
-        storedBodies.put(id, block).pure[F].void
-      }
-
-      val idAndSlotData = idAndHeader.map { case (id, header) => (id, headerToSlotData(header)) }.toList
-      val slotsStorageData = idAndSlotData.toMap
-      (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId => slotsStorageData.get(id).pure[F] }
-      (slotDataStore
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
-        .expects(*, *, *)
-        .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
-          slotsStorageData(id).pure[F]
-        }
-
-      val lastBlockSlotData = idAndSlotData.last._2
-
-      (localChain.isWorseThan _).expects(*).anyNumberOfTimes().onCall { id: SlotData =>
-        (lastBlockSlotData === id).pure[F]
-      }
-
-      (localChain.adopt _).expects(Validated.Valid(lastBlockSlotData)).once().returning(().pure[F])
-
-      (bodyStore.contains _).expects(*).once().returning(true.pure[F])
-
-      (requestsProxy.sendNoWait _).expects(*).never()
-
-      BlockChecker
-        .makeActor(
-          reputationAggregator,
-          requestsProxy,
-          localChain,
-          slotDataStore,
-          headerStore,
-          bodyStore,
-          headerValidation,
-          bodySyntaxValidation,
-          bodySemanticValidation,
-          bodyAuthorizationValidation,
-          chainSelectionAlgebra,
-          Option(BestChain(NonEmptyChain.one(lastBlockSlotData)))
-        )
-        .use { actor =>
-          for {
-            newState <- actor.send(message)
-            _ = assert(newState.bestKnownRemoteSlotDataOpt.isEmpty)
-          } yield ()
-        }
     }
   }
 
@@ -1127,7 +1136,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
 
       val expectedNewRequest = allIdSlotDataHeaderBlock.drop(downloadedBodies)
 
-      val messageData = NonEmptyChain.fromSeq(requestIdSlotDataHeaderBlock.map(d => (d._1, d._4))).get
+      val messageData = NonEmptyChain.fromSeq(requestIdSlotDataHeaderBlock.map(d => Block(d._3, d._4))).get
 
       val message = BlockChecker.Message.RemoteBlockBodies(hostId, messageData)
 
@@ -1146,7 +1155,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
         .expects(*, *, *)
         .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
+        .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
           headerStorageData(id).pure[F]
         }
       (headerStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
@@ -1173,7 +1182,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .validate(_: AuthContext)(_: BlockBody))
         .expects(*, *)
         .rep(requestIdSlotDataHeaderBlockSize)
-        .onCall { case (_: AuthContext, b: BlockBody) =>
+        .onCall { case (_: AuthContext @unchecked, b: BlockBody) =>
           Validated.validNec[BodyAuthorizationError, BlockBody](b).pure[F]
         }
 
@@ -1183,7 +1192,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
         .expects(*, *, *)
         .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
+        .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
           slotDataStoreData(id).pure[F]
         }
 
@@ -1193,7 +1202,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val expectedNewRequestMessage: RequestsProxy.Message =
         RequestsProxy.Message.DownloadBodiesRequest(
           hostId,
-          NonEmptyChain.fromSeq(expectedNewRequest.map(d => (d._1, d._3)).take(chunkSize)).get
+          NonEmptyChain.fromSeq(expectedNewRequest.map(d => d._3.embedId).take(chunkSize)).get
         )
       (requestsProxy.sendNoWait _).expects(expectedNewRequestMessage).once().returning(().pure[F])
 
@@ -1267,7 +1276,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val requestIdSlotDataHeaderBlockSize = requestIdSlotDataHeaderBlock.size
 
       val messageData =
-        NonEmptyChain.fromSeq(requestIdSlotDataHeaderBlock.map(d => (d._1, d._4))).get
+        NonEmptyChain.fromSeq(requestIdSlotDataHeaderBlock.map(d => Block(d._3, d._4))).get
 
       val message =
         BlockChecker.Message.RemoteBlockBodies(hostId, messageData)
@@ -1287,7 +1296,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
         .expects(*, *, *)
         .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
+        .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
           headerStorageData(id).pure[F]
         }
       (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
@@ -1314,7 +1323,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .validate(_: AuthContext)(_: BlockBody))
         .expects(*, *)
         .rep(requestIdSlotDataHeaderBlockSize)
-        .onCall { case (_: AuthContext, b: BlockBody) =>
+        .onCall { case (_: AuthContext @unchecked, b: BlockBody) =>
           Validated.validNec[BodyAuthorizationError, BlockBody](b).pure[F]
         }
 
@@ -1324,7 +1333,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
         .expects(*, *, *)
         .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
+        .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
           slotDataStoreData(id).pure[F]
         }
 
@@ -1402,7 +1411,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         allIdSlotDataHeaderBlock.slice(knownSlotHeaderBodyLen, downloadedBodies)
 
       val messageData =
-        NonEmptyChain.fromSeq(requestIdSlotDataHeaderBlock.map(d => (d._1, d._4))).get
+        NonEmptyChain.fromSeq(requestIdSlotDataHeaderBlock.map(d => Block(d._3, d._4))).get
 
       val message =
         BlockChecker.Message.RemoteBlockBodies(hostId, messageData)
@@ -1412,7 +1421,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       (bodyStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         knownBodyStorageData.contains(id).pure[F]
       }
-      (bodyStore.put(_: BlockId, _: BlockBody)).expects(*, *).anyNumberOfTimes.onCall {
+      (bodyStore.put(_: BlockId, _: BlockBody)).expects(*, *).anyNumberOfTimes().onCall {
         case (id: BlockId, block: BlockBody) =>
           knownBodyStorageData.put(id, block).pure[F].void
       }
@@ -1422,7 +1431,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
         .expects(*, *, *)
         .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
+        .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
           headerStorageData(id).pure[F]
         }
       (headerStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
@@ -1454,7 +1463,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .validate(_: AuthContext)(_: BlockBody))
         .expects(*, *)
         .rep(1)
-        .onCall { case (_: AuthContext, b: BlockBody) =>
+        .onCall { case (_: AuthContext @unchecked, b: BlockBody) =>
           Validated.validNec[BodyAuthorizationError, BlockBody](b).pure[F]
         }
 
@@ -1464,7 +1473,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
         .expects(*, *, *)
         .anyNumberOfTimes()
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
+        .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
           slotDataStoreData(id).pure[F]
         }
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PackageObjectTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PackageObjectTest.scala
@@ -35,10 +35,10 @@ class PackageObjectTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
       val storageData = blockIdSlotId.toList.toMap
       val storage = mock[Store[F, BlockId, SlotData]]
       (storage
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+        .getOrRaise(_: BlockId)(_: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked))
         .expects(*, *, *)
         .rep(testDataSize.toInt)
-        .onCall { case (id: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
+        .onCall { case (id: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
           storageData(id).pure[F]
         }
 
@@ -66,10 +66,10 @@ class PackageObjectTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
       val storageData = blockIdSlotId.toList.toMap
       val storage = mock[Store[F, BlockId, SlotData]]
       (storage
-        .getOrRaise(_: BlockId)(_: MonadThrow[F], _: Show[BlockId]))
+        .getOrRaise(_: BlockId)(_: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked))
         .expects(*, *, *)
         .once()
-        .onCall { case (_: BlockId, _: MonadThrow[F], _: Show[BlockId]) =>
+        .onCall { case (_: BlockId, _: MonadThrow[F] @unchecked, _: Show[BlockId] @unchecked) =>
           val monadThrow = implicitly[MonadThrow[F]]
           monadThrow.raiseError(new IllegalStateException())
         }

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/TestHelper.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/TestHelper.scala
@@ -82,7 +82,7 @@ object TestHelper extends TransactionGenerator {
           if (blocks.isEmpty) {
             List((headerWithTxRoot.id, headerToSlotData(headerWithTxRoot), headerWithTxRoot, body))
           } else {
-            val headerWithParent = headerWithTxRoot.copy(parentHeaderId = blocks.last._2.slotId.blockId)
+            val headerWithParent = headerWithTxRoot.copy(parentHeaderId = blocks.last._2.slotId.blockId).embedId
             blocks.appended((headerWithParent.id, headerToSlotData(headerWithParent), headerWithParent, body))
           }
         })


### PR DESCRIPTION
## Purpose
Refactor code: do not use BlockId if blockId is available from the block header
## Approach
 * Use single BlockHeader instead (BlockId, BlockHeader) where it is possible
 * Unit tests refactoring/removing warnings
 
## Testing
Unit tests, Multinode integration test
## Tickets
*closes BN-1017