### PR TITLE
Implement MempoolGraph

### DIFF
--- a/ledger/src/main/scala/co/topl/ledger/interpreters/Mempool.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/Mempool.scala
@@ -1,141 +1,104 @@
 package co.topl.ledger.interpreters
 
-import cats.{Applicative, MonadThrow}
-import cats.data.OptionT
-import cats.effect.kernel.Spawn
-import cats.effect.{Async, Deferred, Fiber, Ref, Resource, Sync}
+import cats.effect._
+import cats.effect.implicits._
 import cats.implicits._
 import co.topl.algebras.ClockAlgebra
 import co.topl.brambl.models.TransactionId
-import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.syntax._
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
 import co.topl.consensus.models.BlockId
-import co.topl.eventtree.{EventSourcedState, ParentChildTree}
+import co.topl.eventtree.EventSourcedState
+import co.topl.eventtree.ParentChildTree
 import co.topl.ledger.algebras.MempoolAlgebra
-import co.topl.models.Slot
 import co.topl.node.models.BlockBody
 import co.topl.typeclasses.implicits._
 
-// TODO: Non-minting nodes?
 object Mempool {
-  private case class MempoolEntry[F[_]](expirationFiber: Fiber[F, _, _], inputBoxIds: Set[TransactionOutputAddress])
-  private type State[F[_]] = Ref[F, Map[TransactionId, MempoolEntry[F]]]
 
-  /**
-   * @param defaultExpirationLimit The maximum number of slots in the future allowed by a transaction expiration
-   * @param duplicateSpenderSlotLifetime The maximum number of slots that a Transaction should remain in a mempool after detecting
-   *                                     that it double-spends a Box
-   * @return
-   */
+  type State[F[_]] = Ref[F, MempoolGraph]
+
   def make[F[_]: Async](
-    currentBlockId:               F[BlockId],
-    fetchBlockBody:               BlockId => F[BlockBody],
-    fetchTransaction:             TransactionId => F[IoTransaction],
-    parentChildTree:              ParentChildTree[F, BlockId],
-    currentEventChanged:          BlockId => F[Unit],
-    clock:                        ClockAlgebra[F],
-    onExpiration:                 TransactionId => F[Unit],
-    defaultExpirationLimit:       Long,
-    duplicateSpenderSlotLifetime: Long
+    currentBlockId:         F[BlockId],
+    fetchBody:              BlockId => F[BlockBody],
+    fetchTransaction:       TransactionId => F[IoTransaction],
+    parentChildTree:        ParentChildTree[F, BlockId],
+    currentEventChanged:    BlockId => F[Unit],
+    clock:                  ClockAlgebra[F],
+    onExpiration:           TransactionId => F[Unit],
+    defaultExpirationLimit: Long
   ): Resource[F, MempoolAlgebra[F]] =
     for {
-      state <- Resource.make(Ref.of(Map.empty[TransactionId, MempoolEntry[F]]))(
-        _.get.flatMap(_.values.toList.traverse(_.expirationFiber.cancel).void)
+      graphState <- Ref.of(MempoolGraph(Map.empty, Map.empty, Map.empty)).toResource
+      expirationsState <- Resource.make(Ref.of(Map.empty[TransactionId, Fiber[F, Throwable, Unit]]))(
+        _.get.flatMap(_.values.toList.traverse(_.cancel).void)
       )
-      // A function which inserts a transaction into the mempool and schedules its expiration using a Fiber
-      addTransaction = (transaction: IoTransaction, expirationSlot: Slot) =>
-        for {
-          expirationTask <- Async[F].delay(
-            clock.delayedUntilSlot(expirationSlot) >> Sync[F].defer(
-              (
-                state.update(_ - transaction.id),
-                onExpiration(transaction.id)
-              ).tupled
-            )
+      expireTransaction = (transaction: IoTransaction) =>
+        graphState
+          .modify(_.removeSubtree(transaction))
+          .map(_.map(_.id).toList)
+          .flatMap(expired =>
+            expirationsState.update(_.removedAll(expired)) *>
+            expired.traverse(onExpiration)
           )
-          expirationFiber <- Spawn[F].start(expirationTask)
-          entry = MempoolEntry(expirationFiber, transaction.inputs.map(_.address).toSet)
-          _ <- state.update(_.updated(transaction.id, entry))
-        } yield ()
-      // A function which inserts a transaction into the mempool using the limit specified in the transaction
-      addTransactionWithDefaultExpiration = (transaction: IoTransaction) =>
+      addWithExpiration = (transaction: IoTransaction) =>
         for {
           currentSlot <- clock.globalSlot
-          targetSlot = transaction.datum.event.schedule.max.min(currentSlot + defaultExpirationLimit)
-          _ <- addTransaction(transaction, targetSlot)
+          expirationSlot = transaction.datum.event.schedule.max.min(currentSlot + defaultExpirationLimit)
+          expirationFiber <-
+            clock
+              .delayedUntilSlot(expirationSlot)
+              .flatMap(_ => expireTransaction(transaction))
+              .void
+              .start
+          _ <- expirationsState.update(_.updated(transaction.id, expirationFiber))
+          _ <- graphState.update(_.add(transaction))
         } yield ()
+      removeWithExpiration = (transaction: IoTransaction) =>
+        graphState
+          .modify(_.removeSubtree(transaction))
+          .map(_.map(_.id))
+          .flatTap(removed =>
+            expirationsState
+              .getAndUpdate(_.removedAll(removed))
+              .flatTap(expirations => removed.flatMap(expirations.get).toList.traverse(_.cancel))
+          )
+          .void
       applyBlock = (state: State[F], blockId: BlockId) =>
         for {
-          blockBody         <- fetchBlockBody(blockId).map(_.transactionIds.toList)
-          blockTransactions <- blockBody.traverse(fetchTransaction)
-          blockInputIds = blockTransactions.flatMap(_.inputs.map(_.address)).toSet
-          currentEntries <- state.get
-          // First, cancel the scheduled expirations for the transactions associated with the block
-          expirationsToCancel = blockBody.flatMap(currentEntries.get)
-          _ <- expirationsToCancel.traverse(_.expirationFiber.cancel)
-          // Next, calculate which of the remaining Mempool transactions attempt to spend an input that is spent
-          // by the current block
-          duplicateSpenderMempoolEntries = (currentEntries -- blockBody).filter { case (_, entry) =>
-            // Is there overlap between the inputs of the block and the inputs in this current entry/transaction?
-            // If so, consider this entry to be a duplicate spender
-            entry.inputBoxIds.intersect(blockInputIds).nonEmpty
-          }
-          globalSlot <- clock.globalSlot
-          // Now, reschedule the expiration for the duplicate spender transactions
-          _ <- duplicateSpenderMempoolEntries.toList.traverse { case (id, entry) =>
-            // Cancel the current expiration fiber
-            entry.expirationFiber.cancel >>
-            // And create a new one, but with a much shorter expiration window
-            fetchTransaction(id).flatMap(addTransaction(_, globalSlot + duplicateSpenderSlotLifetime))
-          }
-          _ <- state.update(_ -- blockBody)
+          body <- fetchBody(blockId)
+          _    <- body.transactionIds.traverse(fetchTransaction(_).flatMap(removeWithExpiration))
         } yield state
       unapplyBlock = (state: State[F], blockId: BlockId) =>
-        fetchBlockBody(blockId)
-          .map(_.transactionIds.toList)
-          .flatMap(_.traverse(fetchTransaction(_).flatMap(addTransactionWithDefaultExpiration)))
-          .as(state)
-      eventSourcedState <- Resource.eval(
-        EventSourcedState.OfTree.make[F, State[F], BlockId](
-          state.pure[F],
+        for {
+          body <- fetchBody(blockId)
+          _    <- body.transactionIds.traverse(fetchTransaction(_).flatMap(addWithExpiration))
+        } yield state
+      eventSourcedState <- EventSourcedState.OfTree
+        .make[F, State[F], BlockId](
+          graphState.pure[F],
           currentBlockId,
           applyEvent = applyBlock,
           unapplyEvent = unapplyBlock,
           parentChildTree,
           currentEventChanged
         )
-      )
-      finalizing <- Resource.make(Deferred[F, Unit])(_.complete(()).void)
+        .toResource
     } yield new MempoolAlgebra[F] {
 
       def read(blockId: BlockId): F[Set[TransactionId]] =
-        whenNotTerminated(
-          eventSourcedState.stateAt(blockId).flatMap(_.get).map(_.keySet)
-        )
+        eventSourcedState
+          .useStateAt(blockId)(_.get)
+          .map(graph =>
+            // TODO: Traversal
+            graph.transactions.keySet
+          )
 
-      // TODO: Check for double-spends along current canonical chain?
       def add(transactionId: TransactionId): F[Unit] =
-        whenNotTerminated(
-          fetchTransaction(transactionId).flatMap(addTransactionWithDefaultExpiration)
-        )
+        fetchTransaction(transactionId).flatMap(addWithExpiration)
 
       def remove(transactionId: TransactionId): F[Unit] =
-        whenNotTerminated(
-          state
-            .getAndUpdate(_ - transactionId)
-            .flatTap(entries =>
-              OptionT.fromOption[F](entries.get(transactionId)).foldF(Applicative[F].unit)(_.expirationFiber.cancel)
-            )
-            .void
-        )
-
-      /**
-       * Verifies that the mempool is not terminated/finalizing before running the provided action.  If the mempool
-       * is terminated, the call will immediately fail
-       */
-      private def whenNotTerminated[T](f: => F[T]): F[T] =
-        OptionT(finalizing.tryGet)
-          .foldF(f)(_ => MonadThrow[F].raiseError(new IllegalStateException("Mempool Terminated")))
+        fetchTransaction(transactionId).flatMap(removeWithExpiration)
     }
+
 }

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/MempoolGraph.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/MempoolGraph.scala
@@ -1,0 +1,94 @@
+package co.topl.ledger.interpreters
+
+import cats.data.NonEmptySet
+import cats.implicits._
+import co.topl.brambl.models.TransactionId
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.syntax._
+
+/**
+ * @param transactions a collection of all transactions in the mempool
+ * @param spenders a mapping of UTxOs to the set of STxOs that spend them.  The key is the transaction ID and the value
+ *                 is a mapping of UTxO index to the set of STxO addresses that spend the UTxO
+ * @param unresolved a collection of STxOs that attempt to spend unknown UTxOs.  The key is the transaction ID and the
+ *                   value is the set of input indices on that transaction that are unresolved
+ */
+case class MempoolGraph(
+  transactions: Map[TransactionId, IoTransaction],
+  spenders:     Map[TransactionId, Map[Int, Set[(TransactionId, Int)]]],
+  unresolved:   Map[TransactionId, NonEmptySet[Int]]
+) {
+
+  /**
+   * Remove the given transaction from this graph.  This operation will mark any dependent transactions as unresolved.
+   * @param transaction The transaction to remove
+   * @return a new MempoolGraph
+   */
+  def removeSingle(transaction: IoTransaction): MempoolGraph =
+    MempoolGraph(
+      transactions = transactions - transaction.id,
+      // Step through each input of this transaction, and remove any associated spender entries from the referenced UTxOs
+      spenders = transaction.inputs.foldLeft(spenders.removed(transaction.id)) { case (spenders, output) =>
+        spenders.updatedWith(output.address.id)(
+          _.map(
+            _.updatedWith(output.address.index)(
+              _.map(_.excl(transaction.id -> output.address.index))
+            )
+          )
+        )
+      },
+      unresolved =
+        spenders.getOrElse(transaction.id, Map.empty).values.flatten.foldLeft(unresolved.removed(transaction.id)) {
+          case (unresolved, (id, index)) =>
+            unresolved.updatedWith(id)(_.foldLeft(NonEmptySet.one(index))(_.combine(_)).some)
+        }
+    )
+
+  /**
+   * Remove the given transaction from this graph and all recursive transactions that depend on it.
+   * @param transaction The transaction to remove
+   * @return a tuple containing (new MempoolGraph, removed transactions)
+   */
+  def removeSubtree(transaction: IoTransaction): (MempoolGraph, Set[IoTransaction]) = {
+    val (newGraph, removed) =
+      spenders
+        .getOrElse(transaction.id, Map.empty)
+        .values
+        .flatten
+        .foldLeft(this -> Set.empty[IoTransaction]) { case ((graph, removedTransactions), (id, _)) =>
+          transactions.get(id).foldLeft((graph, removedTransactions)) {
+            case ((graph, removedTransactions), transaction) =>
+              val (newGraph, newRemoved) = graph.removeSubtree(transaction)
+              newGraph -> (removedTransactions ++ newRemoved)
+          }
+        }
+    newGraph.removeSingle(transaction) -> (removed + transaction)
+  }
+
+  /**
+   * Add the given transaction to this graph.  Updates any relevant "spender" and "unresolved" entries.
+   * @param transaction the transaction to add
+   * @return an updated MempoolGraph
+   */
+  def add(transaction: IoTransaction): MempoolGraph = {
+    val spenderEntry =
+      unresolved.toSeq
+        .flatMap { case (id, indices) =>
+          val tx = transactions(id)
+          indices.toIterable
+            .filter(index => tx.inputs.lift(index).exists(_.address.id == transaction.id))
+            .map(index => (tx.inputs(index).address.index, (transaction.id, index)))
+        }
+        .groupBy(_._1)
+        .view
+        .mapValues(_.map(_._2).toSet)
+        .toMap
+    MempoolGraph(
+      transactions = transactions + (transaction.id -> transaction),
+      spenders = spenders + (transaction.id         -> spenderEntry),
+      unresolved = spenderEntry.values.flatten.foldLeft(unresolved) { case (unresolved, (id, index)) =>
+        unresolved.updatedWith(id)(_.map(_ - index).flatMap(NonEmptySet.fromSet))
+      }
+    )
+  }
+}

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/MempoolSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/MempoolSpec.scala
@@ -1,9 +1,9 @@
 package co.topl.ledger.interpreters
 
 import cats.Applicative
-import cats.MonadThrow
 import cats.data.NonEmptyChain
 import cats.effect._
+import cats.effect.implicits._
 import cats.implicits._
 import co.topl.algebras.ClockAlgebra
 import co.topl.brambl.generators.ModelGenerators._
@@ -22,8 +22,6 @@ import org.scalacheck.Gen
 import org.scalacheck.Test
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
-
-import scala.concurrent.duration._
 
 class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
@@ -69,7 +67,6 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
               _ => Applicative[F].unit,
               clock,
               _ => Applicative[F].unit,
-              Long.MaxValue,
               Long.MaxValue
             )
             .use(underTest =>
@@ -122,7 +119,6 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
               _ => Applicative[F].unit,
               clock,
               _ => Applicative[F].unit,
-              Long.MaxValue,
               Long.MaxValue
             )
             .use(_.add(transaction.id).assert)
@@ -145,37 +141,36 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
           .expects()
           .once()
           .returning(0L.pure[F])
-        for {
-          deferred <- Deferred[F, Unit]
-          _ =
-            (clock
-              .delayedUntilSlot(_: Long))
-              // This is the real thing being tested here
-              .expects(transaction.datum.event.schedule.max)
-              .once()
-              .returning(deferred.get)
-          _ <-
-            Mempool
-              .make[F](
-                currentBlockId.pure[F],
-                mockFunction[BlockId, F[BlockBody]],
-                fetchTransaction,
-                mock[ParentChildTree[F, BlockId]],
-                _ => Applicative[F].unit,
-                clock,
-                _ => Applicative[F].unit,
-                Long.MaxValue,
-                Long.MaxValue
-              )
-              .use(underTest =>
-                for {
-                  _ <- underTest.add(transaction.id)
-                  _ <- underTest.read(currentBlockId).assertEquals(Set(transaction.id))
-                  _ <- deferred.complete(())
-                  _ <- retry(underTest.read(currentBlockId).assertEquals(Set.empty[TransactionId]))
-                } yield ()
-              )
-        } yield ()
+        val testResource =
+          for {
+            clockDeferred <- Deferred[F, Unit].toResource
+            _ =
+              (clock
+                .delayedUntilSlot(_: Long))
+                // This is the real thing being tested here
+                .expects(transaction.datum.event.schedule.max)
+                .once()
+                .returning(clockDeferred.get)
+            expirationDeferred <- Deferred[F, Unit].toResource
+            underTest <-
+              Mempool
+                .make[F](
+                  currentBlockId.pure[F],
+                  mockFunction[BlockId, F[BlockBody]],
+                  fetchTransaction,
+                  mock[ParentChildTree[F, BlockId]],
+                  _ => Applicative[F].unit,
+                  clock,
+                  _ => expirationDeferred.complete(()).void,
+                  Long.MaxValue
+                )
+            _ <- underTest.add(transaction.id).toResource
+            _ <- underTest.read(currentBlockId).assertEquals(Set(transaction.id)).toResource
+            _ <- clockDeferred.complete(()).toResource
+            _ <- expirationDeferred.get.toResource
+            _ <- underTest.read(currentBlockId).assertEquals(Set.empty[TransactionId]).toResource
+          } yield ()
+        testResource.use_
       }
     }
   }
