### PR TITLE
Prevent Duplicate Staking Addresses

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -187,7 +187,8 @@ object Blockchain {
                 validators.boxState,
                 rewardCalculator,
                 costCalculator,
-                validators.transactionAuthorization
+                validators.transactionAuthorization,
+                validators.registrationAccumulator
               )
           )
           blockProducer <- Stream.eval(

--- a/blockchain/src/main/scala/co/topl/blockchain/DataStores.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/DataStores.scala
@@ -13,21 +13,22 @@ import co.topl.proto.node.EpochData
 import fs2.io.file.Path
 
 case class DataStores[F[_]](
-  baseDirectory:   Path,
-  parentChildTree: Store[F, BlockId, (Long, BlockId)],
-  currentEventIds: Store[F, Byte, BlockId],
-  slotData:        Store[F, BlockId, SlotData],
-  headers:         Store[F, BlockId, BlockHeader],
-  bodies:          Store[F, BlockId, BlockBody],
-  transactions:    Store[F, TransactionId, IoTransaction],
-  spendableBoxIds: Store[F, TransactionId, NonEmptySet[Short]],
-  epochBoundaries: Store[F, Long, BlockId],
-  operatorStakes:  Store[F, StakingAddress, BigInt],
-  activeStake:     Store[F, Unit, BigInt],
-  inactiveStake:   Store[F, Unit, BigInt],
-  registrations:   Store[F, StakingAddress, ActiveStaker],
-  blockHeightTree: Store[F, Long, BlockId],
-  epochData:       Store[F, Epoch, EpochData]
+  baseDirectory:           Path,
+  parentChildTree:         Store[F, BlockId, (Long, BlockId)],
+  currentEventIds:         Store[F, Byte, BlockId],
+  slotData:                Store[F, BlockId, SlotData],
+  headers:                 Store[F, BlockId, BlockHeader],
+  bodies:                  Store[F, BlockId, BlockBody],
+  transactions:            Store[F, TransactionId, IoTransaction],
+  spendableBoxIds:         Store[F, TransactionId, NonEmptySet[Short]],
+  epochBoundaries:         Store[F, Long, BlockId],
+  operatorStakes:          Store[F, StakingAddress, BigInt],
+  activeStake:             Store[F, Unit, BigInt],
+  inactiveStake:           Store[F, Unit, BigInt],
+  registrations:           Store[F, StakingAddress, ActiveStaker],
+  blockHeightTree:         Store[F, Long, BlockId],
+  epochData:               Store[F, Epoch, EpochData],
+  registrationAccumulator: Store[F, StakingAddress, Unit]
 )
 
 class CurrentEventIdGetterSetters[F[_]: MonadThrow](store: Store[F, Byte, BlockId]) {
@@ -53,6 +54,9 @@ class CurrentEventIdGetterSetters[F[_]: MonadThrow](store: Store[F, Byte, BlockI
 
   val epochData: CurrentEventIdGetterSetters.GetterSetter[F] =
     CurrentEventIdGetterSetters.GetterSetter.forByte(store)(Indices.EpochData)
+
+  val registrationAccumulator: CurrentEventIdGetterSetters.GetterSetter[F] =
+    CurrentEventIdGetterSetters.GetterSetter.forByte(store)(Indices.RegistrationAccumulator)
 }
 
 object CurrentEventIdGetterSetters {
@@ -78,5 +82,6 @@ object CurrentEventIdGetterSetters {
     val BoxState: Byte = 4
     val Mempool: Byte = 5
     val EpochData: Byte = 6
+    val RegistrationAccumulator: Byte = 7
   }
 }

--- a/blockchain/src/main/scala/co/topl/blockchain/Validators.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Validators.scala
@@ -1,6 +1,7 @@
 package co.topl.blockchain
 
-import cats.effect.Async
+import cats.effect.{Async, Resource}
+import cats.effect.implicits._
 import cats.implicits._
 import co.topl.algebras.ClockAlgebra
 import co.topl.brambl.validation.TransactionAuthorizationInterpreter
@@ -16,14 +17,17 @@ import co.topl.consensus.interpreters.BlockHeaderToBodyValidation
 import co.topl.consensus.interpreters.BlockHeaderValidation
 import co.topl.consensus.models.BlockId
 import co.topl.eventtree.ParentChildTree
-import co.topl.ledger.algebras.BodyAuthorizationValidationAlgebra
-import co.topl.ledger.algebras.BodySemanticValidationAlgebra
-import co.topl.ledger.algebras.BodySyntaxValidationAlgebra
-import co.topl.ledger.algebras.BoxStateAlgebra
+import co.topl.ledger.algebras.{
+  BodyAuthorizationValidationAlgebra,
+  BodySemanticValidationAlgebra,
+  BodySyntaxValidationAlgebra,
+  BoxStateAlgebra,
+  RegistrationAccumulatorAlgebra,
+  TransactionSemanticValidationAlgebra
+}
 import co.topl.ledger.interpreters._
 import co.topl.quivr.api.Verifier.instances.verifierInstance
 import co.topl.typeclasses.implicits._
-import co.topl.ledger.algebras.TransactionSemanticValidationAlgebra
 import co.topl.brambl.validation.algebras.TransactionAuthorizationVerifier
 
 case class Validators[F[_]](
@@ -35,7 +39,8 @@ case class Validators[F[_]](
   bodySyntax:               BodySyntaxValidationAlgebra[F],
   bodySemantics:            BodySemanticValidationAlgebra[F],
   bodyAuthorization:        BodyAuthorizationValidationAlgebra[F],
-  boxState:                 BoxStateAlgebra[F]
+  boxState:                 BoxStateAlgebra[F],
+  registrationAccumulator:  RegistrationAccumulatorAlgebra[F]
 )
 
 object Validators {
@@ -51,7 +56,7 @@ object Validators {
     consensusValidationState:    ConsensusValidationStateAlgebra[F],
     leaderElectionThreshold:     LeaderElectionValidationAlgebra[F],
     clockAlgebra:                ClockAlgebra[F]
-  ): F[Validators[F]] =
+  ): Resource[F, Validators[F]] =
     for {
       headerValidation <- BlockHeaderValidation
         .make[F](
@@ -68,29 +73,47 @@ object Validators {
           cryptoResources.blake2b256
         )
         .flatMap(BlockHeaderValidation.WithCache.make[F](_))
-      headerToBody <- BlockHeaderToBodyValidation.make()
-      boxState <- BoxState.make(
-        currentEventIdGetterSetters.boxState.get(),
-        dataStores.bodies.getOrRaise,
-        dataStores.transactions.getOrRaise,
-        blockIdTree,
-        currentEventIdGetterSetters.boxState.set,
-        dataStores.spendableBoxIds.pure[F]
-      )
+        .toResource
+      headerToBody <- BlockHeaderToBodyValidation.make().toResource
+      boxState <- BoxState
+        .make(
+          currentEventIdGetterSetters.boxState.get(),
+          dataStores.bodies.getOrRaise,
+          dataStores.transactions.getOrRaise,
+          blockIdTree,
+          currentEventIdGetterSetters.boxState.set,
+          dataStores.spendableBoxIds.pure[F]
+        )
+        .toResource
       transactionSyntaxValidation = TransactionSyntaxInterpreter.make[F]()
       transactionSemanticValidation <- TransactionSemanticValidation
         .make[F](dataStores.transactions.getOrRaise, boxState)
+        .toResource
       transactionAuthorizationValidation = TransactionAuthorizationInterpreter.make[F]()
       bodySyntaxValidation <- BodySyntaxValidation
         .make[F](dataStores.transactions.getOrRaise, transactionSyntaxValidation)
-      bodySemanticValidation <- BodySemanticValidation.make[F](
+        .toResource
+      registrationAccumulator <- RegistrationAccumulator.make[F](
+        currentEventIdGetterSetters.registrationAccumulator.get(),
+        dataStores.bodies.getOrRaise,
         dataStores.transactions.getOrRaise,
-        transactionSemanticValidation
+        blockIdTree,
+        currentEventIdGetterSetters.registrationAccumulator.set,
+        dataStores.registrationAccumulator.pure[F]
       )
-      bodyAuthorizationValidation <- BodyAuthorizationValidation.make[F](
-        dataStores.transactions.getOrRaise,
-        transactionAuthorizationValidation
-      )
+      bodySemanticValidation <- BodySemanticValidation
+        .make[F](
+          dataStores.transactions.getOrRaise,
+          transactionSemanticValidation,
+          registrationAccumulator
+        )
+        .toResource
+      bodyAuthorizationValidation <- BodyAuthorizationValidation
+        .make[F](
+          dataStores.transactions.getOrRaise,
+          transactionAuthorizationValidation
+        )
+        .toResource
     } yield Validators(
       headerValidation,
       headerToBody,
@@ -100,6 +123,7 @@ object Validators {
       bodySyntaxValidation,
       bodySemanticValidation,
       bodyAuthorizationValidation,
-      boxState
+      boxState,
+      registrationAccumulator
     )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -526,7 +526,8 @@ lazy val ledger = project
     algebras % "compile->compile;test->test",
     typeclasses,
     eventTree,
-    munitScalamock % "test->test"
+    munitScalamock % "test->test",
+    numerics % "test->compile"
   )
 
 lazy val blockchain = project

--- a/ledger/src/main/scala/co/topl/ledger/algebras/RegistrationAccumulatorAlgebra.scala
+++ b/ledger/src/main/scala/co/topl/ledger/algebras/RegistrationAccumulatorAlgebra.scala
@@ -1,0 +1,14 @@
+package co.topl.ledger.algebras
+
+import co.topl.consensus.models.{BlockId, StakingAddress}
+
+trait RegistrationAccumulatorAlgebra[F[_]] {
+
+  /**
+   * Determines if the given address is contained in the set of active addresses
+   * @param address the address in question
+   * @return true if the address exists in the set, false otherwise
+   */
+  def contains(blockId: BlockId)(address: StakingAddress): F[Boolean]
+
+}

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BodySemanticValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BodySemanticValidation.scala
@@ -1,6 +1,6 @@
 package co.topl.ledger.interpreters
 
-import cats.data.{NonEmptyChain, Validated, ValidatedNec}
+import cats.data.{EitherT, NonEmptyChain, Validated, ValidatedNec}
 import cats.effect.Sync
 import cats.implicits._
 import co.topl.brambl.models.TransactionId
@@ -13,7 +13,8 @@ object BodySemanticValidation {
 
   def make[F[_]: Sync](
     fetchTransaction:              TransactionId => F[IoTransaction],
-    transactionSemanticValidation: TransactionSemanticValidationAlgebra[F]
+    transactionSemanticValidation: TransactionSemanticValidationAlgebra[F],
+    registrationAccumulator:       RegistrationAccumulatorAlgebra[F]
   ): F[BodySemanticValidationAlgebra[F]] =
     Sync[F].delay {
       new BodySemanticValidationAlgebra[F] {
@@ -26,7 +27,7 @@ object BodySemanticValidation {
           body.transactionIds
             .foldLeftM(List.empty[IoTransaction].validNec[BodySemanticError]) {
               case (Validated.Valid(prefix), transactionId) =>
-                validateTransaction(context, prefix)(transactionId).map(_.map(prefix :+ _))
+                validateTransaction(context, prefix)(transactionId).map(prefix :+ _).value.map(_.toValidated)
               case (invalid, _) => invalid.pure[F]
             }
             .map(_.as(body))
@@ -42,18 +43,38 @@ object BodySemanticValidation {
           prefix:  Seq[IoTransaction]
         )(transactionId: TransactionId) =
           for {
-            transaction <- fetchTransaction(transactionId)
+            transaction <- EitherT.liftF(fetchTransaction(transactionId))
             transactionValidationContext = StaticTransactionValidationContext(
               context.parentHeaderId,
               prefix,
               context.height,
               context.slot
             )
-            validationResult <- transactionSemanticValidation.validate(transactionValidationContext)(transaction)
-          } yield validationResult
-            .leftMap(errors =>
-              NonEmptyChain[BodySemanticError](BodySemanticErrors.TransactionSemanticErrors(transaction, errors))
+            _ <-
+              EitherT(transactionSemanticValidation.validate(transactionValidationContext)(transaction).map(_.toEither))
+                .leftMap(errors =>
+                  NonEmptyChain[BodySemanticError](BodySemanticErrors.TransactionSemanticErrors(transaction, errors))
+                )
+            augmentedRegistrationAccumulator = RegistrationAccumulator.Augmented.make(registrationAccumulator)(
+              prefix.foldLeft(RegistrationAccumulator.Augmentation.empty)(_.augment(_))
             )
+            newRegistrations = transaction.outputs
+              .flatMap(_.value.value.topl.flatMap(_.registration).map(_.address))
+              .toSet -- transaction.inputs.flatMap(_.value.value.topl.flatMap(_.registration).map(_.address))
+            _ <- EitherT
+              .liftF(
+                augmentedRegistrationAccumulator.use(accumulator =>
+                  newRegistrations.toList.forallM(accumulator.contains(context.parentHeaderId)(_).map(!_))
+                )
+              )
+              .flatMap(
+                EitherT.cond(
+                  _,
+                  (),
+                  NonEmptyChain[BodySemanticError](BodySemanticErrors.TransactionRegistrationError(transaction))
+                )
+              )
+          } yield transaction
       }
     }
 

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/RegistrationAccumulator.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/RegistrationAccumulator.scala
@@ -1,0 +1,145 @@
+package co.topl.ledger.interpreters
+
+import cats.MonadThrow
+import cats.effect.{Async, Resource, Sync}
+import cats.effect.implicits._
+import cats.implicits._
+import co.topl.algebras.Store
+import co.topl.brambl.models.TransactionId
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.consensus.models.{BlockId, StakingAddress}
+import co.topl.eventtree.{EventSourcedState, ParentChildTree}
+import co.topl.ledger.algebras.RegistrationAccumulatorAlgebra
+import co.topl.node.models.BlockBody
+import co.topl.typeclasses.implicits._
+
+object RegistrationAccumulator {
+
+  type State[F[_]] = Store[F, StakingAddress, Unit]
+
+  def make[F[_]: Async](
+    currentBlockId:      F[BlockId],
+    fetchBlockBody:      BlockId => F[BlockBody],
+    fetchTransaction:    TransactionId => F[IoTransaction],
+    parentChildTree:     ParentChildTree[F, BlockId],
+    currentEventChanged: BlockId => F[Unit],
+    initialState:        F[State[F]]
+  ): Resource[F, RegistrationAccumulatorAlgebra[F]] =
+    for {
+      eventSourcedState <- EventSourcedState.OfTree
+        .make[F, State[F], BlockId](
+          initialState,
+          currentBlockId,
+          applyEvent = applyBlock(fetchBlockBody, fetchTransaction),
+          unapplyEvent = unapplyBlock(fetchBlockBody, fetchTransaction),
+          parentChildTree,
+          currentEventChanged
+        )
+        .toResource
+    } yield new RegistrationAccumulatorAlgebra[F] {
+
+      def contains(blockId: BlockId)(address: StakingAddress): F[Boolean] =
+        eventSourcedState.useStateAt(blockId)(_.contains(address))
+    }
+
+  /**
+   * Apply the given block to the state.
+   *
+   * - For each transaction
+   *   - Remove each "spent" registration from the state
+   *   - Add each "created" registration to the state
+   */
+  private def applyBlock[F[_]: MonadThrow](
+    fetchBlockBody:   BlockId => F[BlockBody],
+    fetchTransaction: TransactionId => F[IoTransaction]
+  )(state: State[F], blockId: BlockId): F[State[F]] =
+    for {
+      body <- fetchBlockBody(blockId)
+      _ <- body.transactionIds
+        .traverse(
+          fetchTransaction(_)
+            .flatMap(transaction =>
+              (
+                transaction.inputs.flatMap(_.value.value.topl.flatMap(_.registration)).tupleRight(false) ++
+                transaction.outputs.flatMap(_.value.value.topl.flatMap(_.registration)).tupleRight(true)
+              ).toMap.toList
+                .traverse {
+                  case (registration, true)  => state.put(registration.address, ())
+                  case (registration, false) => state.remove(registration.address)
+                }
+            )
+        )
+    } yield state
+
+  /**
+   * Unapply the given block from the state.
+   *
+   * - Reverse transactions, and for each transaction
+   *   - Remove each "created" registration from the state
+   *   - Add each "spent" registration to the state
+   */
+  private def unapplyBlock[F[_]: MonadThrow](
+    fetchBlockBody:   BlockId => F[BlockBody],
+    fetchTransaction: TransactionId => F[IoTransaction]
+  )(state: State[F], blockId: BlockId): F[State[F]] =
+    for {
+      body <- fetchBlockBody(blockId)
+      _ <- body.transactionIds.reverse
+        .traverse(
+          fetchTransaction(_)
+            .flatMap(transaction =>
+              (
+                transaction.outputs.reverse.flatMap(_.value.value.topl.flatMap(_.registration)).tupleRight(false) ++
+                transaction.inputs.reverse.flatMap(_.value.value.topl.flatMap(_.registration)).tupleRight(true)
+              ).toMap.toList
+                .traverse {
+                  case (registration, true)  => state.put(registration.address, ())
+                  case (registration, false) => state.remove(registration.address)
+                }
+            )
+        )
+    } yield state
+
+  /**
+   * Implements a RegistrationAccumulatorAlgebra which wraps another RegistrationAccumulatorAlgebra.  This implementation
+   * allows for dynamically constructing a new interpreter while folding each transaction in a block.
+   */
+  object Augmented {
+
+    def make[F[_]: Sync](
+      state: RegistrationAccumulatorAlgebra[F]
+    )(augmentation: Augmentation): Resource[F, RegistrationAccumulatorAlgebra[F]] =
+      Resource.pure {
+        new RegistrationAccumulatorAlgebra[F] {
+          def contains(blockId: BlockId)(address: StakingAddress): F[Boolean] =
+            if (augmentation.newRegistrationAddresses.contains(address)) true.pure[F]
+            else if (augmentation.spentRegistrationAddresses.contains(address)) false.pure[F]
+            else state.contains(blockId)(address)
+        }
+      }
+  }
+
+  case class Augmentation(
+    spentRegistrationAddresses: Set[StakingAddress],
+    newRegistrationAddresses:   Set[StakingAddress]
+  ) {
+
+    /**
+     * Returns a new StateAugmentation which considers registrations on the inputs and registrations on the outputs.  Spent
+     * registrations are removed from the state, and new registrations are added to the state.
+     */
+    def augment(transaction: IoTransaction): Augmentation = {
+      val txSpentAddresses = transaction.inputs.flatMap(_.value.value.topl.flatMap(_.registration).map(_.address)).toSet
+      val txNewAddresses = transaction.outputs.flatMap(_.value.value.topl.flatMap(_.registration).map(_.address)).toSet
+      Augmentation(
+        spentRegistrationAddresses ++ txSpentAddresses,
+        (newRegistrationAddresses ++ txNewAddresses) -- txSpentAddresses
+      )
+    }
+  }
+
+  object Augmentation {
+    val empty: Augmentation = Augmentation(Set.empty, Set.empty)
+  }
+
+}

--- a/ledger/src/main/scala/co/topl/ledger/models/BodyValidationError.scala
+++ b/ledger/src/main/scala/co/topl/ledger/models/BodyValidationError.scala
@@ -25,6 +25,8 @@ object BodySemanticErrors {
     transaction:    IoTransaction,
     semanticErrors: NonEmptyChain[TransactionSemanticError]
   ) extends BodySemanticError
+
+  case class TransactionRegistrationError(transaction: IoTransaction) extends BodySemanticError
 }
 
 sealed trait BodySyntaxError extends BodyValidationError

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/RegistrationAccumulatorSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/RegistrationAccumulatorSpec.scala
@@ -1,0 +1,117 @@
+package co.topl.ledger.interpreters
+
+import cats.effect.IO
+import cats.implicits._
+import co.topl.algebras.testInterpreters.TestStore
+import co.topl.brambl.constants.NetworkConstants
+import co.topl.brambl.models.{Datum, LockAddress}
+import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
+import co.topl.brambl.syntax._
+import co.topl.consensus.models.{BlockId, StakingAddress}
+import co.topl.eventtree.ParentChildTree
+import co.topl.node.models.BlockBody
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.scalamock.munit.AsyncMockFactory
+import co.topl.models.ModelGenerators._
+import co.topl.models.generators.consensus.ModelGenerators._
+import co.topl.brambl.models.box.{Attestation, Lock, Value}
+import co.topl.typeclasses.implicits._
+import co.topl.numerics.implicits._
+
+class RegistrationAccumulatorSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+
+  type F[A] = IO[A]
+
+  val lock: Lock = Lock().withPredicate(Lock.Predicate())
+
+  val lockAddress: LockAddress = lock.lockAddress(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_LEDGER_ID)
+
+  test("accumulate a set of staking addresses across multiple blocks") {
+    val genesisBlockId = arbitraryBlockId.arbitrary.first
+    val blockId0 = arbitraryBlockId.arbitrary.first
+    val blockId1 = arbitraryBlockId.arbitrary.first
+    val blockId2 = arbitraryBlockId.arbitrary.first
+    val registration0 = arbitraryStakingRegistration.arbitrary.first
+    val tx0 =
+      IoTransaction(datum = Datum.IoTransaction.defaultInstance)
+        .withOutputs(
+          List(UnspentTransactionOutput(lockAddress, Value().withTopl(Value.TOPL(5, registration0.some))))
+        )
+        .embedId
+    val registration1 = arbitraryStakingRegistration.arbitrary.first
+    val tx1 =
+      IoTransaction(datum = Datum.IoTransaction.defaultInstance)
+        .withOutputs(
+          List(UnspentTransactionOutput(lockAddress, Value().withTopl(Value.TOPL(5, registration1.some))))
+        )
+        .embedId
+    val registration2 = arbitraryStakingRegistration.arbitrary.first
+    val tx2 =
+      IoTransaction(datum = Datum.IoTransaction.defaultInstance)
+        .withInputs(
+          List(
+            SpentTransactionOutput(
+              tx1.id.outputAddress(0, 0, 0),
+              Attestation().withPredicate(Attestation.Predicate.defaultInstance),
+              tx1.outputs(0).value
+            )
+          )
+        )
+        .withOutputs(
+          List(UnspentTransactionOutput(lockAddress, Value().withTopl(Value.TOPL(5, registration2.some))))
+        )
+        .embedId
+
+    val registration3 = arbitraryStakingRegistration.arbitrary.first
+    val tx3 =
+      IoTransaction(datum = Datum.IoTransaction.defaultInstance)
+        .withInputs(
+          List(
+            SpentTransactionOutput(
+              tx2.id.outputAddress(0, 0, 0),
+              Attestation().withPredicate(Attestation.Predicate.defaultInstance),
+              tx2.outputs(0).value
+            )
+          )
+        )
+        .withOutputs(
+          List(UnspentTransactionOutput(lockAddress, Value().withTopl(Value.TOPL(5, registration3.some))))
+        )
+        .embedId
+
+    val testResource =
+      for {
+        parentChildTree <- ParentChildTree.FromRef.make[IO, BlockId].toResource
+        _               <- parentChildTree.associate(blockId0, genesisBlockId).toResource
+        _               <- parentChildTree.associate(blockId1, blockId0).toResource
+        _               <- parentChildTree.associate(blockId2, blockId1).toResource
+        underTest <- RegistrationAccumulator.make[IO](
+          genesisBlockId.pure[IO],
+          Map(
+            blockId0 -> BlockBody(List(tx0.id)).pure[IO],
+            blockId1 -> BlockBody(List(tx1.id, tx2.id)).pure[IO],
+            blockId2 -> BlockBody(List(tx3.id)).pure[IO]
+          ).apply _,
+          Map(
+            tx0.id -> tx0.pure[IO],
+            tx1.id -> tx1.pure[IO],
+            tx2.id -> tx2.pure[IO],
+            tx3.id -> tx3.pure[IO]
+          ),
+          parentChildTree,
+          _ => IO.unit,
+          TestStore.make[IO, StakingAddress, Unit].widen
+        )
+        _ <- underTest.contains(blockId0)(registration0.address).assert.toResource
+        _ <- underTest.contains(blockId0)(registration1.address).map(!_).assert.toResource
+        _ <- underTest.contains(blockId1)(registration1.address).map(!_).assert.toResource
+        _ <- underTest.contains(blockId1)(registration2.address).assert.toResource
+        _ <- underTest.contains(blockId2)(registration2.address).map(!_).assert.toResource
+        _ <- underTest.contains(blockId2)(registration3.address).assert.toResource
+      } yield ()
+
+    testResource.use_
+  }
+
+}

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/RegistrationAccumulatorSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/RegistrationAccumulatorSpec.scala
@@ -109,6 +109,9 @@ class RegistrationAccumulatorSpec extends CatsEffectSuite with ScalaCheckEffectS
         _ <- underTest.contains(blockId1)(registration2.address).assert.toResource
         _ <- underTest.contains(blockId2)(registration2.address).map(!_).assert.toResource
         _ <- underTest.contains(blockId2)(registration3.address).assert.toResource
+        _ <- underTest.contains(blockId1)(registration2.address).assert.toResource
+        _ <- underTest.contains(blockId0)(registration0.address).assert.toResource
+        _ <- underTest.contains(blockId0)(registration1.address).map(!_).assert.toResource
       } yield ()
 
     testResource.use_

--- a/minting/src/main/scala/co/topl/minting/interpreters/BlockPacker.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/BlockPacker.scala
@@ -19,9 +19,10 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.collection.immutable.ListSet
 import co.topl.brambl.validation.algebras.TransactionAuthorizationVerifier
-import co.topl.ledger.interpreters.QuivrContext
+import co.topl.ledger.interpreters.{QuivrContext, RegistrationAccumulator}
 import cats.data.EitherT
 import org.typelevel.log4cats.Logger
+
 import scala.concurrent.duration._
 
 /**
@@ -34,7 +35,8 @@ object BlockPacker {
     boxState:                           BoxStateAlgebra[F],
     transactionRewardCalculator:        TransactionRewardCalculatorAlgebra[F],
     transactionCostCalculator:          TransactionCostCalculator[F],
-    transactionAuthorizationValidation: TransactionAuthorizationVerifier[F]
+    transactionAuthorizationValidation: TransactionAuthorizationVerifier[F],
+    registrationAccumulator:            RegistrationAccumulatorAlgebra[F]
   ): Resource[F, BlockPackerAlgebra[F]] =
     Resource.pure(
       new Impl(
@@ -42,7 +44,8 @@ object BlockPacker {
         boxState,
         transactionRewardCalculator,
         transactionCostCalculator,
-        transactionAuthorizationValidation
+        transactionAuthorizationValidation,
+        registrationAccumulator
       )
     )
 
@@ -51,7 +54,8 @@ object BlockPacker {
     boxState:                           BoxStateAlgebra[F],
     transactionRewardCalculator:        TransactionRewardCalculatorAlgebra[F],
     transactionCostCalculator:          TransactionCostCalculator[F],
-    transactionAuthorizationValidation: TransactionAuthorizationVerifier[F]
+    transactionAuthorizationValidation: TransactionAuthorizationVerifier[F],
+    registrationAccumulator:            RegistrationAccumulatorAlgebra[F]
   ) extends BlockPackerAlgebra[F] {
 
     implicit private val logger: SelfAwareStructuredLogger[F] =
@@ -209,26 +213,41 @@ object BlockPacker {
                 .incl(transaction)
 
             def go(
-              accepted: ListSet[IoTransaction],
-              queue:    ListSet[IoTransaction]
+              accepted:                            ListSet[IoTransaction],
+              queue:                               ListSet[IoTransaction],
+              registrationAccumulatorAugmentation: RegistrationAccumulator.Augmentation
             ): F[ListSet[IoTransaction]] =
               queue.headOption match {
                 case Some(transaction) if accepted.contains(transaction) =>
-                  go(accepted, queue.tail)
+                  go(accepted, queue.tail, registrationAccumulatorAugmentation)
                 case Some(transaction) =>
-                  val newAccepted = accepted ++ withDependencies(transaction)
-                  graph.spenders
-                    .get(transaction.id)
-                    .fold(newAccepted.pure[F])(spenders =>
-                      go(
-                        newAccepted,
-                        queue.tail.concat(
-                          spenders.values
-                            .flatMap(_.map(_._1))
-                            .toSet
-                            .flatMap(graph.transactions.get)
-                        )
-                      )
+                  RegistrationAccumulator.Augmented
+                    .make[F](registrationAccumulator)(registrationAccumulatorAugmentation)
+                    .use(registrationAccumulator =>
+                      (transaction.outputs.flatMap(_.value.value.topl).flatMap(_.registration).map(_.address).toSet --
+                      transaction.inputs.flatMap(_.value.value.topl).flatMap(_.registration).map(_.address)).toList
+                        .forallM(registrationAccumulator.contains(parentBlockId)(_).map(!_))
+                    )
+                    .ifM(
+                      Sync[F]
+                        .delay(accepted ++ withDependencies(transaction))
+                        .flatMap(newAccepted =>
+                          graph.spenders
+                            .get(transaction.id)
+                            .fold(newAccepted.pure[F])(spenders =>
+                              go(
+                                newAccepted,
+                                queue.tail.concat(
+                                  spenders.values
+                                    .flatMap(_.map(_._1))
+                                    .toSet
+                                    .flatMap(graph.transactions.get)
+                                ),
+                                registrationAccumulatorAugmentation.augment(transaction)
+                              )
+                            )
+                        ),
+                      go(accepted, queue.tail, registrationAccumulatorAugmentation)
                     )
                 case _ =>
                   accepted.pure[F]
@@ -236,7 +255,13 @@ object BlockPacker {
 
             nextIterationFunction.set(((_: FullBlockBody) => Async[F].never[FullBlockBody]).some) *>
             Sync[F]
-              .defer(go(ListSet.empty, ListSet.from(graph.unresolved.keys.map(graph.transactions))))
+              .defer(
+                go(
+                  ListSet.empty,
+                  ListSet.from(graph.unresolved.keys.map(graph.transactions)),
+                  RegistrationAccumulator.Augmentation.empty
+                )
+              )
               .map(transactionSet => FullBlockBody(transactionSet.toList))
           }
 

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -104,6 +104,9 @@ bifrost {
     epoch-data {
       maximum-entries = 32
     }
+    registration-accumulator {
+      maximum-entries = 256
+    }
   }
   ntp {
     // The server to call to determine the NTP offset

--- a/node/src/main/scala/co/topl/node/ApplicationConfig.scala
+++ b/node/src/main/scala/co/topl/node/ApplicationConfig.scala
@@ -113,18 +113,19 @@ object ApplicationConfig {
 
     @Lenses
     case class Cache(
-      parentChildTree: Cache.CacheConfig,
-      slotData:        Cache.CacheConfig,
-      headers:         Cache.CacheConfig,
-      bodies:          Cache.CacheConfig,
-      transactions:    Cache.CacheConfig,
-      spendableBoxIds: Cache.CacheConfig,
-      epochBoundaries: Cache.CacheConfig,
-      operatorStakes:  Cache.CacheConfig,
-      registrations:   Cache.CacheConfig,
-      blockHeightTree: Cache.CacheConfig,
-      eligibilities:   Cache.CacheConfig,
-      epochData:       Cache.CacheConfig
+      parentChildTree:         Cache.CacheConfig,
+      slotData:                Cache.CacheConfig,
+      headers:                 Cache.CacheConfig,
+      bodies:                  Cache.CacheConfig,
+      transactions:            Cache.CacheConfig,
+      spendableBoxIds:         Cache.CacheConfig,
+      epochBoundaries:         Cache.CacheConfig,
+      operatorStakes:          Cache.CacheConfig,
+      registrations:           Cache.CacheConfig,
+      blockHeightTree:         Cache.CacheConfig,
+      eligibilities:           Cache.CacheConfig,
+      epochData:               Cache.CacheConfig,
+      registrationAccumulator: Cache.CacheConfig
     )
 
     object Cache {

--- a/node/src/main/scala/co/topl/node/DataStoresInit.scala
+++ b/node/src/main/scala/co/topl/node/DataStoresInit.scala
@@ -94,7 +94,16 @@ object DataStoresInit {
         appConfig.bifrost.cache.epochData,
         Long.box
       )
-
+      registrationAccumulatorStore <- makeCachedDb[
+        F,
+        StakingAddress,
+        StakingAddress,
+        Unit
+      ](dataDir)(
+        "registration-accumulator",
+        appConfig.bifrost.cache.registrationAccumulator,
+        identity
+      )
       dataStores = DataStores(
         dataDir,
         parentChildTree,
@@ -110,7 +119,8 @@ object DataStoresInit {
         inactiveStakeStore,
         registrationsStore,
         blockHeightTreeStore,
-        epochDataStore
+        epochDataStore,
+        registrationAccumulatorStore
       )
       _ <- Resource.eval(initialize(dataStores, bigBangBlock))
     } yield dataStores
@@ -150,7 +160,8 @@ object DataStoresInit {
             CurrentEventIdGetterSetters.Indices.BlockHeightTree,
             CurrentEventIdGetterSetters.Indices.BoxState,
             CurrentEventIdGetterSetters.Indices.Mempool,
-            CurrentEventIdGetterSetters.Indices.EpochData
+            CurrentEventIdGetterSetters.Indices.EpochData,
+            CurrentEventIdGetterSetters.Indices.RegistrationAccumulator
           ).traverseTap(dataStores.currentEventIds.put(_, bigBangBlock.header.parentHeaderId)).void
         )
       _ <- dataStores.slotData.put(

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -245,19 +245,17 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
               dataStores.headers.getOrRaise
             )
           )
-      validators <- Resource.eval(
-        Validators.make[F](
-          cryptoResources,
-          dataStores,
-          bigBangBlockId,
-          eligibilityCache,
-          currentEventIdGetterSetters,
-          blockIdTree,
-          etaCalculation,
-          consensusValidationState,
-          leaderElectionThreshold,
-          clock
-        )
+      validators <- Validators.make[F](
+        cryptoResources,
+        dataStores,
+        bigBangBlockId,
+        eligibilityCache,
+        currentEventIdGetterSetters,
+        blockIdTree,
+        etaCalculation,
+        consensusValidationState,
+        leaderElectionThreshold,
+        clock
       )
       genusGrpcServices <-
         if (appConfig.genus.enable) {


### PR DESCRIPTION
## Purpose
- Users participate in staking by owning a single Topl box containing a StakingRegistration
- If another Topl box appears on chain with the same StakingAddress (inside StakingRegistration), stake tracking does not work correctly
- This PR adds a new layer in the ledger which prevents duplicate staking addresses on the chain
## Approach
- Use an EventSourcedState to accumulate a Store-based Set of StakingAddresses
- Use the AugmentedBoxState approach to allow tracking within a block
- Update BlockPacker to prevent duplicates
- Update BodySemanticValidation to error on duplicates
## Testing
- New unit tests
## Tickets
- #BN-1066