### PR TITLE
supports blockchain size

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
@@ -2,6 +2,7 @@ package co.topl.genusLibrary.algebras
 
 import co.topl.brambl.models.{LockAddress, TransactionId, TransactionOutputAddress}
 import co.topl.consensus.models.BlockId
+import co.topl.genus.services.BlockchainSizeStatsRes.BlockchainSizeStats
 import co.topl.genus.services.GetTxoStatsRes.TxoStats
 import co.topl.genusLibrary.model.GE
 import com.tinkerpop.blueprints.Vertex
@@ -87,5 +88,7 @@ trait VertexFetcherAlgebra[F[_]] {
    * @return a vertex with stats TxOs spent, unspent ...
    */
   def fetchTxoStats(): F[Either[GE, TxoStats]]
+
+  def fetchBlockchainSizeStats(): F[Either[GE, BlockchainSizeStats]]
 
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
@@ -2,8 +2,8 @@ package co.topl.genusLibrary.algebras
 
 import co.topl.brambl.models.{LockAddress, TransactionId, TransactionOutputAddress}
 import co.topl.consensus.models.BlockId
-import co.topl.genus.services.BlockchainSizeStatsRes.BlockchainSizeStats
-import co.topl.genus.services.GetTxoStatsRes.TxoStats
+import co.topl.genus.services.BlockchainSizeStats
+import co.topl.genus.services.TxoStats
 import co.topl.genusLibrary.model.GE
 import com.tinkerpop.blueprints.Vertex
 

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcher.scala
@@ -5,14 +5,12 @@ import cats.implicits._
 import co.topl.brambl.models.{LockAddress, TransactionId, TransactionOutputAddress}
 import co.topl.brambl.syntax.transactionIdAsIdSyntaxOps
 import co.topl.consensus.models.BlockId
-import co.topl.genus.services.BlockchainSizeStatsRes.BlockchainSizeStats
-import co.topl.genus.services.GetTxoStatsRes.TxoStats
-import co.topl.genus.services.TxoState
+import co.topl.genus.services._
 import co.topl.genusLibrary.algebras.VertexFetcherAlgebra
 import co.topl.genusLibrary.model.{GE, GEs}
 import co.topl.genusLibrary.orientDb.OrientThread
-import co.topl.genusLibrary.orientDb.instances.{SchemaBlockHeader, SchemaIoTransaction, SchemaLockAddress, SchemaTxo}
 import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances._
+import co.topl.genusLibrary.orientDb.instances.{SchemaBlockHeader, SchemaIoTransaction, SchemaLockAddress, SchemaTxo}
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery
 import com.tinkerpop.blueprints.Vertex
 import com.tinkerpop.blueprints.impls.orient.{OrientGraphNoTx, OrientVertex}

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
@@ -62,7 +62,7 @@ object OrientDBMetadataFactory {
       )
     } yield ()
 
-  private[orientDb] def createVertex[F[_]: Sync: Logger](db: ODatabaseDocumentInternal, schema: VertexSchema[_]) =
+  private[genusLibrary] def createVertex[F[_]: Sync: Logger](db: ODatabaseDocumentInternal, schema: VertexSchema[_]) =
     // Even though the thread should already be active from the call up above, unit tests
     // may directly invoke this method without first initializing
     Sync[F].delay(db.activateOnCurrentThread()) >>

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeader.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeader.scala
@@ -34,7 +34,7 @@ object SchemaBlockHeader {
     val BlockHeaderIndex = "blockHeaderIndex"
   }
 
-  private[instances] def size(blockHeader: BlockHeader): Long =
+  private[genusLibrary] def size(blockHeader: BlockHeader): Long =
     ImmutableCodec.fromScodecCodec[BlockHeader].immutableBytes(blockHeader).size
 
   def make(): VertexSchema[BlockHeader] = VertexSchema.create(

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeader.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeader.scala
@@ -3,6 +3,8 @@ package co.topl.genusLibrary.orientDb.instances
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.consensus.models._
 import co.topl.genusLibrary.orientDb.schema.OIndexable.Instances._
+import co.topl.codecs.bytes.tetra.TetraScodecCodecs._
+import co.topl.codecs.bytes.typeclasses.ImmutableCodec
 import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
 import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, VertexSchema}
 import com.google.protobuf.ByteString
@@ -28,8 +30,12 @@ object SchemaBlockHeader {
     val OperationalCertificate = "operationalCertificate"
     val Metadata = "metadata"
     val Address = "address"
+    val Size = "size"
     val BlockHeaderIndex = "blockHeaderIndex"
   }
