### PR TITLE
BN-696

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ProtocolConfigurationAlgebra.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ProtocolConfigurationAlgebra.scala
@@ -1,0 +1,15 @@
+package co.topl.algebras
+
+import co.topl.proto.node.NodeConfig
+
+/**
+ * Configuration Rpc
+ * An interaction layer intended for users/clients of a blockchain node.
+ *
+ * @tparam F Effect type
+ * @tparam S Node protocol configurations changes container, Ex: Stream, Seq
+ */
+trait ProtocolConfigurationAlgebra[F[_], S[_]] {
+
+  def fetchNodeConfig: F[S[NodeConfig]]
+}

--- a/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ToplRpc.scala
@@ -5,6 +5,7 @@ import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockHeader
 import co.topl.consensus.models.BlockId
 import co.topl.node.models.BlockBody
+import co.topl.proto.node.NodeConfig
 
 /**
  * Topl Rpc
@@ -29,4 +30,5 @@ trait ToplRpc[F[_], S[_]] {
   def blockIdAtDepth(depth: Long): F[Option[BlockId]]
 
   def synchronizationTraversal(): F[S[SynchronizationTraversalStep]]
+  def fetchProtocolConfigs(): F[S[NodeConfig]]
 }

--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -4,7 +4,7 @@ import cats.data.{OptionT, Validated}
 import cats.effect._
 import cats.implicits._
 import cats.Parallel
-import co.topl.algebras.{ClockAlgebra, Store, UnsafeResource}
+import co.topl.algebras.{ClockAlgebra, ProtocolConfigurationAlgebra, Store, UnsafeResource}
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
 import co.topl.consensus.algebras._
@@ -30,7 +30,6 @@ import co.topl.crypto.signing.Ed25519VRF
 import co.topl.minting.interpreters.{BlockPacker, BlockProducer}
 import co.topl.networking.fsnetwork.ActorPeerHandlerBridgeAlgebra
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-
 import scala.jdk.CollectionConverters._
 import fs2._
 
@@ -62,7 +61,8 @@ object Blockchain {
     remotePeers:                 Stream[F, DisconnectedPeer],
     rpcHost:                     String,
     rpcPort:                     Int,
-    experimentalP2P:             Boolean = false
+    experimentalP2P:             Boolean = false,
+    nodeProtocolConfiguration:   ProtocolConfigurationAlgebra[F, Stream[F, *]]
   ): Resource[F, Unit] = {
     implicit val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("Bifrost.Blockchain")
     for {
@@ -163,7 +163,8 @@ object Blockchain {
           localChain,
           blockHeights,
           blockIdTree,
-          droppingBlockAdoptionsTopic.subscribeUnbounded
+          droppingBlockAdoptionsTopic.subscribeUnbounded,
+          nodeProtocolConfiguration
         )
       )
       _ <- ToplGrpc.Server

--- a/blockchain/src/main/scala/co/topl/blockchain/ProtocolConfiguration.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/ProtocolConfiguration.scala
@@ -1,0 +1,25 @@
+package co.topl.blockchain
+
+import cats.effect.{Async, Resource}
+import co.topl.algebras.ProtocolConfigurationAlgebra
+import co.topl.proto.node.NodeConfig
+import fs2.Stream
+
+/**
+ * Emits a stream of node protocol configs.
+ */
+object ProtocolConfiguration {
+
+  def make[F[_]: Async](
+    nodeProtocolConfigs: Seq[NodeConfig]
+  ): Resource[F, ProtocolConfigurationAlgebra[F, Stream[F, *]]] =
+    Resource.pure(
+      new ProtocolConfigurationAlgebra[F, Stream[F, *]] {
+
+        override def fetchNodeConfig: F[Stream[F, NodeConfig]] =
+          Async[F].delay(
+            Stream.emits[F, NodeConfig](nodeProtocolConfigs)
+          )
+      }
+    )
+}

--- a/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
@@ -5,7 +5,7 @@ import cats.data.EitherT
 import cats.data.OptionT
 import cats.implicits._
 import cats.effect.Async
-import co.topl.algebras.{Store, SynchronizationTraversalStep, ToplRpc}
+import co.topl.algebras.{ProtocolConfigurationAlgebra, Store, SynchronizationTraversalStep, ToplRpc}
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.syntax._
@@ -18,6 +18,7 @@ import co.topl.ledger.algebras.MempoolAlgebra
 import co.topl.node.models.BlockBody
 import co.topl.consensus.models.BlockHeader
 import co.topl.consensus.models.BlockId
+import co.topl.proto.node.NodeConfig
 import org.typelevel.log4cats.{Logger, SelfAwareStructuredLogger}
 import co.topl.typeclasses.implicits._
 import fs2.Stream