@@ -195,131 +190,39 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
           .expects()
           .once()
           .returning(0L.pure[F])
-        for {
-          deferred <- Deferred[F, Unit]
-          _ =
-            (clock
-              .delayedUntilSlot(_: Long))
-              // This is the real thing being tested here
-              .expects(100L)
-              .once()
-              .returning(deferred.get)
-          _ <-
-            Mempool
-              .make[F](
-                currentBlockId.pure[F],
-                mockFunction[BlockId, F[BlockBody]],
-                fetchTransaction,
-                mock[ParentChildTree[F, BlockId]],
-                _ => Applicative[F].unit,
-                clock,
-                _ => Applicative[F].unit,
-                100L,
-                Long.MaxValue
-              )
-              .use(underTest =>
-                for {
-                  _ <- underTest.add(transaction.id)
-                  _ <- underTest.read(currentBlockId).assertEquals(Set(transaction.id))
-                  _ <- deferred.complete(())
-                  _ <- retry(underTest.read(currentBlockId).assertEquals(Set.empty[TransactionId]))
-                } yield ()
-              )
+        val testResource =
+          for {
+            clockDeferred <- Deferred[F, Unit].toResource
+            _ =
+              (clock
+                .delayedUntilSlot(_: Long))
+                // This is the real thing being tested here
+                .expects(100L)
+                .once()
+                .returning(clockDeferred.get)
+            expirationDeferred <- Deferred[F, Unit].toResource
+            underTest <-
+              Mempool
+                .make[F](
+                  currentBlockId.pure[F],
+                  mockFunction[BlockId, F[BlockBody]],
+                  fetchTransaction,
+                  mock[ParentChildTree[F, BlockId]],
+                  _ => Applicative[F].unit,
+                  clock,
+                  _ => expirationDeferred.complete(()).void,
+                  100L
+                )
+            _ <- underTest.add(transaction.id).toResource
+            _ <- underTest.read(currentBlockId).assertEquals(Set(transaction.id)).toResource
+            _ <- clockDeferred.complete(()).toResource
+            _ <- expirationDeferred.get.toResource
 
-        } yield ()
+            _ <- underTest.read(currentBlockId).assertEquals(Set.empty[TransactionId]).toResource
+          } yield ()
+        testResource.use_
       }
     }
   }
