### PR TITLE
BN-1044 blocks Status

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/algebras/VertexFetcherAlgebra.scala
@@ -2,8 +2,7 @@ package co.topl.genusLibrary.algebras
 
 import co.topl.brambl.models.{LockAddress, TransactionId, TransactionOutputAddress}
 import co.topl.consensus.models.BlockId
-import co.topl.genus.services.BlockchainSizeStats
-import co.topl.genus.services.TxoStats
+import co.topl.genus.services.{BlockStats, BlockchainSizeStats, TxoStats}
 import co.topl.genusLibrary.model.GE
 import com.tinkerpop.blueprints.Vertex
 
@@ -90,5 +89,11 @@ trait VertexFetcherAlgebra[F[_]] {
   def fetchTxoStats(): F[Either[GE, TxoStats]]
 
   def fetchBlockchainSizeStats(): F[Either[GE, BlockchainSizeStats]]
+
+  /**
+   * Fetch Block Stats
+   * Returns total blocks with and without transactions in them
+   */
+  def fetchBlockStats(): F[Either[GE, BlockStats]]
 
 }

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherV2Test.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherV2Test.scala
@@ -4,7 +4,8 @@ import cats.data.EitherT
 import cats.effect.implicits.effectResourceOps
 import cats.implicits._
 import co.topl.brambl.generators.{ModelGenerators => BramblGenerator}
-import co.topl.genus.services.{BlockchainSizeStats, Txo, TxoState, TxoStats}
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.genus.services.{BlockStats, BlockchainSizeStats, Txo, TxoState, TxoStats}
 import co.topl.genusLibrary.DbFixtureUtilV2
 import co.topl.genusLibrary.model.GE
 import co.topl.genusLibrary.orientDb.OrientThread
@@ -364,5 +365,56 @@ class GraphVertexFetcherV2Test
     } yield ()
 
     res.use_
+  }
+
+  orientDbFixtureV2.test("On fetchBlockStats, BodyStats with 1 empty result should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        tx   <- oThread.delay(odbFactory.getTx).toResource
+        notx <- oThread.delay(odbFactory.getNoTx).toResource
+
+        blockHeader <- ModelGenerators.arbitraryHeader.arbitrary.first.pure[F].toResource
+
+        _ <- oThread.delay {
+          val blockHeaderVertex = tx.addBlockHeader(blockHeader)
+          val bodyVertex = tx.addBody(BlockBody(Seq.empty))
+          bodyVertex.setProperty(blockBodySchema.links.head.propertyName, blockHeaderVertex.getId)
+          tx.commit()
+          tx.shutdown()
+        }.toResource
+
+        graphVertexFetcher <- GraphVertexFetcher.make[F](notx)
+
+        _ <- assertIO(graphVertexFetcher.fetchBlockStats().rethrow, BlockStats(empty = 1, nonEmpty = 0)).toResource
+      } yield ()
+
+      res.use_
+
+  }
+
+  orientDbFixtureV2.test("On fetchBlockStats, BodyStats with 1 non empty result should be returned") {
+    case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+      val res = for {
+        tx   <- oThread.delay(odbFactory.getTx).toResource
+        notx <- oThread.delay(odbFactory.getNoTx).toResource
+
+        blockHeader   <- ModelGenerators.arbitraryHeader.arbitrary.first.pure[F].toResource
+        ioTransaction <- BramblGenerator.arbitraryIoTransaction.arbitrary.first.pure[F].toResource
+
+        _ <- oThread.delay {
+          val blockHeaderVertex = tx.addBlockHeader(blockHeader)
+          val bodyVertex = tx.addBody(BlockBody(Seq(ioTransaction.id)))
+          bodyVertex.setProperty(blockBodySchema.links.head.propertyName, blockHeaderVertex.getId)
+          tx.commit()
+          tx.shutdown()
+        }.toResource
+
+        graphVertexFetcher <- GraphVertexFetcher.make[F](notx)
+
+        _ <- assertIO(graphVertexFetcher.fetchBlockStats().rethrow, BlockStats(empty = 0, nonEmpty = 1)).toResource
+      } yield ()
+
+      res.use_
+
   }
 }

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockBodyTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockBodyTest.scala
@@ -1,0 +1,72 @@
+package co.topl.genusLibrary.orientDb.instances
+
+import cats.effect.implicits.effectResourceOps
+import cats.implicits._
+import co.topl.genusLibrary.DbFixtureUtilV2
+import co.topl.genusLibrary.orientDb.OrientThread
+import co.topl.genusLibrary.orientDb.instances.SchemaBlockBody.Field
+import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.blockBodySchema
+import co.topl.node.models.BlockBody
+import com.orientechnologies.orient.core.metadata.schema.OType
+import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalamock.munit.AsyncMockFactory
+import scala.jdk.CollectionConverters._
+
+class SchemaBlockBodyTest
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with AsyncMockFactory
+    with CatsEffectFunFixtures
+    with DbFixtureUtilV2 {
+
+  orientDbFixtureV2.test("Block body Schema Metadata") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+    val res = for {
+      dbNoTx <- oThread.delay(odbFactory.getNoTx).toResource
+
+      databaseDocumentTx <- oThread.delay(dbNoTx.getRawGraph).toResource
+
+      oClass <- oThread.delay(databaseDocumentTx.getClass(Field.SchemaName)).toResource
+
+      _ <- assertIO(oClass.getName.pure[F], Field.SchemaName, s"${Field.SchemaName} Class was not created").toResource
+
+      txIdsProperty <- oClass.getProperty(Field.TransactionIds).pure[F].toResource
+      _ <- (
+        assertIO(txIdsProperty.getName.pure[F], Field.TransactionIds) &>
+        assertIO(txIdsProperty.isMandatory.pure[F], false) &>
+        assertIO(txIdsProperty.isReadonly.pure[F], false) &>
+        assertIO(txIdsProperty.isNotNull.pure[F], false) &>
+        assertIO(txIdsProperty.getType.pure[F], OType.BINARY)
+      ).toResource
+
+    } yield ()
+
+    res.use_
+
+  }
+
+  orientDbFixtureV2.test("Block Body Schema Add vertex") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+    val res = for {
+
+      dbTx <- oThread.delay(odbFactory.getTx).toResource
+
+      vertex <- oThread
+        .delay(
+          dbTx
+            .addVertex(s"class:${blockBodySchema.name}", blockBodySchema.encode(BlockBody(Seq.empty)).asJava)
+        )
+        .toResource
+
+      _ <- assertIO(
+        vertex
+          .getProperty[Array[Byte]](blockBodySchema.properties.filter(_.name == Field.TransactionIds).head.name)
+          .toSeq
+          .pure[F],
+        Array.empty[Byte].toSeq
+      ).toResource
+
+    } yield ()
+    res.use_
+
+  }
+
+}

