### PR TITLE
ConsensusData Track ActiveStaker

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/DataStores.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/DataStores.scala
@@ -25,7 +25,7 @@ case class DataStores[F[_]](
   operatorStakes:  Store[F, StakingAddress, BigInt],
   activeStake:     Store[F, Unit, BigInt],
   inactiveStake:   Store[F, Unit, BigInt],
-  registrations:   Store[F, StakingAddress, SignatureKesProduct],
+  registrations:   Store[F, StakingAddress, ActiveStaker],
   blockHeightTree: Store[F, Long, BlockId],
   epochData:       Store[F, Epoch, EpochData]
 )

--- a/blockchain/src/test/scala/co/topl/blockchain/StakerInitializersSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/StakerInitializersSpec.scala
@@ -5,7 +5,6 @@ import cats.effect.kernel.Async
 import cats.implicits._
 import co.topl.blockchain.PrivateTestnet.DefaultTotalStake
 import co.topl.brambl.models.box.Value
-import co.topl.models.NetworkPrefix
 import co.topl.models.utility.Ratio
 import co.topl.numerics.implicits._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -17,28 +16,18 @@ class StakerInitializersSpec extends CatsEffectSuite with ScalaCheckEffectSuite 
 
   test("Big bang outputs for PrivateTestnet, currentTime, 1 staker") {
     for {
-      implicit0(networkPrefix: NetworkPrefix) <- NetworkPrefix(1: Byte).pure[F]
-      timestamp                               <- System.currentTimeMillis().pure[F]
-      operator                                <- PrivateTestnet.stakerInitializers(timestamp, 1).pure[F]
+      timestamp      <- System.currentTimeMillis().pure[F]
+      operator       <- PrivateTestnet.stakerInitializers(timestamp, 1).pure[F]
       bigBangOutputs <- Async[F].delay(operator.head.bigBangOutputs(Ratio(DefaultTotalStake, 1: BigInt).round))
 
-      _ <- assertIO(bigBangOutputs.size.pure[F], 2)
+      _ <- assertIO(bigBangOutputs.size.pure[F], 1)
       _ <- assertIOBoolean(bigBangOutputs.forall(_.address == operator.head.lockAddress).pure[F])
       _ <- assertIOBoolean(
         bigBangOutputs
           .map(_.value)
           .contains(
             Value.defaultInstance
-              .withTopl(Value.TOPL(Ratio(DefaultTotalStake, 1: BigInt).round, operator.head.stakingAddress.some))
-          )
-          .pure[F]
-      )
-      _ <- assertIOBoolean(
-        bigBangOutputs
-          .map(_.value)
-          .contains(
-            Value.defaultInstance
-              .withRegistration(Value.Registration(operator.head.registration, operator.head.stakingAddress))
+              .withTopl(Value.TOPL(Ratio(DefaultTotalStake, 1: BigInt).round, operator.head.registration.some))
           )
           .pure[F]
       )
@@ -47,28 +36,18 @@ class StakerInitializersSpec extends CatsEffectSuite with ScalaCheckEffectSuite 
 
   test("Big bang outputs for PrivateTestnet, currentTime + 5 seg, 1 staker") {
     for {
-      implicit0(networkPrefix: NetworkPrefix) <- NetworkPrefix(1: Byte).pure[F]
-      timestamp                               <- (System.currentTimeMillis() + 5000).pure[F]
-      operator                                <- PrivateTestnet.stakerInitializers(timestamp, 1).pure[F]
+      timestamp      <- (System.currentTimeMillis() + 5000).pure[F]
+      operator       <- PrivateTestnet.stakerInitializers(timestamp, 1).pure[F]
       bigBangOutputs <- Async[F].delay(operator.head.bigBangOutputs(Ratio(DefaultTotalStake, 1: BigInt).round))
 
-      _ <- assertIO(bigBangOutputs.size.pure[F], 2)
+      _ <- assertIO(bigBangOutputs.size.pure[F], 1)
       _ <- assertIOBoolean(bigBangOutputs.forall(_.address == operator.head.lockAddress).pure[F])
       _ <- assertIOBoolean(
         bigBangOutputs
           .map(_.value)
           .contains(
             Value.defaultInstance
-              .withTopl(Value.TOPL(Ratio(DefaultTotalStake, 1: BigInt).round, operator.head.stakingAddress.some))
-          )
-          .pure[F]
-      )
-      _ <- assertIOBoolean(
-        bigBangOutputs
-          .map(_.value)
-          .contains(
-            Value.defaultInstance
-              .withRegistration(Value.Registration(operator.head.registration, operator.head.stakingAddress))
+              .withTopl(Value.TOPL(Ratio(DefaultTotalStake, 1: BigInt).round, operator.head.registration.some))
           )
           .pure[F]
       )
@@ -77,31 +56,21 @@ class StakerInitializersSpec extends CatsEffectSuite with ScalaCheckEffectSuite 
 
   test("Big bang outputs for PrivateTestnet, currentTime, 10 stakers") {
     for {
-      implicit0(networkPrefix: NetworkPrefix) <- NetworkPrefix(1: Byte).pure[F]
-      timestamp                               <- System.currentTimeMillis().pure[F]
-      operator                                <- PrivateTestnet.stakerInitializers(timestamp, 2).pure[F]
+      timestamp <- System.currentTimeMillis().pure[F]
+      operator  <- PrivateTestnet.stakerInitializers(timestamp, 2).pure[F]
       _ <- operator
         .zip(LazyList.from(1))
         .traverse { case (operator, index) =>
           val bigBangOutputs = operator.bigBangOutputs(Ratio(DefaultTotalStake, index: BigInt).round)
 
-          assertIO(bigBangOutputs.size.pure[F], 2) &>
+          assertIO(bigBangOutputs.size.pure[F], 1) &>
           assertIOBoolean(bigBangOutputs.forall(_.address == operator.lockAddress).pure[F]) &>
           assertIOBoolean(
             bigBangOutputs
               .map(_.value)
               .contains(
                 Value.defaultInstance
-                  .withTopl(Value.TOPL(Ratio(DefaultTotalStake, index: BigInt).round, operator.stakingAddress.some))
-              )
-              .pure[F]
-          ) &>
-          assertIOBoolean(
-            bigBangOutputs
-              .map(_.value)
-              .contains(
-                Value.defaultInstance
-                  .withRegistration(Value.Registration(operator.registration, operator.stakingAddress))
+                  .withTopl(Value.TOPL(Ratio(DefaultTotalStake, index: BigInt).round, operator.registration.some))
               )
               .pure[F]
           )

--- a/blockchain/src/test/scala/co/topl/blockchain/interpreters/EpochDataInterpreterSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/interpreters/EpochDataInterpreterSpec.scala
@@ -123,7 +123,7 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
                 TestStore.make[F, Unit, BigInt].flatTap(_.put((), 40)),
                 TestStore.make[F, Unit, BigInt].flatTap(_.put((), 0))
               )
-                .mapN(ConsensusDataEventSourcedState.ConsensusData(null, _, _, null))
+                .mapN(ConsensusDataEventSourcedState.ConsensusData(_, _, null))
                 .flatMap(f)
             }
           _ = (consensusDataEss
@@ -135,7 +135,7 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
                 TestStore.make[F, Unit, BigInt].flatTap(_.put((), 20)),
                 TestStore.make[F, Unit, BigInt].flatTap(_.put((), 20))
               )
-                .mapN(ConsensusDataEventSourcedState.ConsensusData(null, _, _, null))
+                .mapN(ConsensusDataEventSourcedState.ConsensusData(_, _, null))
                 .flatMap(f)
             }
           _ = (consensusDataEss
@@ -147,7 +147,7 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
                 TestStore.make[F, Unit, BigInt].flatTap(_.put((), 30)),
                 TestStore.make[F, Unit, BigInt].flatTap(_.put((), 10))
               )
-                .mapN(ConsensusDataEventSourcedState.ConsensusData(null, _, _, null))
+                .mapN(ConsensusDataEventSourcedState.ConsensusData(_, _, null))
                 .flatMap(f)
             }
           ess <- EpochDataEventSourcedState.make[F](

--- a/consensus/src/main/scala/co/topl/consensus/algebras/ConsensusValidationStateAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/ConsensusValidationStateAlgebra.scala
@@ -1,29 +1,29 @@
 package co.topl.consensus.algebras
 
-import co.topl.consensus.models.BlockId
-import co.topl.consensus.models.SignatureKesProduct
-import co.topl.consensus.models.StakingAddress
+import cats.Monad
+import cats.data.OptionT
+import cats.implicits._
+import co.topl.consensus.models.{ActiveStaker, BlockId, StakingAddress}
 import co.topl.models._
 import co.topl.models.utility.Ratio
+import co.topl.numerics.implicits._
 
-// TODO: Maybe collapse into a single method returning (Relative Stake, Registration)?
 trait ConsensusValidationStateAlgebra[F[_]] {
 
   /**
-   * Determines the "usable" relative stake associated with the given Operator's address at the given "head" Block ID.
+   * Determines the "usable" total active stake associated.
    *
    * The interpreter is responsible for returning a result that is derived from data that lags behind `currentBlockId`.
    *
    * @param currentBlockId The ID of the block being validated
    * @param slot The slot to use when considering the epoch to read from.  When validating a header, simply
    *             use the slot of `currentBlockId`.  When producing a header, use the slot being tested.
-   * @param address The address of the operator that produced the block
-   * @return a ratio, if one exists and is greater than 0.  None otherwise.
+   * @return a value indicating the total usable stake
    */
-  def operatorRelativeStake(currentBlockId: BlockId, slot: Slot)(address: StakingAddress): F[Option[Ratio]]
+  def totalActiveStake(currentBlockId: BlockId, slot: Slot): F[BigInt]
 
   /**
-   * Retrieves the Registration associated with the given operator address
+   * Retrieves the ActiveStaker associated with the given operator address
    *
    * The interpreter is responsible for returning a result that is derived from data that lags behind `currentBlockId`.
    *
@@ -31,8 +31,24 @@ trait ConsensusValidationStateAlgebra[F[_]] {
    * @param slot           The slot to use when considering the epoch to read from.  When validating a header, simply
    *                       use the slot of `currentBlockId`.  When producing a header, use the slot being tested.
    * @param address        The address of the operator that produced the block
+   * @return an ActiveStaker, if one exists.  None otherwise.
+   */
+  def staker(currentBlockId: BlockId, slot: Slot)(address: StakingAddress): F[Option[ActiveStaker]]
+
+  /**
+   * Determines the "usable" relative stake associated with the given Operator's address at the given "head" Block ID.
+   *
+   * @param currentBlockId The ID of the block being validated
+   * @param slot           The slot to use when considering the epoch to read from.  When validating a header, simply
+   *                       use the slot of `currentBlockId`.  When producing a header, use the slot being tested.
+   * @param address        The address of the operator that produced the block
    * @return a ratio, if one exists and is greater than 0.  None otherwise.
    */
-  def operatorRegistration(currentBlockId: BlockId, slot: Slot)(address: StakingAddress): F[Option[SignatureKesProduct]]
+  def operatorRelativeStake(currentBlockId: BlockId, slot: Slot)(
+    address: StakingAddress
+  )(implicit monadF: Monad[F]): F[Option[Ratio]] =
+    OptionT(staker(currentBlockId, slot)(address))
+      .semiflatMap(registration => totalActiveStake(currentBlockId, slot).map(Ratio(registration.quantity: BigInt, _)))
+      .value
 
 }

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusDataEventSourcedState.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusDataEventSourcedState.scala
@@ -70,20 +70,6 @@ object ConsensusDataEventSourcedState {
         _ <- addedRegistrations.traverseTap(r => state.stakers.put(r.registration.address, r))
       } yield state
 
-    private def activeQuantityOf(values: Seq[Value]) =
-      values
-        .flatMap(_.value.topl)
-        .filter(_.registration.nonEmpty)
-        .map(_.quantity.value.toByteArray)
-        .foldMap(BigInt(_))
-
-    private def inactiveQuantityOf(values: Seq[Value]) =
-      values
-        .flatMap(_.value.topl)
-        .filter(_.registration.isEmpty)
-        .map(_.quantity.value.toByteArray)
-        .foldMap(BigInt(_))
-
     private def removedStakersOf(transaction: IoTransaction): List[ActiveStaker] =
       transaction.inputs
         .flatMap(_.value.value.topl)
@@ -121,20 +107,6 @@ object ConsensusDataEventSourcedState {
         _ <- removedStakers.traverseTap(r => state.stakers.put(r.registration.address, r))
       } yield state
 
-    private def activeQuantityOf(values: Seq[Value]) =
-      values
-        .flatMap(_.value.topl)
-        .filter(_.registration.nonEmpty)
-        .map(_.quantity.value.toByteArray)
-        .foldMap(BigInt(_))
-
-    private def inactiveQuantityOf(values: Seq[Value]) =
-      values
-        .flatMap(_.value.topl)
-        .filter(_.registration.isEmpty)
-        .map(_.quantity.value.toByteArray)
-        .foldMap(BigInt(_))
-
     private def removedStakersOf(transaction: IoTransaction): List[ActiveStaker] =
       transaction.inputs.reverse
         .flatMap(_.value.value.topl)
@@ -148,4 +120,18 @@ object ConsensusDataEventSourcedState {
         .toList
 
   }
+
+  private def activeQuantityOf(values: Seq[Value]) =
+    values
+      .flatMap(_.value.topl)
+      .filter(_.registration.nonEmpty)
+      .map(_.quantity.value.toByteArray)
+      .foldMap(BigInt(_))
+
+  private def inactiveQuantityOf(values: Seq[Value]) =
+    values
+      .flatMap(_.value.topl)
+      .filter(_.registration.isEmpty)
+      .map(_.quantity.value.toByteArray)
+      .foldMap(BigInt(_))
 }

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusDataEventSourcedState.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusDataEventSourcedState.scala
@@ -1,20 +1,15 @@
 package co.topl.consensus.interpreters
 
 import cats.MonadThrow
-import cats.Monoid
-import cats.data.OptionT
 import cats.effect.Async
 import cats.implicits._
 import co.topl.algebras._
 import co.topl.brambl.models.TransactionId
+import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.consensus.models.BlockId
-import co.topl.consensus.models.SignatureKesProduct
-import co.topl.consensus.models.StakingAddress
-import co.topl.eventtree.EventSourcedState
-import co.topl.eventtree.ParentChildTree
+import co.topl.consensus.models.{ActiveStaker, BlockId, StakingAddress}
+import co.topl.eventtree.{EventSourcedState, ParentChildTree}
 import co.topl.node.models.BlockBody
-import co.topl.numerics.implicits._
 import co.topl.typeclasses.implicits._
 
 /**
@@ -30,10 +25,9 @@ import co.topl.typeclasses.implicits._
 object ConsensusDataEventSourcedState {
 
   case class ConsensusData[F[_]](
-    operatorStakes:     Store[F, StakingAddress, BigInt],
     totalActiveStake:   Store[F, Unit, BigInt],
     totalInactiveStake: Store[F, Unit, BigInt],
-    registrations:      Store[F, StakingAddress, SignatureKesProduct]
+    stakers:            Store[F, StakingAddress, ActiveStaker]
   )
 
   def make[F[_]: Async](
@@ -60,59 +54,47 @@ object ConsensusDataEventSourcedState {
 
     def apply(state: ConsensusData[F], blockId: BlockId): F[ConsensusData[F]] =
       for {
-        body                     <- fetchBlockBody(blockId)
-        transactions             <- body.transactionIds.traverse(fetchTransaction)
-        stakeChanges             <- transactions.foldMapM(calculateStakeChanges)
-        registrationChanges      <- transactions.foldMapM(calculateRegistrationChanges)
+        body         <- fetchBlockBody(blockId)
+        transactions <- body.transactionIds.traverse(fetchTransaction)
+        spentActiveStake = activeQuantityOf(transactions.flatMap(_.inputs).map(_.value))
+        createdActiveStake = activeQuantityOf(transactions.flatMap(_.outputs).map(_.value))
         previousTotalActiveStake <- state.totalActiveStake.getOrRaise(())
-        newTotalActiveStake = previousTotalActiveStake + stakeChanges.flatMap(c => c.address.as(c.delta)).sumAll
-        _ <- state.totalActiveStake.put((), newTotalActiveStake)
-        _ <- stakeChanges.groupBy(_.address).view.mapValues(_.map(_.delta).sum).toList.traverseTap {
-          case (Some(address), quantity) =>
-            OptionT(state.operatorStakes.get(address))
-              .fold(quantity)(_ + quantity)
-              .flatMap(newQuantity => state.operatorStakes.put(address, newQuantity))
-          case (_, quantity) =>
-            state.totalInactiveStake
-              .getOrRaise(())
-              .map(_ + quantity)
-              .flatMap(state.totalInactiveStake.put((), _))
-        }
-        _ <- registrationChanges.toSeq.traverseTap {
-          case (address, Some(registration)) =>
-            state.registrations.put(address, registration)
-          case (address, _) =>
-            state.registrations.remove(address)
-        }
+        _ <- state.totalActiveStake.put((), previousTotalActiveStake - spentActiveStake + createdActiveStake)
+        spentInactiveStake = inactiveQuantityOf(transactions.flatMap(_.inputs).map(_.value))
+        createdInactiveStake = inactiveQuantityOf(transactions.flatMap(_.outputs).map(_.value))
+        previousTotalInactiveStake <- state.totalInactiveStake.getOrRaise(())
+        _ <- state.totalInactiveStake.put((), previousTotalInactiveStake - spentInactiveStake + createdInactiveStake)
+        removedRegistrations = transactions.flatMap(removedStakersOf)
+        addedRegistrations = transactions.flatMap(addedStakersOf)
+        _ <- removedRegistrations.map(_.registration.address).traverseTap(state.stakers.remove)
+        _ <- addedRegistrations.traverseTap(r => state.stakers.put(r.registration.address, r))
       } yield state
 
-    private def calculateStakeChanges(transaction: IoTransaction): F[Seq[StakeChange]] =
-      for {
-        inputStakeChanges <-
-          transaction.inputs
-            .flatMap(_.value.value.topl)
-            .map(v => StakeChange(v.stakingAddress, -(v.quantity): BigInt))
-            .pure[F]
-        outputStakeChanges = transaction.outputs
-          .flatMap(_.value.value.topl)
-          .map(v => StakeChange(v.stakingAddress, v.quantity: BigInt))
-      } yield inputStakeChanges ++ outputStakeChanges
+    private def activeQuantityOf(values: Seq[Value]) =
+      values
+        .flatMap(_.value.topl)
+        .filter(_.registration.nonEmpty)
+        .map(_.quantity.value.toByteArray)
+        .foldMap(BigInt(_))
 
-    private def calculateRegistrationChanges(
-      transaction: IoTransaction
-    ): F[Map[StakingAddress, Option[SignatureKesProduct]]] =
-      for {
-        deregistrations <- transaction.inputs
-          .flatMap(_.value.value.registration)
-          .map(_.stakingAddress)
-          .tupleRight(none[SignatureKesProduct])
-          .toMap
-          .pure[F]
-        registrations = transaction.outputs
-          .flatMap(_.value.value.registration)
-          .map(r => r.stakingAddress -> r.registration.some)
-          .toMap
-      } yield deregistrations ++ registrations
+    private def inactiveQuantityOf(values: Seq[Value]) =
+      values
+        .flatMap(_.value.topl)
+        .filter(_.registration.isEmpty)
+        .map(_.quantity.value.toByteArray)
+        .foldMap(BigInt(_))
+
+    private def removedStakersOf(transaction: IoTransaction): List[ActiveStaker] =
+      transaction.inputs
+        .flatMap(_.value.value.topl)
+        .flatMap(t => t.registration.map(ActiveStaker(_, t.quantity)))
+        .toList
+
+    private def addedStakersOf(transaction: IoTransaction): List[ActiveStaker] =
+      transaction.outputs
+        .flatMap(_.value.value.topl)
+        .flatMap(t => t.registration.map(ActiveStaker(_, t.quantity)))
+        .toList
 
   }
 
@@ -123,61 +105,47 @@ object ConsensusDataEventSourcedState {
 
     def apply(state: ConsensusData[F], blockId: BlockId): F[ConsensusData[F]] =
       for {
-        body                     <- fetchBlockBody(blockId)
-        transactions             <- body.transactionIds.reverse.traverse(fetchTransaction)
-        stakeChanges             <- transactions.foldMapM(calculateStakeChanges)
-        registrationChanges      <- transactions.foldMapM(calculateRegistrationChanges)
+        body         <- fetchBlockBody(blockId)
+        transactions <- body.transactionIds.reverse.traverse(fetchTransaction)
+        spentActiveStake = activeQuantityOf(transactions.flatMap(_.inputs.reverse).map(_.value))
+        createdActiveStake = activeQuantityOf(transactions.flatMap(_.outputs.reverse).map(_.value))
         previousTotalActiveStake <- state.totalActiveStake.getOrRaise(())
-        newTotalActiveStake = previousTotalActiveStake + stakeChanges.flatMap(c => c.address.as(c.delta)).sumAll
-        _ <- state.totalActiveStake.put((), newTotalActiveStake)
-        _ <- stakeChanges.groupBy(_.address).view.mapValues(_.map(_.delta).sum).toList.traverseTap {
-          case (Some(address), quantity) =>
-            OptionT(state.operatorStakes.get(address))
-              .fold(quantity)(_ + quantity)
-              .flatMap(newQuantity => state.operatorStakes.put(address, newQuantity))
-          case (_, quantity) =>
-            state.totalInactiveStake
-              .getOrRaise(())
-              .map(_ + quantity)
-              .flatMap(state.totalInactiveStake.put((), _))
-        }
-        _ <- registrationChanges.toSeq.traverseTap {
-          case (address, Some(registration)) =>
-            state.registrations.put(address, registration)
-          case (address, _) =>
-            state.registrations.remove(address)
-        }
+        _ <- state.totalActiveStake.put((), previousTotalActiveStake + spentActiveStake - createdActiveStake)
+        spentInactiveStake = inactiveQuantityOf(transactions.flatMap(_.inputs.reverse).map(_.value))
+        createdInactiveStake = inactiveQuantityOf(transactions.flatMap(_.outputs.reverse).map(_.value))
+        previousTotalInactiveStake <- state.totalInactiveStake.getOrRaise(())
+        _ <- state.totalInactiveStake.put((), previousTotalInactiveStake + spentInactiveStake - createdInactiveStake)
+        addedStakers = transactions.flatMap(addedStakersOf)
+        removedStakers = transactions.flatMap(removedStakersOf)
+        _ <- addedStakers.map(_.registration.address).traverseTap(state.stakers.remove)
+        _ <- removedStakers.traverseTap(r => state.stakers.put(r.registration.address, r))
       } yield state
 
-    private def calculateStakeChanges(transaction: IoTransaction): F[Seq[StakeChange]] =
-      for {
-        outputStakeChanges <- transaction.outputs.reverse
-          .flatMap(_.value.value.topl)
-          .map(v => StakeChange(v.stakingAddress, -(v.quantity): BigInt))
-          .pure[F]
-        inputStakeChanges = transaction.inputs.reverse
-          .flatMap(_.value.value.topl)
-          .map(v => StakeChange(v.stakingAddress, v.quantity: BigInt))
-      } yield inputStakeChanges ++ outputStakeChanges
+    private def activeQuantityOf(values: Seq[Value]) =
+      values
+        .flatMap(_.value.topl)
+        .filter(_.registration.nonEmpty)
+        .map(_.quantity.value.toByteArray)
+        .foldMap(BigInt(_))
 
-    private def calculateRegistrationChanges(
-      transaction: IoTransaction
-    ): F[Map[StakingAddress, Option[SignatureKesProduct]]] =
-      for {
-        deregistrations <- transaction.outputs.reverse
-          .flatMap(_.value.value.registration)
-          .map(_.stakingAddress -> none[SignatureKesProduct])
-          .toMap
-          .pure[F]
-        registrations = transaction.inputs.reverse
-          .flatMap(_.value.value.registration)
-          .map(r => r.stakingAddress -> r.registration.some)
-          .toMap
-      } yield deregistrations ++ registrations
+    private def inactiveQuantityOf(values: Seq[Value]) =
+      values
+        .flatMap(_.value.topl)
+        .filter(_.registration.isEmpty)
+        .map(_.quantity.value.toByteArray)
+        .foldMap(BigInt(_))
+
+    private def removedStakersOf(transaction: IoTransaction): List[ActiveStaker] =
+      transaction.inputs.reverse
+        .flatMap(_.value.value.topl)
+        .flatMap(t => t.registration.map(ActiveStaker(_, t.quantity)))
+        .toList
+
+    private def addedStakersOf(transaction: IoTransaction): List[ActiveStaker] =
+      transaction.outputs.reverse
+        .flatMap(_.value.value.topl)
+        .flatMap(t => t.registration.map(ActiveStaker(_, t.quantity)))
+        .toList
+
   }
-
-  private case class StakeChange(address: Option[StakingAddress], delta: BigInt)
-
-  implicit val registrationChangesMonoid: Monoid[Map[StakingAddress, Option[SignatureKesProduct]]] =
-    Monoid.instance(Map.empty, _ ++ _)
 }

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusValidationStateSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusValidationStateSpec.scala
@@ -5,15 +5,12 @@ import cats.implicits._
 import co.topl.algebras.ClockAlgebra
 import co.topl.algebras.testInterpreters.TestStore
 import co.topl.consensus.interpreters.EpochBoundariesEventSourcedState.EpochBoundaries
-import co.topl.consensus.models.BlockId
-import co.topl.consensus.models.SignatureKesProduct
-import co.topl.consensus.models.StakingAddress
+import co.topl.consensus.models._
 import co.topl.eventtree.EventSourcedState
 import co.topl.models._
 import co.topl.models.generators.consensus.ModelGenerators._
-import co.topl.models.utility.Ratio
-import munit.CatsEffectSuite
-import munit.ScalaCheckEffectSuite
+import co.topl.numerics.implicits._
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 
@@ -21,89 +18,26 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
 
   type F[A] = IO[A]
 
-  test("Retrieve relative stakes at epoch N-2 of the requested block for epoch N > 1") {
-    PropF.forAllF {
-      (
-        genesisId: BlockId,
-        n2Id:      BlockId,
-        nId:       BlockId,
-        address:   StakingAddress
-      ) =>
-        withMock {
-          val slot = 5
-          for {
-            boundaryStore <- TestStore.make[F, Epoch, BlockId]
-            consensusData <- (
-              TestStore.make[F, StakingAddress, BigInt],
-              TestStore.make[F, Unit, BigInt],
-              TestStore.make[F, Unit, BigInt],
-              TestStore.make[F, StakingAddress, SignatureKesProduct]
-            ).mapN(ConsensusDataEventSourcedState.ConsensusData[F])
-            _ <- boundaryStore.put(3L, n2Id)
-            _ <- consensusData.operatorStakes.put(address, 1)
-            _ <- consensusData.totalActiveStake.put((), 5)
-            epochBoundaryEventSourcedState = new EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
-              F
-            ], BlockId] {
-              def stateAt(eventId: BlockId): F[EpochBoundaries[F]] = ???
-
-              def useStateAt[U](eventId: BlockId)(f: EpochBoundaries[F] => F[U]): F[U] = {
-                assert(eventId == nId)
-                f(boundaryStore)
-              }
-            }
-            consensusDataEventSourcedState = new EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[
-              F
-            ], BlockId] {
-              def stateAt(eventId: BlockId): F[ConsensusDataEventSourcedState.ConsensusData[F]] = ???
-
-              def useStateAt[U](
-                eventId: BlockId
-              )(f: ConsensusDataEventSourcedState.ConsensusData[F] => F[U]): F[U] = {
-                assert(eventId == n2Id)
-                f(consensusData)
-              }
-            }
-            clock = mock[ClockAlgebra[F]]
-
-            _ = (() => clock.slotsPerEpoch)
-              .expects()
-              .once()
-              .returning(1L.pure[F])
-
-            underTest <- ConsensusValidationState
-              .make[F](genesisId, epochBoundaryEventSourcedState, consensusDataEventSourcedState, clock)
-
-            _ <- underTest.operatorRelativeStake(nId, slot)(address).assertEquals(Some(Ratio(1, 5)))
-
-          } yield ()
-
-        }
-    }
-  }
-
   test("Retrieve registrations at epoch N-2 of the requested block for epoch N > 1") {
     PropF.forAllF {
       (
         genesisId:    BlockId,
         n2Id:         BlockId,
         nId:          BlockId,
-        address:      StakingAddress,
-        registration: SignatureKesProduct
+        registration: StakingRegistration
       ) =>
         withMock {
+          val staker = ActiveStaker(registration, 5)
           val slot = 5
           for {
             boundaryStore <- TestStore.make[F, Epoch, BlockId]
             consensusData <- (
-              TestStore.make[F, StakingAddress, BigInt],
               TestStore.make[F, Unit, BigInt],
               TestStore.make[F, Unit, BigInt],
-              TestStore.make[F, StakingAddress, SignatureKesProduct]
+              TestStore.make[F, StakingAddress, ActiveStaker]
             ).mapN(ConsensusDataEventSourcedState.ConsensusData[F])
             _ <- boundaryStore.put(3L, n2Id)
-            _ <- consensusData.operatorStakes.put(address, 1)
-            _ <- consensusData.registrations.put(address, registration)
+            _ <- consensusData.stakers.put(staker.registration.address, staker)
             epochBoundaryEventSourcedState = new EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
               F
             ], BlockId] {
@@ -136,66 +70,7 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
             underTest <- ConsensusValidationState
               .make[F](genesisId, epochBoundaryEventSourcedState, consensusDataEventSourcedState, clock)
 
-            _ <- underTest.operatorRegistration(nId, slot)(address).assertEquals(Some(registration))
-
-          } yield ()
-
-        }
-    }
-  }
-
-  test("Retrieve relative stakes at the big bang block for epoch N <= 1") {
-    PropF.forAllF {
-      (
-        bigBangId: BlockId,
-        nId:       BlockId,
-        address:   StakingAddress
-      ) =>
-        withMock {
-          val slot = 3
-          for {
-            boundaryStore <- TestStore.make[F, Epoch, BlockId]
-            consensusData <- (
-              TestStore.make[F, StakingAddress, BigInt],
-              TestStore.make[F, Unit, BigInt],
-              TestStore.make[F, Unit, BigInt],
-              TestStore.make[F, StakingAddress, SignatureKesProduct]
-            ).mapN(ConsensusDataEventSourcedState.ConsensusData[F])
-            _ <- consensusData.operatorStakes.put(address, 1)
-            _ <- consensusData.totalActiveStake.put((), 5)
-            epochBoundaryEventSourcedState = new EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
-              F
-            ], BlockId] {
-              def stateAt(eventId: BlockId): F[EpochBoundaries[F]] = ???
-
-              def useStateAt[U](eventId: BlockId)(f: EpochBoundaries[F] => F[U]): F[U] = {
-                assert(eventId == nId)
-                f(boundaryStore)
-              }
-            }
-            consensusDataEventSourcedState = new EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[
-              F
-            ], BlockId] {
-              def stateAt(eventId: BlockId): F[ConsensusDataEventSourcedState.ConsensusData[F]] = ???
-
-              def useStateAt[U](
-                eventId: BlockId
-              )(f: ConsensusDataEventSourcedState.ConsensusData[F] => F[U]): F[U] = {
-                assert(eventId == bigBangId)
-                f(consensusData)
-              }
-            }
-            clock = mock[ClockAlgebra[F]]
-
-            _ = (() => clock.slotsPerEpoch)
-              .expects()
-              .once()
-              .returning(2L.pure[F])
-
-            underTest <- ConsensusValidationState
-              .make[F](bigBangId, epochBoundaryEventSourcedState, consensusDataEventSourcedState, clock)
-
-            _ <- underTest.operatorRelativeStake(nId, slot)(address).assertEquals(Some(Ratio(1, 5)))
+            _ <- underTest.staker(nId, slot)(staker.registration.address).assertEquals(Some(staker))
 
           } yield ()
 
@@ -208,20 +83,19 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
       (
         bigBangId:    BlockId,
         nId:          BlockId,
-        address:      StakingAddress,
-        registration: SignatureKesProduct
+        registration: StakingRegistration
       ) =>
         withMock {
+          val staker = ActiveStaker(registration, 5)
           val slot = 3
           for {
             boundaryStore <- TestStore.make[F, Epoch, BlockId]
             consensusData <- (
-              TestStore.make[F, StakingAddress, BigInt],
               TestStore.make[F, Unit, BigInt],
               TestStore.make[F, Unit, BigInt],
-              TestStore.make[F, StakingAddress, SignatureKesProduct]
+              TestStore.make[F, StakingAddress, ActiveStaker]
             ).mapN(ConsensusDataEventSourcedState.ConsensusData[F])
-            _ <- consensusData.registrations.put(address, registration)
+            _ <- consensusData.stakers.put(staker.registration.address, staker)
             epochBoundaryEventSourcedState = new EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
               F
             ], BlockId] {
@@ -254,7 +128,7 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
             underTest <- ConsensusValidationState
               .make[F](bigBangId, epochBoundaryEventSourcedState, consensusDataEventSourcedState, clock)
 
-            _ <- underTest.operatorRegistration(nId, slot)(address).assertEquals(Some(registration))
+            _ <- underTest.staker(nId, slot)(staker.registration.address).assertEquals(Some(staker))
 
           } yield ()
 

--- a/minting/src/test/scala/co/topl/minting/interpreters/OperationalKeyMakerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/OperationalKeyMakerSpec.scala
@@ -1,6 +1,6 @@
 package co.topl.minting.interpreters
 
-import cats.Applicative
+import cats.{Applicative, Monad}
 import cats.data.Chain
 import cats.effect.IO
 import cats.effect.IO.asyncForIO
@@ -114,8 +114,8 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
         }
 
       (consensusState
-        .operatorRelativeStake(_: BlockId, _: Slot)(_: StakingAddress))
-        .expects(*, *, *)
+        .operatorRelativeStake(_: BlockId, _: Slot)(_: StakingAddress)(_: Monad[F]))
+        .expects(*, *, *, *)
         .once()
         .returning(Ratio.One.some.pure[F])
 
@@ -219,8 +219,8 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
         .returning(eta.pure[F])
 
       (consensusState
-        .operatorRelativeStake(_: BlockId, _: Slot)(_: StakingAddress))
-        .expects(*, *, *)
+        .operatorRelativeStake(_: BlockId, _: Slot)(_: StakingAddress)(_: Monad[F]))
+        .expects(*, *, *, *)
         .once()
         .returning(Ratio.One.some.pure[F])
 

--- a/minting/src/test/scala/co/topl/minting/interpreters/StakingSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/StakingSpec.scala
@@ -1,5 +1,6 @@
 package co.topl.minting.interpreters
 
+import cats.Monad
 import cats.effect.IO
 import cats.effect.IO.asyncForIO
 import cats.implicits._
@@ -59,8 +60,8 @@ class StakingSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
           .returning(eta.pure[F])
 
         (consensusState
-          .operatorRelativeStake(_: BlockId, _: Slot)(_: StakingAddress))
-          .expects(blockId, slot, address)
+          .operatorRelativeStake(_: BlockId, _: Slot)(_: StakingAddress)(_: Monad[F]))
+          .expects(blockId, slot, address, *)
           .once()
           .returning(relativeStake.some.pure[F])
 

--- a/models/src/test/scala/co/topl/models/generators/consensus/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/generators/consensus/ModelGenerators.scala
@@ -68,6 +68,14 @@ trait ModelGenerators {
       )
     )
 
+  implicit val arbitraryStakingRegistration: Arbitrary[StakingRegistration] =
+    Arbitrary(
+      for {
+        address   <- arbitraryStakingAddress.arbitrary
+        signature <- signatureKesProductArbitrary.arbitrary
+      } yield StakingRegistration(address, signature)
+    )
+
   // Verifications
   def vkVrfEd25519Gen: Gen[ByteString] =
     genSizedStrictByteString[Lengths.`32`.type]().map(_.data)

--- a/node/src/main/scala/co/topl/node/DataStoresInit.scala
+++ b/node/src/main/scala/co/topl/node/DataStoresInit.scala
@@ -78,7 +78,7 @@ object DataStoresInit {
         F,
         StakingAddress,
         StakingAddress,
-        SignatureKesProduct
+        ActiveStaker
       ](dataDir)(
         "registrations",
         appConfig.bifrost.cache.registrations,

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -430,7 +430,6 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
         currentEventIdGetterSetters.consensusData.set,
         ConsensusDataEventSourcedState
           .ConsensusData(
-            dataStores.operatorStakes,
             dataStores.activeStake,
             dataStores.inactiveStake,
             dataStores.registrations

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,8 +10,8 @@ object Dependencies {
   val fs2Version = "3.7.0"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.19"
-  val protobufSpecsVersion = "73d1844" // scala-steward:off
-  val bramblScVersion = "1379dab" // scala-steward:off
+  val protobufSpecsVersion = "e03a093" // scala-steward:off
+  val bramblScVersion = "d5bc746" // scala-steward:off
   val quivr4sVersion = "1e48130" // scala-steward:off
 
   val catsSlf4j =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,8 +10,8 @@ object Dependencies {
   val fs2Version = "3.7.0"
   val logback = "1.4.7"
   val orientDbVersion = "3.2.19"
-  val protobufSpecsVersion = "e3cc5f8" // scala-steward:off
-  val bramblScVersion = "c7ff17a" // scala-steward:off
+  val protobufSpecsVersion = "73d1844" // scala-steward:off
+  val bramblScVersion = "1379dab" // scala-steward:off
   val quivr4sVersion = "1e48130" // scala-steward:off
 
   val catsSlf4j =


### PR DESCRIPTION
## Purpose
- A protobuf-specs update modifies the Topl token to embed an optional StakingRegistration, and removes the Registration token
- This modification prevents cases where stake is assigned to a non-registered address or a registration is associated with 0 stake.
## Approach
- Change ConsensusDataEventSourcedState to only track changes to Topl box values
## Testing
- `preparePR` locally
## Tickets
- #2712 

## Notes
- There is still a remaining edge case where a user may attempt to hold multiple Topl tokens under the same address.  This needs to be prevented in a future ticket at the ledger level since it needs to be validated in a non-lagging manner
- Depends on https://github.com/Topl/protobuf-specs/pull/73 and https://github.com/Topl/BramblSc/pull/68