### PR TITLE
BN-1072 Added reputation performance calculation for P2P network

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockApplyError.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockApplyError.scala
@@ -1,5 +1,6 @@
 package co.topl.networking.fsnetwork
 
+import cats.implicits._
 import cats.data.NonEmptyChain
 import co.topl.consensus.models.{BlockHeaderValidationFailure, BlockId}
 import co.topl.ledger.models.BodyValidationError
@@ -20,7 +21,7 @@ object BlockApplyError {
       override def toString: String = {
         val name = Option(ex.getClass.getName).getOrElse("")
         val message = Option(ex.getLocalizedMessage).getOrElse("")
-        s"Unknown error during applying block header due next throwable $name : $message"
+        show"Unknown error during applying block header due next throwable $name : $message"
       }
     }
   }
@@ -38,7 +39,7 @@ object BlockApplyError {
       override def toString: String = {
         val name = Option(ex.getClass.getName).getOrElse("")
         val message = Option(ex.getLocalizedMessage).getOrElse("")
-        s"Unknown error during applying block body due next throwable $name : $message"
+        show"Unknown error during applying block body due next throwable $name : $message"
       }
     }
   }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockDownloadError.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockDownloadError.scala
@@ -27,7 +27,7 @@ object BlockDownloadError {
       override def toString: String = {
         val name = Option(ex.getClass.getName).getOrElse("")
         val message = Option(ex.getLocalizedMessage).getOrElse("")
-        s"Unknown error during getting header from peer due next throwable $name : $message"
+        show"Unknown error during getting header from peer due next throwable $name : $message"
       }
     }
   }
@@ -59,7 +59,7 @@ object BlockDownloadError {
       override def toString: String = {
         val name = Option(ex.getClass.getName).getOrElse("")
         val message = Option(ex.getLocalizedMessage).getOrElse("")
-        s"Unknown error during getting block from peer due next throwable $name : $message"
+        show"Unknown error during getting block from peer due next throwable $name : $message"
       }
     }
   }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
@@ -1,6 +1,5 @@
 package co.topl.networking.fsnetwork
 
-import cats.Applicative
 import cats.effect.{Async, Resource}
 import cats.implicits._
 import co.topl.actor.{Actor, Fsm}
@@ -8,16 +7,26 @@ import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.networking.fsnetwork.ReputationAggregator.Message._
 import org.typelevel.log4cats.Logger
 
