### PR TITLE
BN-1009-  Genus remove blocks that have been un-adopted 

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/BlockUpdaterAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/BlockUpdaterAlgebra.scala
@@ -7,7 +7,7 @@ import co.topl.genusLibrary.model.GE
  * Inserter of blocks to the chain in the data store.
  * @tparam F the effect-ful context to retrieve the value in
  */
-trait BlockInserterAlgebra[F[_]] {
+trait BlockUpdaterAlgebra[F[_]] {
 
   /**
    * Inserts a block to the chain in the data store.
@@ -15,5 +15,13 @@ trait BlockInserterAlgebra[F[_]] {
    * @return Unit
    */
   def insert(block: BlockData): F[Either[GE, Unit]]
+
+  /**
+   * Removes a block from the chain in the data store.
+   *
+   * @param block the block to be removed in the data store.
+   * @return Unit
+   */
+  def remove(block: BlockData): F[Either[GE, Unit]]
 
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/NodeBlockFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/NodeBlockFetcherAlgebra.scala
@@ -42,11 +42,4 @@ trait NodeBlockFetcherAlgebra[F[_], G[_]] {
    */
   def fetchHeight(): F[Option[Long]]
 
-  /**
-   * Look-up up node's applied blocks ids
-   *
-   * @return height
-   */
-  def fetchAdoptions(): F[G[BlockId]]
-
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcher.scala
@@ -4,7 +4,7 @@ import cats.data.{Chain, EitherT, OptionT}
 import cats.effect.Resource
 import cats.effect.kernel.Async
 import cats.implicits._
-import co.topl.algebras.{SynchronizationTraversalSteps, ToplRpc}
+import co.topl.algebras.ToplRpc
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction._
 import co.topl.consensus.models.BlockId
@@ -14,7 +14,6 @@ import co.topl.genusLibrary.model.{GE, GEs}
 import co.topl.node.models.BlockBody
 import fs2.Stream
 import org.typelevel.log4cats.Logger
-
 import scala.collection.immutable.ListSet
 
 object NodeBlockFetcher {
@@ -96,15 +95,6 @@ object NodeBlockFetcher {
             headBlockId <- OptionT(toplRpc.blockIdAtDepth(depth = 0))
             blockHeader <- OptionT(toplRpc.fetchBlockHeader(headBlockId))
           } yield blockHeader.height).value
-
-        def fetchAdoptions(): F[Stream[F, BlockId]] =
-          for {
-            adoptions <- toplRpc
-              .synchronizationTraversal()
-              .map(_.collect { case SynchronizationTraversalSteps.Applied(blockId) =>
-                blockId
-              })
-          } yield adoptions
 
       }
     }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
@@ -66,7 +66,7 @@ object OrientDBMetadataFactory {
       .flatMap {
         case Some(oClass) =>
           Logger[F]
-            .info(s"${oClass.getName} class found, schema remains equals")
+            .debug(s"${oClass.getName} class found, schema remains equals")
             .as(oClass)
         case _ =>
           Sync[F]
@@ -120,17 +120,17 @@ object OrientDBMetadataFactory {
       .onError { case e => Logger[F].error(e)(s"Failed to create link on ${vs.name}") }
       .void
 
-  private[orientDb] def createEdge[F[_]: Sync: Logger: OrientThread](
+  private[orientDb] def createEdge[F[_]: Sync: Logger](
     db:   ODatabaseDocumentInternal,
     edge: EdgeSchema
-  ) =
-    OrientThread[F].delay(db.activateOnCurrentThread()) >>
-    OrientThread[F]
+  ): F[Unit] =
+    Sync[F].delay(db.activateOnCurrentThread()) >>
+    Sync[F]
       .delay(Option(db.getClass(edge.label)))
       .flatMap {
         case Some(oClass) =>
-          Logger[F].info(s"${oClass.getName} class found, schema remains equals")
+          Logger[F].debug(s"${oClass.getName} class found, schema remains equals")
         case _ =>
-          OrientThread[F].delay(db.createClass(edge.label, "E")).void
+          Sync[F].delay(db.createClass(edge.label, "E")).void
       }
 }

--- a/genus-library/src/test/scala/co/topl/genusLibrary/DbFixtureUtil.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/DbFixtureUtil.scala
@@ -1,7 +1,8 @@
-package co.topl.genusLibrary.orientDb
+package co.topl.genusLibrary
 
 import cats.effect.{IO, Resource, SyncIO}
 import cats.implicits._
+import co.topl.genusLibrary.orientDb.OrientThread
 import com.orientechnologies.orient.core.db.{ODatabaseType, OrientDB, OrientDBConfigBuilder}
 import munit.{CatsEffectSuite, FunSuite, TestOptions}
 import org.typelevel.log4cats.Logger

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphBlockUpdaterTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphBlockUpdaterTest.scala
@@ -21,7 +21,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
-class GraphBlockInserterSuite extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+class GraphBlockUpdaterTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
   type F[A] = IO[A]
 
@@ -36,9 +36,9 @@ class GraphBlockInserterSuite extends CatsEffectSuite with ScalaCheckEffectSuite
       val res = for {
         implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
         blockData                                <- Resource.pure(BlockData(blockHeader.copy(height = 1), null, null))
-        graphHeaderInserter                      <- GraphBlockInserter.make[F](orientGraph)
+        graphBlockUpdater                        <- GraphBlockUpdater.make[F](orientGraph)
         _ <- assertIO(
-          graphHeaderInserter.insert(blockData),
+          graphBlockUpdater.insert(blockData),
           (GEs.InternalMessage("boom!"): GE).asLeft[Unit]
         ).toResource
       } yield ()
@@ -58,9 +58,9 @@ class GraphBlockInserterSuite extends CatsEffectSuite with ScalaCheckEffectSuite
       val res = for {
         implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
         blockData                                <- Resource.pure(BlockData(blockHeader.copy(height = 1), null, null))
-        graphHeaderInserter                      <- GraphBlockInserter.make[F](orientGraph)
+        graphBlockUpdater                        <- GraphBlockUpdater.make[F](orientGraph)
         _ <- assertIO(
-          graphHeaderInserter.insert(blockData),
+          graphBlockUpdater.insert(blockData),
           ().asRight[GE]
         ).toResource
       } yield ()
@@ -80,9 +80,9 @@ class GraphBlockInserterSuite extends CatsEffectSuite with ScalaCheckEffectSuite
         val res = for {
           implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
           blockData                                <- Resource.pure(BlockData(blockHeader.copy(height = 2), null, null))
-          graphHeaderInserter                      <- GraphBlockInserter.make[F](orientGraph)
+          graphBlockUpdater                        <- GraphBlockUpdater.make[F](orientGraph)
           _ <- assertIO(
-            graphHeaderInserter.insert(blockData),
+            graphBlockUpdater.insert(blockData),
             (GEs.InternalMessage("boom!"): GE).asLeft[Unit]
           ).toResource
         } yield ()
@@ -111,9 +111,9 @@ class GraphBlockInserterSuite extends CatsEffectSuite with ScalaCheckEffectSuite
         val res = for {
           implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
           blockData                                <- Resource.pure(BlockData(blockHeader.copy(height = 2), null, null))
-          graphHeaderInserter                      <- GraphBlockInserter.make[F](orientGraph)
+          graphBlockUpdater                        <- GraphBlockUpdater.make[F](orientGraph)
           _ <- assertIO(
-            graphHeaderInserter.insert(blockData),
+            graphBlockUpdater.insert(blockData),
             ().asRight[GE]
           ).toResource
         } yield ()
@@ -140,9 +140,9 @@ class GraphBlockInserterSuite extends CatsEffectSuite with ScalaCheckEffectSuite
         val res = for {
           implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
           blockData                                <- Resource.pure(BlockData(blockHeader.copy(height = 2), null, null))
-          graphHeaderInserter                      <- GraphBlockInserter.make[F](orientGraph)
+          graphBlockUpdater                        <- GraphBlockUpdater.make[F](orientGraph)
           _ <- assertIO(
-            graphHeaderInserter.insert(blockData),
+            graphBlockUpdater.insert(blockData),
             (GEs.InternalMessage("boom!"): GE).asLeft[Unit]
           ).toResource
         } yield ()

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/GraphBlockUpdaterFixtureTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/GraphBlockUpdaterFixtureTest.scala
@@ -1,0 +1,96 @@
+package co.topl.genusLibrary.orientDb
+
+import cats.effect.implicits.effectResourceOps
+import cats.implicits.toTraverseOps
+import co.topl.brambl.generators.ModelGenerators._
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.consensus.models.BlockHeader
+import co.topl.genus.services.BlockData
+import co.topl.genusLibrary.DbFixtureUtil
+import co.topl.genusLibrary.interpreter.GraphBlockUpdater
+import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances._
+import co.topl.genusLibrary.orientDb.schema.EdgeSchemaInstances._
+import co.topl.models.generators.consensus.ModelGenerators._
+import co.topl.models.generators.node.ModelGenerators._
+import co.topl.node.models.BlockBody
+import com.tinkerpop.blueprints.impls.orient.OrientGraphFactoryV2
+import java.util.concurrent.TimeUnit
+import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF
+import org.scalamock.munit.AsyncMockFactory
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.jdk.CollectionConverters.IterableHasAsScala
+
+class GraphBlockUpdaterFixtureTest
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with AsyncMockFactory
+    with CatsEffectFunFixtures
+    with DbFixtureUtil {
+
+  orientDbFixture.test("Insert and remove genesis block") { case (odb, oThread) =>
+    PropF.forAllF { (blockHeader: BlockHeader, blockBody: BlockBody, ioTransaction: IoTransaction) =>
+      val res = for {
+        implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
+        odbFactory <- oThread.delay(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
+        dbNoTx     <- oThread.delay(odbFactory.getNoTx).toResource
+        _          <- oThread.delay(dbNoTx.makeActive()).toResource
+
+        databaseDocumentTx <- oThread.delay(odbFactory.getNoTx.getRawGraph).toResource
+
+        _ <- Seq(
+          blockHeaderSchema,
+          blockBodySchema,
+          ioTransactionSchema,
+          canonicalHeadSchema,
+          lockAddressSchema,
+          txoSchema
+        )
+          .traverse(OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, _))
+          .void
+          .toResource
+
+        _ <- Seq(blockHeaderEdge, blockHeaderBodyEdge, blockHeaderTxIOEdge, addressTxIOEdge, addressTxoEdge)
+          .traverse(e => OrientDBMetadataFactory.createEdge[F](databaseDocumentTx, e))
+          .void
+          .toResource
+
+        blockData = BlockData(
+          blockHeader.copy(height = 1),
+          blockBody,
+          transactions = Seq(ioTransaction.embedId)
+        )
+
+        dbTx <- oThread.delay(odbFactory.getTx).toResource
+
+        graphBlockUpdater <- GraphBlockUpdater.make[F](dbTx)
+        _                 <- graphBlockUpdater.insert(blockData).toResource
+
+        blockHeaderVertex = dbTx.getHeader(blockData.header)
+        _ = assert(blockHeaderVertex.isDefined)
+        _ <- assertIOBoolean(oThread.delay(dbTx.getHeader(blockData.header).isDefined)).toResource
+        _ <- assertIOBoolean(oThread.delay(dbTx.getBody(blockHeaderVertex.get).isDefined)).toResource
+
+        _ <- graphBlockUpdater.remove(blockData).toResource
+
+        // When we remove headerVertex, the canonicalHead schema is not updated, insertions handle it
+        // When we remove txoVertex, lockAddress schema is not updated, because lockAddress references many txo
+        // Eventually could create an orphan lockAddress, it is not a problem cause some future txo will reference it
+        blockHeaderVertex = dbTx.getHeader(blockData.header)
+        _ = assert(blockHeaderVertex.isEmpty)
+        _ <- assertIOBoolean(oThread.delay(dbTx.getHeader(blockData.header).isEmpty)).toResource
+        _ <- assertIOBoolean(oThread.delay(dbTx.getVerticesOfClass(blockBodySchema.name).asScala.isEmpty)).toResource
+        _ <- assertIOBoolean(
+          oThread.delay(dbTx.getVerticesOfClass(ioTransactionSchema.name).asScala.isEmpty)
+        ).toResource
+        _ <- assertIOBoolean(oThread.delay(dbTx.getVerticesOfClass(txoSchema.name).asScala.isEmpty)).toResource
+
+      } yield ()
+
+      res.use_
+    }
+  }
+
+  override def munitTimeout: Duration = new FiniteDuration(60, TimeUnit.SECONDS)
+}

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeaderTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeaderTest.scala
@@ -3,7 +3,8 @@ package co.topl.genusLibrary.orientDb.instances
 import cats.effect.implicits.effectResourceOps
 import cats.implicits._
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
-import co.topl.genusLibrary.orientDb.{DbFixtureUtil, OrientDBMetadataFactory}
+import co.topl.genusLibrary.DbFixtureUtil
+import co.topl.genusLibrary.orientDb.OrientDBMetadataFactory
 import co.topl.genusLibrary.orientDb.instances.SchemaBlockHeader.Field
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.models.generators.consensus.ModelGenerators

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaCanonicalHeadTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaCanonicalHeadTest.scala
@@ -3,9 +3,10 @@ package co.topl.genusLibrary.orientDb.instances
 import cats.effect.implicits.effectResourceOps
 import cats.implicits._
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
+import co.topl.genusLibrary.DbFixtureUtil
 import co.topl.genusLibrary.orientDb.instances.SchemaBlockHeader.Field
 import co.topl.genusLibrary.orientDb.instances.SchemaCanonicalHead.CanonicalHead
-import co.topl.genusLibrary.orientDb.{DbFixtureUtil, OrientDBMetadataFactory}
+import co.topl.genusLibrary.orientDb.OrientDBMetadataFactory
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.models.generators.consensus.ModelGenerators
 import com.orientechnologies.orient.core.metadata.schema.OType

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaLockAddressTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaLockAddressTest.scala
@@ -3,11 +3,12 @@ package co.topl.genusLibrary.orientDb.instances
 import cats.effect.implicits.effectResourceOps
 import cats.implicits._
 import co.topl.genusLibrary.orientDb.instances.SchemaLockAddress.Field
-import co.topl.genusLibrary.orientDb.{DbFixtureUtil, OrientDBMetadataFactory}
+import co.topl.genusLibrary.orientDb.OrientDBMetadataFactory
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.brambl.generators.{ModelGenerators => BramblGens}
 import co.topl.brambl.models.LockAddress
 import co.topl.brambl.codecs.AddressCodecs
+import co.topl.genusLibrary.DbFixtureUtil
 import com.orientechnologies.orient.core.metadata.schema.OType
 import com.tinkerpop.blueprints.impls.orient.OrientGraphFactoryV2
 import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaTxoTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaTxoTest.scala
@@ -4,8 +4,9 @@ import cats.effect.implicits.effectResourceOps
 import cats.implicits._
 import co.topl.brambl.generators.{ModelGenerators => BramblGens}
 import co.topl.genus.services.{Txo, TxoState}
+import co.topl.genusLibrary.DbFixtureUtil
 import co.topl.genusLibrary.orientDb.instances.SchemaTxo.Field
-import co.topl.genusLibrary.orientDb.{DbFixtureUtil, OrientDBMetadataFactory}
+import co.topl.genusLibrary.orientDb.OrientDBMetadataFactory
 import co.topl.models.ModelGenerators.GenHelper
 import com.orientechnologies.orient.core.metadata.schema.OType
 import com.tinkerpop.blueprints.impls.orient.OrientGraphFactoryV2

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/schema/VertexSchemaTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/schema/VertexSchemaTest.scala
@@ -2,7 +2,8 @@ package co.topl.genusLibrary.orientDb.schema
 
 import cats.effect.implicits.effectResourceOps
 import cats.implicits._
-import co.topl.genusLibrary.orientDb.{DbFixtureUtil, OrientDBMetadataFactory}
+import co.topl.genusLibrary.DbFixtureUtil
+import co.topl.genusLibrary.orientDb.OrientDBMetadataFactory
 import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
 import com.tinkerpop.blueprints.impls.orient.OrientGraphFactoryV2
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}


### PR DESCRIPTION
## Purpose
the GraphBlockInserter will need to support the ability to remove blocks that have been un-adopted by the node
## Approach
- When Genus server live block stream receives Applied block -> insert BlockData
- When Genus server live block  stream receives Unapplied block -> delete BlockData

## Testing
- GraphBlockUpdaterFixtureTest was created to test insert/delete of a block, this test uses a memory database without mocking any vertex. The db drop at the end
- To full coverage this implementation, I will need to create a GenusServerTest, which is not implemented yet, and this server is where the processorStream is being called.

## Tickets
BN-1009