+
+  private[instances] def size(blockHeader: BlockHeader): Long =
+    ImmutableCodec.fromScodecCodec[BlockHeader].immutableBytes(blockHeader).size
 
   def make(): VertexSchema[BlockHeader] = VertexSchema.create(
     Field.SchemaName,
@@ -47,6 +53,7 @@ object SchemaBlockHeader {
       .withProperty(Field.OperationalCertificate,_.operationalCertificate.toByteArray,mandatory = true, readOnly = true, notNull = true)
       .withProperty(Field.Metadata,_.metadata.toByteArray,mandatory = true, readOnly = true, notNull = false)
       .withProperty(Field.Address,_.address.toByteArray,mandatory = true, readOnly = true, notNull = true)
+      .withProperty(Field.Size, blockHeader => java.lang.Long.valueOf(size(blockHeader)) ,mandatory = true, readOnly = true, notNull = true)
       .withIndex[BlockHeader](Field.BlockHeaderIndex, Field.BlockId),
       // @formatter:on
     v =>

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransaction.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransaction.scala
@@ -2,12 +2,11 @@ package co.topl.genusLibrary.orientDb.instances
 
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.syntax._
-import co.topl.codecs.bytes.typeclasses.ImmutableCodec
-import co.topl.codecs.bytes.tetra.TetraScodecCodecs._
 import co.topl.genusLibrary.orientDb.schema.OIndexable.Instances._
 import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
 import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, VertexSchema}
 import com.orientechnologies.orient.core.metadata.schema.OType
+import co.topl.brambl.common.ContainsImmutable.instances.ioTransactionImmutable
 
 object SchemaIoTransaction {
 
@@ -23,8 +22,8 @@ object SchemaIoTransaction {
     val TransactionIndex = "transactionIdIndex"
   }
 
-  private[instances] def size(ioTransaction: IoTransaction): Long =
-    ImmutableCodec.fromScodecCodec[IoTransaction].immutableBytes(ioTransaction).size
+  private[genusLibrary] def size(ioTransaction: IoTransaction): Long =
+    ioTransactionImmutable.immutableBytes(ioTransaction).value.size
 
   def make(): VertexSchema[IoTransaction] =
     VertexSchema.create(

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransaction.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransaction.scala
@@ -2,6 +2,8 @@ package co.topl.genusLibrary.orientDb.instances
 
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.syntax._
+import co.topl.codecs.bytes.typeclasses.ImmutableCodec
+import co.topl.codecs.bytes.tetra.TetraScodecCodecs._
 import co.topl.genusLibrary.orientDb.schema.OIndexable.Instances._
 import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
 import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, VertexSchema}
@@ -17,8 +19,12 @@ object SchemaIoTransaction {
     val SchemaName = "Transaction"
     val TransactionId = "transactionId"
     val Transaction = "transaction"
+    val Size = "size"
     val TransactionIndex = "transactionIdIndex"
   }
+
+  private[instances] def size(ioTransaction: IoTransaction): Long =
+    ImmutableCodec.fromScodecCodec[IoTransaction].immutableBytes(ioTransaction).size
 
   def make(): VertexSchema[IoTransaction] =
     VertexSchema.create(
@@ -33,6 +39,13 @@ object SchemaIoTransaction {
           notNull = true
         )
         .withProperty(Field.Transaction, _.toByteArray, mandatory = false, readOnly = false, notNull = true)
+        .withProperty(
+          Field.Size,
+          ioTransaction => java.lang.Long.valueOf(size(ioTransaction)),
+          mandatory = true,
+          readOnly = true,
+          notNull = true
+        )
         .withIndex[IoTransaction](Field.TransactionIndex, Field.TransactionId)
         .withLink(SchemaBlockHeader.Field.BlockId, OType.LINK, SchemaBlockHeader.Field.SchemaName),
       v => IoTransaction.parseFrom(v(Field.Transaction): Array[Byte])

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherTest.scala
@@ -8,8 +8,7 @@ import co.topl.brambl.models.{LockAddress, TransactionOutputAddress}
 import co.topl.brambl.generators.ModelGenerators._
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.consensus.models.BlockHeader
-import co.topl.genus.services.BlockchainSizeStatsRes.BlockchainSizeStats
-import co.topl.genus.services.GetTxoStatsRes.TxoStats
+import co.topl.genus.services._
 import co.topl.genusLibrary.DbFixtureUtil
 import co.topl.genusLibrary.model.{GE, GEs}
 import co.topl.genusLibrary.orientDb.{OrientDBMetadataFactory, OrientThread}

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherTest.scala
@@ -2,29 +2,34 @@ package co.topl.genusLibrary.interpreter
 
 import cats.data.EitherT
 import cats.effect.implicits.effectResourceOps
-import cats.effect.{IO, Resource, Sync}
+import cats.effect.{Resource, Sync}
 import cats.implicits._
 import co.topl.brambl.models.{LockAddress, TransactionOutputAddress}
 import co.topl.brambl.generators.ModelGenerators._
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.consensus.models.BlockHeader
+import co.topl.genus.services.BlockchainSizeStatsRes.BlockchainSizeStats
 import co.topl.genus.services.GetTxoStatsRes.TxoStats
+import co.topl.genusLibrary.DbFixtureUtil
 import co.topl.genusLibrary.model.{GE, GEs}
-import co.topl.genusLibrary.orientDb.OrientThread
+import co.topl.genusLibrary.orientDb.{OrientDBMetadataFactory, OrientThread}
+import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.{
+  blockHeaderSchema,
+  ioTransactionSchema,
+  txoSchema
+}
 import co.topl.models.generators.consensus.ModelGenerators._
 import com.tinkerpop.blueprints.Vertex
-import com.tinkerpop.blueprints.impls.orient.OrientGraphNoTx
+import com.tinkerpop.blueprints.impls.orient.{OrientGraphFactoryV2, OrientGraphNoTx}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-class GraphVertexFetcherTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
-
-  type F[A] = IO[A]
-
-  implicit private val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
+class GraphVertexFetcherTest
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with AsyncMockFactory
+    with DbFixtureUtil {
 
   test("On fetchHeader with throwable response, a MessageWithCause should be returned") {
 
@@ -342,20 +347,56 @@ class GraphVertexFetcherTest extends CatsEffectSuite with ScalaCheckEffectSuite 
     }
   }
 
-  test("On fetchTxoStats if an empty iterator is returned, a default instance of TxoStats should be returned") {
-
-    val g: OrientGraphNoTx = new OrientGraphNoTx("memory:test")
-
+  orientDbFixture.test(
+    "On fetchTxoStats if an empty iterator is returned, a default instance of TxoStats should be returned"
+  ) { case (odb, oThread) =>
     val res = for {
       implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
 
-      orientGraphNoTx    <- Resource.make(Sync[F].blocking(g))(g => Sync[F].delay(g.shutdown()))
-      graphVertexFetcher <- GraphVertexFetcher.make[F](orientGraphNoTx)
-      _                  <- Sync[F].blocking(orientGraphNoTx.createVertexType("Txo")).toResource
+      odbFactory         <- oThread.delay(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
+      graphVertexFetcher <- GraphVertexFetcher.make[F](odbFactory.getNoTx)
+      databaseDocumentTx <- oThread.delay(odbFactory.getNoTx.getRawGraph).toResource
+
+      _ <- Seq(
+        txoSchema
+      )
+        .traverse(OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, _))
+        .void
+        .toResource
 
       _ <- assertIO(
         graphVertexFetcher.fetchTxoStats(),
         TxoStats.defaultInstance.asRight[GE]
+      ).toResource
+    } yield ()
+
+    res.use_
+
+  }
+
+  orientDbFixture.test(
+    "On fetchBlockchainSizeStats if an empty iterator is returned in both cases, a default instance of BlockchainSizeStats should be returned"
+  ) { case (odb, oThread) =>
+    val res = for {
+      implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
+
+      odbFactory         <- oThread.delay(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
+      databaseDocumentTx <- oThread.delay(odbFactory.getNoTx.getRawGraph).toResource
+
+      _ <- Seq(
+        blockHeaderSchema,
+        ioTransactionSchema
+      )
+        .traverse(OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, _))
+        .void
+        .toResource
+
+      dbNoTx <- oThread.delay(odbFactory.getNoTx).toResource
+
+      graphVertexFetcher <- GraphVertexFetcher.make[F](dbNoTx)
+      _ <- assertIO(
+        graphVertexFetcher.fetchBlockchainSizeStats(),
+        BlockchainSizeStats.defaultInstance.asRight[GE]
       ).toResource
     } yield ()
 

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherV2Test.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherV2Test.scala
@@ -1,0 +1,73 @@
+package co.topl.genusLibrary.interpreter
+
+import cats.effect.implicits.effectResourceOps
+import cats.implicits._
+import co.topl.brambl.generators.{ModelGenerators => BramblGenerator}
+import co.topl.genus.services.BlockchainSizeStats
+import co.topl.genusLibrary.DbFixtureUtilV2
+import co.topl.genusLibrary.model.GE
+import co.topl.genusLibrary.orientDb.instances.{SchemaBlockHeader, SchemaIoTransaction}
+import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.{blockHeaderSchema, ioTransactionSchema}
+import co.topl.genusLibrary.orientDb.{OrientDBMetadataFactory, OrientThread}
+import co.topl.models.ModelGenerators.GenHelper
+import co.topl.models.generators.consensus.ModelGenerators
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalamock.munit.AsyncMockFactory
+import scala.jdk.CollectionConverters._
+
+class GraphVertexFetcherV2Test
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with AsyncMockFactory
+    with DbFixtureUtilV2 {
+
+  orientDbFixtureV2.test(
+    "On fetchBlockchainSizeStats, after saving a blockheader and an IoTransaction, BlockchainSizeStats should be returned with sizes"
+  ) { case (odbFactory, oThread) =>
+    val res = for {
+      implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
+
+      databaseDocumentTx <- oThread.delay(odbFactory.getNoTx.getRawGraph).toResource
+
+      _ <- Seq(
+        blockHeaderSchema,
+        ioTransactionSchema
+      )
+        .traverse(OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, _))
+        .void
+        .toResource
+
+      blockHeader   <- ModelGenerators.arbitraryHeader.arbitrary.first.pure[F].toResource
+      ioTransaction <- BramblGenerator.arbitraryIoTransaction.arbitrary.first.pure[F].toResource
+
+      _ <- oThread
+        .delay(odbFactory.getTx)
+        .map { tx =>
+          tx.addVertex(s"class:${blockHeaderSchema.name}", blockHeaderSchema.encode(blockHeader).asJava)
+          tx.commit()
+        }
+        .toResource
+
+      _ <- orientThread
+        .delay(odbFactory.getTx)
+        .map { tx =>
+          tx.addVertex(s"class:${ioTransactionSchema.name}", ioTransactionSchema.encode(ioTransaction).asJava)
+          tx.commit()
+        }
+        .toResource
+
+      graphVertexFetcher <- GraphVertexFetcher.make[F](odbFactory.getNoTx)
+      _ <- assertIO(
+        graphVertexFetcher.fetchBlockchainSizeStats(),
+        BlockchainSizeStats.defaultInstance
+          .withBlockHeaderBytes(SchemaBlockHeader.size(blockHeader))
+          .withTransactionBytes(SchemaIoTransaction.size(ioTransaction))
+          .asRight[GE]
+      ).toResource
+    } yield ()
+
+    res.use_
+
+  }
+
+}

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeaderTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeaderTest.scala
@@ -143,6 +143,15 @@ class SchemaBlockHeaderTest
         assertIO(addressProperty.getType.pure[F], OType.BINARY)
       ).toResource
 
+      sizeProperty <- oClass.getProperty(Field.Size).pure[F].toResource
+      _ <- (
+        assertIO(sizeProperty.getName.pure[F], Field.Size) &>
+        assertIO(sizeProperty.isMandatory.pure[F], true) &>
+        assertIO(sizeProperty.isReadonly.pure[F], true) &>
+        assertIO(sizeProperty.isNotNull.pure[F], true) &>
+        assertIO(sizeProperty.getType.pure[F], OType.LONG)
+      ).toResource
+
     } yield ()
 
     res.use_
@@ -237,6 +246,11 @@ class SchemaBlockHeaderTest
       _ <- assertIO(
         vertex.getProperty[Array[Byte]](schema.properties.filter(_.name == Field.Address).head.name).toSeq.pure[F],
         blockHeader.address.toByteArray.toSeq
+      ).toResource
+
+      _ <- assertIO(
+        vertex.getProperty[Long](schema.properties.filter(_.name == Field.Size).head.name).pure[F],
+        SchemaBlockHeader.size(blockHeader)
       ).toResource
 
     } yield ()

--- a/node/src/main/scala/co/topl/genus/GrpcNetworkMetricsService.scala
+++ b/node/src/main/scala/co/topl/genus/GrpcNetworkMetricsService.scala
@@ -10,11 +10,19 @@ import io.grpc.Metadata
 class GrpcNetworkMetricsService[F[_]: Async](vertexFetcher: VertexFetcherAlgebra[F])
     extends NetworkMetricsServiceFs2Grpc[F, Metadata] {
 
-  override def getTxoStats(request: GetTxoStatsReq, ctx: Metadata): F[GetTxoStatsRes] =
+  def getTxoStats(request: GetTxoStatsReq, ctx: Metadata): F[GetTxoStatsRes] =
     EitherT(vertexFetcher.fetchTxoStats())
       .foldF(
         ge => Async[F].raiseError[GetTxoStatsRes](GEs.Internal(ge)),
         stats => Async[F].delay(GetTxoStatsRes(stats))
+      )
+      .adaptErrorsToGrpc
+
+  def getBlockchainSizeStats(request: BlockchainSizeStatsReq, ctx: Metadata): F[BlockchainSizeStatsRes] =
+    EitherT(vertexFetcher.fetchBlockchainSizeStats())
+      .foldF(
+        ge => Async[F].raiseError[BlockchainSizeStatsRes](GEs.Internal(ge)),
+        stats => Async[F].delay(BlockchainSizeStatsRes(stats))
       )
       .adaptErrorsToGrpc
 }

--- a/node/src/test/scala/co/topl/genus/GrpcNetworkMetricsServiceTest.scala
+++ b/node/src/test/scala/co/topl/genus/GrpcNetworkMetricsServiceTest.scala
@@ -2,7 +2,7 @@ package co.topl.genus
 
 import cats.effect.IO
 import cats.implicits._
-import co.topl.genus.services.GetTxoStatsRes.TxoStats
+import co.topl.genus.services.TxoStats
 import co.topl.genus.services._
 import co.topl.genusLibrary.algebras.VertexFetcherAlgebra
 import co.topl.genusLibrary.model.{GE, GEs}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.18"
-  val protobufSpecsVersion = "5eb3af4a9c14145f18a28af5814e2231ffc71239" // scala-steward:off // TODO replace whit protobuf-specs BN-1043 main commit
+  val protobufSpecsVersion = "17a28eb" // scala-steward:off
   val bramblScVersion = "c7ff17a" // scala-steward:off
   val quivr4sVersion = "1e48130" // scala-steward:off
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.18"
-  val protobufSpecsVersion = "62f91f6" // scala-steward:off //
+  val protobufSpecsVersion = "5eb3af4a9c14145f18a28af5814e2231ffc71239" // scala-steward:off // TODO replace whit protobuf-specs BN-1043 main commit
   val bramblScVersion = "c7ff17a" // scala-steward:off
   val quivr4sVersion = "1e48130" // scala-steward:off
 

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -1,5 +1,6 @@
 package co.topl.codecs.bytes.tetra
 
+import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.codecs.bytes.scodecs._
 import co.topl.consensus.models._
 import co.topl.crypto.{models => nodeCryptoModels}
@@ -150,5 +151,8 @@ trait TetraScodecCodecs {
       byteStringCodec :: // metadata
       stakingAddressCodec // address
   ).as[UnsignedBlockHeader]
+
+  implicit val IoTransactionCodec: Codec[IoTransaction] =
+    byteArrayCodec.xmapc(t => IoTransaction.parseFrom(t))(_.toByteArray)
 
 }

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -1,6 +1,5 @@
 package co.topl.codecs.bytes.tetra
 
-import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.codecs.bytes.scodecs._
 import co.topl.consensus.models._
 import co.topl.crypto.{models => nodeCryptoModels}
@@ -151,8 +150,4 @@ trait TetraScodecCodecs {
       byteStringCodec :: // metadata
       stakingAddressCodec // address
   ).as[UnsignedBlockHeader]
-
-  implicit val IoTransactionCodec: Codec[IoTransaction] =
-    byteArrayCodec.xmapc(t => IoTransaction.parseFrom(t))(_.toByteArray)
-
 }


### PR DESCRIPTION
## Purpose
Supports "blockchain size"
## Approach
- Save Transaction immutableBytes size and BlockHeader immutableBytes size in OrientDB
-  new Rpc required PR: https://github.com/Topl/protobuf-specs/pull/62

## Testing

![image](https://github.com/Topl/Bifrost/assets/8540107/7f080d4c-1eb4-455e-8cc9-6d670d92a12e)

![image](https://github.com/Topl/Bifrost/assets/8540107/4b7ad65a-e4df-497e-98b9-c700e115211c)

## Tickets
https://topl.atlassian.net/browse/BN-1043