--- a/node/src/main/scala/co/topl/genus/GrpcNetworkMetricsService.scala
+++ b/node/src/main/scala/co/topl/genus/GrpcNetworkMetricsService.scala
@@ -4,7 +4,6 @@ import cats.data.EitherT
 import cats.effect.kernel.Async
 import co.topl.genus.services._
 import co.topl.genusLibrary.algebras.VertexFetcherAlgebra
-import co.topl.genusLibrary.model.GEs
 import io.grpc.Metadata
 
 class GrpcNetworkMetricsService[F[_]: Async](vertexFetcher: VertexFetcherAlgebra[F])
@@ -12,17 +11,19 @@ class GrpcNetworkMetricsService[F[_]: Async](vertexFetcher: VertexFetcherAlgebra
 
   def getTxoStats(request: GetTxoStatsReq, ctx: Metadata): F[GetTxoStatsRes] =
     EitherT(vertexFetcher.fetchTxoStats())
-      .foldF(
-        ge => Async[F].raiseError[GetTxoStatsRes](GEs.Internal(ge)),
-        stats => Async[F].delay(GetTxoStatsRes(stats))
-      )
+      .map(GetTxoStatsRes(_))
+      .rethrowT
       .adaptErrorsToGrpc
 
   def getBlockchainSizeStats(request: BlockchainSizeStatsReq, ctx: Metadata): F[BlockchainSizeStatsRes] =
     EitherT(vertexFetcher.fetchBlockchainSizeStats())
-      .foldF(
-        ge => Async[F].raiseError[BlockchainSizeStatsRes](GEs.Internal(ge)),
-        stats => Async[F].delay(BlockchainSizeStatsRes(stats))
-      )
+      .map(BlockchainSizeStatsRes(_))
+      .rethrowT
+      .adaptErrorsToGrpc
+
+  def getBlockStats(request: BlockStatsReq, ctx: Metadata): F[BlockStatsRes] =
+    EitherT(vertexFetcher.fetchBlockStats())
+      .map(BlockStatsRes(_))
+      .rethrowT
       .adaptErrorsToGrpc
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.18"
-  val protobufSpecsVersion = "f1468ecc55cdd5ca4bb139d49c87b956d53f87dc" // scala-steward:off TODO replace
+  val protobufSpecsVersion = "ae3f01df" // scala-steward:off
   val bramblScVersion = "c7ff17a" // scala-steward:off
   val quivr4sVersion = "1e48130" // scala-steward:off
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.18"
-  val protobufSpecsVersion = "17a28eb" // scala-steward:off
+  val protobufSpecsVersion = "f1468ecc55cdd5ca4bb139d49c87b956d53f87dc" // scala-steward:off TODO replace
   val bramblScVersion = "c7ff17a" // scala-steward:off
   val quivr4sVersion = "1e48130" // scala-steward:off
 


### PR DESCRIPTION
## Purpose
- Add empty blocks count to NetworkStats, Supports "total blocks with and without transactions in them"

### Pending PR
- new Genus rpc approval. https://github.com/Topl/protobuf-specs/pull/64

### Testing

```shell
fernando@fernando-um700:~/topl/Bifrost$ gwhisper 0.0.0.0:9084 co.topl.genus.services.NetworkMetricsService getBlockStats 
2023-06-02 17:22:37: Received message:
| blockStats = {BlockStats}      <<< node is running, block produced = 4 (3+1) 1 is the genesis transaction
| | empty... = 3 (0x0000000000000003)             
| | nonEmpty = 1 (0x0000000000000001)
RPC succeeded :D
fernando@fernando-um700:~/topl/Bifrost$ gwhisper 0.0.0.0:9084 co.topl.genus.services.NetworkMetricsService getBlockStats 
2023-06-02 17:22:49: Received message:
| blockStats = {BlockStats}    <<< node is running, block produced = 7 (6+1)  1 is the genesis transaction
| | empty... = 6 (0x0000000000000006)
| | nonEmpty = 1 (0x0000000000000001)
RPC succeeded :D

``` 
