### PR TITLE
BN-1025-node-checks-mempool-membership

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
@@ -16,6 +16,7 @@ trait ToplRpc[F[_], S[_]] {
   def broadcastTransaction(transaction: IoTransaction): F[Unit]
 
   def currentMempool(): F[Set[TransactionId]]
+  def currentMempoolContains(transactionId: TransactionId): F[Boolean]
 
   def fetchBlockHeader(blockId: BlockId): F[Option[BlockHeader]]
 

--- a/blockchain/src/main/scala/co/topl/blockchain/MempoolBroadcaster.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/MempoolBroadcaster.scala
@@ -28,6 +28,9 @@ object MempoolBroadcaster {
                 .rethrowT
 
             def remove(transactionId: TransactionId): F[Unit] = mempool.remove(transactionId)
+
+            def contains(blockId: BlockId, transactionId: TransactionId): F[Boolean] =
+              mempool.contains(blockId, transactionId)
           }
 
         (interpreter, topic)

--- a/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
@@ -78,6 +78,9 @@ object ToplRpcServer {
         def currentMempool(): F[Set[TransactionId]] =
           localChain.head.map(_.slotId.blockId).flatMap(blockId => mempool.read(blockId))
 
+        override def currentMempoolContains(transactionId: TransactionId): F[Boolean] =
+          localChain.head.map(_.slotId.blockId).flatMap(blockId => mempool.contains(blockId, transactionId))
+
         def fetchBlockHeader(blockId: BlockId): F[Option[BlockHeader]] =
           OptionT(headerStore.get(blockId)).map(_.embedId).value
 

--- a/common-interpreters/src/main/scala/co/topl/interpreters/MultiToplRpc.scala
+++ b/common-interpreters/src/main/scala/co/topl/interpreters/MultiToplRpc.scala
@@ -41,6 +41,9 @@ object MultiToplRpc {
       def currentMempool(): F[Set[TransactionId]] =
         randomDelegate.flatMap(_.currentMempool())
 
+      def currentMempoolContains(transactionId: TransactionId): F[Boolean] =
+        randomDelegate.flatMap(_.currentMempoolContains(transactionId))
+
       def fetchBlockHeader(blockId: BlockId): F[Option[BlockHeader]] =
         randomDelegate.flatMap(_.fetchBlockHeader(blockId))
 

--- a/ledger/src/main/scala/co/topl/ledger/algebras/MempoolAlgebra.scala
+++ b/ledger/src/main/scala/co/topl/ledger/algebras/MempoolAlgebra.scala
@@ -20,4 +20,9 @@ trait MempoolAlgebra[F[_]] {
    */
   def remove(transactionId: TransactionId): F[Unit]
 
+  /**
+   * Check the set of unconfirmed Transaction IDs at the given block ID, if it contains a specific Transaction ID
+   */
+  def contains(blockId: BlockId, transactionId: TransactionId): F[Boolean]
+
 }

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/Mempool.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/Mempool.scala
@@ -99,6 +99,11 @@ object Mempool {
 
       def remove(transactionId: TransactionId): F[Unit] =
         fetchTransaction(transactionId).flatMap(removeWithExpiration)
+
+      def contains(blockId: BlockId, transactionId: TransactionId): F[Boolean] =
+        eventSourcedState
+          .useStateAt(blockId)(_.get)
+          .map(_.transactions.contains(transactionId))
     }
 
 }

--- a/node/src/main/scala/co/topl/genus/GrpcTransactionService.scala
+++ b/node/src/main/scala/co/topl/genus/GrpcTransactionService.scala
@@ -27,19 +27,22 @@ class GrpcTransactionService[F[_]: Async](transactionFetcher: TransactionFetcher
       .map(TransactionResponse(_))
       .adaptErrorsToGrpc
 
-  override def getTransactionByAddressStream(
-    request: QueryByAddressRequest,
+  override def getTransactionByLockAddressStream(
+    request: QueryByLockAddressRequest,
     ctx:     Metadata
   ): Stream[F, TransactionResponse] =
     Stream.raiseError[F](GEs.UnImplemented).adaptErrorsToGrpc
 
-  override def getTxosByAddress(request: QueryByAddressRequest, ctx: Metadata): F[TxoAddressResponse] =
+  override def getTxosByLockAddress(request: QueryByLockAddressRequest, ctx: Metadata): F[TxoLockAddressResponse] =
     EitherT(transactionFetcher.fetchTransactionByLockAddress(request.address, request.state))
-      .map(TxoAddressResponse(_))
+      .map(TxoLockAddressResponse(_))
       .rethrowT
       .adaptErrorsToGrpc
 
-  override def getTxosByAddressStream(request: QueryByAddressRequest, ctx: Metadata): Stream[F, TxoAddressResponse] =
+  override def getTxosByLockAddressStream(
+    request: QueryByLockAddressRequest,
+    ctx:     Metadata
+  ): Stream[F, TxoLockAddressResponse] =
     Stream.raiseError[F](GEs.UnImplemented).adaptErrorsToGrpc
 
   override def getTxosByAssetLabel(request: QueryByAssetLabelRequest, ctx: Metadata): Stream[F, TxoResponse] =

--- a/node/src/test/scala/co/topl/genus/GrpcTransactionServiceTest.scala
+++ b/node/src/test/scala/co/topl/genus/GrpcTransactionServiceTest.scala
@@ -90,7 +90,7 @@ class GrpcTransactionServiceTest extends CatsEffectSuite with ScalaCheckEffectSu
 
   }
 
-  test("getTxosByAddress: Exceptions") {
+  test("getTxosByLockAddress: Exceptions") {
     PropF.forAllF { (lockAddress: LockAddress) =>
       withMock {
         val transactionFetcher = mock[TransactionFetcherAlgebra[F]]
@@ -103,14 +103,14 @@ class GrpcTransactionServiceTest extends CatsEffectSuite with ScalaCheckEffectSu
 
         for {
           _ <- interceptMessageIO[StatusException]("INTERNAL: Boom!")(
-            underTest.getTxosByAddress(QueryByAddressRequest(lockAddress), new Metadata())
+            underTest.getTxosByLockAddress(QueryByLockAddressRequest(lockAddress), new Metadata())
           )
         } yield ()
       }
     }
   }
 
-  test("getTxosByAddress: Empty sequence") {
+  test("getTxosByLockAddress: Empty sequence") {
     PropF.forAllF { (lockAddress: LockAddress) =>
       withMock {
         val transactionFetcher = mock[TransactionFetcherAlgebra[F]]
@@ -122,7 +122,7 @@ class GrpcTransactionServiceTest extends CatsEffectSuite with ScalaCheckEffectSu
           .returning(Seq.empty[Txo].asRight[GE].pure[F])
 
         for {
-          res <- underTest.getTxosByAddress(QueryByAddressRequest(lockAddress), new Metadata())
+          res <- underTest.getTxosByLockAddress(QueryByLockAddressRequest(lockAddress), new Metadata())
           _ = assert(res.txos.isEmpty)
 
         } yield ()
@@ -130,7 +130,7 @@ class GrpcTransactionServiceTest extends CatsEffectSuite with ScalaCheckEffectSu
     }
   }
 
-  test("getTxosByAddress: ok") {
+  test("getTxosByLockAddress: ok") {
     PropF.forAllF {
       (
         lockAddress:       LockAddress,
@@ -152,7 +152,7 @@ class GrpcTransactionServiceTest extends CatsEffectSuite with ScalaCheckEffectSu
             .returning(Seq(txo).asRight[GE].pure[F])
 
           for {
-            res <- underTest.getTxosByAddress(QueryByAddressRequest(lockAddress), new Metadata())
+            res <- underTest.getTxosByLockAddress(QueryByLockAddressRequest(lockAddress), new Metadata())
             _ = assert(res.txos.head == txo)
 
           } yield ()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.18"
-  val protobufSpecsVersion = "e7b3bec" // scala-steward:off
+  val protobufSpecsVersion = "4ef9028" // scala-steward:off // TODO change once Pr is merged https://github.com/Topl/protobuf-specs/pull/60
   val bramblScVersion = "01cad77" // scala-steward:off
   val quivr4sVersion = "1e48130" // scala-steward:off
 

--- a/topl-grpc/src/main/scala/co/topl/grpc/ToplGrpc.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/ToplGrpc.scala
@@ -66,6 +66,14 @@ object ToplGrpc {
                 )
                 .map(_.transactionIds.toSet)
 
+            override def currentMempoolContains(transactionId: TransactionId): F[Boolean] =
+              client
+                .currentMempoolContains(
+                  CurrentMempoolContainsReq(transactionId),
+                  new Metadata()
+                )
+                .map(_.inMempool)
+
             def fetchBlockHeader(blockId: BlockId): F[Option[BlockHeader]] =
               client
                 .fetchBlockHeader(
@@ -153,6 +161,15 @@ object ToplGrpc {
           .currentMempool()
           .map(_.toList)
           .map(CurrentMempoolRes(_))
+          .adaptErrorsToGrpc
+
+      override def currentMempoolContains(
+        request: CurrentMempoolContainsReq,
+        ctx:     Metadata
+      ): F[CurrentMempoolContainsRes] =
+        interpreter
+          .currentMempoolContains(request.transactionId)
+          .map(CurrentMempoolContainsRes(_))
           .adaptErrorsToGrpc
 
       def fetchBlockHeader(in: FetchBlockHeaderReq, ctx: Metadata): F[FetchBlockHeaderRes] =

--- a/topl-grpc/src/test/scala/co/topl/grpc/ToplGrpcSpec.scala
+++ b/topl-grpc/src/test/scala/co/topl/grpc/ToplGrpcSpec.scala
@@ -125,6 +125,28 @@ class ToplGrpcSpec extends CatsEffectSuite with ScalaCheckEffectSuite with Async
     }
   }
 
+  test("Current Mempool Contains transactionId can be retrieved") {
+    PropF.forAllF { (transaction: IoTransaction) =>
+      val transactionId = transaction.id
+      withMock {
+        val interpreter = mock[ToplRpc[F, Stream[F, *]]]
+        val underTest = new ToplGrpc.Server.GrpcServerImpl[F](interpreter)
+
+        (interpreter.currentMempoolContains _)
+          .expects(transactionId)
+          .once()
+          .returning(false.pure[F])
+
+        for {
+          _ <- assertIO(
+            underTest.currentMempoolContains(CurrentMempoolContainsReq(transactionId), new Metadata()),
+            CurrentMempoolContainsRes(inMempool = false)
+          )
+        } yield ()
+      }
+    }
+  }
+
   // TODO: fetchBlockIdAtDepth has no unit testing
   // TODO: currentMempool has no unit testing
   // TODO: synchronizationTraversal has no unit Testing


### PR DESCRIPTION
## Purpose
BN-1025-node-checks-mempool-membership

## Approach
- new Rpc Node service on protobuf-spec: TODO Merge:  https://github.com/Topl/protobuf-specs/pull/60
- implement node rpc server/client
- new method in mempool algebra

## Testing
- preparePr, 

## Tickets
BN-1095