@@ -43,15 +44,16 @@ object ToplRpcServer {
    * Interpreter which serves Topl RPC data using local blockchain interpreters
    */
   def make[F[_]: Async](
-    headerStore:               Store[F, BlockId, BlockHeader],
-    bodyStore:                 Store[F, BlockId, BlockBody],
-    transactionStore:          Store[F, TransactionId, IoTransaction],
-    mempool:                   MempoolAlgebra[F],
-    syntacticValidation:       TransactionSyntaxVerifier[F],
-    localChain:                LocalChainAlgebra[F],
-    blockHeights:              EventSourcedState[F, Long => F[Option[BlockId]], BlockId],
-    blockIdTree:               ParentChildTree[F, BlockId],
-    localBlockAdoptionsStream: Stream[F, BlockId]
+    headerStore:                  Store[F, BlockId, BlockHeader],
+    bodyStore:                    Store[F, BlockId, BlockBody],
+    transactionStore:             Store[F, TransactionId, IoTransaction],
+    mempool:                      MempoolAlgebra[F],
+    syntacticValidation:          TransactionSyntaxVerifier[F],
+    localChain:                   LocalChainAlgebra[F],
+    blockHeights:                 EventSourcedState[F, Long => F[Option[BlockId]], BlockId],
+    blockIdTree:                  ParentChildTree[F, BlockId],
+    localBlockAdoptionsStream:    Stream[F, BlockId],
+    protocolConfigurationAlgebra: ProtocolConfigurationAlgebra[F, Stream[F, *]]
   ): F[ToplRpc[F, Stream[F, *]]] =
     Async[F].delay {
       new ToplRpc[F, Stream[F, *]] {
@@ -122,6 +124,9 @@ object ToplRpcServer {
                 )
                 .headChanges
             }
+
+        def fetchProtocolConfigs(): F[Stream[F, NodeConfig]] =
+          protocolConfigurationAlgebra.fetchNodeConfig
 
         private def syntacticValidateOrRaise(transaction: IoTransaction) =
           EitherT(syntacticValidation.validate(transaction))

--- a/common-interpreters/src/main/scala/co/topl/interpreters/MultiToplRpc.scala
+++ b/common-interpreters/src/main/scala/co/topl/interpreters/MultiToplRpc.scala
@@ -10,6 +10,7 @@ import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockHeader
 import co.topl.consensus.models.BlockId
 import co.topl.node.models.BlockBody
+import co.topl.proto.node.NodeConfig
 import fs2.Stream
 
 object MultiToplRpc {
@@ -59,7 +60,10 @@ object MultiToplRpc {
       def blockIdAtDepth(depth: Long): F[Option[BlockId]] =
         randomDelegate.flatMap(_.blockIdAtDepth(depth))
 
-      override def synchronizationTraversal(): F[Stream[F, SynchronizationTraversalStep]] =
+      def synchronizationTraversal(): F[Stream[F, SynchronizationTraversalStep]] =
         randomDelegate.flatMap(_.synchronizationTraversal())
+
+      def fetchProtocolConfigs(): F[Stream[F, NodeConfig]] =
+        randomDelegate.flatMap(_.fetchProtocolConfigs())
     }
 }

--- a/node/src/main/scala/co/topl/node/ApplicationConfig.scala
+++ b/node/src/main/scala/co/topl/node/ApplicationConfig.scala
@@ -6,6 +6,7 @@ import co.topl.models.Slot
 import co.topl.models.utility.Ratio
 import co.topl.networking.p2p.{DisconnectedPeer, RemoteAddress}
 import co.topl.numerics.implicits._
+import co.topl.proto.node.NodeConfig
 import com.typesafe.config.Config
 import monocle._
 import monocle.macros._
@@ -13,7 +14,6 @@ import pureconfig._
 import pureconfig.generic.ProductHint
 import pureconfig.generic.auto._
 import pureconfig.configurable._
-
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
@@ -102,6 +102,12 @@ object ApplicationConfig {
 
       val vrfCacheSize: Long =
         operationalPeriodLength * 4
+
+      def nodeConfig(slot: Slot): NodeConfig = NodeConfig(
+        slot = slot,
+        slotDurationMillis = slotDuration.toMillis,
+        epochLength = epochLength
+      )
     }
 
     @Lenses

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -247,6 +247,11 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
           Logger[F].warn(e)("Failed to start Genus server, continuing without it").void.toResource
         }
       implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F].toResource
+
+      protocolConfig <- ProtocolConfiguration.make[F](
+        appConfig.bifrost.protocols.map { case (slot, protocol) => protocol.nodeConfig(slot) }.toSeq
+      )
+
       // Finally, run the program
       _ <- Blockchain
         .make[F](
@@ -274,7 +279,8 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
           Stream.never[F],
           appConfig.bifrost.rpc.bindHost,
           appConfig.bifrost.rpc.bindPort,
-          appConfig.bifrost.p2p.experimental.getOrElse(false)
+          appConfig.bifrost.p2p.experimental.getOrElse(false),
+          protocolConfig
         )
     } yield ()
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.18"
-  val protobufSpecsVersion = "1bcd8ca289d4b8bd4689417f8c7ce7c6941d0fc1" // scala-steward:off // TODO: replace with main version when BN-696 is merged
+  val protobufSpecsVersion = "62f91f6" // scala-steward:off //
   val bramblScVersion = "c7ff17a" // scala-steward:off
   val quivr4sVersion = "1e48130" // scala-steward:off
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.18"
-  val protobufSpecsVersion = "8bb8a3b" // scala-steward:off
+  val protobufSpecsVersion = "1bcd8ca289d4b8bd4689417f8c7ce7c6941d0fc1" // scala-steward:off // TODO: replace with main version when BN-696 is merged
   val bramblScVersion = "c7ff17a" // scala-steward:off
   val quivr4sVersion = "1e48130" // scala-steward:off
 


### PR DESCRIPTION
## Purpose
Add a new RPC to the NodeRpc service named getNodeConfig that returns the node's configuration information, including the slot duration.

The message type returned from getNodeConfig should be co.topl.proto.models.node.NodeConfig.


**Depends on**  https://github.com/Topl/protobuf-specs/pull/61

## Testing
![image](https://github.com/Topl/Bifrost/assets/8540107/e61ded66-c637-47c5-9fa4-36c585a03ab3)

## Tickets
https://topl.atlassian.net/browse/BN-696
