### PR TITLE
Track Epoch Data

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/ClockAlgebra.scala
+++ b/algebras/src/main/scala/co/topl/algebras/ClockAlgebra.scala
@@ -33,7 +33,8 @@ object ClockAlgebra {
 
     implicit final class ClockOps[F[_]: Apply](clock: ClockAlgebra[F]) {
 
-      def epochOf(slot: Slot): F[Epoch] = clock.slotsPerEpoch.map(numberOfSlots => slot / numberOfSlots)
+      def epochOf(slot: Slot): F[Epoch] =
+        clock.slotsPerEpoch.map(numberOfSlots => slot / numberOfSlots).map(v => if (slot < 0) v - 1 else v)
 
       def epochRange(epoch: Epoch): F[EpochBoundary] =
         clock.slotsPerEpoch.map(slotsPerEpoch => (epoch * slotsPerEpoch) to (((epoch + 1) * slotsPerEpoch) - 1))

--- a/blockchain/src/main/scala/co/topl/blockchain/DataStores.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/DataStores.scala
@@ -22,6 +22,7 @@ case class DataStores[F[_]](
   epochBoundaries: Store[F, Long, BlockId],
   operatorStakes:  Store[F, StakingAddress, BigInt],
   activeStake:     Store[F, Unit, BigInt],
+  inactiveStake:   Store[F, Unit, BigInt],
   registrations:   Store[F, StakingAddress, SignatureKesProduct],
   blockHeightTree: Store[F, Long, BlockId]
 )

--- a/blockchain/src/main/scala/co/topl/blockchain/algebras/EpochDataAlgebra.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/algebras/EpochDataAlgebra.scala
@@ -27,8 +27,11 @@ case class EpochData(
   endHeight:              Long,
   startSlot:              Long,
   endSlot:                Long,
+  startTimestamp:         Long,
+  endTimestamp:           Long,
   transactionCount:       Long,
   totalTransactionReward: Int128,
   activeStake:            Int128,
-  inactiveStake:          Int128
+  inactiveStake:          Int128,
+  dataBytes:              Long
 )

--- a/blockchain/src/main/scala/co/topl/blockchain/algebras/EpochDataAlgebra.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/algebras/EpochDataAlgebra.scala
@@ -13,7 +13,7 @@ trait EpochDataAlgebra[F[_]] {
    * @param epoch the epoch number to request
    * @return EpochData
    */
-  def dataOf(epoch: Epoch): F[EpochData]
+  def dataOf(epoch: Epoch): F[Option[EpochData]]
 
 }
 

--- a/blockchain/src/main/scala/co/topl/blockchain/algebras/EpochDataAlgebra.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/algebras/EpochDataAlgebra.scala
@@ -1,0 +1,34 @@
+package co.topl.blockchain.algebras
+
+import co.topl.models.Epoch
+import quivr.models.Int128
+
+/**
+ * Provides epoch-level statistics
+ */
+trait EpochDataAlgebra[F[_]] {
+
+  /**
+   * Constructs the EpochData for the requested epoch.  The "current" epoch is updated as blocks are adopted.
+   * @param epoch the epoch number to request
+   * @return EpochData
+   */
+  def dataOf(epoch: Epoch): F[EpochData]
+
+}
+
+// TODO: Re-implement in Protobuf in BN-1046
+case class EpochData(
+  epoch:                  Epoch,
+  eon:                    Long,
+  era:                    Long,
+  isComplete:             Boolean,
+  startHeight:            Long,
+  endHeight:              Long,
+  startSlot:              Long,
+  endSlot:                Long,
+  transactionCount:       Long,
+  totalTransactionReward: Int128,
+  activeStake:            Int128,
+  inactiveStake:          Int128
+)

--- a/blockchain/src/main/scala/co/topl/blockchain/interpreters/EpochDataInterpreter.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/interpreters/EpochDataInterpreter.scala
@@ -1,0 +1,210 @@
+package co.topl.blockchain.interpreters
+
+import cats.MonadThrow
+import cats.effect.{Async, Resource}
+import cats.effect.implicits._
+import cats.implicits._
+import co.topl.algebras.ClockAlgebra.implicits.ClockOps
+import co.topl.algebras.{ClockAlgebra, Store}
+import co.topl.blockchain.algebras.{EpochData, EpochDataAlgebra}
+import co.topl.brambl.models.TransactionId
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
+import co.topl.consensus.algebras.LocalChainAlgebra
+import co.topl.consensus.interpreters.{ConsensusDataEventSourcedState, EpochBoundariesEventSourcedState}
+import co.topl.consensus.models.{BlockHeader, BlockId}
+import co.topl.eventtree.{EventSourcedState, ParentChildTree}
+import co.topl.ledger.algebras.TransactionRewardCalculatorAlgebra
+import co.topl.models._
+import co.topl.node.models.BlockBody
+import co.topl.numerics.implicits._
+import co.topl.typeclasses.implicits._
+
+object EpochDataInterpreter {
+
+  def make[F[_]: MonadThrow](
+    localChain:                 LocalChainAlgebra[F],
+    epochDataEventSourcedState: EventSourcedState[F, EpochDataEventSourcedState.State[F], BlockId]
+  ): Resource[F, EpochDataAlgebra[F]] =
+    Resource.pure((epoch: Epoch) =>
+      localChain.head
+        .map(_.slotId.blockId)
+        .flatMap(epochDataEventSourcedState.useStateAt(_)(_.getOrRaise(epoch)))
+    )
+}
+
+object EpochDataEventSourcedState {
+
+  type State[F[_]] = Store[F, Epoch, EpochData]
+
+  def make[F[_]: Async](
+    currentBlockId:              F[BlockId],
+    genesisBlockId:              BlockId,
+    parentChildTree:             ParentChildTree[F, BlockId],
+    currentEventChanged:         BlockId => F[Unit],
+    initialState:                F[State[F]],
+    clock:                       ClockAlgebra[F],
+    fetchBlockHeader:            BlockId => F[BlockHeader],
+    fetchBlockBody:              BlockId => F[BlockBody],
+    fetchTransaction:            TransactionId => F[IoTransaction],
+    transactionRewardCalculator: TransactionRewardCalculatorAlgebra[F],
+    epochBoundaryEventSourcedState: EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
+      F
+    ], BlockId],
+    consensusDataEventSourcedState: EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[
+      F
+    ], BlockId]
+  ): Resource[F, EventSourcedState[F, State[F], BlockId]] =
+    EventSourcedState.OfTree
+      .make(
+        initialState = initialState,
+        initialEventId = currentBlockId,
+        applyEvent = new ApplyBlock(
+          genesisBlockId,
+          clock,
+          fetchBlockHeader,
+          fetchBlockBody,
+          fetchTransaction,
+          transactionRewardCalculator,
+          epochBoundaryEventSourcedState,
+          consensusDataEventSourcedState
+        ),
+        unapplyEvent =
+          new UnapplyBlock(clock, fetchBlockHeader, fetchBlockBody, fetchTransaction, transactionRewardCalculator),
+        parentChildTree = parentChildTree,
+        currentEventChanged
+      )
+      .toResource
+
+  private class ApplyBlock[F[_]: MonadThrow](
+    genesisBlockId:              BlockId,
+    clock:                       ClockAlgebra[F],
+    fetchBlockHeader:            BlockId => F[BlockHeader],
+    fetchBlockBody:              BlockId => F[BlockBody],
+    fetchTransaction:            TransactionId => F[IoTransaction],
+    transactionRewardCalculator: TransactionRewardCalculatorAlgebra[F],
+    epochBoundaryEventSourcedState: EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
+      F
+    ], BlockId],
+    consensusDataEventSourcedState: EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[
+      F
+    ], BlockId]
+  ) extends ((State[F], BlockId) => F[State[F]]) {
+
+    def apply(state: State[F], blockId: BlockId): F[State[F]] =
+      for {
+        header      <- fetchBlockHeader(blockId)
+        epoch       <- clock.epochOf(header.slot)
+        parentEpoch <- clock.epochOf(header.parentSlot)
+        _ <-
+          if (epoch != parentEpoch) epochBoundaryCrossed(state)(header, epoch)
+          else epochBoundaryNotCrossed(state)(header, epoch)
+      } yield state
+
+    private def epochBoundaryCrossed(state: State[F])(header: BlockHeader, epoch: Epoch) =
+      for {
+        previousEpochData <- state.getOrRaise(epoch - 1)
+        updatedPreviousEpochData = previousEpochData.copy(isComplete = true)
+        _ <- state.put(epoch - 1, updatedPreviousEpochData)
+        stakesBoundaryBlock <-
+          if (epoch >= 2)
+            epochBoundaryEventSourcedState.useStateAt(header.id)(_.getOrRaise(epoch - 2))
+          else
+            genesisBlockId.pure[F]
+        (activeStake, inactiveStake) <-
+          consensusDataEventSourcedState.useStateAt(stakesBoundaryBlock)(s =>
+            (s.totalActiveStake.getOrRaise(()), s.totalInactiveStake.getOrRaise(())).tupled
+          )
+        newEpochBoundary <- clock.epochRange(epoch)
+        newEpochDataBase = EpochData(
+          epoch = epoch,
+          eon = 1,
+          era = 0,
+          isComplete = false,
+          startHeight = header.height,
+          endHeight = header.height,
+          startSlot = newEpochBoundary.start,
+          endSlot = newEpochBoundary.end,
+          transactionCount = 0,
+          totalTransactionReward = 0,
+          activeStake = activeStake,
+          inactiveStake = inactiveStake
+        )
+        newEpochData <- applyTransactions(newEpochDataBase)(header)
+        _            <- state.put(epoch, newEpochData)
+      } yield state
+
+    private def epochBoundaryNotCrossed(state: State[F])(header: BlockHeader, epoch: Epoch) =
+      for {
+        previousEpochData <- state.getOrRaise(epoch)
+        newEpochData      <- applyTransactions(previousEpochData.copy(endHeight = header.height))(header)
+        _                 <- state.put(epoch, newEpochData)
+      } yield state
+
+    private def applyTransactions(epochData: EpochData)(header: BlockHeader): F[EpochData] =
+      fetchBlockBody(header.id)
+        .flatMap(body =>
+          if (body.transactionIds.isEmpty) epochData.pure[F]
+          else
+            body.transactionIds
+              .foldMapM(fetchTransaction(_).flatMap(transactionRewardCalculator.rewardOf))
+              .map(rewards =>
+                epochData.copy(
+                  transactionCount = epochData.transactionCount + body.transactionIds.length,
+                  totalTransactionReward = epochData.totalTransactionReward + rewards
+                )
+              )
+        )
+
+  }
+
+  private class UnapplyBlock[F[_]: MonadThrow](
+    clock:                       ClockAlgebra[F],
+    fetchBlockHeader:            BlockId => F[BlockHeader],
+    fetchBlockBody:              BlockId => F[BlockBody],
+    fetchTransaction:            TransactionId => F[IoTransaction],
+    transactionRewardCalculator: TransactionRewardCalculatorAlgebra[F]
+  ) extends ((State[F], BlockId) => F[State[F]]) {
+
+    def apply(state: State[F], blockId: BlockId): F[State[F]] =
+      for {
+        header      <- fetchBlockHeader(blockId)
+        epoch       <- clock.epochOf(header.slot)
+        parentEpoch <- clock.epochOf(header.parentSlot)
+        _ <-
+          if (epoch != parentEpoch) epochBoundaryCrossed(state)(header, epoch)
+          else epochBoundaryNotCrossed(state)(header, epoch)
+      } yield state
+
+    private def epochBoundaryCrossed(state: State[F])(header: BlockHeader, epoch: Epoch) =
+      for {
+        previousEpochData <- state.getOrRaise(epoch - 1)
+        updatedPreviousEpochData = previousEpochData.copy(isComplete = false)
+        _ <- state.put(epoch - 1, updatedPreviousEpochData)
+        _ <- state.remove(epoch)
+      } yield state
+
+    private def epochBoundaryNotCrossed(state: State[F])(header: BlockHeader, epoch: Epoch) =
+      for {
+        previousEpochData <- state.getOrRaise(epoch)
+        newEpochData      <- unapplyTransactions(previousEpochData.copy(endHeight = header.height))(header)
+        _                 <- state.put(epoch, newEpochData)
+      } yield state
+
+    private def unapplyTransactions(epochData: EpochData)(header: BlockHeader): F[EpochData] =
+      fetchBlockBody(header.id)
+        .flatMap(body =>
+          if (body.transactionIds.isEmpty) epochData.pure[F]
+          else
+            body.transactionIds.reverse
+              .foldMapM(fetchTransaction(_).flatMap(transactionRewardCalculator.rewardOf))
+              .map(rewards =>
+                epochData.copy(
+                  transactionCount = epochData.transactionCount - body.transactionIds.length,
+                  totalTransactionReward = epochData.totalTransactionReward - rewards
+                )
+              )
+        )
+
+  }
+}

