### PR TITLE
unitTestResulUpgrade

### DIFF
--- a/.github/workflows/_publish_test_results.yml
+++ b/.github/workflows/_publish_test_results.yml
@@ -21,7 +21,7 @@ jobs:
           path: artifacts
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           files: "artifacts/**/*.xml"
           check_run_annotations_branch: main, dev


### PR DESCRIPTION
## Purpose
testing Pr, trying to avoid this message

"Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/"


## testing
ci/cd finish with success and no warning on logs: https://github.com/Topl/Bifrost/actions/runs/5337378228/jobs/9673610263
