### PR TITLE
BN-1047 V2  Include size on blockHeader rpc Genus/Node calls 

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeader.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeader.scala
@@ -3,8 +3,6 @@ package co.topl.genusLibrary.orientDb.instances
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.consensus.models._
 import co.topl.genusLibrary.orientDb.schema.OIndexable.Instances._
-import co.topl.codecs.bytes.tetra.TetraScodecCodecs._
-import co.topl.codecs.bytes.typeclasses.ImmutableCodec
 import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
 import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, VertexSchema}
 import com.google.protobuf.ByteString
@@ -34,9 +32,6 @@ object SchemaBlockHeader {
     val BlockHeaderIndex = "blockHeaderIndex"
   }
 
-  private[genusLibrary] def size(blockHeader: BlockHeader): Long =
-    ImmutableCodec.fromScodecCodec[BlockHeader].immutableBytes(blockHeader).size
-
   def make(): VertexSchema[BlockHeader] = VertexSchema.create(
     Field.SchemaName,
     GraphDataEncoder[BlockHeader]
@@ -53,7 +48,7 @@ object SchemaBlockHeader {
       .withProperty(Field.OperationalCertificate,_.operationalCertificate.toByteArray,mandatory = true, readOnly = true, notNull = true)
       .withProperty(Field.Metadata,_.metadata.toByteArray,mandatory = true, readOnly = true, notNull = false)
       .withProperty(Field.Address,_.address.toByteArray,mandatory = true, readOnly = true, notNull = true)
-      .withProperty(Field.Size, blockHeader => java.lang.Long.valueOf(size(blockHeader)) ,mandatory = true, readOnly = true, notNull = true)
+      .withProperty(Field.Size, blockHeader => java.lang.Long.valueOf(blockHeader.size) ,mandatory = true, readOnly = true, notNull = true)
       .withIndex[BlockHeader](Field.BlockHeaderIndex, Field.BlockId),
       // @formatter:on
     v =>

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherV2Test.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherV2Test.scala
@@ -10,7 +10,7 @@ import co.topl.genusLibrary.model.GE
 import co.topl.genusLibrary.orientDb.OrientThread
 import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.{blockBodySchema, Ops}
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
-import co.topl.genusLibrary.orientDb.instances.{SchemaBlockHeader, SchemaIoTransaction}
+import co.topl.genusLibrary.orientDb.instances.SchemaIoTransaction
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.models.generators.consensus.ModelGenerators
 import co.topl.node.models.BlockBody
@@ -357,7 +357,7 @@ class GraphVertexFetcherV2Test
       _ <- assertIO(
         graphVertexFetcher.fetchBlockchainSizeStats(),
         BlockchainSizeStats.defaultInstance
-          .withBlockHeaderBytes(SchemaBlockHeader.size(blockHeader))
+          .withBlockHeaderBytes(blockHeader.size)
           .withTransactionBytes(SchemaIoTransaction.size(ioTransaction))
           .asRight[GE]
       ).toResource

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeaderTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeaderTest.scala
@@ -249,7 +249,7 @@ class SchemaBlockHeaderTest
 
       _ <- assertIO(
         vertex.getProperty[Long](schema.properties.filter(_.name == Field.Size).head.name).pure[F],
-        SchemaBlockHeader.size(blockHeader)
+        blockHeader.size
       ).toResource
 
     } yield ()

--- a/node/src/main/scala/co/topl/genus/GrpcBlockService.scala
+++ b/node/src/main/scala/co/topl/genus/GrpcBlockService.scala
@@ -3,6 +3,7 @@ package co.topl.genus
 import cats.data.EitherT
 import cats.effect.kernel.Async
 import cats.implicits._
+import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.genus.services._
 import co.topl.genusLibrary.algebras.BlockFetcherAlgebra
 import co.topl.genusLibrary.model.GEs
@@ -23,7 +24,15 @@ class GrpcBlockService[F[_]: Async](blockFetcher: BlockFetcherAlgebra[F]) extend
               .raiseError[BlockData](GEs.NotFound(s"BlockId:${request.blockId.show}"))
           )
       )