--- a/blockchain/src/main/scala/co/topl/blockchain/interpreters/EpochDataInterpreter.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/interpreters/EpochDataInterpreter.scala
@@ -27,6 +27,11 @@ import co.topl.codecs.bytes.tetra.TetraScodecCodecs
  */
 object EpochDataInterpreter {
 
+  /**
+   * Implements the EpochDataAlgebra
+   * @param fetchCanonicalHead a function to retrieve the current canonical head ID.  This will be invoked multiple times over the runtime of the program.
+   * @param epochDataEventSourcedState an implementation of a backing EventSourcedState
+   */
   def make[F[_]: MonadThrow](
     fetchCanonicalHead:         F[BlockId],
     epochDataEventSourcedState: EventSourcedState[F, EpochDataEventSourcedState.State[F], BlockId]
@@ -41,6 +46,21 @@ object EpochDataEventSourcedState {
 
   type State[F[_]] = Store[F, Epoch, EpochData]
 
+  /**
+   * Implements an EventSourcedState which tracks/accumulates data as blocks are applied
+   * @param currentBlockId The initial ID when launching the interpreter
+   * @param genesisBlockId The chain's genesis block ID
+   * @param parentChildTree A block ID parent-child tree
+   * @param currentEventChanged A callback function that is invoked whenever a block is applied or unapplied
+   * @param initialState The initial state of the event-sourced state at `currentBlockId`
+   * @param clock a clock
+   * @param fetchBlockHeader lookup a block header by ID
+   * @param fetchBlockBody lookup a block body by ID
+   * @param fetchTransaction lookup a transaction by ID
+   * @param transactionRewardCalculator calculate a transaction's rewards
+   * @param epochBoundaryEventSourcedState an event-sourced state which tracks the last block of each epoch
+   * @param consensusDataEventSourcedState an event-sourced state which tracks staking information
+   */
   def make[F[_]: Async](
     currentBlockId:              F[BlockId],
     genesisBlockId:              BlockId,

--- a/blockchain/src/test/scala/co/topl/blockchain/interpreters/EpochDataInterpreterSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/interpreters/EpochDataInterpreterSpec.scala
@@ -1,0 +1,300 @@
+package co.topl.blockchain.interpreters
+
+import cats.data.OptionT
+import cats.effect.{IO, Sync}
+import cats.implicits._
+import co.topl.algebras.ClockAlgebra
+import co.topl.algebras.testInterpreters.TestStore
+import co.topl.blockchain.algebras.EpochData
+import co.topl.brambl.models.box.{Attestation, Value}
+import co.topl.brambl.models.{Datum, LockAddress, LockId, TransactionId, TransactionOutputAddress}
+import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
+import co.topl.consensus.interpreters.{ConsensusDataEventSourcedState, EpochBoundariesEventSourcedState}
+import co.topl.consensus.models._
+import co.topl.eventtree.{EventSourcedState, ParentChildTree}
+import co.topl.ledger.algebras.TransactionRewardCalculatorAlgebra
+import co.topl.node.models.{BlockBody, FullBlock, FullBlockBody}
+import co.topl.numerics.implicits._
+import co.topl.typeclasses.implicits._
+import com.google.protobuf.ByteString
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.scalamock.munit.AsyncMockFactory
+import quivr.models.Int128
+import co.topl.models._
+
+class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+
+  type F[A] = IO[A]
+
+  private val lvlValue: Value =
+    Value().withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(100).toByteArray))))
+
+  private val emptyLockAddress =
+    LockAddress(id = LockId(zeroBytes(32)))
+
+  test("apply and unapply blocks") {
+    withMock {
+      val tx1 =
+        IoTransaction(datum = Datum.IoTransaction.defaultInstance)
+          .withOutputs(
+            List(
+              UnspentTransactionOutput(value = lvlValue, address = emptyLockAddress)
+            )
+          )
+      val List(tx2, tx3, tx4, tx5, tx6, tx7) =
+        LazyList
+          .unfold(tx1)(parent =>
+            IoTransaction(datum = Datum.IoTransaction.defaultInstance)
+              .withInputs(List(stxo(parent, 0)))
+              .withOutputs(
+                List(
+                  UnspentTransactionOutput(value = lvlValue, address = emptyLockAddress)
+                )
+              )
+              .some
+              .map(v => (v, v))
+          )
+          .take(6)
+          .toList
+      val genesisBlock = createGenesisBlock(List(tx1))
+      val block2 = createChildBlock(genesisBlock.header, 5)(List(tx2, tx3))
+      val block3 = createChildBlock(block2.header, 15)(List(tx4))
+      val block4 = createChildBlock(block3.header, 25)(List(tx5, tx6))
+      val block5 = createChildBlock(block4.header, 35)(List(tx7))
+      val testResource =
+        for {
+          parentChildTree <- ParentChildTree.FromRef.make[F, BlockId].toResource
+          _               <- parentChildTree.associate(genesisBlock.header.id, BlockId(zeroBytes(32))).toResource
+          _               <- parentChildTree.associate(block2.header.id, genesisBlock.header.id).toResource
+          _               <- parentChildTree.associate(block3.header.id, block2.header.id).toResource
+          _               <- parentChildTree.associate(block4.header.id, block3.header.id).toResource
+          _               <- parentChildTree.associate(block5.header.id, block4.header.id).toResource
+          state           <- TestStore.make[F, Epoch, EpochData].toResource
+          clock = mock[ClockAlgebra[F]]
+          _ = (() => clock.slotsPerEpoch).expects().anyNumberOfTimes().returning(10L.pure[F])
+          headerStore      <- TestStore.make[F, BlockId, BlockHeader].toResource
+          bodyStore        <- TestStore.make[F, BlockId, BlockBody].toResource
+          transactionStore <- TestStore.make[F, TransactionId, IoTransaction].toResource
+          _ <- List(genesisBlock, block2, block3, block4, block5)
+            .traverse(block =>
+              headerStore.put(block.header.id, block.header) *>
+              bodyStore.put(block.header.id, BlockBody(block.fullBody.transactions.map(_.id))) *>
+              block.fullBody.transactions.traverse(tx => transactionStore.put(tx.id, tx))
+            )
+            .toResource
+          rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
+          _ = (rewardCalculator.rewardOf(_: IoTransaction)).expects(*).anyNumberOfTimes().returning(BigInt(50).pure[F])
+          epochBoundaryEss = mock[EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
+            F
+          ], BlockId]]
+          _ = (epochBoundaryEss
+            .useStateAt(_: BlockId)(_: EpochBoundariesEventSourcedState.EpochBoundaries[F] => F[BlockId]))
+            .expects(*, *)
+            .twice()
+            .onCall { case (_: BlockId, f: (EpochBoundariesEventSourcedState.EpochBoundaries[F] => F[BlockId])) =>
+              TestStore
+                .make[F, Epoch, BlockId]
+                .flatTap(_.put(0, block2.header.id))
+                .flatTap(_.put(1, block3.header.id))
+                .flatTap(_.put(2, block4.header.id))
+                .flatTap(_.put(3, block5.header.id))
+                .flatMap(f)
+            }
+          consensusDataEss = mock[EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[
+            F
+          ], BlockId]]
+          _ = (consensusDataEss
+            .useStateAt(_: BlockId)(_: ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)]))
+            .expects(genesisBlock.header.id, *)
+            .repeat(2)
+            .onCall { case (_: BlockId, f: (ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)])) =>
+              (
+                TestStore.make[F, Unit, BigInt].flatTap(_.put((), 40)),
+                TestStore.make[F, Unit, BigInt].flatTap(_.put((), 0))
+              )
+                .mapN(ConsensusDataEventSourcedState.ConsensusData(null, _, _, null))
+                .flatMap(f)
+            }
+          _ = (consensusDataEss
+            .useStateAt(_: BlockId)(_: ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)]))
+            .expects(block2.header.id, *)
+            .once()
+            .onCall { case (_: BlockId, f: (ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)])) =>
+              (
+                TestStore.make[F, Unit, BigInt].flatTap(_.put((), 20)),
+                TestStore.make[F, Unit, BigInt].flatTap(_.put((), 20))
+              )
+                .mapN(ConsensusDataEventSourcedState.ConsensusData(null, _, _, null))
+                .flatMap(f)
+            }
+          _ = (consensusDataEss
+            .useStateAt(_: BlockId)(_: ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)]))
+            .expects(block3.header.id, *)
+            .once()
+            .onCall { case (_: BlockId, f: (ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)])) =>
+              (
+                TestStore.make[F, Unit, BigInt].flatTap(_.put((), 30)),
+                TestStore.make[F, Unit, BigInt].flatTap(_.put((), 10))
+              )
+                .mapN(ConsensusDataEventSourcedState.ConsensusData(null, _, _, null))
+                .flatMap(f)
+            }
+          ess <- EpochDataEventSourcedState.make[F](
+            BlockId(zeroBytes(32)).pure[F],
+            genesisBlock.header.id,
+            parentChildTree,
+            _ => IO.unit,
+            state.pure[F],
+            clock,
+            headerStore.getOrRaise,
+            bodyStore.getOrRaise,
+            transactionStore.getOrRaise,
+            rewardCalculator,
+            epochBoundaryEss,
+            consensusDataEss
+          )
+          underTest <- EpochDataInterpreter.make[F](Sync[F].delay(block5.header.id), ess)
+          expectedData0 =
+            EpochData(
+              epoch = 0,
+              eon = 1,
+              era = 0,
+              isComplete = true,
+              startHeight = 1,
+              endHeight = 2,
+              startSlot = 0,
+              endSlot = 9,
+              transactionCount = 3,
+              totalTransactionReward = 150,
+              activeStake = 40,
+              inactiveStake = 0
+            )
+          expectedData1 = EpochData(
+            epoch = 1,
+            eon = 1,
+            era = 0,
+            isComplete = true,
+            startHeight = 3,
+            endHeight = 3,
+            startSlot = 10,
+            endSlot = 19,
+            transactionCount = 1,
+            totalTransactionReward = 50,
+            activeStake = 40,
+            inactiveStake = 0
+          )
+          expectedData2 = EpochData(
+            epoch = 2,
+            eon = 1,
+            era = 0,
+            isComplete = true,
+            startHeight = 4,
+            endHeight = 4,
+            startSlot = 20,
+            endSlot = 29,
+            transactionCount = 2,
+            totalTransactionReward = 100,
+            activeStake = 20,
+            inactiveStake = 20
+          )
+          expectedData3 = EpochData(
+            epoch = 3,
+            eon = 1,
+            era = 0,
+            isComplete = false,
+            startHeight = 5,
+            endHeight = 5,
+            startSlot = 30,
+            endSlot = 39,
+            transactionCount = 1,
+            totalTransactionReward = 50,
+            activeStake = 30,
+            inactiveStake = 10
+          )
+          _ <-
+            OptionT(underTest.dataOf(0)).getOrRaise(new NoSuchElementException).assertEquals(expectedData0).toResource
+          _ <-
+            OptionT(underTest.dataOf(1)).getOrRaise(new NoSuchElementException).assertEquals(expectedData1).toResource
+          _ <-
+            OptionT(underTest.dataOf(2)).getOrRaise(new NoSuchElementException).assertEquals(expectedData2).toResource
+          _ <-
+            OptionT(underTest.dataOf(3)).getOrRaise(new NoSuchElementException).assertEquals(expectedData3).toResource
+          _ <-
+            OptionT(underTest.dataOf(2)).getOrRaise(new NoSuchElementException).assertEquals(expectedData2).toResource
+          _ <-
+            OptionT(underTest.dataOf(1)).getOrRaise(new NoSuchElementException).assertEquals(expectedData1).toResource
+          _ <-
+            OptionT(underTest.dataOf(0)).getOrRaise(new NoSuchElementException).assertEquals(expectedData0).toResource
+        } yield ()
+      testResource.use_
+    }
+  }
+
+  private def createGenesisBlock(transactions: Seq[IoTransaction]) = {
+    val header = BlockHeader(
+      parentHeaderId = BlockId(zeroBytes(32)),
+      parentSlot = -1,
+      txRoot = zeroBytes(32),
+      bloomFilter = zeroBytes(256),
+      timestamp = System.currentTimeMillis(),
+      height = 1,
+      slot = 0,
+      eligibilityCertificate = eligibilityCertificate,
+      operationalCertificate = operationalCertificate,
+      metadata = ByteString.EMPTY,
+      address = StakingAddress(zeroBytes(32))
+    ).embedId
+    FullBlock(header, FullBlockBody(transactions))
+  }
+
+  private def createChildBlock(parent: BlockHeader, slot: Slot)(transactions: Seq[IoTransaction]): FullBlock = {
+    val header = BlockHeader(
+      parentHeaderId = parent.id,
+      parentSlot = parent.slot,
+      txRoot = ByteString.copyFrom(Array.fill(32)(0: Byte)),
+      bloomFilter = ByteString.copyFrom(Array.fill(256)(0: Byte)),
+      timestamp = System.currentTimeMillis(),
+      height = parent.height + 1,
+      slot = slot,
+      eligibilityCertificate = eligibilityCertificate,
+      operationalCertificate = operationalCertificate,
+      metadata = ByteString.EMPTY,
+      address = StakingAddress(zeroBytes(32))
+    ).embedId
+    FullBlock(header, FullBlockBody(transactions))
+  }
+
+  private val eligibilityCertificate: EligibilityCertificate =
+    EligibilityCertificate(
+      zeroBytes(80),
+      zeroBytes(32),
+      zeroBytes(32),
+      zeroBytes(32)
+    )
+
+  private val operationalCertificate: OperationalCertificate =
+    OperationalCertificate(
+      VerificationKeyKesProduct(zeroBytes(32), 0),
+      SignatureKesProduct(
+        SignatureKesSum(zeroBytes(32), zeroBytes(64), Vector.empty),
+        SignatureKesSum(zeroBytes(32), zeroBytes(64), Vector.empty),
+        zeroBytes(32)
+      ),
+      zeroBytes(32),
+      zeroBytes(64)
+    )
+
+  private def zeroBytes(length: Int): ByteString =
+    ByteString.copyFrom(Array.fill[Byte](length)(0))
+
+  private def stxo(tx: IoTransaction, index: Int) =
+    SpentTransactionOutput(
+      TransactionOutputAddress(id = tx.id).withIndex(index),
+      Attestation().withPredicate(Attestation.Predicate.defaultInstance),
+      tx.outputs(index).value
+    )
+
+}

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusDataEventSourcedStateSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusDataEventSourcedStateSpec.scala
@@ -18,7 +18,6 @@ import co.topl.numerics.implicits._
 import co.topl.typeclasses.implicits._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalamock.munit.AsyncMockFactory