-
-  test("expire a transaction more aggressively when a double-spend is detected") {
-    PropF.forAllF {
-      (
-        baseTransaction: IoTransaction,
-        input:           SpentTransactionOutput,
-        ancestorBlockId: BlockId,
-        blockIdA:        BlockId,
-        blockIdB:        BlockId
-      ) =>
-        withMock {
-          val transactionWithSingleInput = baseTransaction.addInputs(input)
-          // Transaction A and Transaction B are exactly the same, except for the creation schedule to force a different ID
-          val transactionA = transactionWithSingleInput.update(_.datum.event.schedule.set(Schedule(0, 100))).embedId
-          val transactionB = transactionWithSingleInput.update(_.datum.event.schedule.set(Schedule(1, 100))).embedId
-          val bodies =
-            Map(
-              blockIdA -> List(transactionA.id),
-              blockIdB -> List(transactionB.id)
-            )
-          val transactions =
-            Map(
-              transactionA.id -> transactionA,
-              transactionB.id -> transactionB
-            )
-
-          val fetchBody = (id: BlockId) => BlockBody(bodies(id)).pure[F]
-          val fetchTransaction = (id: TransactionId) => transactions(id).pure[F]
-          val clock = mock[ClockAlgebra[F]]
-          (() => clock.globalSlot)
-            .expects()
-            .anyNumberOfTimes()
-            .returning(0L.pure[F])
-          for {
-            tree <- ParentChildTree.FromRef.make[F, BlockId]
-            _    <- tree.associate(blockIdA, ancestorBlockId)
-            _    <- tree.associate(blockIdB, ancestorBlockId)
-            _ <- Mempool
-              .make[F](
-                ancestorBlockId.pure[F],
-                fetchBody,
-                fetchTransaction,
-                tree,
-                _ => Applicative[F].unit,
-                clock,
-                _ => Applicative[F].unit,
-                Long.MaxValue,
-                1L
-              )
-              .use(underTest =>
-                for {
-                  _ <- underTest.read(blockIdA).assertEquals(Set.empty[TransactionId])
-                  _ <-
-                    inSequence {
-                      if (transactionA.datum.event.schedule.max != 1L) {
-                        // The "unapply" operation will schedule a normal expiration
-                        (clock
-                          .delayedUntilSlot(_: Long))
-                          .expects(transactionA.datum.event.schedule.max)
-                          .once()
-                          .returning(MonadCancel[F].never[Unit])
-                        // But the "apply" operation will re-schedule the expiration
-                        (clock
-                          .delayedUntilSlot(_: Long))
-                          .expects(1L)
-                          .once()
-                          .returning(MonadCancel[F].never[Unit])
-                      } else {
-                        // This is just an edge-case where the Schedule generator produces a maximum slot of 1L,
-                        // so the scalamock expectation needs to expect the value twice instead of just once
-                        (clock
-                          .delayedUntilSlot(_: Long))
-                          .expects(1L)
-                          .twice()
-                          .returning(MonadCancel[F].never[Unit])
-                      }
-                      underTest.read(blockIdB).assertEquals(Set(transactionA.id))
-                    }
-                } yield ()
-              )
-          } yield ()
-
-        }
-    }
-  }
-
-  private def retry[A](f: => F[A], attempts: Int = 5, delay: FiniteDuration = 100.milli): F[A] =
-    if (attempts > 1)
-      MonadThrow[F].recoverWith(f) { case _ => IO.sleep(delay) >> retry(f, attempts - 1, delay) }
-    else
-      f
 
 }

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -35,8 +35,6 @@ bifrost {
   mempool {
     // The maximum number of slots to retain a Transaction that fails to find its way into a block
     default-expiration-slots = 1000
-    // The maximum number of slots to retain a Transaction that attempts to double-spend
-    duplicate-spender-expiration-slots = 500
   }
   // Settings for the big bang initialization
   big-bang {

--- a/node/src/main/scala/co/topl/node/ApplicationConfig.scala
+++ b/node/src/main/scala/co/topl/node/ApplicationConfig.scala
@@ -62,7 +62,7 @@ object ApplicationConfig {
     case class RPC(bindHost: String, bindPort: Int)
 
     @Lenses
-    case class Mempool(defaultExpirationSlots: Long, duplicateSpenderExpirationSlots: Long)
+    case class Mempool(defaultExpirationSlots: Long)
     sealed abstract class BigBang
 
     object BigBangs {

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -193,8 +193,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig)(implicit syste
         currentEventIdGetterSetters.mempool.set,
         clock,
         id => Logger[F].info(show"Expiring transaction id=$id"),
-        appConfig.bifrost.mempool.defaultExpirationSlots,
-        appConfig.bifrost.mempool.duplicateSpenderExpirationSlots
+        appConfig.bifrost.mempool.defaultExpirationSlots
       )
       implicit0(networkRandom: Random) = new Random(new SecureRandom())
       staking <- privateBigBang.localStakerIndex


### PR DESCRIPTION
## Purpose
- Adds a `MempoolGraph` class which manages the dependencies of transactions within the Mempool
- Updates the old Mempool implementation to use a MempoolGraph internally
- Note: The underlying benefits of the graph structure aren't used yet
- Note: I removed the duplicate-spender detection from the mempool.  It introduced too much complexity, had too many gaps, and needs to be redesigned using the graph model anyway
## Approach
- Added MempoolGraph which tracks Transactions, the Transactions that spend them, and the Transactions that try to spend UTxOs that aren't im the mempool graph
## Testing
- Updated MempoolSpec
- Ran testnet simulator with 2 nodes
## Tickets
- #BN-904
  - Note: I would like to do a follow-up PR with unit tests on the MempoolGraph itself