### PR TITLE
BN-1047 Include size on blockHeader rpc Genus calls

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeader.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeader.scala
@@ -69,7 +69,8 @@ object SchemaBlockHeader {
         eligibilityCertificate = EligibilityCertificate.parseFrom(v(Field.EligibilityCertificate): Array[Byte]),
         operationalCertificate = OperationalCertificate.parseFrom(v(Field.OperationalCertificate): Array[Byte]),
         ByteString.copyFrom(v(Field.Metadata): Array[Byte]),
-        address = StakingAddress.parseFrom(v(Field.Address): Array[Byte])
+        address = StakingAddress.parseFrom(v(Field.Address): Array[Byte]),
+        size = Option(v(Field.Size))
       )
   )
 

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphTransactionFetcherTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphTransactionFetcherTest.scala
@@ -186,13 +186,14 @@ class GraphTransactionFetcherTest extends CatsEffectSuite with ScalaCheckEffectS
 
   test("On fetchTransactionReceipt if IoTransactionVertex exist, Some TransactionReceipt should be returned") {
 
+    val iotxVertex = mock[Vertex]
+    val blockHeaderVertex = mock[Vertex] // OrientVertex is not possible to mock
+
     PropF.forAllF { (transactionId: TransactionId, ioTransaction: IoTransaction, blockHeader: BlockHeader) =>
       withMock {
 
         val res = for {
           vertexFetcher <- mock[VertexFetcherAlgebra[F]].pure[F].toResource
-          iotxVertex = mock[Vertex]
-          blockHeaderVertex = mock[Vertex] // OrientVertex is not possible to mock
 
           _ = (vertexFetcher.fetchTransaction _)
             .expects(transactionId)
@@ -287,6 +288,12 @@ class GraphTransactionFetcherTest extends CatsEffectSuite with ScalaCheckEffectS
             .once()
             .returning(blockHeader.timestamp)
 
+          _ = (blockHeaderVertex
+            .getProperty[java.lang.Long] _)
+            .expects(SchemaBlockHeader.Field.Size)
+            .once()
+            .returning(0L)
+
           _ = (blockHeaderVertex.getPropertyKeys _)
             .expects()
             .once()
@@ -303,7 +310,8 @@ class GraphTransactionFetcherTest extends CatsEffectSuite with ScalaCheckEffectS
                 SchemaBlockHeader.Field.EligibilityCertificate,
                 SchemaBlockHeader.Field.OperationalCertificate,
                 SchemaBlockHeader.Field.Metadata,
-                SchemaBlockHeader.Field.Address
+                SchemaBlockHeader.Field.Address,
+                SchemaBlockHeader.Field.Size
               )
             )
 

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherV2Test.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherV2Test.scala
@@ -57,6 +57,10 @@ class GraphVertexFetcherV2Test
 
         blockHeaderVertex <- graphVertexFetcher.fetchHeader(blockHeader.id).rethrow.toResource
         _                 <- assertIOBoolean(blockHeaderVertex.isDefined.pure[F]).toResource
+        _ <- assertIO(
+          blockHeaderVertex.get.getProperty[Long]("size").pure[F],
+          SchemaBlockHeader.size(blockHeader)
+        ).toResource
       } yield ()
 
       res.use_

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaCanonicalHeadTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaCanonicalHeadTest.scala
@@ -110,7 +110,8 @@ class SchemaCanonicalHeadTest
       ).toResource
 
       blockHeaderDecoded = blockHeaderSchema.decodeVertex(blockHeaderFromCanonicalHead)
-      _ <- assertIOBoolean((blockHeader == blockHeaderDecoded).pure[F]).toResource
+      blockHeaderSize = SchemaBlockHeader.size(blockHeader)
+      _ <- assertIOBoolean((blockHeader.withSize(blockHeaderSize) == blockHeaderDecoded).pure[F]).toResource
 
     } yield ()
     res.use_

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val fs2Version = "3.6.1"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.18"
-  val protobufSpecsVersion = "17a28eb" // scala-steward:off
+  val protobufSpecsVersion = "f2abc673737e6756c8f7599681b6ad598ee161ef" // scala-steward:off TODO replace with main version
   val bramblScVersion = "c7ff17a" // scala-steward:off
   val quivr4sVersion = "1e48130" // scala-steward:off
 

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -134,6 +134,7 @@ trait TetraScodecCodecs {
       operationalCertificateCodec ::
       byteStringCodec :: // metadata
       stakingAddressCodec :: // address
+      emptyCodec[Option[Long]](None) :: // size
       unknownFieldSetCodec
   ).as[BlockHeader]
 


### PR DESCRIPTION
## Purpose
Return  Blockheader size on Genus/Node rpc, size is on orientdb

## Pending PR
https://github.com/Topl/protobuf-specs/pull/66

## Testing

![image](https://github.com/Topl/Bifrost/assets/8540107/7fd35003-b090-47c3-bede-617cd1de7da3)

## Tickets
https://topl.atlassian.net/browse/BN-1047