-      .map(blockData => BlockResponse.of(FullBlock.of(blockData.header, FullBlockBody.of(blockData.transactions))))
+      .map(blockData =>
+        BlockResponse.of(
+          FullBlock.of(
+            blockData.header,
+            FullBlockBody.of(blockData.transactions),
+            headerSize = Some(blockData.header.size)
+          )
+        )
+      )
       .adaptErrorsToGrpc
 
   override def getBlockByHeight(request: GetBlockByHeightRequest, ctx: Metadata): F[BlockResponse] =
@@ -35,7 +44,15 @@ class GrpcBlockService[F[_]: Async](blockFetcher: BlockFetcherAlgebra[F]) extend
             Async[F].raiseError[BlockData](GEs.NotFound(s"Height:${request.height.value.show}"))
           )
       )
-      .map(blockData => BlockResponse.of(FullBlock.of(blockData.header, FullBlockBody.of(blockData.transactions))))
+      .map(blockData =>
+        BlockResponse.of(
+          FullBlock.of(
+            blockData.header,
+            FullBlockBody.of(blockData.transactions),
+            headerSize = Some(blockData.header.size)
+          )
+        )
+      )
       .adaptErrorsToGrpc
 
   override def getBlockByDepth(request: GetBlockByDepthRequest, ctx: Metadata): F[BlockResponse] =
@@ -47,7 +64,15 @@ class GrpcBlockService[F[_]: Async](blockFetcher: BlockFetcherAlgebra[F]) extend
             Async[F].raiseError[BlockData](GEs.NotFound(s"Depth:${request.depth.value.show}"))
           )
       )
-      .map(blockData => BlockResponse.of(FullBlock.of(blockData.header, FullBlockBody.of(blockData.transactions))))
+      .map(blockData =>
+        BlockResponse.of(
+          FullBlock.of(
+            blockData.header,
+            FullBlockBody.of(blockData.transactions),
+            headerSize = Some(blockData.header.size)
+          )
+        )
+      )
       .adaptErrorsToGrpc
 
 }

--- a/node/src/test/scala/co/topl/genus/GrpcBlockServiceTest.scala
+++ b/node/src/test/scala/co/topl/genus/GrpcBlockServiceTest.scala
@@ -2,6 +2,7 @@ package co.topl.genus
 
 import cats.effect.IO
 import cats.implicits._
+import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.typeclasses.implicits._
 import co.topl.consensus.models._
 import co.topl.genus.services._
@@ -35,7 +36,7 @@ class GrpcBlockServiceTest extends CatsEffectSuite with ScalaCheckEffectSuite wi
           res <- underTest.getBlockById(GetBlockByIdRequest(blockId), new Metadata())
           _ = assert(
             res == BlockResponse(
-              FullBlock(blockData.header, fullBody = FullBlockBody(blockData.transactions))
+              FullBlock(blockData.header, fullBody = FullBlockBody(blockData.transactions), Some(blockData.header.size))
             )
           )
         } yield ()
@@ -102,7 +103,7 @@ class GrpcBlockServiceTest extends CatsEffectSuite with ScalaCheckEffectSuite wi
           res <- underTest.getBlockByHeight(GetBlockByHeightRequest(ChainDistance(height)), new Metadata())
           _ = assert(
             res == BlockResponse(
-              FullBlock(blockData.header, fullBody = FullBlockBody(blockData.transactions))
+              FullBlock(blockData.header, fullBody = FullBlockBody(blockData.transactions), Some(blockData.header.size))
             )
           )
         } yield ()
@@ -169,7 +170,7 @@ class GrpcBlockServiceTest extends CatsEffectSuite with ScalaCheckEffectSuite wi
           res <- underTest.getBlockByDepth(GetBlockByDepthRequest(ChainDistance(depth)), new Metadata())
           _ = assert(
             res == BlockResponse(
-              FullBlock(blockData.header, fullBody = FullBlockBody(blockData.transactions))
+              FullBlock(blockData.header, fullBody = FullBlockBody(blockData.transactions), Some(blockData.header.size))
             )
           )
         } yield ()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val fs2Version = "3.7.0"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.19"
