### PR TITLE
BN-1026-implement-network-metrics-p-1

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
@@ -2,6 +2,7 @@ package co.topl.genusLibrary.algebras
 
 import co.topl.brambl.models.{LockAddress, TransactionId, TransactionOutputAddress}
 import co.topl.consensus.models.BlockId
+import co.topl.genus.services.GetTxoStatsRes.TxoStats
 import co.topl.genusLibrary.model.GE
 import com.tinkerpop.blueprints.Vertex
 
@@ -79,5 +80,12 @@ trait VertexFetcherAlgebra[F[_]] {
    * @return Optional Txo vertex, None if it was not found
    */
   def fetchTxo(transactionOutputAddress: TransactionOutputAddress): F[Either[GE, Option[Vertex]]]
+
+  /**
+   * Fetch Txo Stats
+   *
+   * @return a vertex with stats TxOs spent, unspent ...
+   */
+  def fetchTxoStats(): F[Either[GE, TxoStats]]
 
 }

--- a/node/src/main/scala/co/topl/genus/GenusServer.scala
+++ b/node/src/main/scala/co/topl/genus/GenusServer.scala
@@ -45,7 +45,7 @@ object GenusServer {
       nodeBlockFetcher <- NodeBlockFetcher.make(rpcInterpreter)
 
       _ <- GenusGrpc.Server
-        .serve(conf.rpcHost, conf.rpcPort, blockFetcher, transactionFetcher)
+        .serve(conf.rpcHost, conf.rpcPort, blockFetcher, transactionFetcher, vertexFetcher)
         .evalTap(grpcServer =>
           Logger[F].info(s"RPC Server bound at ${grpcServer.getListenSockets.asScala.toList.mkString(",")}")
         )

--- a/node/src/main/scala/co/topl/genus/GrpcNetworkMetricsService.scala
+++ b/node/src/main/scala/co/topl/genus/GrpcNetworkMetricsService.scala
@@ -1,0 +1,20 @@
+package co.topl.genus
+
+import cats.data.EitherT
+import cats.effect.kernel.Async
+import co.topl.genus.services._
+import co.topl.genusLibrary.algebras.VertexFetcherAlgebra
+import co.topl.genusLibrary.model.GEs
+import io.grpc.Metadata
+
+class GrpcNetworkMetricsService[F[_]: Async](vertexFetcher: VertexFetcherAlgebra[F])
+    extends NetworkMetricsServiceFs2Grpc[F, Metadata] {
+
+  override def getTxoStats(request: GetTxoStatsReq, ctx: Metadata): F[GetTxoStatsRes] =
+    EitherT(vertexFetcher.fetchTxoStats())
+      .foldF(
+        ge => Async[F].raiseError[GetTxoStatsRes](GEs.Internal(ge)),
+        stats => Async[F].delay(GetTxoStatsRes(stats))
+      )
+      .adaptErrorsToGrpc
+}

--- a/node/src/main/scala/co/topl/genus/GrpcTransactionService.scala
+++ b/node/src/main/scala/co/topl/genus/GrpcTransactionService.scala
@@ -27,19 +27,22 @@ class GrpcTransactionService[F[_]: Async](transactionFetcher: TransactionFetcher
       .map(TransactionResponse(_))
       .adaptErrorsToGrpc
 
-  override def getTransactionByAddressStream(
-    request: QueryByAddressRequest,
+  override def getTransactionByLockAddressStream(
+    request: QueryByLockAddressRequest,
     ctx:     Metadata
   ): Stream[F, TransactionResponse] =
     Stream.raiseError[F](GEs.UnImplemented).adaptErrorsToGrpc
 
-  override def getTxosByAddress(request: QueryByAddressRequest, ctx: Metadata): F[TxoAddressResponse] =
+  override def getTxosByLockAddress(request: QueryByLockAddressRequest, ctx: Metadata): F[TxoLockAddressResponse] =
     EitherT(transactionFetcher.fetchTransactionByLockAddress(request.address, request.state))
-      .map(TxoAddressResponse(_))
+      .map(TxoLockAddressResponse(_))
       .rethrowT
       .adaptErrorsToGrpc
 
-  override def getTxosByAddressStream(request: QueryByAddressRequest, ctx: Metadata): Stream[F, TxoAddressResponse] =
+  override def getTxosByLockAddressStream(
+    request: QueryByLockAddressRequest,
+    ctx:     Metadata
+  ): Stream[F, TxoLockAddressResponse] =
     Stream.raiseError[F](GEs.UnImplemented).adaptErrorsToGrpc
 
   override def getTxosByAssetLabel(request: QueryByAssetLabelRequest, ctx: Metadata): Stream[F, TxoResponse] =

--- a/node/src/test/scala/co/topl/genus/GrpcBlockServiceTest.scala
+++ b/node/src/test/scala/co/topl/genus/GrpcBlockServiceTest.scala
@@ -15,7 +15,7 @@ import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 
-class GrpcBlockServiceSuite extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+class GrpcBlockServiceTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   type F[A] = IO[A]
 
   test("getBlockById: OK") {

--- a/node/src/test/scala/co/topl/genus/GrpcNetworkMetricsServiceTest.scala
+++ b/node/src/test/scala/co/topl/genus/GrpcNetworkMetricsServiceTest.scala
@@ -1,0 +1,55 @@
+package co.topl.genus
+
+import cats.effect.IO
+import cats.implicits._
+import co.topl.genus.services.GetTxoStatsRes.TxoStats
+import co.topl.genus.services._
+import co.topl.genusLibrary.algebras.VertexFetcherAlgebra
+import co.topl.genusLibrary.model.{GE, GEs}
+import io.grpc.{Metadata, StatusException}
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalamock.munit.AsyncMockFactory
+
+class GrpcNetworkMetricsServiceTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+  type F[A] = IO[A]
+
+  test("getTxoStats: Exceptions") {
+
+    withMock {
+      val vertexFetcher = mock[VertexFetcherAlgebra[F]]
+      val underTest = new GrpcNetworkMetricsService[F](vertexFetcher)
+
+      (() => vertexFetcher.fetchTxoStats())
+        .expects()
+        .once()
+        .returning((GEs.Internal(new IllegalStateException("Boom!")): GE).asLeft[TxoStats].pure[F])
+
+      for {
+        _ <- interceptMessageIO[StatusException]("INTERNAL: Boom!")(
+          underTest.getTxoStats(GetTxoStatsReq(), new Metadata())
+        )
+      } yield ()
+    }
+
+  }
+
+  test("getTxoStats: Default Stats") {
+
+    withMock {
+      val vertexFetcher = mock[VertexFetcherAlgebra[F]]
+      val underTest = new GrpcNetworkMetricsService[F](vertexFetcher)
+
+      (() => vertexFetcher.fetchTxoStats())
+        .expects()
+        .once()
+        .returning(TxoStats.defaultInstance.asRight[GE].pure[F])
+
+      for {
+        res <- underTest.getTxoStats(GetTxoStatsReq(), new Metadata())
+        _ = assert(res.txos.total == 0)
+      } yield ()
+    }
+
+  }
+
+}

--- a/node/src/test/scala/co/topl/genus/GrpcTransactionServiceTest.scala
+++ b/node/src/test/scala/co/topl/genus/GrpcTransactionServiceTest.scala
@@ -90,7 +90,7 @@ class GrpcTransactionServiceTest extends CatsEffectSuite with ScalaCheckEffectSu
 
   }
 
-  test("getTxosByAddress: Exceptions") {
+  test("getTxosByLockAddress: Exceptions") {
     PropF.forAllF { (lockAddress: LockAddress) =>
       withMock {
         val transactionFetcher = mock[TransactionFetcherAlgebra[F]]
@@ -103,14 +103,14 @@ class GrpcTransactionServiceTest extends CatsEffectSuite with ScalaCheckEffectSu
 
         for {
           _ <- interceptMessageIO[StatusException]("INTERNAL: Boom!")(
-            underTest.getTxosByAddress(QueryByAddressRequest(lockAddress), new Metadata())
+            underTest.getTxosByLockAddress(QueryByLockAddressRequest(lockAddress), new Metadata())
           )
         } yield ()
       }
     }
   }
 
-  test("getTxosByAddress: Empty sequence") {
+  test("getTxosByLockAddress: Empty sequence") {
     PropF.forAllF { (lockAddress: LockAddress) =>
       withMock {
         val transactionFetcher = mock[TransactionFetcherAlgebra[F]]
@@ -122,7 +122,7 @@ class GrpcTransactionServiceTest extends CatsEffectSuite with ScalaCheckEffectSu
           .returning(Seq.empty[Txo].asRight[GE].pure[F])
 
         for {
-          res <- underTest.getTxosByAddress(QueryByAddressRequest(lockAddress), new Metadata())
+          res <- underTest.getTxosByLockAddress(QueryByLockAddressRequest(lockAddress), new Metadata())
           _ = assert(res.txos.isEmpty)
 
         } yield ()
@@ -130,7 +130,7 @@ class GrpcTransactionServiceTest extends CatsEffectSuite with ScalaCheckEffectSu
     }
   }
 
-  test("getTxosByAddress: ok") {
+  test("getTxosByLockAddress: ok") {
     PropF.forAllF {
       (
         lockAddress:       LockAddress,
@@ -152,7 +152,7 @@ class GrpcTransactionServiceTest extends CatsEffectSuite with ScalaCheckEffectSu
             .returning(Seq(txo).asRight[GE].pure[F])
 
           for {
-            res <- underTest.getTxosByAddress(QueryByAddressRequest(lockAddress), new Metadata())
+            res <- underTest.getTxosByLockAddress(QueryByLockAddressRequest(lockAddress), new Metadata())
             _ = assert(res.txos.head == txo)
 
           } yield ()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.18"
-  val protobufSpecsVersion = "e7b3bec" // scala-steward:off
+  val protobufSpecsVersion = "dfec2a0" // scala-steward:off
   val bramblScVersion = "01cad77" // scala-steward:off
   val quivr4sVersion = "1e48130" // scala-steward:off
 


### PR DESCRIPTION
## Purpose
BN-1026-implement-network-metrics-p-1
## Approach
- for this initial implementation,  "txo spent / txo unspent / txo pending / txo total"
- update protobudSpecs lates, which includes the new rpc Netowrk metrics service, and LockAdressRefactor
## Testing
The endpoint is returning 3 unspent TxOs generated by genesis-block
![image](https://github.com/Topl/Bifrost/assets/8540107/6e2f51bd-201c-4d61-8624-fb10fdda79f7)

## Tickets
BN-1026