-import quivr.models.SmallData
 
 class ConsensusDataEventSourcedStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusValidationStateSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusValidationStateSpec.scala
@@ -36,6 +36,7 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
             consensusData <- (
               TestStore.make[F, StakingAddress, BigInt],
               TestStore.make[F, Unit, BigInt],
+              TestStore.make[F, Unit, BigInt],
               TestStore.make[F, StakingAddress, SignatureKesProduct]
             ).mapN(ConsensusDataEventSourcedState.ConsensusData[F])
             _ <- boundaryStore.put(3L, n2Id)
@@ -97,6 +98,7 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
             consensusData <- (
               TestStore.make[F, StakingAddress, BigInt],
               TestStore.make[F, Unit, BigInt],
+              TestStore.make[F, Unit, BigInt],
               TestStore.make[F, StakingAddress, SignatureKesProduct]
             ).mapN(ConsensusDataEventSourcedState.ConsensusData[F])
             _ <- boundaryStore.put(3L, n2Id)
@@ -156,6 +158,7 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
             consensusData <- (
               TestStore.make[F, StakingAddress, BigInt],
               TestStore.make[F, Unit, BigInt],
+              TestStore.make[F, Unit, BigInt],
               TestStore.make[F, StakingAddress, SignatureKesProduct]
             ).mapN(ConsensusDataEventSourcedState.ConsensusData[F])
             _ <- consensusData.operatorStakes.put(address, 1)