-  val protobufSpecsVersion = "ae3f01df" // scala-steward:off
+  val protobufSpecsVersion = "743daebf318e64688d4e2122a1b34eadca3444d6" // scala-steward:off TODO replace
   val bramblScVersion = "c7ff17a" // scala-steward:off
   val quivr4sVersion = "1e48130" // scala-steward:off
 

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraIdentifiableInstances.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraIdentifiableInstances.scala
@@ -1,9 +1,10 @@
 package co.topl.codecs.bytes.tetra
 
+import co.topl.codecs.bytes.typeclasses.ImmutableCodec
+import co.topl.codecs.bytes.tetra.TetraScodecCodecs._
 import co.topl.consensus.models.BlockHeader
 import co.topl.consensus.models.BlockId
 import co.topl.crypto.hash.Blake2b256
-
 import scala.language.implicitConversions
 
 trait ProtoIdentifiableOps {
@@ -44,4 +45,11 @@ class BlockHeaderIdOps(val header: BlockHeader) extends AnyVal {
    */
   def containsValidId: Boolean =
     header.headerId.contains(computeId)
+
+  /**
+   * Block header immutable bytes size
+   * @return
+   */
+  def size: Long =
+    ImmutableCodec.fromScodecCodec[BlockHeader].immutableBytes(header).size
 }

--- a/topl-grpc/src/main/scala/co/topl/grpc/NodeGrpc.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/NodeGrpc.scala
@@ -11,6 +11,7 @@ import co.topl.algebras.SynchronizationTraversalSteps
 import co.topl.algebras.NodeRpc
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.consensus.models._
 import co.topl.node.models.BlockBody
 import co.topl.node.services._
@@ -23,7 +24,6 @@ import io.grpc.ServerServiceDefinition
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
 import io.grpc.protobuf.services.ProtoReflectionService
-
 import java.net.InetSocketAddress
 
 object NodeGrpc {
@@ -187,7 +187,7 @@ object NodeGrpc {
       def fetchBlockHeader(in: FetchBlockHeaderReq, ctx: Metadata): F[FetchBlockHeaderRes] =
         interpreter
           .fetchBlockHeader(in.blockId)
-          .map(FetchBlockHeaderRes(_))
+          .map(h => FetchBlockHeaderRes(h, h.map(_.size)))
           .adaptErrorsToGrpc
 
       def fetchBlockBody(in: FetchBlockBodyReq, ctx: Metadata): F[FetchBlockBodyRes] =


### PR DESCRIPTION
## Purpose
Return Blockheader size on Genus/Node rpc, size is on orientdb

### Pending PR
https://github.com/Topl/protobuf-specs/pull/67

## Approach
- this implementation does not use the size storage on orientdb, it obtains the size each time the rpc is called.
- benefits, all rpcs (node + bifrost) return the size populated, this pr only returns on genus rpc (https://github.com/Topl/Bifrost/pull/2968)

### Note
- we should merge #2968 or this pr, depending which protobuf-specs implementation is chosen. 
- https://github.com/Topl/protobuf-specs/pull/67   alternative 2
- https://github.com/Topl/protobuf-specs/pull/66  alternative 1


## Testing NodeRpc

```shell
fernando@fernando-um700:~/topl/Bifrost$ gwhisper 0.0.0.0:9084 co.topl.node.services.NodeRpc FetchBlockHeader blockId=:value=0x2d39ed54f6f08d995b80b3fdf00edfd713078864c7058e6e6564c4894b69fcf0:

2023-06-07 09:39:19: Received message:
| header.... = {BlockHeader}
| headerSize = {UInt64Value}
| | value = 893 (0x000000000000037d)

``` 
## Testing GenusRpc

```shell
fernando@fernando-um700:~/topl/Bifrost$ gwhisper 0.0.0.0:9084 co.topl.genus.services.BlockService getBlockByHeight height=:value=1:

2023-06-07 09:39:19: Received message:
| header.... = {BlockHeader}
| headerSize = {UInt64Value}
| | value = 893 (0x000000000000037d)

``` 



## Tickets
* BN-1047
