### PR TITLE
Orientdb fixture Util V2

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphBlockUpdater.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphBlockUpdater.scala
@@ -46,7 +46,7 @@ object GraphBlockUpdater {
         private def insertBlock(block: BlockData): F[Either[GE, Unit]] =
           OrientThread[F].delay {
             Try {
-              val headerVertex = graph.addHeader(block.header)
+              val headerVertex = graph.addBlockHeader(block.header)
 
               graph.addCanonicalHead(headerVertex)
 
@@ -77,7 +77,7 @@ object GraphBlockUpdater {
                       graph.getVertices(SchemaLockAddress.Field.AddressId, utxo.address.id.value.toByteArray).iterator()
 
                     if (addressIterator.hasNext) addressIterator.next()
-                    else graph.addAddress(utxo.address)
+                    else graph.addLockAddress(utxo.address)
 
                   }
                   graph.addEdge(s"class:${addressTxIOEdge.name}", lockAddressVertex, ioTxVertex, addressTxIOEdge.label)
@@ -123,7 +123,7 @@ object GraphBlockUpdater {
                 }
                 .map(graph.getTxo)
 
-              graph.getHeader(block.header).foreach { headerVertex =>
+              graph.getBlockHeader(block.header).foreach { headerVertex =>
                 (
                   Seq(graph.getBody(headerVertex)) ++
                   graph.getIoTxs(headerVertex).map(_.some) ++

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcher.scala
@@ -121,6 +121,7 @@ object GraphVertexFetcher {
               .leftMap[GE](tx => GEs.InternalMessageCause("GraphVertexFetcher:fetchTransaction", tx))
           )
 
+        // TODO Create method fetchLockAddress(lockId: LockId)
         def fetchLockAddress(lockAddress: LockAddress): F[Either[GE, Option[Vertex]]] =
           OrientThread[F].delay(
             Try(
@@ -141,7 +142,7 @@ object GraphVertexFetcher {
               orientGraph
                 .getVertices(
                   SchemaTxo.Field.TxoId,
-                  transactionOutputAddress.id.value.toByteArray :+ transactionOutputAddress.index
+                  transactionOutputAddress.id.value.toByteArray :+ transactionOutputAddress.index.byteValue
                 )
                 .asScala
             ).toEither

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/VertexSchemaInstances.scala
@@ -22,7 +22,7 @@ object VertexSchemaInstances {
 
     implicit class Ops(graph: OrientGraph) {
 
-      def addHeader(blockHeader: BlockHeader): OrientVertex =
+      def addBlockHeader(blockHeader: BlockHeader): OrientVertex =
         graph.addVertex(s"class:${blockHeaderSchema.name}", blockHeaderSchema.encode(blockHeader).asJava)
 
       def addBody(blockBody: BlockBody): OrientVertex =
@@ -44,13 +44,13 @@ object VertexSchemaInstances {
             v
         }
 
-      def addAddress(address: LockAddress): OrientVertex =
+      def addLockAddress(address: LockAddress): OrientVertex =
         graph.addVertex(s"class:${lockAddressSchema.name}", lockAddressSchema.encode(address).asJava)
 
       def addTxo(txo: Txo): OrientVertex =
         graph.addVertex(s"class:${txoSchema.name}", txoSchema.encode(txo).asJava)
 
-      def getHeader(blockHeader: BlockHeader): Option[Vertex] =
+      def getBlockHeader(blockHeader: BlockHeader): Option[Vertex] =
         graph
           .getVertices(SchemaBlockHeader.Field.BlockId, blockHeader.id.value.toByteArray)
           .asScala

--- a/genus-library/src/test/scala/co/topl/genusLibrary/DbFixtureUtil.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/DbFixtureUtil.scala
@@ -2,11 +2,7 @@ package co.topl.genusLibrary
 
 import cats.effect.{IO, Resource, SyncIO}
 import cats.implicits._
-import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.{
-  blockHeaderSchema,
-  ioTransactionSchema,
-  txoSchema
-}
+import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances._
 import co.topl.genusLibrary.orientDb.{OrientDBMetadataFactory, OrientThread}
 import com.orientechnologies.orient.core.db.{ODatabaseType, OrientDB, OrientDBConfigBuilder}
 import com.tinkerpop.blueprints.impls.orient.OrientGraphFactoryV2
@@ -85,7 +81,9 @@ trait DbFixtureUtilV2 { self: FunSuite with CatsEffectSuite =>
         databaseDocumentTx <- odb._2.delay(odb._1.getNoTx.getRawGraph)
         r <- Seq(
           blockHeaderSchema,
+          blockBodySchema,
           ioTransactionSchema,
+          lockAddressSchema,
           txoSchema
         )
           .traverse(OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, _))

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherExceptionTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherExceptionTest.scala
@@ -1,14 +1,12 @@
 package co.topl.genusLibrary.interpreter
 
-import cats.data.EitherT
 import cats.effect.implicits.effectResourceOps
-import cats.effect.{Resource, Sync}
+import cats.effect.{IO, Resource, Sync}
 import cats.implicits._
 import co.topl.brambl.models.{LockAddress, TransactionOutputAddress}
 import co.topl.brambl.generators.ModelGenerators._
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.consensus.models.BlockHeader
-import co.topl.genusLibrary.DbFixtureUtil
 import co.topl.genusLibrary.model.{GE, GEs}
 import co.topl.genusLibrary.orientDb.OrientThread
 import co.topl.models.generators.consensus.ModelGenerators._
@@ -17,12 +15,13 @@ import com.tinkerpop.blueprints.impls.orient.OrientGraphNoTx
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-class GraphVertexFetcherTest
-    extends CatsEffectSuite
-    with ScalaCheckEffectSuite
-    with AsyncMockFactory
-    with DbFixtureUtil {
+class GraphVertexFetcherExceptionTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+
+  type F[A] = IO[A]
+  implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
 
   test("On fetchHeader with throwable response, a MessageWithCause should be returned") {
 
@@ -41,28 +40,6 @@ class GraphVertexFetcherTest
             graphVertexFetcher.fetchHeader(header.id),
             (GEs.InternalMessageCause("GraphVertexFetcher:fetchHeader", expectedTh): GE)
               .asLeft[Option[Vertex]]
-          ).toResource
-        } yield ()
-
-        res.use_
-      }
-    }
-  }
-
-  test("On fetchHeader if an empty iterator is returned, a Right None should be returned") {
-    val g: OrientGraphNoTx = new OrientGraphNoTx("memory:test") {
-      override def getVertices(iKey: String, iValue: Object) = new java.util.Vector[Vertex]()
-    }
-
-    PropF.forAllF { (header: BlockHeader) =>
-      withMock {
-        val res = for {
-          implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
-          orientGraphNoTx    <- Resource.make(Sync[F].blocking(g))(g => Sync[F].delay(g.shutdown()))
-          graphVertexFetcher <- GraphVertexFetcher.make[F](orientGraphNoTx)
-          _ <- assertIO(
-            graphVertexFetcher.fetchHeader(header.id),
-            Option.empty[Vertex].asRight[GE]
           ).toResource
         } yield ()
 
@@ -96,51 +73,6 @@ class GraphVertexFetcherTest
     }
   }
 
-  test("On fetchHeaderByHeight, if an empty iterator is returned, a Right None should be returned") {
-    val g: OrientGraphNoTx = new OrientGraphNoTx("memory:test") {
-      override def getVertices(label: String, iKey: Array[String], iValue: Array[AnyRef]) =
-        new java.util.Vector[Vertex]()
-    }
-
-    PropF.forAllF { (height: Long) =>
-      withMock {
-        val res = for {
-          implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
-          orientGraphNoTx    <- Resource.make(Sync[F].blocking(g))(g => Sync[F].delay(g.shutdown()))
-          graphVertexFetcher <- GraphVertexFetcher.make[F](orientGraphNoTx)
-          _ <- assertIO(graphVertexFetcher.fetchHeaderByHeight(height), Option.empty[Vertex].asRight[GE]).toResource
-        } yield ()
-
-        res.use_
-      }
-    }
-  }
-
-  test("On fetchHeaderByDepth, if an empty iterator is returned, a Right None should be returned") {
-
-    val g: OrientGraphNoTx = new OrientGraphNoTx("memory:test") {
-      override def getVertices(label: String, iKey: Array[String], iValue: Array[AnyRef]) =
-        new java.util.Vector[Vertex]()
-    }
-
-    val res = for {
-      implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
-      orientGraphNoTx <- Resource.make(Sync[F].blocking(g))(g =>
-        Sync[F].delay {
-          g.drop()
-          g.shutdown()
-        }
-      )
-      graphVertexFetcher <- GraphVertexFetcher.make[F](orientGraphNoTx)
-      _                  <- Sync[F].blocking(orientGraphNoTx.createVertexType("BlockHeader")).toResource
-
-      _ <- assertIO(graphVertexFetcher.fetchHeaderByDepth(1), Option.empty[Vertex].asRight[GE]).toResource
-    } yield ()
-
-    res.use_
-
-  }
-
   test("On fetchBody with throwable response, a MessageWithCause should be returned") {
 
     val expectedTh = new IllegalStateException("boom!")
@@ -161,28 +93,6 @@ class GraphVertexFetcherTest
           (GEs.InternalMessageCause("GraphVertexFetcher:fetchBody", expectedTh): GE)
             .asLeft[Option[Vertex]]
         ).toResource
-      } yield ()
-
-      res.use_
-    }
-
-  }
-
-  test("On fetchBody if an empty iterator is returned, a Right None should be returned") {
-
-    val g: OrientGraphNoTx = new OrientGraphNoTx("memory:test") {
-      override def getVertices(label: String, iKey: Array[String], iValue: Array[AnyRef]) =
-        new java.util.Vector[Vertex]()
-    }
-
-    withMock {
-      val res = for {
-        implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
-        orientGraphNoTx                          <- Resource.make(Sync[F].blocking(g))(g => Sync[F].delay(g.shutdown()))
-        vertex                                   <- mock[Vertex].pure[F].toResource
-        _ = (() => vertex.getId).expects().once().returning(new Object())
-        graphVertexFetcher <- GraphVertexFetcher.make[F](orientGraphNoTx)
-        _ <- assertIO(graphVertexFetcher.fetchBody(vertex), Option.empty[Vertex].asRight[GE]).toResource
       } yield ()
 
       res.use_
@@ -217,29 +127,6 @@ class GraphVertexFetcherTest
 
   }
 
-  test("On fetchTransactions if an empty iterator is returned, a Right None should be returned") {
-
-    val g: OrientGraphNoTx = new OrientGraphNoTx("memory:test") {
-      override def getVertices(label: String, iKey: Array[String], iValue: Array[AnyRef]) =
-        new java.util.Vector[Vertex]()
-    }
-
-    withMock {
-      val res = for {
-        implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
-        orientGraphNoTx                          <- Resource.make(Sync[F].blocking(g))(g => Sync[F].delay(g.shutdown()))
-        vertex                                   <- mock[Vertex].pure[F].toResource
-        _ = (() => vertex.getId).expects().once().returning(new Object())
-        graphVertexFetcher <- GraphVertexFetcher.make[F](orientGraphNoTx)
-
-        _ <- assertIO(EitherT(graphVertexFetcher.fetchTransactions(vertex)).map(_.size).value, 0.asRight[GE]).toResource
-      } yield ()
-
-      res.use_
-    }
-
-  }
-
   test("On fetchLockAddress with throwable response, a MessageWithCause should be returned") {
 
     val expectedTh = new IllegalStateException("boom!")
@@ -265,31 +152,6 @@ class GraphVertexFetcherTest
     }
   }
 
-  test("On fetchLockAddress if an empty iterator is returned, a Right None should be returned") {
-
-    val g: OrientGraphNoTx = new OrientGraphNoTx("memory:test") {
-      override def getVertices(iKey: String, iValue: Object) = new java.util.Vector[Vertex]()
-    }
-
-    PropF.forAllF { (lockAddress: LockAddress) =>
-      withMock {
-        val res = for {
-          implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
-          orientGraphNoTx    <- Resource.make(Sync[F].blocking(g))(g => Sync[F].delay(g.shutdown()))
-          graphVertexFetcher <- GraphVertexFetcher.make[F](orientGraphNoTx)
-
-          _ <- assertIO(
-            graphVertexFetcher.fetchLockAddress(lockAddress),
-            Option.empty[Vertex].asRight[GE]
-          ).toResource
-        } yield ()
-
-        res.use_
-      }
-
-    }
-  }
-
   test("On fetchTxo with throwable response, a MessageWithCause should be returned") {
 
     val expectedTh = new IllegalStateException("boom!")
@@ -312,31 +174,6 @@ class GraphVertexFetcherTest
 
         res.use_
       }
-    }
-  }
-
-  test("On fetchTxo if an empty iterator is returned, a Right None should be returned") {
-
-    val g: OrientGraphNoTx = new OrientGraphNoTx("memory:test") {
-      override def getVertices(iKey: String, iValue: Object) = new java.util.Vector[Vertex]()
-    }
-
-    PropF.forAllF { (transactionOutputAddress: TransactionOutputAddress) =>
-      withMock {
-        val res = for {
-          implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
-          orientGraphNoTx    <- Resource.make(Sync[F].blocking(g))(g => Sync[F].delay(g.shutdown()))
-          graphVertexFetcher <- GraphVertexFetcher.make[F](orientGraphNoTx)
-
-          _ <- assertIO(
-            graphVertexFetcher.fetchTxo(transactionOutputAddress),
-            Option.empty[Vertex].asRight[GE]
-          ).toResource
-        } yield ()
-
-        res.use_
-      }
-
     }
   }
 

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherV2Test.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherV2Test.scala
@@ -1,5 +1,6 @@
 package co.topl.genusLibrary.interpreter
 
+import cats.data.EitherT
 import cats.effect.implicits.effectResourceOps
 import cats.implicits._
 import co.topl.brambl.generators.{ModelGenerators => BramblGenerator}
@@ -7,18 +8,17 @@ import co.topl.genus.services.{BlockchainSizeStats, Txo, TxoState, TxoStats}
 import co.topl.genusLibrary.DbFixtureUtilV2
 import co.topl.genusLibrary.model.GE
 import co.topl.genusLibrary.orientDb.OrientThread
-import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.{
-  blockHeaderSchema,
-  ioTransactionSchema,
-  txoSchema,
-  Ops
-}
+import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.{blockBodySchema, Ops}
+import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.genusLibrary.orientDb.instances.{SchemaBlockHeader, SchemaIoTransaction}
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.models.generators.consensus.ModelGenerators
+import co.topl.node.models.BlockBody
+import com.orientechnologies.orient.core.id.ORecordId
+import com.tinkerpop.blueprints.Vertex
+import com.tinkerpop.blueprints.impls.orient.OrientVertex
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalamock.munit.AsyncMockFactory
-import scala.jdk.CollectionConverters._
 
 class GraphVertexFetcherV2Test
     extends CatsEffectSuite
@@ -26,8 +26,227 @@ class GraphVertexFetcherV2Test
     with AsyncMockFactory
     with DbFixtureUtilV2 {
 
+  orientDbFixtureV2.test("On fetchBlockHeader, None should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        blockHeader        <- ModelGenerators.arbitraryHeader.arbitrary.first.pure[F].toResource
+        notx               <- oThread.delay(odbFactory.getNoTx).toResource
+        graphVertexFetcher <- GraphVertexFetcher.make[F](notx)
+        _ <- assertIO(
+          graphVertexFetcher.fetchHeader(blockHeader.id),
+          Option.empty[Vertex].asRight[GE]
+        ).toResource
+      } yield ()
+
+      res.use_
+  }
+
+  orientDbFixtureV2.test("On fetchBlockHeader, a blockHeader should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        blockHeader        <- ModelGenerators.arbitraryHeader.arbitrary.first.pure[F].toResource
+        tx                 <- oThread.delay(odbFactory.getTx).toResource
+        notx               <- oThread.delay(odbFactory.getNoTx).toResource
+        graphVertexFetcher <- GraphVertexFetcher.make[F](notx)
+
+        _ <- oThread.delay {
+          tx.addBlockHeader(blockHeader)
+          tx.commit()
+          tx.shutdown()
+        }.toResource
+
+        blockHeaderVertex <- graphVertexFetcher.fetchHeader(blockHeader.id).rethrow.toResource
+        _                 <- assertIOBoolean(blockHeaderVertex.isDefined.pure[F]).toResource
+      } yield ()
+
+      res.use_
+  }
+
+  orientDbFixtureV2.test("On fetchHeaderByHeight, a blockHeader should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        blockHeader        <- ModelGenerators.arbitraryHeader.arbitrary.first.copy(height = 1).pure[F].toResource
+        tx                 <- oThread.delay(odbFactory.getTx).toResource
+        notx               <- oThread.delay(odbFactory.getNoTx).toResource
+        graphVertexFetcher <- GraphVertexFetcher.make[F](notx)
+
+        _ <- oThread.delay {
+          tx.addBlockHeader(blockHeader)
+          tx.commit()
+          tx.shutdown()
+        }.toResource
+
+        blockHeaderVertex <- graphVertexFetcher.fetchHeaderByHeight(1L).rethrow.toResource
+        _                 <- assertIOBoolean(blockHeaderVertex.isDefined.pure[F]).toResource
+      } yield ()
+
+      res.use_
+  }
+
+  orientDbFixtureV2.test("On fetchHeaderByDepth, a blockHeader should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        blockHeader        <- ModelGenerators.arbitraryHeader.arbitrary.first.copy(height = 1).pure[F].toResource
+        tx                 <- oThread.delay(odbFactory.getTx).toResource
+        notx               <- oThread.delay(odbFactory.getNoTx).toResource
+        graphVertexFetcher <- GraphVertexFetcher.make[F](notx)
+
+        _ <- oThread.delay {
+          tx.addBlockHeader(blockHeader)
+          tx.commit()
+          tx.shutdown()
+        }.toResource
+
+        // depth = 0, if we have 1 vertex with height = 1, 1-0=1. It will return a vertex with height=1
+        blockHeaderVertex <- graphVertexFetcher.fetchHeaderByDepth(0L).rethrow.toResource
+        _                 <- assertIOBoolean(blockHeaderVertex.isDefined.pure[F]).toResource
+      } yield ()
+
+      res.use_
+  }
+
+  orientDbFixtureV2.test("On fetchBody, None should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        notx <- oThread.delay(odbFactory.getNoTx).toResource
+
+        blockHeaderVertex = new OrientVertex(notx, new ORecordId(1, 1))
+
+        graphVertexFetcher <- GraphVertexFetcher.make[F](notx)
+        _ <- assertIO(graphVertexFetcher.fetchBody(blockHeaderVertex), Option.empty[Vertex].asRight[GE]).toResource
+      } yield ()
+
+      res.use_
+
+  }
+
+  orientDbFixtureV2.test("On fetchBody, Body should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        tx   <- oThread.delay(odbFactory.getTx).toResource
+        notx <- oThread.delay(odbFactory.getNoTx).toResource
+
+        blockHeader <- ModelGenerators.arbitraryHeader.arbitrary.first.pure[F].toResource
+
+        blockHeaderVertex <- oThread.delay {
+          val blockHeaderVertex = tx.addBlockHeader(blockHeader)
+          // TODO add body Vertex should set the property inside the ops method
+          val bodyVertex = tx.addBody(BlockBody(Seq.empty))
+          bodyVertex.setProperty(blockBodySchema.links.head.propertyName, blockHeaderVertex.getId)
+          tx.commit()
+          tx.shutdown()
+          blockHeaderVertex
+        }.toResource
+
+        graphVertexFetcher <- GraphVertexFetcher.make[F](notx)
+
+        bodyVertex <- graphVertexFetcher.fetchBody(blockHeaderVertex).rethrow.toResource
+        _          <- assertIOBoolean(bodyVertex.isDefined.pure[F]).toResource
+      } yield ()
+
+      res.use_
+
+  }
+
+  orientDbFixtureV2.test("On fetchTransactions, None should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        notx <- oThread.delay(odbFactory.getNoTx).toResource
+
+        blockHeaderVertex = new OrientVertex(notx, new ORecordId(1, 1))
+
+        graphVertexFetcher <- GraphVertexFetcher.make[F](notx)
+        _ <- assertIO(
+          EitherT(graphVertexFetcher.fetchTransactions(blockHeaderVertex)).map(_.size).value,
+          0.asRight[GE]
+        ).toResource
+      } yield ()
+
+      res.use_
+
+  }
+
+  orientDbFixtureV2.test("On fetchLockAddress, None should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        lockAddress        <- BramblGenerator.arbitraryLockAddress.arbitrary.first.pure[F].toResource
+        notx               <- oThread.delay(odbFactory.getNoTx).toResource
+        graphVertexFetcher <- GraphVertexFetcher.make[F](notx)
+
+        _ <- assertIO(
+          graphVertexFetcher.fetchLockAddress(lockAddress),
+          Option.empty[Vertex].asRight[GE]
+        ).toResource
+      } yield ()
+
+      res.use_
+  }
+
+  orientDbFixtureV2.test("On fetchLockAddress, a LockAddress should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        lockAddress        <- BramblGenerator.arbitraryLockAddress.arbitrary.first.pure[F].toResource
+        tx                 <- oThread.delay(odbFactory.getTx).toResource
+        notx               <- oThread.delay(odbFactory.getNoTx).toResource
+        graphVertexFetcher <- GraphVertexFetcher.make[F](notx)
+
+        _ <- oThread.delay {
+          tx.addLockAddress(lockAddress)
+          tx.commit()
+          tx.shutdown()
+        }.toResource
+
+        lockAddressVertex <- graphVertexFetcher.fetchLockAddress(lockAddress).rethrow.toResource
+        _                 <- assertIOBoolean(lockAddressVertex.isDefined.pure[F]).toResource
+      } yield ()
+
+      res.use_
+
+  }
+
+  orientDbFixtureV2.test("On fetchTxo, None should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        transactionOutputAddress <- BramblGenerator.arbitraryTransactionOutputAddress.arbitrary.first.pure[F].toResource
+        notx                     <- oThread.delay(odbFactory.getNoTx).toResource
+        graphVertexFetcher       <- GraphVertexFetcher.make[F](notx)
+
+        _ <- assertIO(
+          graphVertexFetcher.fetchTxo(transactionOutputAddress),
+          Option.empty[Vertex].asRight[GE]
+        ).toResource
+      } yield ()
+
+      res.use_
+
+  }
+
+  orientDbFixtureV2.test("On fetchTxo, Txo should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        transactionOutputAddress <- BramblGenerator.arbitraryTransactionOutputAddress.arbitrary.first.pure[F].toResource
+        unspentTransactionOutput <- BramblGenerator.arbitraryUnspentTransactionOutput.arbitrary.first.pure[F].toResource
+
+        tx                 <- oThread.delay(odbFactory.getTx).toResource
+        notx               <- oThread.delay(odbFactory.getNoTx).toResource
+        graphVertexFetcher <- GraphVertexFetcher.make[F](notx)
+
+        _ <- oThread.delay {
+          tx.addTxo(Txo(unspentTransactionOutput, TxoState.SPENT, transactionOutputAddress))
+          tx.commit()
+          tx.shutdown()
+        }.toResource
+
+        txoVertex <- graphVertexFetcher.fetchTxo(transactionOutputAddress).rethrow.toResource
+        _         <- assertIOBoolean(txoVertex.isDefined.pure[F]).toResource
+      } yield ()
+
+      res.use_
+
+  }
+
   orientDbFixtureV2.test(
-    "On fetchTxoStats if an empty iterator is returned, a default instance of TxoStats should be returned"
+    "On fetchTxoStats, a default instance of TxoStats should be returned"
   ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
       graphVertexFetcher <- GraphVertexFetcher.make[F](odbFactory.getNoTx)
@@ -38,24 +257,19 @@ class GraphVertexFetcherV2Test
   }
 
   orientDbFixtureV2.test(
-    "On fetchTxoStats if an empty iterator is returned, TxoStats SPENT should be returned"
+    "On fetchTxoStats, TxoStats SPENT should be returned"
   ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
 
       transactionOutputAddress <- BramblGenerator.arbitraryTransactionOutputAddress.arbitrary.first.pure[F].toResource
       unspentTransactionOutput <- BramblGenerator.arbitraryUnspentTransactionOutput.arbitrary.first.pure[F].toResource
 
-      tx   <- oThread.delay(odbFactory.getTx).toResource
-      notx <- oThread.delay(odbFactory.getNoTx).toResource
+      tx <- oThread.delay(odbFactory.getTx).toResource
 
       _ <- oThread.delay {
         tx.addTxo(Txo(unspentTransactionOutput, TxoState.SPENT, transactionOutputAddress))
         tx.commit()
         tx.shutdown()
-      }.toResource
-
-      _ <- oThread.delay {
-        notx.getVerticesOfClass(s"${txoSchema.name}").asScala.foreach(v => println(v.getProperty("state")))
       }.toResource
 
       graphVertexFetcher <- GraphVertexFetcher.make[F](odbFactory.getNoTx)
@@ -71,24 +285,19 @@ class GraphVertexFetcherV2Test
   }
 
   orientDbFixtureV2.test(
-    "On fetchTxoStats if an empty iterator is returned, TxoStats UNSPENT should be returned"
+    "On fetchTxoStats, TxoStats UNSPENT should be returned"
   ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
 
       transactionOutputAddress <- BramblGenerator.arbitraryTransactionOutputAddress.arbitrary.first.pure[F].toResource
       unspentTransactionOutput <- BramblGenerator.arbitraryUnspentTransactionOutput.arbitrary.first.pure[F].toResource
 
-      tx   <- oThread.delay(odbFactory.getTx).toResource
-      notx <- oThread.delay(odbFactory.getNoTx).toResource
+      tx <- oThread.delay(odbFactory.getTx).toResource
 
       _ <- oThread.delay {
         tx.addTxo(Txo(unspentTransactionOutput, TxoState.UNSPENT, transactionOutputAddress))
         tx.commit()
         tx.shutdown()
-      }.toResource
-
-      _ <- oThread.delay {
-        notx.getVerticesOfClass(s"${txoSchema.name}").asScala.foreach(v => println(v.getProperty("state")))
       }.toResource
 
       graphVertexFetcher <- GraphVertexFetcher.make[F](odbFactory.getNoTx)
@@ -104,7 +313,7 @@ class GraphVertexFetcherV2Test
   }
 
   orientDbFixtureV2.test(
-    "On fetchBlockchainSizeStats if an empty iterator is returned in both cases, a default instance of BlockchainSizeStats should be returned"
+    "On fetchBlockchainSizeStats, a default instance of BlockchainSizeStats should be returned"
   ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
 
@@ -131,7 +340,7 @@ class GraphVertexFetcherV2Test
       _ <- oThread
         .delay(odbFactory.getTx)
         .map { tx =>
-          tx.addVertex(s"class:${blockHeaderSchema.name}", blockHeaderSchema.encode(blockHeader).asJava)
+          tx.addBlockHeader(blockHeader)
           tx.commit()
         }
         .toResource
@@ -139,7 +348,7 @@ class GraphVertexFetcherV2Test
       _ <- oThread
         .delay(odbFactory.getTx)
         .map { tx =>
-          tx.addVertex(s"class:${ioTransactionSchema.name}", ioTransactionSchema.encode(ioTransaction).asJava)
+          tx.addIoTx(ioTransaction)
           tx.commit()
         }
         .toResource

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherV2Test.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherV2Test.scala
@@ -3,12 +3,17 @@ package co.topl.genusLibrary.interpreter
 import cats.effect.implicits.effectResourceOps
 import cats.implicits._
 import co.topl.brambl.generators.{ModelGenerators => BramblGenerator}
-import co.topl.genus.services.BlockchainSizeStats
+import co.topl.genus.services.{BlockchainSizeStats, Txo, TxoState, TxoStats}
 import co.topl.genusLibrary.DbFixtureUtilV2
 import co.topl.genusLibrary.model.GE
+import co.topl.genusLibrary.orientDb.OrientThread
+import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.{
+  blockHeaderSchema,
+  ioTransactionSchema,
+  txoSchema,
+  Ops
+}
 import co.topl.genusLibrary.orientDb.instances.{SchemaBlockHeader, SchemaIoTransaction}
-import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.{blockHeaderSchema, ioTransactionSchema}
-import co.topl.genusLibrary.orientDb.{OrientDBMetadataFactory, OrientThread}
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.models.generators.consensus.ModelGenerators
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -22,20 +27,103 @@ class GraphVertexFetcherV2Test
     with DbFixtureUtilV2 {
 
   orientDbFixtureV2.test(
-    "On fetchBlockchainSizeStats, after saving a blockheader and an IoTransaction, BlockchainSizeStats should be returned with sizes"
-  ) { case (odbFactory, oThread) =>
+    "On fetchTxoStats if an empty iterator is returned, a default instance of TxoStats should be returned"
+  ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
-      implicit0(orientThread: OrientThread[F]) <- OrientThread.create[F]
+      graphVertexFetcher <- GraphVertexFetcher.make[F](odbFactory.getNoTx)
+      _ <- assertIO(graphVertexFetcher.fetchTxoStats(), TxoStats.defaultInstance.asRight[GE]).toResource
+    } yield ()
 
-      databaseDocumentTx <- oThread.delay(odbFactory.getNoTx.getRawGraph).toResource
+    res.use_
+  }
 
-      _ <- Seq(
-        blockHeaderSchema,
-        ioTransactionSchema
-      )
-        .traverse(OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, _))
-        .void
-        .toResource
+  orientDbFixtureV2.test(
+    "On fetchTxoStats if an empty iterator is returned, TxoStats SPENT should be returned"
+  ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+    val res = for {
+
+      transactionOutputAddress <- BramblGenerator.arbitraryTransactionOutputAddress.arbitrary.first.pure[F].toResource
+      unspentTransactionOutput <- BramblGenerator.arbitraryUnspentTransactionOutput.arbitrary.first.pure[F].toResource
+
+      tx   <- oThread.delay(odbFactory.getTx).toResource
+      notx <- oThread.delay(odbFactory.getNoTx).toResource
+
+      _ <- oThread.delay {
+        tx.addTxo(Txo(unspentTransactionOutput, TxoState.SPENT, transactionOutputAddress))
+        tx.commit()
+        tx.shutdown()
+      }.toResource
+
+      _ <- oThread.delay {
+        notx.getVerticesOfClass(s"${txoSchema.name}").asScala.foreach(v => println(v.getProperty("state")))
+      }.toResource
+
+      graphVertexFetcher <- GraphVertexFetcher.make[F](odbFactory.getNoTx)
+      _ <- assertIO(
+        graphVertexFetcher.fetchTxoStats(),
+        TxoStats.defaultInstance
+          .withSpent(1)
+          .withTotal(1)
+          .asRight[GE]
+      ).toResource
+    } yield ()
+    res.use_
+  }
+
+  orientDbFixtureV2.test(
+    "On fetchTxoStats if an empty iterator is returned, TxoStats UNSPENT should be returned"
+  ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+    val res = for {
+
+      transactionOutputAddress <- BramblGenerator.arbitraryTransactionOutputAddress.arbitrary.first.pure[F].toResource
+      unspentTransactionOutput <- BramblGenerator.arbitraryUnspentTransactionOutput.arbitrary.first.pure[F].toResource
+
+      tx   <- oThread.delay(odbFactory.getTx).toResource
+      notx <- oThread.delay(odbFactory.getNoTx).toResource
+
+      _ <- oThread.delay {
+        tx.addTxo(Txo(unspentTransactionOutput, TxoState.UNSPENT, transactionOutputAddress))
+        tx.commit()
+        tx.shutdown()
+      }.toResource
+
+      _ <- oThread.delay {
+        notx.getVerticesOfClass(s"${txoSchema.name}").asScala.foreach(v => println(v.getProperty("state")))
+      }.toResource
+
+      graphVertexFetcher <- GraphVertexFetcher.make[F](odbFactory.getNoTx)
+      _ <- assertIO(
+        graphVertexFetcher.fetchTxoStats(),
+        TxoStats.defaultInstance
+          .withUnspent(1)
+          .withTotal(1)
+          .asRight[GE]
+      ).toResource
+    } yield ()
+    res.use_
+  }
+
+  orientDbFixtureV2.test(
+    "On fetchBlockchainSizeStats if an empty iterator is returned in both cases, a default instance of BlockchainSizeStats should be returned"
+  ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+    val res = for {
+
+      dbNoTx <- oThread.delay(odbFactory.getNoTx).toResource
+
+      graphVertexFetcher <- GraphVertexFetcher.make[F](dbNoTx)
+      _ <- assertIO(
+        graphVertexFetcher.fetchBlockchainSizeStats(),
+        BlockchainSizeStats.defaultInstance.asRight[GE]
+      ).toResource
+    } yield ()
+
+    res.use_
+  }
+
+  orientDbFixtureV2.test(
+    "On fetchBlockchainSizeStats, after saving a blockheader and an IoTransaction, BlockchainSizeStats should be returned with sizes"
+  ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+    val res = for {
 
       blockHeader   <- ModelGenerators.arbitraryHeader.arbitrary.first.pure[F].toResource
       ioTransaction <- BramblGenerator.arbitraryIoTransaction.arbitrary.first.pure[F].toResource
@@ -48,7 +136,7 @@ class GraphVertexFetcherV2Test
         }
         .toResource
 
-      _ <- orientThread
+      _ <- oThread
         .delay(odbFactory.getTx)
         .map { tx =>
           tx.addVertex(s"class:${ioTransactionSchema.name}", ioTransactionSchema.encode(ioTransaction).asJava)
@@ -67,7 +155,5 @@ class GraphVertexFetcherV2Test
     } yield ()
 
     res.use_
-
   }