@@ -214,6 +217,7 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
             boundaryStore <- TestStore.make[F, Epoch, BlockId]
             consensusData <- (
               TestStore.make[F, StakingAddress, BigInt],
+              TestStore.make[F, Unit, BigInt],
               TestStore.make[F, Unit, BigInt],
               TestStore.make[F, StakingAddress, SignatureKesProduct]
             ).mapN(ConsensusDataEventSourcedState.ConsensusData[F])

--- a/node/src/main/scala/co/topl/node/DataStoresInit.scala
+++ b/node/src/main/scala/co/topl/node/DataStoresInit.scala
@@ -74,7 +74,8 @@ object DataStoresInit {
         appConfig.bifrost.cache.operatorStakes,
         identity
       )
-      activeStakeStore <- makeDb[F, Unit, BigInt](dataDir)("active-stake")
+      activeStakeStore   <- makeDb[F, Unit, BigInt](dataDir)("active-stake")
+      inactiveStakeStore <- makeDb[F, Unit, BigInt](dataDir)("inactive-stake")
       registrationsStore <- makeCachedDb[
         F,
         StakingAddress,
@@ -103,6 +104,7 @@ object DataStoresInit {
         epochBoundariesStore,
         operatorStakesStore,
         activeStakeStore,
+        inactiveStakeStore,
         registrationsStore,
         blockHeightTreeStore
       )

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -379,7 +379,12 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
         blockIdTree,
         currentEventIdGetterSetters.consensusData.set,
         ConsensusDataEventSourcedState
-          .ConsensusData(dataStores.operatorStakes, dataStores.activeStake, dataStores.registrations)
+          .ConsensusData(
+            dataStores.operatorStakes,
+            dataStores.activeStake,
+            dataStores.inactiveStake,
+            dataStores.registrations
+          )
           .pure[F],
         dataStores.bodies.getOrRaise,
         dataStores.transactions.getOrRaise


### PR DESCRIPTION
## Purpose
- Some clients/consumers are interested in aggregate statistics about blockchain data.  Epochs can serve as effective time-windows for these aggregations.
## Approach
- Use the EventSourcedState implementation to modify a stateful mapping of Epoch to Epoch Data
- Each block modifies the current epoch's data.  If a block crosses an epoch boundary, a new epoch data is created
- To accumulate staking statistics, the total inactive stake information needed to be counted in ConsensusData
## Testing
- New unit test for EpochDataInterpreter
## Tickets
- #BN-1045
## Notes
- This process is not integrated into the node yet.  That will be done in a later ticket.