### PR TITLE
BN-1101 Send information about block novelty to reputation aggregator

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/LocalChainBroadcaster.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/LocalChainBroadcaster.scala
@@ -27,6 +27,8 @@ object LocalChainBroadcaster {
         val interpreter = new LocalChainAlgebra[F] {
           def isWorseThan(newHead: SlotData): F[Boolean] = localChain.isWorseThan(newHead)
 
+          def couldBeWorse(newHead: SlotData): F[Boolean] = localChain.couldBeWorse(newHead)
+
           /**
            * TODO adoptionsTopic.publish1:
            * This operation does not complete until after the given element has been enqued on all subscribers,

--- a/consensus/src/main/scala/co/topl/consensus/algebras/LocalChainAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/LocalChainAlgebra.scala
@@ -9,6 +9,20 @@ import co.topl.consensus.models.SlotData
 trait LocalChainAlgebra[F[_]] {
 
   /**
+   * Indicates if the provided "newHead" COULD result in a better chain than the current local chain.
+   * isWorseThan function could return false for the same newHead even if couldBeWorse function returns true.
+   * However, if isWorseThan returns false then couldBeWorse always returns false as well.
+   *
+   * The `newHead` _can_ be invalid.  (For example, the block needs to have the proper syntax,
+   * but it may not necessarily need to be validated for consensus and ledger purposes)
+   *
+   * @param newHead The head of a new tine, either from a network peer or from a local staker
+   * @return True if the provided segment could be better than the local canonical chain,
+   *         false otherwise including case if newHead is a a head of current local chain
+   */
+  def couldBeWorse(newHead: SlotData): F[Boolean]
+
+  /**
    * Indicates if the provided "newHead" results in a better chain than the current local chain.
    *
    * The `newHead` _can_ be invalid.  (For example, the block needs to have the proper syntax,

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/LocalChain.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/LocalChain.scala
@@ -28,6 +28,9 @@ object LocalChain {
           implicit private val logger: SelfAwareStructuredLogger[F] =
             Slf4jLogger.getLoggerFromName[F]("Bifrost.LocalChain")
 
+          def couldBeWorse(newHead: SlotData): F[Boolean] =
+            head.map(slotData => slotData.height <= newHead.height && slotData.slotId.blockId != newHead.slotId.blockId)
+
           def isWorseThan(newHead: SlotData): F[Boolean] =
             head.flatMap(chainSelection.compare(_, newHead).map(_ < 0))
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -11,7 +11,6 @@ import co.topl.consensus.algebras.{BlockHeaderToBodyValidationAlgebra, LocalChai
 import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
 import co.topl.eventtree.ParentChildTree
 import co.topl.networking.blockchain.BlockchainPeerClient
-import co.topl.networking.fsnetwork.BlockChecker.BlockCheckerActor
 import co.topl.networking.fsnetwork.PeerActor.Message._
 import co.topl.networking.fsnetwork.PeerBlockBodyFetcher.PeerBlockBodyFetcherActor
 import co.topl.networking.fsnetwork.PeerBlockHeaderFetcher.PeerBlockHeaderFetcherActor
@@ -73,7 +72,6 @@ object PeerActor {
   def makeActor[F[_]: Async: Logger](
     hostId:                 HostId,
     client:                 BlockchainPeerClient[F],
-    blockChecker:           BlockCheckerActor[F],
     requestsProxy:          RequestsProxyActor[F],
     reputationAggregator:   ReputationAggregatorActor[F],
     localChain:             LocalChainAlgebra[F],
@@ -87,7 +85,6 @@ object PeerActor {
       header <- PeerBlockHeaderFetcher.makeActor(
         hostId,
         client,
-        blockChecker,
         requestsProxy,
         localChain,
         slotDataStore,

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockBodyFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockBodyFetcher.scala
@@ -83,11 +83,11 @@ object PeerBlockBodyFetcher {
 
     val body: F[UnverifiedBlockBody] =
       for {
-        _                 <- Logger[F].info(show"Fetching remote body id=$blockId")
+        _                 <- Logger[F].info(show"Fetching remote body id=$blockId from peer ${state.hostId}")
         bodyStart         <- System.currentTimeMillis().pure[F]
         body              <- downloadBlockBody(state, blockId)
         bodyEnd           <- System.currentTimeMillis().pure[F]
-        _                 <- Logger[F].info(show"Fetched remote body id=$blockId")
+        _                 <- Logger[F].info(show"Fetched remote body id=$blockId from peer ${state.hostId}")
         _                 <- checkBody(state, Block(blockHeader, body))
         txAndDownloadTime <- downloadingMissingTransactions(state, body)
         allTxDownloadTime = txAndDownloadTime.collect { case (_, Some(time)) => time }
@@ -142,7 +142,7 @@ object PeerBlockBodyFetcher {
     transactionId: TransactionId
   ): F[(TransactionId, Option[Long])] =
     for {
-      _                     <- Logger[F].debug(show"Fetching remote transaction id=$transactionId")
+      _                     <- Logger[F].debug(show"Fetching transaction id=$transactionId from peer ${state.hostId}")
       transactionStart      <- System.currentTimeMillis().pure[F]
       downloadedTransaction <- downloadTransaction(state, transactionId)
       transactionEnd        <- System.currentTimeMillis().pure[F]
@@ -172,10 +172,10 @@ object PeerBlockBodyFetcher {
       .map(_.embedId)
 
   private def startActor[F[_]: Async: Logger](state: State[F]): F[(State[F], Response[F])] =
-    Logger[F].info(show"Start body fetcher actor for ${state.hostId}") >>
+    Logger[F].info(show"Start body fetcher actor for peer ${state.hostId}") >>
     (state, state).pure[F]
 
   private def stopActor[F[_]: Async: Logger](state: State[F]): F[(State[F], Response[F])] =
-    Logger[F].info(show"Stop body fetcher actor for ${state.hostId}") >>
+    Logger[F].info(show"Stop body fetcher actor for peer ${state.hostId}") >>
     (state, state).pure[F]
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -12,7 +12,6 @@ import co.topl.consensus.algebras.LocalChainAlgebra
 import co.topl.consensus.models.{BlockId, SlotData}
 import co.topl.eventtree.ParentChildTree
 import co.topl.networking.blockchain.BlockchainPeerClient
-import co.topl.networking.fsnetwork.BlockChecker.BlockCheckerActor
 import co.topl.networking.fsnetwork.BlockDownloadError.BlockHeaderDownloadError
 import co.topl.networking.fsnetwork.BlockDownloadError.BlockHeaderDownloadError._
 import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
@@ -43,7 +42,6 @@ object PeerBlockHeaderFetcher {
   case class State[F[_]](
     hostId:        HostId,
     client:        BlockchainPeerClient[F],
-    blockChecker:  BlockCheckerActor[F],
     requestsProxy: RequestsProxyActor[F],
     localChain:    LocalChainAlgebra[F],
     slotDataStore: Store[F, BlockId, SlotData],
@@ -64,13 +62,13 @@ object PeerBlockHeaderFetcher {
   def makeActor[F[_]: Async: Logger](
     hostId:        HostId,
     client:        BlockchainPeerClient[F],
-    blockChecker:  BlockCheckerActor[F],
     requestsProxy: RequestsProxyActor[F],
     localChain:    LocalChainAlgebra[F],
     slotDataStore: Store[F, BlockId, SlotData],
     blockIdTree:   ParentChildTree[F, BlockId]
   ): Resource[F, Actor[F, Message, Response[F]]] = {
-    val initialState = State(hostId, client, blockChecker, requestsProxy, localChain, slotDataStore, blockIdTree, None)
+    val initialState =
+      State(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, None)
     Actor.makeWithFinalize(initialState, getFsm[F], finalizer[F])
   }
 
@@ -80,13 +78,13 @@ object PeerBlockHeaderFetcher {
   private def startActor[F[_]: Async: Logger](state: State[F]): F[(State[F], Response[F])] =
     if (state.fetchingFiber.isEmpty) {
       for {
-        _                 <- Logger[F].info(show"Start block header actor for host ${state.hostId}")
+        _                 <- Logger[F].info(show"Start block header actor for peer ${state.hostId}")
         newBlockIdsStream <- state.client.remotePeerAdoptions
         fiber             <- Spawn[F].start(slotDataFetcher(state, newBlockIdsStream).compile.drain)
         newState = state.copy(fetchingFiber = Option(fiber))
       } yield (newState, newState)
     } else {
-      Logger[F].info(show"Ignore starting block header actor for host ${state.hostId}") >>
+      Logger[F].info(show"Ignore starting block header actor for peer ${state.hostId}") >>
       (state, state).pure[F]
     }
 
@@ -94,38 +92,93 @@ object PeerBlockHeaderFetcher {
     state:             State[F],
     newBlockIdsStream: Stream[F, BlockId]
   ): Stream[F, Unit] =
-    newBlockIdsStream.evalMap { blockId =>
-      {
-        for {
-          _          <- OptionT.liftF(Logger[F].info(show"Got slot for $blockId from remote host ${state.hostId}"))
-          newBlockId <- isUnknownBlockOpt(state, blockId)
-          _          <- buildAndAdoptSlotDataForBlockId(state, newBlockId)
-        } yield ()
-      }.value.void.handleErrorWith(Logger[F].error(_)("Fetching slot data from remote host return error"))
+    // TODO close connection to remote peer in case of error
+    newBlockIdsStream.evalMap { newBlockId =>
+      getRemoteSlotDataByBlockId(state, newBlockId)
+        .handleErrorWith(Logger[F].error(_)("Fetching slot data from remote host return error"))
     }
 
-  private def buildAndAdoptSlotDataForBlockId[F[_]: Async: Logger](
-    state:      State[F],
-    newBlockId: BlockId
-  ): OptionT[F, Unit] =
+  private def getRemoteSlotDataByBlockId[F[_]: Async: Logger](state: State[F], blockId: BlockId): F[Unit] =
     for {
-      slotDataChain  <- buildSlotDataChain(state.slotDataStore, state.client, newBlockId)
-      _              <- OptionT.liftF(Logger[F].info(show"Retrieved remote tine length=${slotDataChain.length}"))
-      savedSlotData  <- OptionT.liftF(saveSlotDataChain(state, slotDataChain))
-      betterSlotData <- compareWithLocalChain(savedSlotData, state)
-      _              <- OptionT.liftF(sendProposalToBlockChecker(state, betterSlotData))
+      _                 <- Logger[F].info(show"Got blockId: $blockId from remote peer ${state.hostId}")
+      newSlotDataOpt    <- getNewSlotDataChain(state, blockId).value
+      _                 <- Logger[F].info(show"Build slot data chain from tip $blockId is ${newSlotDataOpt.isDefined}")
+      newBlockSourceOpt <- buildBlockSource(state, blockId, newSlotDataOpt)
+      _                 <- sendMessagesToProxy(state, newSlotDataOpt, newBlockSourceOpt)
     } yield ()
 
-  private def isUnknownBlockOpt[F[_]: Async: Logger](state: State[F], blockId: BlockId): OptionT[F, BlockId] =
-    OptionT(
-      state.slotDataStore
-        .contains(blockId)
-        .flatTap {
-          case true  => Logger[F].info(show"Ignoring already-known slot data for block id=$blockId")
-          case false => Logger[F].info(show"Received unknown slot data for block id=$blockId")
-        }
-        .map(Option.unless(_)(blockId))
-    )
+  private def getNewSlotDataChain[F[_]: Async: Logger](
+    state:   State[F],
+    blockId: BlockId
+  ): OptionT[F, NonEmptyChain[SlotData]] =
+    for {
+      newSlotData            <- OptionT.liftF(getSlotDataFromStorageOrRemote(state)(blockId))
+      possibleBetterSlotData <- slotDataCouldBeBetter(state, newSlotData)
+      savedSlotData          <- downloadAndSaveSlotDataChain(state, possibleBetterSlotData)
+      betterSlotData         <- compareSlotDataWithLocal(savedSlotData, state)
+    } yield betterSlotData
+
+  private def buildBlockSource[F[_]: Async: Logger](
+    state:          State[F],
+    blockId:        BlockId,
+    newSlotDataOpt: Option[NonEmptyChain[SlotData]]
+  ): F[Option[NonEmptyChain[(HostId, BlockId)]]] =
+    OptionT
+      .fromOption[F](newSlotDataOpt)
+      .map(newSlotData => newSlotData.map(sd => (state.hostId, sd.slotId.blockId)))
+      .orElseF {
+        sourceOfAlreadyAdoptedBlockIsUseful(state, blockId).ifM(
+          ifTrue = Option(NonEmptyChain.one(state.hostId -> blockId)).pure[F],
+          ifFalse = Option.empty[NonEmptyChain[(HostId, BlockId)]].pure[F]
+        )
+      }
+      .value
+
+  private def slotDataCouldBeBetter[F[_]: Async: Logger](state: State[F], newSlotData: SlotData): OptionT[F, SlotData] =
+    OptionT
+      .liftF(state.localChain.couldBeWorse(newSlotData).flatTap {
+        case true =>
+          Logger[F]
+            .debug(show"Received tip ${newSlotData.slotId} from peer ${state.hostId}could be better than current block")
+        case false =>
+          Logger[F]
+            .info(show"Ignoring weaker (or equal) block tip id=${newSlotData.slotId} from peer ${state.hostId}")
+      })
+      .flatMap(OptionT.when(_)(newSlotData))
+
+  private def sendMessagesToProxy[F[_]: Async](
+    state:          State[F],
+    newSlotDataOpt: Option[NonEmptyChain[SlotData]],
+    newSourcesOpt:  Option[NonEmptyChain[(HostId, BlockId)]]
+  ): F[Unit] = {
+    val newSourcesF =
+      newSourcesOpt
+        .map(sources => state.requestsProxy.sendNoWait(RequestsProxy.Message.BlocksSource(sources)))
+        .getOrElse(().pure[F])
+
+    val newSlotDataF =
+      newSlotDataOpt
+        .map(newSlotData =>
+          state.requestsProxy.sendNoWait(RequestsProxy.Message.RemoteSlotData(state.hostId, newSlotData))
+        )
+        .getOrElse(().pure[F])
+
+    newSourcesF >> newSlotDataF
+  }
+
+  // we still interesting in source if we receive current best block
+  private def sourceOfAlreadyAdoptedBlockIsUseful[F[_]: Async](state: State[F], blockId: BlockId): F[Boolean] =
+    state.localChain.head.map(_.slotId.blockId == blockId)
+
+  private def downloadAndSaveSlotDataChain[F[_]: Async: Logger](
+    state: State[F],
+    from:  SlotData
+  ): OptionT[F, NonEmptyChain[SlotData]] =
+    for {
+      slotDataChain <- buildSlotDataChain(state, from)
+      _             <- OptionT.liftF(Logger[F].info(show"Going to save remote tine length=${slotDataChain.length}"))
+      savedSlotData <- OptionT.liftF(saveSlotDataChain(state, slotDataChain))
+    } yield savedSlotData
 
   private def saveSlotDataChain[F[_]: Async: Logger](
     state: State[F],
@@ -144,26 +197,31 @@ object PeerBlockHeaderFetcher {
     tine.traverse(adoptSlotData) >> tine.pure[F]
   }
 
+  private def getSlotDataFromStorageOrRemote[F[_]: Async: Logger](state: State[F])(blockId: BlockId): F[SlotData] =
+    state.slotDataStore.get(blockId).flatMap {
+      case Some(sd) => sd.pure[F]
+      case None =>
+        Logger[F].info(show"Fetching remote SlotData id=$blockId from peer ${state.hostId}") >>
+        state.client.getSlotDataOrError(blockId, new NoSuchElementException(blockId.toString))
+    }
+
   // return: recent (current) block is the last
   private def buildSlotDataChain[F[_]: Async: Logger](
-    store:  Store[F, BlockId, SlotData],
-    client: BlockchainPeerClient[F],
-    from:   BlockId
+    state: State[F],
+    from:  SlotData
   ): OptionT[F, NonEmptyChain[SlotData]] = {
-    val getSlotData: BlockId => F[SlotData] =
-      id =>
-        store.get(id).flatMap {
-          case Some(sd) => sd.pure[F]
-          case None =>
-            Logger[F].info(show"Fetching remote SlotData id=$id") >>
-            client.getSlotDataOrError(id, new NoSuchElementException(id.toString))
-        }
+    val getSlotData: BlockId => F[SlotData] = id =>
+      if (id == from.slotId.blockId) {
+        from.pure[F]
+      } else {
+        getSlotDataFromStorageOrRemote(state)(id)
+      }
 
     val tine = getFromChainUntil(
       (s: SlotData) => s.pure[F],
       getSlotData,
-      (sd: SlotData) => store.contains(sd.slotId.blockId)
-    )(from)
+      (sd: SlotData) => state.slotDataStore.contains(sd.slotId.blockId)
+    )(from.slotId.blockId)
       .handleErrorWith { error =>
         Logger[F].error(show"Failed to get remote slot data due to ${error.getLocalizedMessage}") >>
         List.empty[SlotData].pure[F] // TODO send information about error to reputation handler
@@ -172,33 +230,33 @@ object PeerBlockHeaderFetcher {
     OptionT(tine.map(NonEmptyChain.fromSeq(_)))
   }
 
-  private def compareWithLocalChain[F[_]: Async: Logger](
-    blockIds: NonEmptyChain[SlotData],
+  private def compareSlotDataWithLocal[F[_]: Async: Logger](
+    slotData: NonEmptyChain[SlotData],
     state:    State[F]
   ): OptionT[F, NonEmptyChain[SlotData]] = {
-    val bestBlockInChain = blockIds.last
+    val bestSlotData = slotData.last
+    val bestBlockId = bestSlotData.slotId.blockId
     OptionT(
       state.localChain
-        .isWorseThan(bestBlockInChain)
-        .flatTap {
-          case true  => Logger[F].debug(show"Received tip ${bestBlockInChain.slotId} is better than current block")
-          case false => Logger[F].info(show"Ignoring weaker (or equal) block tip id=${bestBlockInChain.slotId}")
+        .isWorseThan(bestSlotData)
+        .flatMap {
+          case true =>
+            Logger[F].debug(show"Received tip $bestBlockId is better than current block") >>
+            Option(slotData).pure[F]
+          case false =>
+            Logger[F].info(show"Ignoring tip because of density rule which id=$bestBlockId") >>
+            state.requestsProxy.sendNoWait(RequestsProxy.Message.BadKLoopbackSlotData(state.hostId)) >>
+            Option.empty[NonEmptyChain[SlotData]].pure[F]
         }
-        .map(Option.when(_)(blockIds))
     )
-  }
-
-  private def sendProposalToBlockChecker[F[_]](state: State[F], slotData: NonEmptyChain[SlotData]) = {
-    val message = BlockChecker.Message.RemoteSlotData(state.hostId, slotData)
-    state.blockChecker.sendNoWait(message)
   }
 
   private def getCurrentTip[F[_]: Async: Logger](state: State[F]): F[(State[F], Response[F])] = {
     for {
-      _   <- OptionT.liftF(Logger[F].info(show"Requested current tip from host ${state.hostId}"))
+      _   <- OptionT.liftF(Logger[F].info(show"Requested current tip from peer ${state.hostId}"))
       tip <- OptionT(state.client.remoteCurrentTip())
-      _   <- buildAndAdoptSlotDataForBlockId(state, tip)
-      _   <- OptionT.liftF(Logger[F].info(show"Send tip $tip from host ${state.hostId}"))
+      _   <- OptionT.liftF(getRemoteSlotDataByBlockId(state, tip))
+      _   <- OptionT.liftF(Logger[F].info(show"Received current tip $tip from peer ${state.hostId}"))
     } yield (state, state)
   }.getOrElse((state, state))
     .handleErrorWith(Logger[F].error(_)("Get tip from remote host return error") >> (state, state).pure[F])
@@ -230,12 +288,12 @@ object PeerBlockHeaderFetcher {
   ): F[(BlockId, Either[BlockHeaderDownloadError, UnverifiedBlockHeader])] = {
     val headerEither =
       for {
-        _               <- Logger[F].info(show"Fetching remote header id=$blockId")
+        _               <- Logger[F].info(show"Fetching remote header id=$blockId from peer $hostId")
         startHeaderTime <- System.currentTimeMillis().pure[F]
         headerWithNoId  <- client.getHeaderOrError(blockId, HeaderNotFoundInPeer)
         endHeaderTime   <- System.currentTimeMillis().pure[F]
         header          <- headerWithNoId.embedId.pure[F]
-        _               <- Logger[F].info(show"Fetched remote header id=$blockId")
+        _               <- Logger[F].info(show"Fetched remote header id=$blockId  from peer $hostId")
         _               <- MonadThrow[F].raiseWhen(header.id =!= blockId)(HeaderHaveIncorrectId(blockId, header.id))
       } yield UnverifiedBlockHeader(hostId, header, endHeaderTime - startHeaderTime)
 
@@ -266,12 +324,12 @@ object PeerBlockHeaderFetcher {
     state.fetchingFiber
       .map { fiber =>
         val newState = state.copy(fetchingFiber = None)
-        Logger[F].info(show"Stop block header fetcher fiber for host ${state.hostId}") >>
+        Logger[F].info(show"Stop block header fetcher fiber for peer ${state.hostId}") >>
         fiber.cancel >>
         (newState, newState).pure[F]
       }
       .getOrElse {
-        Logger[F].info(show"Ignoring stopping block header fetcher fiber for host ${state.hostId}") >>
+        Logger[F].info(show"Ignoring stopping block header fetcher fiber for peer ${state.hostId}") >>
         (state, state).pure[F]
       }
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
@@ -108,7 +108,7 @@ object PeersManager {
   case class State[F[_]](
     networkAlgebra:         NetworkAlgebra[F],
     reputationAggregator:   Option[ReputationAggregatorActor[F]],
-    blocksChecker:          Option[BlockCheckerActor[F]],
+    blocksChecker:          Option[BlockCheckerActor[F]], // TODO remove it
     requestsProxy:          Option[RequestsProxyActor[F]],
     peers:                  Map[HostId, Peer[F]],
     localChain:             LocalChainAlgebra[F],
@@ -172,14 +172,12 @@ object PeersManager {
 
     require(state.blocksChecker.isDefined)
     require(state.reputationAggregator.isDefined)
-    require(state.blocksChecker.isDefined)
 
     val peerActorF: F[PeerActor[F]] =
       thisActor.acquireActor(() =>
         PeerActor.makeActor(
           hostId,
           client,
-          state.blocksChecker.get,
           state.requestsProxy.get,
           state.reputationAggregator.get,
           state.localChain,

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
@@ -1,5 +1,6 @@
 package co.topl.networking.fsnetwork
 
+import cats.data.NonEmptyChain
 import cats.effect.{Async, Resource}
 import cats.implicits._
 import co.topl.actor.{Actor, Fsm}
@@ -28,18 +29,22 @@ object ReputationAggregator {
     case class DownloadTimeHeader(hostId: HostId, delay: Long) extends Message
     case class DownloadTimeBody(hostId: HostId, bodyDelay: Long, txDelays: Seq[Long]) extends Message
     case class HostProvideIncorrectBlock(hostId: HostId) extends Message
+
+    case class HostsNoveltyProviding(data: NonEmptyChain[(HostId, Long)]) extends Message
+    case class BadKLoopbackSlotData(hostId: HostId) extends Message
   }
 
   type ReputationAggregatorActor[F[_]] = Actor[F, Message, Response[F]]
 
   def getFsm[F[_]: Async: Logger]: Fsm[F, State[F], Message, Response[F]] =
     Fsm {
-      case (state, RemoveReputationForHost(hostId))   => removeReputationForHost(state, hostId)
-      case (state, HostProvideIncorrectBlock(hostId)) => incorrectBlockReceived(state, hostId)
-
+      case (state, RemoveReputationForHost(hostId))           => removeReputationForHost(state, hostId)
+      case (state, HostProvideIncorrectBlock(hostId))         => incorrectBlockReceived(state, hostId)
       case (state, PingPongMessagePing(hostId, pongResponse)) => pongMessageProcessing(state, hostId, pongResponse)
       case (state, DownloadTimeHeader(hostId, delay))         => headerDownloadTime(state, hostId, delay)
       case (state, DownloadTimeBody(hostId, delay, txDelays)) => blockDownloadTime(state, hostId, delay, txDelays)
+      case (state, HostsNoveltyProviding(data))               => hostNoveltyProviding(state, data)
+      case (state, BadKLoopbackSlotData(hostId))              => badKLoopbackSlotData(state, hostId)
     }
 
   def makeActor[F[_]: Async: Logger](
@@ -142,6 +147,15 @@ object ReputationAggregator {
     Logger[F].debug(show"Received block download from host $hostId with max delay $delay") >>
     (newState, newState).pure[F]
   }
+
+  private def hostNoveltyProviding[F[_]: Async](
+    state: State[F],
+    data:  NonEmptyChain[(HostId, Long)]
+  ): F[(State[F], Response[F])] =
+    (state, state).pure[F]
+
+  private def badKLoopbackSlotData[F[_]: Async](state: State[F], hostId: HostId): F[(State[F], Response[F])] =
+    (state, state).pure[F]
 
   def delayToReputation(delayInMs: Long): Double = {
     val zeroReputationDelay = 2000.0

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
@@ -31,7 +31,7 @@ object ReputationAggregator {
     case class HostProvideIncorrectBlock(hostId: HostId) extends Message
 
     case class HostsNoveltyProviding(data: NonEmptyChain[(HostId, Long)]) extends Message
-    case class BadKLoopbackSlotData(hostId: HostId) extends Message
+    case class BadKLookbackSlotData(hostId: HostId) extends Message
   }
 
   type ReputationAggregatorActor[F[_]] = Actor[F, Message, Response[F]]
@@ -44,7 +44,7 @@ object ReputationAggregator {
       case (state, DownloadTimeHeader(hostId, delay))         => headerDownloadTime(state, hostId, delay)
       case (state, DownloadTimeBody(hostId, delay, txDelays)) => blockDownloadTime(state, hostId, delay, txDelays)
       case (state, HostsNoveltyProviding(data))               => hostNoveltyProviding(state, data)
-      case (state, BadKLoopbackSlotData(hostId))              => badKLoopbackSlotData(state, hostId)
+      case (state, BadKLookbackSlotData(hostId))              => badKLoopbackSlotData(state, hostId)
     }
 
   def makeActor[F[_]: Async: Logger](

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
@@ -139,7 +139,7 @@ object RequestsProxy {
     source: HostId
   ): F[(State[F], Response[F])] =
     Logger[F].warn(show"Received declined remote slot data chain because of low density") >>
-    state.reputationAggregator.sendNoWait(ReputationAggregator.Message.BadKLoopbackSlotData(source)) >>
+    state.reputationAggregator.sendNoWait(ReputationAggregator.Message.BadKLookbackSlotData(source)) >>
     (state, state).pure[F]
 
   private def blocksSourceProcessing[F[_]: Async](

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -26,6 +26,8 @@ package object fsnetwork {
 
   val requestCacheSize = 100
 
+  val blockSourceCacheSize = 512
+
   implicit class CacheOps[K, V](cache: Cache[K, V]) {
     def contains(key: K): Boolean = cache.getIfPresent(key) != null
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
@@ -11,7 +11,6 @@ import co.topl.consensus.algebras.{BlockHeaderToBodyValidationAlgebra, LocalChai
 import co.topl.consensus.models.{BlockId, SlotData}
 import co.topl.eventtree.ParentChildTree
 import co.topl.networking.blockchain.BlockchainPeerClient
-import co.topl.networking.fsnetwork.BlockChecker.BlockCheckerActor
 import co.topl.networking.fsnetwork.PeerActorTest.F
 import co.topl.networking.fsnetwork.ReputationAggregator.Message.PingPongMessagePing
 import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
@@ -35,7 +34,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
   test("Ping shall be started for warm hosts and sent result to reputation aggregator") {
     withMock {
-      val blockChecker = mock[BlockCheckerActor[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
@@ -64,7 +62,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
         .makeActor(
           hostId,
           client,
-          blockChecker,
           requestsProxy,
           reputationAggregation,
           localChain,

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
@@ -12,7 +12,6 @@ import co.topl.eventtree.ParentChildTree
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.networking.blockchain.BlockchainPeerClient
-import co.topl.networking.fsnetwork.BlockChecker.BlockCheckerActor
 import co.topl.networking.fsnetwork.BlockDownloadError.BlockHeaderDownloadError
 import co.topl.networking.fsnetwork.BlockDownloadError.BlockHeaderDownloadError._
 import co.topl.networking.fsnetwork.PeerBlockHeaderFetcherTest.{BlockHeaderDownloadErrorByName, F}
@@ -78,8 +77,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           OptionT(idToHeader.get(id).pure[F]).getOrRaise(e.apply())
         }
 
-      val blockChecker = mock[BlockCheckerActor[F]]
-
       val requestsProxy = mock[RequestsProxyActor[F]]
       val expectedMessage: RequestsProxy.Message =
         RequestsProxy.Message.DownloadHeadersResponse(
@@ -98,7 +95,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
 
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, blockChecker, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
         .use { actor =>
           for {
             _ <- actor.sendNoWait(PeerBlockHeaderFetcher.Message.DownloadBlockHeaders(idAndHeader.map(_._1)))
@@ -118,8 +115,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
         .expects(header.id, *, *)
         .once
         .returns(Async[F].delayBy(header.pure[F], FiniteDuration(pingDelay, MILLISECONDS)))
-
-      val blockChecker = mock[BlockCheckerActor[F]]
 
       val requestsProxy = mock[RequestsProxyActor[F]]
 
@@ -144,7 +139,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
 
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, blockChecker, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
         .use { actor =>
           for {
             _ <- actor.sendNoWait(PeerBlockHeaderFetcher.Message.DownloadBlockHeaders(NonEmptyChain.one(header.id)))
@@ -172,8 +167,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           OptionT(idToHeaderOnClient.get(id).pure[F]).getOrRaise(e.apply())
         }
 
-      val blockChecker = mock[BlockCheckerActor[F]]
-
       val requestsProxy = mock[RequestsProxyActor[F]]
       val expectedMessage: RequestsProxy.Message =
         RequestsProxy.Message.DownloadHeadersResponse(
@@ -198,7 +191,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
 
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, blockChecker, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
         .use { actor =>
           for {
             _ <- actor.sendNoWait(PeerBlockHeaderFetcher.Message.DownloadBlockHeaders(idAndHeader.map(_._1)))
@@ -232,8 +225,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           }
         }
 
-      val blockChecker = mock[BlockCheckerActor[F]]
-
       val requestsProxy = mock[RequestsProxyActor[F]]
       val expectedMessage: RequestsProxy.Message =
         RequestsProxy.Message.DownloadHeadersResponse(
@@ -258,7 +249,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
 
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, blockChecker, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
         .use { actor =>
           for {
             _ <- actor.sendNoWait(PeerBlockHeaderFetcher.Message.DownloadBlockHeaders(idAndHeader.map(_._1)))
@@ -267,7 +258,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
     }
   }
 
-  test("New better slot data shall be sent if local chain is worse") {
+  test("New better slot data and block source shall be sent if local chain is worse") {
     withMock {
       val slotData: NonEmptyChain[SlotData] =
         arbitraryLinkedSlotDataChainFor(Gen.choose(2, maxChainSize)).arbitrary.first
@@ -283,7 +274,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       (client
         .getSlotDataOrError(_: BlockId, _: Throwable)(_: MonadThrow[F]))
         .expects(*, *, *)
-        .rep(remoteSlotDataCount)
+        .anyNumberOfTimes()
         .onCall { case (id: BlockId, e: BlockHeaderDownloadErrorByName @unchecked, _: MonadThrow[F] @unchecked) =>
           OptionT(remoteIdToSlotData.get(id).pure[F]).getOrRaise(e.apply())
         }
@@ -291,21 +282,24 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
         Stream.eval[F, BlockId](bestSlotId.pure[F]).pure[F]
       }
 
-      val blockChecker = mock[BlockCheckerActor[F]]
-      val expectedMessage: BlockChecker.Message = BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData.map(_._2))
-      (blockChecker.sendNoWait _).expects(expectedMessage).once().returning(().pure[F])
-
       val requestsProxy = mock[RequestsProxyActor[F]]
+      val expectedSourceMessage: RequestsProxy.Message =
+        RequestsProxy.Message.BlocksSource(remoteSlotData.map(d => (hostId, d._1)))
+      (requestsProxy.sendNoWait _).expects(expectedSourceMessage).once().returning(().pure[F])
+      val expectedSlotDataMessage: RequestsProxy.Message =
+        RequestsProxy.Message.RemoteSlotData(hostId, remoteSlotData.map(_._2))
+      (requestsProxy.sendNoWait _).expects(expectedSlotDataMessage).once().returning(().pure[F])
 
       val localChain = mock[LocalChainAlgebra[F]]
+      (localChain.couldBeWorse _).expects(bestSlotData).once().returns(true.pure[F])
       (localChain.isWorseThan _).expects(bestSlotData).once().returning(true.pure[F])
 
       val slotDataStoreMap = mutable.Map.empty[BlockId, SlotData]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      (slotDataStore.get _).expects(*).rep(remoteSlotDataCount + 1).onCall { id: BlockId =>
+      (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         { if (id === knownId) Option(knownSlotData) else None }.pure[F]
       }
-      (slotDataStore.contains _).expects(*).rep(remoteSlotDataCount + 2).onCall { id: BlockId =>
+      (slotDataStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         (!remoteIdToSlotData.contains(id)).pure[F]
       }
       (slotDataStore.put _).expects(*, *).rep(remoteSlotDataCount).onCall { case (id: BlockId, slotData: SlotData) =>
@@ -316,7 +310,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       (blockIdTree.associate _).expects(*, *).rep(remoteSlotDataCount).returning(().pure[F])
 
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, blockChecker, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
         .use { actor =>
           for {
             state <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)
@@ -326,7 +320,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
     }
   }
 
-  test("New better slot data shall not be sent if local chain is better") {
+  test("New better slot data shall not be sent if local chain is better and block source is not interesting") {
     withMock {
       val slotData: NonEmptyChain[SlotData] =
         arbitraryLinkedSlotDataChainFor(Gen.choose(2, maxChainSize)).arbitrary.first
@@ -336,13 +330,12 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val (bestSlotId, bestSlotData) = remoteSlotData.last
       val remoteIdToSlotData: Map[BlockId, SlotData] = remoteSlotData.toList.toMap
-      val remoteSlotDataCount = remoteIdToSlotData.size
 
       val client = mock[BlockchainPeerClient[F]]
       (client
         .getSlotDataOrError(_: BlockId, _: Throwable)(_: MonadThrow[F]))
         .expects(*, *, *)
-        .rep(remoteSlotDataCount)
+        .anyNumberOfTimes()
         .onCall { case (id: BlockId, e: BlockHeaderDownloadErrorByName @unchecked, _: MonadThrow[F] @unchecked) =>
           OptionT(remoteIdToSlotData.get(id).pure[F]).getOrRaise(e.apply())
         }
@@ -350,34 +343,29 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
         Stream.eval[F, BlockId](bestSlotId.pure[F]).pure[F]
       }
 
-      val blockChecker = mock[BlockCheckerActor[F]]
-      val expectedMessage: BlockChecker.Message = BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData.map(_._2))
-      (blockChecker.sendNoWait _).expects(expectedMessage).never()
-
       val requestsProxy = mock[RequestsProxyActor[F]]
+      val expectedMessage: RequestsProxy.Message =
+        RequestsProxy.Message.RemoteSlotData(hostId, remoteSlotData.map(_._2))
+      (requestsProxy.sendNoWait _).expects(expectedMessage).never()
 
       val localChain = mock[LocalChainAlgebra[F]]
-      (localChain.isWorseThan _).expects(bestSlotData).once().returning(false.pure[F])
+      (localChain.couldBeWorse _).expects(bestSlotData).once().returning(false.pure[F])
+      (localChain.head _).expects().once().returning(knownSlotData.pure[F])
 
-      val slotDataStoreMap = mutable.Map.empty[BlockId, SlotData]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      (slotDataStore.get _).expects(*).rep(remoteSlotDataCount + 1).onCall { id: BlockId =>
+      (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         {
           if (id === knownId) Option(knownSlotData) else None
         }.pure[F]
       }
-      (slotDataStore.contains _).expects(*).rep(remoteSlotDataCount + 2).onCall { id: BlockId =>
+      (slotDataStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         (!remoteIdToSlotData.contains(id)).pure[F]
-      }
-      (slotDataStore.put _).expects(*, *).rep(remoteSlotDataCount).onCall { case (id: BlockId, slotData: SlotData) =>
-        slotDataStoreMap.put(id, slotData).pure[F].void
       }
 
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).rep(remoteSlotDataCount).returning(().pure[F])
 
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, blockChecker, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
         .use { actor =>
           for {
             state <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)
@@ -388,7 +376,63 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
     }
   }
 
-  test("Requested tip shall be sent if local chain is better") {
+  test("Sent only block source if local chain is better and block source is interesting") {
+    withMock {
+      val slotData: NonEmptyChain[SlotData] =
+        arbitraryLinkedSlotDataChainFor(Gen.choose(2, maxChainSize)).arbitrary.first
+      val idAndSlotData: NonEmptyChain[(BlockId, SlotData)] = slotData.map(s => (s.slotId.blockId, s))
+      val (knownId, knownSlotData) = idAndSlotData.head
+      val remoteSlotData = NonEmptyChain.fromChain(idAndSlotData.tail).get
+
+      val (bestSlotId, bestSlotData) = remoteSlotData.last
+      val remoteIdToSlotData: Map[BlockId, SlotData] = remoteSlotData.toList.toMap
+
+      val client = mock[BlockchainPeerClient[F]]
+      (client
+        .getSlotDataOrError(_: BlockId, _: Throwable)(_: MonadThrow[F]))
+        .expects(*, *, *)
+        .anyNumberOfTimes()
+        .onCall { case (id: BlockId, e: BlockHeaderDownloadErrorByName @unchecked, _: MonadThrow[F] @unchecked) =>
+          OptionT(remoteIdToSlotData.get(id).pure[F]).getOrRaise(e.apply())
+        }
+      (() => client.remotePeerAdoptions).expects().once().onCall { () =>
+        Stream.eval[F, BlockId](bestSlotId.pure[F]).pure[F]
+      }
+
+      val requestsProxy = mock[RequestsProxyActor[F]]
+      val expectedMessage: RequestsProxy.Message =
+        RequestsProxy.Message.BlocksSource(NonEmptyChain.one((hostId, bestSlotData.slotId.blockId)))
+      (requestsProxy.sendNoWait _).expects(expectedMessage).never()
+
+      val localChain = mock[LocalChainAlgebra[F]]
+      (localChain.couldBeWorse _).expects(bestSlotData).once().returning(false.pure[F])
+      (localChain.head _).expects().once().returning(knownSlotData.pure[F])
+
+      val slotDataStore = mock[Store[F, BlockId, SlotData]]
+      (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+        {
+          if (id === knownId) Option(knownSlotData) else None
+        }.pure[F]
+      }
+      (slotDataStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
+        (!remoteIdToSlotData.contains(id)).pure[F]
+      }
+
+      val blockIdTree = mock[ParentChildTree[F, BlockId]]
+
+      PeerBlockHeaderFetcher
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .use { actor =>
+          for {
+            state <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)
+            _     <- state.fetchingFiber.get.join
+          } yield ()
+        }
+
+    }
+  }
+
+  test("Requested tip shall be sent if local chain is worse") {
     withMock {
       val slotData: NonEmptyChain[SlotData] =
         arbitraryLinkedSlotDataChainFor(Gen.choose(2, maxChainSize)).arbitrary.first
@@ -415,19 +459,22 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           OptionT(remoteIdToSlotData.get(id).pure[F]).getOrRaise(e.apply())
         }
 
-      val blockChecker = mock[BlockCheckerActor[F]]
-      val expectedMessage: BlockChecker.Message = BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData.map(_._2))
-      (blockChecker.sendNoWait _).expects(expectedMessage).returns(().pure[F])
-
       val requestsProxy = mock[RequestsProxyActor[F]]
+      val expectedSourceMessage: RequestsProxy.Message =
+        RequestsProxy.Message.BlocksSource(remoteSlotData.map(d => (hostId, d._1)))
+      (requestsProxy.sendNoWait _).expects(expectedSourceMessage).once().returning(().pure[F])
+      val expectedSlotDataMessage: RequestsProxy.Message =
+        RequestsProxy.Message.RemoteSlotData(hostId, remoteSlotData.map(_._2))
+      (requestsProxy.sendNoWait _).expects(expectedSlotDataMessage).once().returning(().pure[F])
 
       val localChain = mock[LocalChainAlgebra[F]]
+      (localChain.couldBeWorse _).expects(bestTip).once().returns(true.pure[F])
       (localChain.isWorseThan _).expects(bestTip).once().returning(true.pure[F])
 
       val slotDataStoreMap = mutable.Map.empty[BlockId, SlotData]
       slotDataStoreMap.put(knownId, knownSlotData)
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      (slotDataStore.get _).expects(*).rep(idAndSlotData.size.toInt).onCall { id: BlockId =>
+      (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         slotDataStoreMap.get(id).pure[F]
       }
       (slotDataStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
@@ -441,7 +488,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
 
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, blockChecker, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
         .use { actor =>
           for {
             _     <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)
@@ -452,7 +499,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
     }
   }
 
-  test("Requested tip shall not be sent if local chain is worse") {
+  test("Requested tip shall not be sent if local chain is better") {
     withMock {
       val slotData: NonEmptyChain[SlotData] =
         arbitraryLinkedSlotDataChainFor(Gen.choose(2, maxChainSize)).arbitrary.first
@@ -479,33 +526,29 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           OptionT(remoteIdToSlotData.get(id).pure[F]).getOrRaise(e.apply())
         }
 
-      val blockChecker = mock[BlockCheckerActor[F]]
-      val expectedMessage: BlockChecker.Message = BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData.map(_._2))
-      (blockChecker.sendNoWait _).expects(expectedMessage).never()
-
       val requestsProxy = mock[RequestsProxyActor[F]]
+      val expectedMessage: RequestsProxy.Message =
+        RequestsProxy.Message.RemoteSlotData(hostId, remoteSlotData.map(_._2))
+      (requestsProxy.sendNoWait _).expects(expectedMessage).never()
 
       val localChain = mock[LocalChainAlgebra[F]]
-      (localChain.isWorseThan _).expects(bestTip).once().returning(false.pure[F])
+      (localChain.couldBeWorse _).expects(bestTip).once().returning(false.pure[F])
+      (localChain.head _).expects().once().returning(knownSlotData.pure[F])
 
       val slotDataStoreMap = mutable.Map.empty[BlockId, SlotData]
       slotDataStoreMap.put(knownId, knownSlotData)
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
-      (slotDataStore.get _).expects(*).rep(idAndSlotData.size.toInt).onCall { id: BlockId =>
+      (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         slotDataStoreMap.get(id).pure[F]
       }
       (slotDataStore.contains _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         slotDataStoreMap.contains(id).pure[F]
       }
-      (slotDataStore.put _).expects(*, *).anyNumberOfTimes().onCall { case (id: BlockId, slotData: SlotData) =>
-        slotDataStoreMap.put(id, slotData).pure[F].void
-      }
 
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
 
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, blockChecker, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
         .use { actor =>
           for {
             _     <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
@@ -437,7 +437,7 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
 
       (reputationAggregator.sendNoWait _)
-        .expects(ReputationAggregator.Message.BadKLoopbackSlotData(hostId))
+        .expects(ReputationAggregator.Message.BadKLookbackSlotData(hostId))
         .returns(().pure[F])
 
       RequestsProxy

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/TestHelper.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/TestHelper.scala
@@ -9,6 +9,7 @@ import co.topl.codecs.bytes.tetra.instances._
 import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.models.generators.consensus.ModelGenerators
+import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.node.models.BlockBody
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalamock.handlers.{CallHandler1, CallHandler2, CallHandler3}
@@ -44,6 +45,13 @@ object TestHelper extends TransactionGenerator {
     }
 
   val arbitraryHost: Arbitrary[HostId] = Arbitrary(Arbitrary.arbitrary[String])
+
+  val arbitraryHostBlockId: Arbitrary[(HostId, BlockId)] = Arbitrary(
+    for {
+      host    <- arbitraryHost.arbitrary
+      blockId <- arbitraryBlockId.arbitrary
+    } yield (host, blockId)
+  )
 
   def arbitraryLinkedBlockHeaderChain(sizeGen: Gen[Long]): Arbitrary[NonEmptyChain[BlockHeader]] =
     Arbitrary(


### PR DESCRIPTION
Send information about block novelty to the reputation aggregator
Slot data is no longer requested and saved if remote slot data can't be new best tip after the sanity check

## Purpose
For novelty reputation information about newly received remote slot data shall be sent to the reputation aggregator

## Approach
No longer decline any already known slot data, accept it and send information about it if block source could be useful for us

## Testing
Unit test + Multinode integration test

## Tickets
closes #BN-1101