### PR TITLE
BN-1069 Move Bifrist configuration case classes to separated module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -158,6 +158,7 @@ lazy val bifrost = project
   .aggregate(
     node,
     typeclasses,
+    config,
     toplGrpc,
     nodeCrypto,
     catsUtils,
@@ -202,6 +203,7 @@ lazy val node = project
   )
   .dependsOn(
     models % "compile->compile;test->test",
+    config,
     typeclasses,
     consensus,
     minting,
@@ -217,6 +219,16 @@ lazy val node = project
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, DockerPlugin)
   .settings(scalamacrosParadiseSettings)
 
+lazy val config = project
+  .in(file("config"))
+  .settings(
+    name := "config",
+    commonSettings,
+    crossScalaVersions := Seq(scala213),
+    libraryDependencies ++= Dependencies.monocle
+  )
+  .dependsOn(models, numerics)
+  .settings(scalamacrosParadiseSettings)
 
 lazy val networkDelayer = project
   .in(file("network-delayer"))
@@ -468,6 +480,7 @@ lazy val networking = project
   .settings(scalamacrosParadiseSettings)
   .dependsOn(
     models % "compile->compile;test->test",
+    config,
     typeclasses,
     nodeCrypto,
     byteCodecs,
@@ -545,6 +558,7 @@ lazy val blockchain = project
   .dependsOn(
     models   % "compile->compile;test->test",
     algebras % "compile->compile;test->test",
+    config,
     typeclasses,
     eventTree,
     ledger,

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -1,0 +1,146 @@
+package co.topl.config
+
+import co.topl.models.Slot
+import co.topl.models.utility.Ratio
+import co.topl.numerics.implicits.Ops
+import co.topl.proto.node.NodeConfig
+import monocle.macros.Lenses
+
+import scala.concurrent.duration.FiniteDuration
+
+// $COVERAGE-OFF$
+@Lenses
+case class ApplicationConfig(
+  bifrost: ApplicationConfig.Bifrost,
+  genus:   ApplicationConfig.Genus,
+  kamon:   ApplicationConfig.Kamon
+)
+
+object ApplicationConfig {
+
+  @Lenses
+  case class Bifrost(
+    data:      Bifrost.Data,
+    staking:   Bifrost.Staking,
+    p2p:       Bifrost.P2P,
+    rpc:       Bifrost.RPC,
+    mempool:   Bifrost.Mempool,
+    bigBang:   Bifrost.BigBang,
+    protocols: Map[Slot, Bifrost.Protocol],
+    cache:     Bifrost.Cache,
+    ntp:       Bifrost.Ntp
+  )
+
+  object Bifrost {
+
+    @Lenses
+    case class Data(directory: String)
+
+    @Lenses
+    case class Staking(directory: String)
+
+    @Lenses
+    case class P2P(
+      bindHost:          String,
+      bindPort:          Int,
+      publicHost:        String,
+      publicPort:        Int,
+      knownPeers:        List[KnownPeer],
+      networkProperties: NetworkProperties
+    )
+
+    case class NetworkProperties(experimental: Boolean, pingPongInterval: FiniteDuration)
+
+    case class KnownPeer(host: String, port: Int)
+
+    @Lenses
+    case class RPC(bindHost: String, bindPort: Int)
+
+    @Lenses
+    case class Mempool(defaultExpirationSlots: Long)
+    sealed abstract class BigBang
+
+    object BigBangs {
+
+      @Lenses
+      case class Private(
+        timestamp:        Long = System.currentTimeMillis() + 5_000L,
+        stakerCount:      Int,
+        stakes:           Option[List[BigInt]],
+        localStakerIndex: Option[Int]
+      ) extends BigBang
+    }
+
+    @Lenses
+    case class Protocol(
+      fEffective:                 Ratio,
+      vrfLddCutoff:               Int,
+      vrfPrecision:               Int,
+      vrfBaselineDifficulty:      Ratio,
+      vrfAmplitude:               Ratio,
+      chainSelectionKLookback:    Long,
+      slotDuration:               FiniteDuration,
+      forwardBiasedSlotWindow:    Slot,
+      operationalPeriodsPerEpoch: Long,
+      kesKeyHours:                Int,
+      kesKeyMinutes:              Int
+    ) {
+
+      val chainSelectionSWindow: Long =
+        (Ratio(chainSelectionKLookback, 4L) * fEffective.inverse).round.toLong
+
+      val epochLength: Long =
+        chainSelectionKLookback * 6
+
+      val operationalPeriodLength: Long =
+        epochLength / operationalPeriodsPerEpoch
+
+      val vrfCacheSize: Long =
+        operationalPeriodLength * 4
+
+      def nodeConfig(slot: Slot): NodeConfig = NodeConfig(
+        slot = slot,
+        slotDurationMillis = slotDuration.toMillis,
+        epochLength = epochLength
+      )
+    }
+
+    @Lenses
+    case class Cache(
+      parentChildTree:         Cache.CacheConfig,
+      slotData:                Cache.CacheConfig,
+      headers:                 Cache.CacheConfig,
+      bodies:                  Cache.CacheConfig,
+      transactions:            Cache.CacheConfig,
+      spendableBoxIds:         Cache.CacheConfig,
+      epochBoundaries:         Cache.CacheConfig,
+      operatorStakes:          Cache.CacheConfig,
+      registrations:           Cache.CacheConfig,
+      blockHeightTree:         Cache.CacheConfig,
+      eligibilities:           Cache.CacheConfig,
+      epochData:               Cache.CacheConfig,
+      registrationAccumulator: Cache.CacheConfig
+    )
+
+    object Cache {
+
+      @Lenses
+      case class CacheConfig(maximumEntries: Long, ttl: Option[FiniteDuration])
+    }
+
+    @Lenses
+    case class Ntp(server: String, refreshInterval: FiniteDuration, timeout: FiniteDuration)
+
+  }
+
+  @Lenses
+  case class Genus(
+    enable:            Boolean,
+    orientDbDirectory: String,
+    orientDbPassword:  String
+  )
+
+  @Lenses
+  case class Kamon(enable: Boolean)
+}
+// $COVERAGE-ON$

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -8,6 +8,7 @@ import cats.implicits._
 import co.topl.algebras.Store
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.config.ApplicationConfig.Bifrost.NetworkProperties
 import co.topl.consensus.algebras._
 import co.topl.consensus.models.BlockHeader
 import co.topl.consensus.models.BlockId
@@ -19,8 +20,6 @@ import co.topl.networking.blockchain.BlockchainPeerHandlerAlgebra
 import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.node.models.BlockBody
 import org.typelevel.log4cats.Logger
-
-import scala.concurrent.duration.FiniteDuration
 
 object ActorPeerHandlerBridgeAlgebra {
 
@@ -37,7 +36,7 @@ object ActorPeerHandlerBridgeAlgebra {
     bodyStore:                   Store[F, BlockId, BlockBody],
     transactionStore:            Store[F, TransactionId, IoTransaction],
     blockIdTree:                 ParentChildTree[F, BlockId],
-    pingPongInterval:            FiniteDuration
+    networkProperties:           NetworkProperties
   ): Resource[F, BlockchainPeerHandlerAlgebra[F]] = {
     val networkAlgebra = new NetworkAlgebraImpl[F]()
     val networkManager =
@@ -56,7 +55,7 @@ object ActorPeerHandlerBridgeAlgebra {
         blockIdTree,
         networkAlgebra,
         List.empty,
-        pingPongInterval
+        networkProperties
       )
 
     networkManager.map(makeAlgebra(_))

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
@@ -4,17 +4,14 @@ import cats.effect.kernel.Resource
 import co.topl.algebras.Store
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.config.ApplicationConfig.Bifrost.NetworkProperties
 import co.topl.consensus.algebras._
-import co.topl.consensus.models.BlockId
-import co.topl.consensus.models.BlockHeader
-import co.topl.consensus.models.SlotData
+import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
 import co.topl.eventtree.ParentChildTree
 import co.topl.ledger.algebras._
 import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.node.models.BlockBody
 import org.typelevel.log4cats.Logger
-
-import scala.concurrent.duration.FiniteDuration
 
 object NetworkManager {
 
@@ -33,7 +30,7 @@ object NetworkManager {
     blockIdTree:                 ParentChildTree[F, BlockId],
     networkAlgebra:              NetworkAlgebra[F],
     initialHosts:                List[HostId],
-    pingPongInterval:            FiniteDuration
+    networkProperties:           NetworkProperties
   ): Resource[F, PeersManagerActor[F]] =
     for {
       _ <- Resource.liftK(Logger[F].info("Start actors network"))
@@ -44,7 +41,7 @@ object NetworkManager {
         transactionStore,
         blockIdTree,
         headerToBodyValidation,
-        pingPongInterval
+        networkProperties.pingPongInterval
       )
       reputationAggregator <- networkAlgebra.makeReputationAggregation(peerManager)
       requestsProxy <- networkAlgebra.makeRequestsProxy(reputationAggregator, peerManager, headerStore, bodyStore)

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
@@ -186,7 +186,7 @@ class ReputationAggregatorTest
         val initialNewMap = Map(host -> 0.5)
 
         val downloadTime: Long = 120
-        val reputation = ReputationAggregator.delayToReputation((txDownloadTime :+ downloadTime).max)
+        val reputation = ReputationAggregator.delayToReputation((txDownloadTime.filter(_ > 0) :+ downloadTime).max)
 
         ReputationAggregator
           .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)

--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -49,7 +49,8 @@ class NodeAppTest extends CatsEffectSuite {
          |  p2p:
          |    bind-port: 9150
          |    public-port: 9150
-         |    experimental: false
+         |    network-properties:
+         |      experimental: false
          |  rpc:
          |    bind-port: 9151
          |  big-bang:
@@ -72,7 +73,8 @@ class NodeAppTest extends CatsEffectSuite {
          |    bind-port: 9152
          |    public-port: 9152
          |    known-peers: localhost:9150
-         |    experimental: false
+         |    network-properties:
+         |      experimental: false
          |  rpc:
          |    bind-port: 9153
          |  big-bang:

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -22,7 +22,10 @@ bifrost {
     // A comma-delimited list of host:port pairs to connect to initially (i.e. `1.2.3.4:9085,5.6.7.8:9085`)
     known-peers = ""
     // Use actors system
-    // experimental = true
+    network-properties {
+      experimental = false
+      ping-pong-interval = 300 seconds
+    }
   }
   // Settings for RPC/gRPC
   rpc {

--- a/node/src/main/scala/co/topl/node/DataStoresInit.scala
+++ b/node/src/main/scala/co/topl/node/DataStoresInit.scala
@@ -11,6 +11,7 @@ import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.Persistable
+import co.topl.config.ApplicationConfig
 import co.topl.consensus.models._
 import co.topl.crypto.signing.Ed25519VRF
 import co.topl.db.leveldb.LevelDbStore


### PR DESCRIPTION
BN-1069 Move Bifrist configuration case classes to a separated module, add separate config for network properties

## Purpose
Config case classes in separate module allow passing them to different subsystems without any issues with circular dependencies

## Approach
New module for config files had been created

## Testing
Unit test + integration test

## Tickets
*closes #BN-1069