-//TODO Reputation mechanism is not defined yet
+//TODO Reputation mechanism is not fully defined yet
 object ReputationAggregator {
-  case class State[F[_]](peerManager: PeersManagerActor[F], reputation: Map[HostId, HostReputationValue])
+
+  case class State[F[_]](
+    peerManager:              PeersManagerActor[F],
+    performanceReputation:    Map[HostId, HostReputationValue],
+    blockProvidingReputation: Map[HostId, HostReputationValue],
+    newnessReputation:        Map[HostId, HostReputationValue]
+  )
+
   type Response[F[_]] = State[F]
 
   sealed trait Message
 
   object Message {
-    case class UpdatePeerReputation(hostId: HostId, hostReputationValue: HostReputationValue) extends Message
-    case class PingPongMessagePing(hostId: HostId, delay: Either[NetworkQualityError, Long]) extends Message
+    case class RemoveReputationForHost(hostId: HostId) extends Message
+
+    case class PingPongMessagePing(hostId: HostId, response: Either[NetworkQualityError, Long]) extends Message
+    case class DownloadTimeHeader(hostId: HostId, delay: Long) extends Message
+    case class DownloadTimeBody(hostId: HostId, bodyDelay: Long, txDelays: Seq[Long]) extends Message
     case class HostProvideIncorrectBlock(hostId: HostId) extends Message
   }
 
@@ -25,28 +34,62 @@ object ReputationAggregator {
 
   def getFsm[F[_]: Async: Logger]: Fsm[F, State[F], Message, Response[F]] =
     Fsm {
-      case (state, update: UpdatePeerReputation)      => updatePeerReputation(state, update)
-      case (state, pongMessage: PingPongMessagePing)  => pongMessageProcessing(state, pongMessage)
+      case (state, RemoveReputationForHost(hostId))   => removeReputationForHost(state, hostId)
       case (state, HostProvideIncorrectBlock(hostId)) => incorrectBlockReceived(state, hostId)
+
+      case (state, PingPongMessagePing(hostId, pongResponse)) => pongMessageProcessing(state, hostId, pongResponse)
+      case (state, DownloadTimeHeader(hostId, delay))         => headerDownloadTime(state, hostId, delay)
+      case (state, DownloadTimeBody(hostId, delay, txDelays)) => blockDownloadTime(state, hostId, delay, txDelays)
     }
 
-  def makeActor[F[_]: Async: Logger](peersManager: PeersManagerActor[F]): Resource[F, ReputationAggregatorActor[F]] = {
-    val initialState = ReputationAggregator.State[F](peersManager, Map.empty[HostId, HostReputationValue])
+  def makeActor[F[_]: Async: Logger](
+    peersManager:             PeersManagerActor[F],
+    performanceReputation:    Map[HostId, HostReputationValue] = Map.empty[HostId, HostReputationValue],
+    blockProvidingReputation: Map[HostId, HostReputationValue] = Map.empty[HostId, HostReputationValue],
+    newnessReputation:        Map[HostId, HostReputationValue] = Map.empty[HostId, HostReputationValue]
+  ): Resource[F, ReputationAggregatorActor[F]] = {
+    val initialState = ReputationAggregator.State[F](
+      peersManager,
+      performanceReputation,
+      blockProvidingReputation,
+      newnessReputation
+    )
     Actor.make[F, State[F], Message, Response[F]](initialState, getFsm)
   }
 
-  private def updatePeerReputation[F[_]: Applicative](
-    state:            State[F],
-    reputationUpdate: UpdatePeerReputation
-  ) =
-    (state, state).pure[F]
+  private def removeReputationForHost[F[_]: Async: Logger](
+    state:  State[F],
+    hostId: HostId
+  ): F[(State[F], Response[F])] = {
+    val newState = state.copy(
+      performanceReputation = state.performanceReputation - hostId,
+      blockProvidingReputation = state.blockProvidingReputation - hostId,
+      newnessReputation = state.newnessReputation - hostId
+    )
+
+    Logger[F].info(show"Remove reputation for host $hostId") >>
+    (newState, newState).pure[F]
+  }
 
   private def pongMessageProcessing[F[_]: Async: Logger](
-    state:            State[F],
-    reputationUpdate: PingPongMessagePing
-  ) =
-    Logger[F].info(show"Received pong message from host ${reputationUpdate.hostId}") >>
-    (state, state).pure[F]
+    state:    State[F],
+    hostId:   HostId,
+    response: Either[NetworkQualityError, Long]
+  ): F[(State[F], Response[F])] =
+    response match {
+      case Right(value) =>
+        val newReputation = delayToReputation(value)
+        val newPerformanceReputation =
+          state.performanceReputation + (hostId -> newReputation)
+        val newState = state.copy(performanceReputation = newPerformanceReputation)
+        Logger[F].info(show"Got pong message delay $value from remote host $hostId") >>
+        (newState, newState).pure[F]
+
+      case Left(error) =>
+        Logger[F].error(show"Bad pong message: $error from host $hostId") >>
+        state.peerManager.sendNoWait(PeersManager.Message.UpdatePeerStatus(hostId, PeerState.Banned)) >>
+        (state, state).pure[F]
+    }
 
   private def incorrectBlockReceived[F[_]: Async: Logger](
     state:  State[F],
@@ -55,4 +98,55 @@ object ReputationAggregator {
     Logger[F].error(show"Received incorrect block from host $hostId") >>
     state.peerManager.sendNoWait(PeersManager.Message.UpdatePeerStatus(hostId, PeerState.Banned)) >>
     (state, state).pure[F]
+
+  private def headerDownloadTime[F[_]: Async: Logger](
+    state:  State[F],
+    hostId: HostId,
+    delay:  Long
+  ): F[(State[F], Response[F])] = {
+    val newReputation = delayToReputation(delay)
+    val updatedReputation = state.performanceReputation
+      .get(hostId)
+      .map { currentReputation =>
+        (currentReputation * 2 + newReputation) / 3.0
+      }
+      .getOrElse(newReputation)
+
+    val newPerformanceReputation: Map[HostId, HostReputationValue] =
+      state.performanceReputation + (hostId -> updatedReputation)
+    val newState = state.copy(performanceReputation = newPerformanceReputation)
+
+    Logger[F].debug(show"Received header download from host $hostId with delay $delay") >>
+    (newState, newState).pure[F]
+  }
+
+  private def blockDownloadTime[F[_]: Async: Logger](
+    state:    State[F],
+    hostId:   HostId,
+    delay:    Long,
+    tsDelays: Seq[Long]
+  ): F[(State[F], Response[F])] = {
+    val maxDelay = (tsDelays :+ delay).max
+    val newReputation = delayToReputation(maxDelay)
+    val updatedReputation = state.performanceReputation
+      .get(hostId)
+      .map { currentReputation =>
+        (currentReputation * 2 + newReputation) / 3.0
+      }
+      .getOrElse(newReputation)
+
+    val newPerformanceReputation: Map[HostId, HostReputationValue] =
+      state.performanceReputation + (hostId -> updatedReputation)
+    val newState = state.copy(performanceReputation = newPerformanceReputation)
+
+    Logger[F].debug(show"Received block download from host $hostId with max delay $delay") >>
+    (newState, newState).pure[F]
+  }
+
+  def delayToReputation(delayInMs: Long): Double = {
+    val zeroReputationDelay = 2000.0
+    val reputationReducing = delayInMs.toDouble / zeroReputationDelay
+
+    1.0 - reputationReducing
+  }
 }

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
@@ -2,7 +2,7 @@ package co.topl.networking.fsnetwork
 
 import cats.MonadThrow
 import cats.data.{NonEmptyChain, OptionT}
-import cats.effect.IO
+import cats.effect.{Async, IO}
 import cats.implicits._
 import co.topl.algebras.Store
 import co.topl.codecs.bytes.tetra.instances._
@@ -22,11 +22,13 @@ import co.topl.typeclasses.implicits._
 import fs2.Stream
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.Gen
+import org.scalamock.function.FunctionAdapter1
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.collection.mutable
+import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
 
 object PeerBlockHeaderFetcherTest {
   type F[A] = IO[A]
@@ -38,6 +40,25 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
   val hostId: HostId = "127.0.0.1"
   val maxChainSize = 99
+
+  private def compareWithoutDownloadTimeMatcher(
+    rawExpectedMessage: RequestsProxy.Message
+  ): FunctionAdapter1[RequestsProxy.Message, Boolean] = {
+    val matchingFunction: RequestsProxy.Message => Boolean =
+      (rawActualMessage: RequestsProxy.Message) =>
+        (rawExpectedMessage, rawActualMessage) match {
+          case (
+                expectedMessage: RequestsProxy.Message.DownloadHeadersResponse,
+                actualMessage: RequestsProxy.Message.DownloadHeadersResponse
+              ) =>
+            val newResp =
+              actualMessage.response.map { case (header, res) =>
+                (header, res.map(b => b.copy(downloadTimeMs = 0)))
+              }
+            expectedMessage == actualMessage.copy(response = newResp)
+        }
+    new FunctionAdapter1[RequestsProxy.Message, Boolean](matchingFunction)
+  }
 
   test("Block header shall be downloaded by request") {
     withMock {
@@ -63,9 +84,12 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       val expectedMessage: RequestsProxy.Message =
         RequestsProxy.Message.DownloadHeadersResponse(
           hostId,
-          idAndHeader.map { case (id, header) => (id, Either.right(header)) }
+          idAndHeader.map { case (id, header) => (id, Either.right(UnverifiedBlockHeader(hostId, header, 0))) }
         )
-      (requestsProxy.sendNoWait _).expects(expectedMessage).once().returning(().pure[F])
+      (requestsProxy.sendNoWait _)
+        .expects(compareWithoutDownloadTimeMatcher(expectedMessage))
+        .once()
+        .returning(().pure[F])
 
       val localChain = mock[LocalChainAlgebra[F]]
 
@@ -78,6 +102,52 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
         .use { actor =>
           for {
             _ <- actor.sendNoWait(PeerBlockHeaderFetcher.Message.DownloadBlockHeaders(idAndHeader.map(_._1)))
+          } yield ()
+        }
+    }
+  }
+
+  test("One block header shall be downloaded by request proper with delay measurements") {
+    withMock {
+      val pingDelay = 90
+
+      val header: BlockHeader = arbitraryHeader.arbitrary.first.embedId
+      val client = mock[BlockchainPeerClient[F]]
+      (client
+        .getHeaderOrError(_: BlockId, _: Throwable)(_: MonadThrow[F]))
+        .expects(header.id, *, *)
+        .once
+        .returns(Async[F].delayBy(header.pure[F], FiniteDuration(pingDelay, MILLISECONDS)))
+
+      val blockChecker = mock[BlockCheckerActor[F]]
+
+      val requestsProxy = mock[RequestsProxyActor[F]]
+
+      (requestsProxy.sendNoWait _)
+        .expects(*)
+        .once()
+        .onCall { message: RequestsProxy.Message =>
+          message match {
+            case RequestsProxy.Message.DownloadHeadersResponse(`hostId`, response) =>
+              if (response.head._2.forall(b => b.downloadTimeMs < pingDelay || b.downloadTimeMs > pingDelay + 30))
+                throw new IllegalStateException()
+              else
+                ().pure[F]
+            case _ => throw new IllegalStateException()
+          }
+        }
+
+      val localChain = mock[LocalChainAlgebra[F]]
+
+      val slotDataStore = mock[Store[F, BlockId, SlotData]]
+
+      val blockIdTree = mock[ParentChildTree[F, BlockId]]
+
+      PeerBlockHeaderFetcher
+        .makeActor(hostId, client, blockChecker, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .use { actor =>
+          for {
+            _ <- actor.sendNoWait(PeerBlockHeaderFetcher.Message.DownloadBlockHeaders(NonEmptyChain.one(header.id)))
           } yield ()
         }
     }
@@ -112,11 +182,14 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
             if (missedBlockId(id)) {
               (id, Either.left(HeaderNotFoundInPeer))
             } else {
-              (id, Either.right(header))
+              (id, Either.right(UnverifiedBlockHeader(hostId, header, 0)))
             }
           }
         )
-      (requestsProxy.sendNoWait _).expects(expectedMessage).once().returning(().pure[F])
+      (requestsProxy.sendNoWait _)
+        .expects(compareWithoutDownloadTimeMatcher(expectedMessage))
+        .once()
+        .returning(().pure[F])
 
       val localChain = mock[LocalChainAlgebra[F]]
 
@@ -169,11 +242,14 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
             if (missedBlockId(id)) {
               (id, Either.left(HeaderHaveIncorrectId(id, incorrectHeaderId)))
             } else {
-              (id, Either.right(header))
+              (id, Either.right(UnverifiedBlockHeader(hostId, header, 0)))
             }
           }
         )
-      (requestsProxy.sendNoWait _).expects(expectedMessage).once().returning(().pure[F])
+      (requestsProxy.sendNoWait _)
+        .expects(compareWithoutDownloadTimeMatcher(expectedMessage))
+        .once()
+        .returning(().pure[F])
 
       val localChain = mock[LocalChainAlgebra[F]]
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
@@ -1,0 +1,204 @@
+package co.topl.networking.fsnetwork
+
+import cats.effect.IO
+import cats.implicits._
+import co.topl.brambl.generators.TransactionGenerator
+import co.topl.models.ModelGenerators.GenHelper
+import co.topl.networking.fsnetwork.NetworkQualityError.{IncorrectPongMessage, NoPongMessage}
+import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
+import co.topl.networking.fsnetwork.ReputationAggregatorTest.F
+import co.topl.networking.fsnetwork.TestHelper.arbitraryHost
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF
+import org.scalamock.munit.AsyncMockFactory
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object ReputationAggregatorTest {
+  type F[A] = IO[A]
+}
+
+class ReputationAggregatorTest
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with AsyncMockFactory
+    with TransactionGenerator {
+  implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
+
+  test("Reputation shall be removed by request") {
+    withMock {
+      val peersManager = mock[PeersManagerActor[F]]
+      val hostToRemove = arbitraryHost.arbitrary.first
+
+      val initialPerfMap = Map(hostToRemove -> 0.5, arbitraryHost.arbitrary.first -> 0.1)
+      val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, hostToRemove -> 0.7)
+      val initialNewMap = Map(hostToRemove -> 0.5)
+      ReputationAggregator
+        .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+        .use { actor =>
+          for {
+            newState <- actor.send(ReputationAggregator.Message.RemoveReputationForHost(hostToRemove))
+            _ = assert(!newState.performanceReputation.contains(hostToRemove))
+            _ = assert(!newState.blockProvidingReputation.contains(hostToRemove))
+            _ = assert(!newState.newnessReputation.contains(hostToRemove))
+            newState2 <- actor.send(ReputationAggregator.Message.RemoveReputationForHost(hostToRemove))
+            _ = assert(!newState2.performanceReputation.contains(hostToRemove))
+            _ = assert(!newState2.blockProvidingReputation.contains(hostToRemove))
+            _ = assert(!newState2.newnessReputation.contains(hostToRemove))
+          } yield ()
+        }
+    }
+  }
+
+  test("Correct pong message shall be processed") {
+    withMock {
+      val peersManager = mock[PeersManagerActor[F]]
+      val host = arbitraryHost.arbitrary.first
+
+      val initialPerfMap = Map(host -> 0.5, arbitraryHost.arbitrary.first -> 0.1)
+      val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
+      val initialNewMap = Map(host -> 0.5)
+
+      val delay = 230
+      ReputationAggregator
+        .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+        .use { actor =>
+          for {
+            newState <- actor.send(ReputationAggregator.Message.PingPongMessagePing(host, Right(delay)))
+            _ = assert(newState.performanceReputation(host) == ReputationAggregator.delayToReputation(delay))
+            _ = assert(newState.blockProvidingReputation == initialBlockMap)
+            _ = assert(newState.newnessReputation == initialNewMap)
+          } yield ()
+        }
+    }
+  }
+
+  test("NoPongMessage message shall be processed") {
+    withMock {
+      val peersManager = mock[PeersManagerActor[F]]
+      val host = arbitraryHost.arbitrary.first
+
+      val initialPerfMap = Map(host -> 0.5, arbitraryHost.arbitrary.first -> 0.1)
+      val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
+      val initialNewMap = Map(host -> 0.5)
+
+      (peersManager.sendNoWait _)
+        .expects(PeersManager.Message.UpdatePeerStatus(host, PeerState.Banned))
+        .returns(().pure[F])
+      ReputationAggregator
+        .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+        .use { actor =>
+          for {
+            newState <- actor.send(ReputationAggregator.Message.PingPongMessagePing(host, Left(NoPongMessage)))
+            _ = assert(newState.performanceReputation == initialPerfMap)
+            _ = assert(newState.blockProvidingReputation == initialBlockMap)
+            _ = assert(newState.newnessReputation == initialNewMap)
+          } yield ()
+        }
+    }
+  }
+
+  test("IncorrectPongMessage message shall be processed") {
+    withMock {
+      val peersManager = mock[PeersManagerActor[F]]
+      val host = arbitraryHost.arbitrary.first
+
+      val initialPerfMap = Map(host -> 0.5, arbitraryHost.arbitrary.first -> 0.1)
+      val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
+      val initialNewMap = Map(host -> 0.5)
+
+      (peersManager.sendNoWait _)
+        .expects(PeersManager.Message.UpdatePeerStatus(host, PeerState.Banned))
+        .returns(().pure[F])
+      ReputationAggregator
+        .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+        .use { actor =>
+          for {
+            newState <- actor.send(ReputationAggregator.Message.PingPongMessagePing(host, Left(IncorrectPongMessage)))
+            _ = assert(newState.performanceReputation == initialPerfMap)
+            _ = assert(newState.blockProvidingReputation == initialBlockMap)
+            _ = assert(newState.newnessReputation == initialNewMap)
+          } yield ()
+        }
+    }
+  }
+
+  test("IncorrectBlock message shall be processed") {
+    withMock {
+      val peersManager = mock[PeersManagerActor[F]]
+      val host = arbitraryHost.arbitrary.first
+
+      val initialPerfMap = Map(host -> 0.5, arbitraryHost.arbitrary.first -> 0.1)
+      val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
+      val initialNewMap = Map(host -> 0.5)
+
+      (peersManager.sendNoWait _)
+        .expects(PeersManager.Message.UpdatePeerStatus(host, PeerState.Banned))
+        .returns(().pure[F])
+      ReputationAggregator
+        .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+        .use { actor =>
+          for {
+            newState <- actor.send(ReputationAggregator.Message.HostProvideIncorrectBlock(host))
+            _ = assert(newState.performanceReputation == initialPerfMap)
+            _ = assert(newState.blockProvidingReputation == initialBlockMap)
+            _ = assert(newState.newnessReputation == initialNewMap)
+          } yield ()
+        }
+    }
+  }
+
+  test("Performance reputation after header downloading shall be updated") {
+    withMock {
+      val peersManager = mock[PeersManagerActor[F]]
+      val host = arbitraryHost.arbitrary.first
+
+      val initialReputation = 0.5
+      val initialPerfMap = Map(host -> initialReputation, arbitraryHost.arbitrary.first -> 0.1)
+      val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
+      val initialNewMap = Map(host -> 0.5)
+
+      val downloadTime = 120
+      val reputation = ReputationAggregator.delayToReputation(downloadTime)
+
+      ReputationAggregator
+        .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+        .use { actor =>
+          for {
+            newState <- actor.send(ReputationAggregator.Message.DownloadTimeHeader(host, downloadTime))
+            _ = assert(newState.performanceReputation(host) == (initialReputation * 2 + reputation) / 3.0)
+            _ = assert(newState.blockProvidingReputation == initialBlockMap)
+            _ = assert(newState.newnessReputation == initialNewMap)
+          } yield ()
+        }
+    }
+  }
+
+  test("Performance reputation after body downloading shall be updated") {
+    PropF.forAllF { (txDownloadTime: Seq[Long]) =>
+      withMock {
+        val peersManager = mock[PeersManagerActor[F]]
+        val host = arbitraryHost.arbitrary.first
+
+        val initialReputation = 0.5
+        val initialPerfMap = Map(host -> initialReputation, arbitraryHost.arbitrary.first -> 0.1)
+        val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
+        val initialNewMap = Map(host -> 0.5)
+
+        val downloadTime: Long = 120
+        val reputation = ReputationAggregator.delayToReputation((txDownloadTime :+ downloadTime).max)
+
+        ReputationAggregator
+          .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+          .use { actor =>
+            for {
+              newState <- actor.send(ReputationAggregator.Message.DownloadTimeBody(host, downloadTime, txDownloadTime))
+              _ = assert(newState.performanceReputation(host) == (initialReputation * 2 + reputation) / 3.0)
+              _ = assert(newState.blockProvidingReputation == initialBlockMap)
+              _ = assert(newState.newnessReputation == initialNewMap)
+            } yield ()
+          }
+      }
+    }
+  }
+}

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/TestHelper.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/TestHelper.scala
@@ -43,6 +43,8 @@ object TestHelper extends TransactionGenerator {
         addHeaderToChain(headers.append(gen.sample.get.copy(parentHeaderId = parentId)), gen, count - 1)
     }
 
+  val arbitraryHost: Arbitrary[HostId] = Arbitrary(Arbitrary.arbitrary[String])
+
   def arbitraryLinkedBlockHeaderChain(sizeGen: Gen[Long]): Arbitrary[NonEmptyChain[BlockHeader]] =
     Arbitrary(
       for {


### PR DESCRIPTION
## Purpose
Adding simple performance calculation for P2P remote peer for future Network discovery

## Approach
Receiving data from a remote host triggers a performance reputation update

## Testing
Unit tests + multinode test

## Tickets
*closes #BN-1072