-
 }

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/GraphBlockUpdaterFixtureTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/GraphBlockUpdaterFixtureTest.scala
@@ -72,9 +72,9 @@ class GraphBlockUpdaterFixtureTest
           graphBlockUpdater <- GraphBlockUpdater.make[F](dbTx, blockFetcher, nodeBlockFetcher)
           _                 <- graphBlockUpdater.insert(blockData).toResource
 
-          blockHeaderVertex = dbTx.getHeader(blockData.header)
+          blockHeaderVertex = dbTx.getBlockHeader(blockData.header)
           _ = assert(blockHeaderVertex.isDefined)
-          _ <- assertIOBoolean(oThread.delay(dbTx.getHeader(blockData.header).isDefined)).toResource
+          _ <- assertIOBoolean(oThread.delay(dbTx.getBlockHeader(blockData.header).isDefined)).toResource
           _ <- assertIOBoolean(oThread.delay(dbTx.getBody(blockHeaderVertex.get).isDefined)).toResource
 
           _ <- graphBlockUpdater.remove(blockData).toResource
@@ -82,9 +82,9 @@ class GraphBlockUpdaterFixtureTest
           // When we remove headerVertex, the canonicalHead schema is not updated, insertions handle it
           // When we remove txoVertex, lockAddress schema is not updated, because lockAddress references many txo
           // Eventually could create an orphan lockAddress, it is not a problem cause some future txo will reference it
-          blockHeaderVertex = dbTx.getHeader(blockData.header)
+          blockHeaderVertex = dbTx.getBlockHeader(blockData.header)
           _ = assert(blockHeaderVertex.isEmpty)
-          _ <- assertIOBoolean(oThread.delay(dbTx.getHeader(blockData.header).isEmpty)).toResource
+          _ <- assertIOBoolean(oThread.delay(dbTx.getBlockHeader(blockData.header).isEmpty)).toResource
           _ <- assertIOBoolean(oThread.delay(dbTx.getVerticesOfClass(blockBodySchema.name).asScala.isEmpty)).toResource
           _ <- assertIOBoolean(
             oThread.delay(dbTx.getVerticesOfClass(ioTransactionSchema.name).asScala.isEmpty)


### PR DESCRIPTION
## Purpose
this pr moves some unit/integration test from DbFixture to DbFixture V2

## Approach
- schemas are being created on the setup step after creating the memory database
- use generators to create some vertex, save it and fetch the information.
- there are still more than 10 tests that should be migrated.
- in a future PR GraphVertexFetcherTest and GraphVertexFetcherV2Test, will be the same, and I will remove DbFixtureUtil
- no ticket was created it is tech debt that we have to fix better handling of unit testing  against orientdb-memory
