### PR TITLE
Private StakerInitializer LockAddress.  Genesis Eta Timestamp

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
@@ -10,6 +10,7 @@ import co.topl.models.utility.HasLength.instances.byteStringLength
 import co.topl.models.utility._
 import co.topl.node.models._
 import co.topl.typeclasses.implicits._
+import com.google.common.primitives.Longs
 import com.google.protobuf.ByteString
 import quivr.models.SmallData
 
@@ -55,8 +56,9 @@ object BigBang {
     val eta: Eta =
       Sized.strictUnsafe(
         new Blake2b256().hash(
-          (config.etaPrefix +:
-          transactions.map(_.id.value)).map(v => v: Array[Byte]): _*
+          (config.etaPrefix.toByteArray +:
+          Longs.toByteArray(config.timestamp) +:
+          transactions.map(_.id.value.toByteArray)): _*
         )
       )
 

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/package.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/package.scala
@@ -49,16 +49,17 @@ package object interpreters {
     val spentBoxIds = transaction.inputs.map(_.address)
 
     val transactionId = transaction.id
-    val newBoxes = transaction.outputs.zipWithIndex.flatMap { case (output, index) =>
-      wallet.propositions
-        .get(output.address)
-        .map(lock =>
-          (
-            transactionId.outputAddress(0, 0, index),
-            Box(lock, output.value)
+    val newBoxes =
+      transaction.outputs.zipWithIndex.filter(_._1.value.value.isLvl).flatMap { case (output, index) =>
+        wallet.propositions
+          .get(output.address)
+          .map(lock =>
+            (
+              transactionId.outputAddress(0, 0, index),
+              Box(lock, output.value)
+            )
           )
-        )
-    }
+      }
     wallet.copy(spendableBoxes = wallet.spendableBoxes -- spentBoxIds ++ newBoxes)
   }
 }


### PR DESCRIPTION
## Purpose
- The private testnet Staker UTxOs use Ed25519 Locks which aren't supported at this time
- To simplify, the 
## Approach
- Staker UTxOs use the same HeightLock as the rest of the genesis transactions
- Add genesis timestamp into genesis Eta calculation
## Testing
- preparePR
## Tickets
- Part 1 of #BN-908