### PR TITLE
add Genus genesis block to sanityCheck

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ToplGenusRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ToplGenusRpc.scala
@@ -1,0 +1,19 @@
+package co.topl.algebras
+
+import co.topl.genus.services.BlockResponse
+
+/**
+ * Topl Genus Rpc
+ * An interaction layer intended for users/clients of a blockchain node.
+ *
+ * @tparam F Effect type
+ * @tparam S Canonical head changes Synchronization Traversal Container, Ex: Stream, Seq
+ */
+
+/**
+ * TODO Genus Rpc is used by GenusGrpc Client Implementation, which is used only right now by Byzantine test
+ * In future PRs, we should complete the Client Implementation, and this trait
+ */
+trait ToplGenusRpc[F[_]] {
+  def blockIdAtHeight(height: Long): F[BlockResponse]
+}

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/SanityCheckNodeTest.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/SanityCheckNodeTest.scala
@@ -12,13 +12,17 @@ class SanityCheckNodeTest extends IntegrationSuite {
       for {
         (dockerSupport, _dockerClient) <- DockerSupport.make[F]()
         implicit0(dockerClient: DockerClient) = _dockerClient
-        node1       <- dockerSupport.createNode("SingleNodeTest-node1", "SingleNodeTest", TestNodeConfig().yaml)
-        _           <- node1.startContainer[F].toResource
-        node1Client <- node1.rpcClient[F]
-        _           <- node1Client.waitForRpcStartUp.toResource
-        _           <- Logger[F].info("Fetching genesis block").toResource
-        _           <- node1Client.blockIdAtHeight(1).map(_.nonEmpty).assert.toResource
-        _           <- Logger[F].info("Success").toResource
+        node1        <- dockerSupport.createNode("SingleNodeTest-node1", "SingleNodeTest", TestNodeConfig(genusEnabled = true))
+        _            <- node1.startContainer[F].toResource
+        node1Client  <- node1.rpcClient[F](node1.config.rpcPort, tls = false)
+        genus1Client <- node1.rpcGenusClient[F](node1.config.genusRpcPort, tls = false)
+        _            <- node1Client.waitForRpcStartUp.toResource
+        _            <- genus1Client.waitForRpcStartUp.toResource
+        _            <- Logger[F].info("Fetching genesis block Node Grpc Client").toResource
+        _            <- node1Client.blockIdAtHeight(1).map(_.nonEmpty).assert.toResource
+        _            <- Logger[F].info("Fetching genesis block Genus Grpc Client").toResource
+        _            <- genus1Client.blockIdAtHeight(1).map(_.block.header.height).assertEquals(1L).toResource
+        _            <- Logger[F].info("Success").toResource
       } yield ()
 
     resource.use_

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/BifrostDockerTetraNode.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/BifrostDockerTetraNode.scala
@@ -1,3 +1,3 @@
 package co.topl.tetra.it.util
 
-case class BifrostDockerTetraNode(containerId: String, name: String)
+case class BifrostDockerTetraNode(containerId: String, name: String, config: TestNodeConfig)

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/DockerSupport.scala
@@ -22,9 +22,8 @@ trait DockerSupport[F[_]] {
   def createNode(
     name:          String,
     nodeGroupName: String,
-    configYaml:    String = ""
+    config:        TestNodeConfig
   ): Resource[F, BifrostDockerTetraNode]
-
 }
 
 object DockerSupport {
@@ -76,9 +75,9 @@ object DockerSupport {
   )(implicit dockerClient: DockerClient)
       extends DockerSupport[F] {
 
-    def createNode(name: String, nodeGroupName: String, configYaml: String): Resource[F, BifrostDockerTetraNode] =
+    def createNode(name: String, nodeGroupName: String, config: TestNodeConfig): Resource[F, BifrostDockerTetraNode] =
       for {
-        node <- Resource.make(createContainer(name, nodeGroupName))(node =>
+        node <- Resource.make(createContainer(name, nodeGroupName, config))(node =>
           Sync[F].defer(node.stop[F]) >>
           containerLogsDirectory
             .map(_ / s"$name-${node.containerId.take(8)}.log")
@@ -86,16 +85,21 @@ object DockerSupport {
           deleteContainer(node)
         )
         _ <- Resource.onFinalize(Sync[F].defer(nodeCache.update(_ - node)))
-        _ <- node.configure(configYaml).toResource
+        _ <- node.configure(config.yaml).toResource
       } yield node
 
-    private def createContainer(name: String, nodeGroupName: String): F[BifrostDockerTetraNode] =
+    private def createContainer(
+      name:          String,
+      nodeGroupName: String,
+      config:        TestNodeConfig
+    ): F[BifrostDockerTetraNode] = {
+      val networkNamePrefix: String = "bifrost-it"
       for {
-        networkName <- (DockerSupport.networkNamePrefix + nodeGroupName).pure[F]
+        networkName <- (networkNamePrefix + nodeGroupName).pure[F]
         environment = Map("BIFROST_LOG_LEVEL" -> (if (debugLoggingEnabled) "DEBUG" else "INFO"))
-        containerConfig   <- buildContainerConfig(name, environment).pure[F]
+        containerConfig   <- buildContainerConfig(name, environment, config).pure[F]
         containerCreation <- Sync[F].blocking(dockerClient.createContainer(containerConfig, name))
-        node              <- BifrostDockerTetraNode(containerCreation.id(), name).pure[F]
+        node              <- BifrostDockerTetraNode(containerCreation.id(), name, config).pure[F]
         _                 <- nodeCache.update(_ + node)
         networkId <- Sync[F].blocking(dockerClient.listNetworks().asScala.find(_.name == networkName)).flatMap {
           case Some(network) => network.id().pure[F]
@@ -107,20 +111,28 @@ object DockerSupport {
         }
         _ <- Sync[F].blocking(dockerClient.connectToNetwork(node.containerId, networkId))
       } yield node
+    }
 
     private def deleteContainer(node: BifrostDockerTetraNode): F[Unit] =
       Sync[F].blocking(
         dockerClient.removeContainer(node.containerId, DockerClient.RemoveContainerParam.forceKill)
       )
 
-    private def buildContainerConfig(name: String, environment: Map[String, String]): ContainerConfig = {
+    private def buildContainerConfig(
+      name:        String,
+      environment: Map[String, String],
+      config:      TestNodeConfig
+    ): ContainerConfig = {
+      val configDirectory = "/opt/docker/config"
+      val bifrostImage: String = s"toplprotocol/bifrost-node:${BuildInfo.version}"
+      val exposedPorts: Seq[String] = List(config.rpcPort, config.p2pPort, config.jmxRemotePort).map(_.toString)
       val env =
         environment.toList.map { case (key, value) => s"$key=$value" }
 
       val cmd =
         List(
-          s"-Dcom.sun.management.jmxremote.port=$jmxRemotePort",
-          s"-Dcom.sun.management.jmxremote.rmi.port=$jmxRemotePort",
+          s"-Dcom.sun.management.jmxremote.port=${config.jmxRemotePort}",
+          s"-Dcom.sun.management.jmxremote.rmi.port=${config.jmxRemotePort}",
           "-Dcom.sun.management.jmxremote.ssl=false",
           "-Dcom.sun.management.jmxremote.local.only=false",
           "-Dcom.sun.management.jmxremote.authenticate=false",
@@ -136,7 +148,7 @@ object DockerSupport {
 
       ContainerConfig
         .builder()
-        .image(DockerSupport.bifrostImage)
+        .image(bifrostImage)
         .env(env: _*)
         .volumes(configDirectory)
         .cmd(cmd: _*)
@@ -146,17 +158,6 @@ object DockerSupport {
         .build()
     }
   }
-
-  val configDirectory = "/opt/docker/config"
-
-  val bifrostImage: String = s"toplprotocol/bifrost-node:${BuildInfo.version}"
-  val networkNamePrefix: String = "bifrost-it"
-
-  val rpcPortKeyPath = "bifrost.rpc.bind-port"
-  val rpcPort = "9084"
-  val p2pPort = "9085"
-  val jmxRemotePort = "9083"
-  val exposedPorts: Seq[String] = List(rpcPort, p2pPort, jmxRemotePort)
 }
 
 case class TestNodeConfig(
@@ -164,7 +165,12 @@ case class TestNodeConfig(
   stakerCount:      Int = 1,
   localStakerIndex: Int = 0,
   knownPeers:       List[String] = Nil,
-  stakes:           Option[List[BigInt]] = None
+  stakes:           Option[List[BigInt]] = None,
+  rpcPort:          Int = 9084,
+  p2pPort:          Int = 9085,
+  jmxRemotePort:    Int = 9083,
+  genusEnabled:     Boolean = false,
+  genusRpcPort:     Int = 9091
 ) {
 
   def yaml: String = {
@@ -175,10 +181,10 @@ case class TestNodeConfig(
        |bifrost:
        |  rpc:
        |    bind-host: 0.0.0.0
-       |    port: 9084
+       |    port: "$rpcPort"
        |  p2p:
        |    bind-host: 0.0.0.0
-       |    port: 9085
+       |    port: "$p2pPort"
        |    known-peers: "${knownPeers.map(p => s"$p:9085").mkString(",")}"
        |  big-bang:
        |    staker-count: $stakerCount
@@ -188,6 +194,14 @@ case class TestNodeConfig(
        |  protocols:
        |    0:
        |      slot-duration: 200 milli
+       |genus:
+       |  enable: "$genusEnabled"
+       |  rpc:
+       |    port: "$genusRpcPort"
+       |    node:
+       |      host: "localhost"
+       |      port: "$rpcPort"
+       |      tls: "false"
        |""".stripMargin
   }
 

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/GenusRpcApi.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/GenusRpcApi.scala
@@ -1,0 +1,29 @@
+package co.topl.tetra.it.util
+
+import cats.effect._
+import cats.implicits._
+import co.topl.algebras.ToplGenusRpc
+
+import fs2.Stream
+import org.typelevel.log4cats.Logger
+import scala.concurrent.duration._
+
+class GenusRpcApi[F[_]](val client: ToplGenusRpc[F]) extends AnyVal {
+
+  def waitForRpcStartUp(implicit asyncF: Async[F], loggerF: Logger[F]): F[Unit] =
+    for {
+      _ <- Logger[F].info("Waiting for Genus RPC to start up")
+      _ <-
+        Stream
+          .retry(
+            client
+              .blockIdAtHeight(1),
+            250.milli,
+            identity,
+            200
+          )
+          .compile
+          .lastOrError
+      _ <- Logger[F].info("Genesis block timestamp reached.  Node is ready.")
+    } yield ()
+}

--- a/byzantine-tests/src/it/scala/co/topl/tetra/it/util/package.scala
+++ b/byzantine-tests/src/it/scala/co/topl/tetra/it/util/package.scala
@@ -1,14 +1,16 @@
 package co.topl.tetra.it
 
-import co.topl.algebras.ToplRpc
+import co.topl.algebras.{ToplGenusRpc, ToplRpc}
 import com.spotify.docker.client.DockerClient
-
 import scala.language.implicitConversions
 
 package object util {
 
   implicit def rpcToRpcApi[F[_]](rpc: ToplRpc[F, fs2.Stream[F, *]]): NodeRpcApi[F] =
     new NodeRpcApi(rpc)
+
+  implicit def rpcToGenusRpcApi[F[_]](rpc: ToplGenusRpc[F]): GenusRpcApi[F] =
+    new GenusRpcApi(rpc)
 
   implicit def nodeToDockerApi(node: BifrostDockerTetraNode)(implicit
     dockerClient: DockerClient

--- a/node/src/main/scala/co/topl/genus/GenusGrpc.scala
+++ b/node/src/main/scala/co/topl/genus/GenusGrpc.scala
@@ -1,18 +1,59 @@
 package co.topl.genus
 
+import cats.{Eval, Now}
 import cats.effect.kernel.Async
 import cats.effect.kernel.Resource
+import cats.implicits._
+import co.topl.algebras.ToplGenusRpc
 import co.topl.genus.services._
 import co.topl.genusLibrary.algebras.BlockFetcherAlgebra
 import co.topl.genusLibrary.algebras.TransactionFetcherAlgebra
 import fs2.grpc.syntax.all._
-import io.grpc.Server
-import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
+import io.grpc.{Metadata, Server}
+import io.grpc.netty.shaded.io.grpc.netty.{NettyChannelBuilder, NettyServerBuilder}
 import io.grpc.protobuf.services.ProtoReflectionService
-
 import java.net.InetSocketAddress
 
 object GenusGrpc {
+
+  object Client {
+
+    /**
+     * Creates a Genus RPC Client for interacting with a Bifrost node
+     *
+     * @param host Genus node host/IP
+     * @param port Genus node port
+     * @param tls  Should the connection use TLS?
+     */
+    def make[F[_]: Async](host: String, port: Int, tls: Boolean): Resource[F, ToplGenusRpc[F]] =
+      Eval
+        .now(NettyChannelBuilder.forAddress(host, port))
+        .flatMap(ncb =>
+          Eval
+            .now(tls)
+            .ifM(
+              Now(ncb.useTransportSecurity()),
+              Now(ncb.usePlaintext())
+            )
+        )
+        .value
+        .resource[F]
+        .flatMap(BlockServiceFs2Grpc.stubResource[F])
+        .map(client =>
+          new ToplGenusRpc[F] {
+
+            override def blockIdAtHeight(height: Long): F[BlockResponse] =
+              client.getBlockByHeight(
+                GetBlockByHeightRequest(
+                  ChainDistance(height),
+                  confidenceFactor = None
+                ),
+                new Metadata()
+              )
+          }
+        )
+
+  }
 
   object Server {
 


### PR DESCRIPTION
## Purpose
add Genus genesis block to sanityCheck
## Approach
- Create Genus Grpc client, with only 1 methd used by byzantine test, In futures PR, complete the implementation
- refactor on Test config, and not hard code ports or tls communications with Rpcs

## Testing
Byzantine test, preparePr

## Tickets
BN-1032
