### PR TITLE
BN -  leveldbjni from other source

### DIFF
--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -205,7 +205,7 @@ class NodeAppTest extends CatsEffectSuite {
           .flatMap(filterTransactions(_)(ids))
           .map(_.isEmpty)
           .assert,
-        1000.milli,
+        1500.milli,
         identity,
         30
       )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -90,8 +90,8 @@ object Dependencies {
   )
 
   val levelDb: Seq[ModuleID] = Seq(
-    "org.ethereum"     % "leveldbjni-all" % "1.18.3",
-    "org.iq80.leveldb" % "leveldb"        % "0.12"
+    "io.github.tronprotocol" % "leveldbjni-all" % "1.18.3",
+    "org.iq80.leveldb"       % "leveldb"        % "0.12"
   )
 
   val scodec = Seq(


### PR DESCRIPTION
## Purpose
test alternative solution if we are not able to reach out this dependency: 
> sbt.librarymanagement.ResolveException: Error downloading org.ethereum:leveldbjni-all:1.18.3
## Approach
- https://repo1.maven.org/maven2/io/github/tronprotocol/leveldbjni-all/1.18.3/
