### PR TITLE
BN-1070 Calculation of Block providing reputation

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -107,7 +107,8 @@ object Blockchain {
             dataStores.bodies,
             dataStores.transactions,
             blockIdTree,
-            networkProperties
+            networkProperties,
+            clock
           )
         }
       clientHandler <- Resource.pure[F, BlockchainPeerHandlerAlgebra[F]](

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -6,7 +6,7 @@ import co.topl.numerics.implicits.Ops
 import co.topl.proto.node.NodeConfig
 import monocle.macros.Lenses
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{FiniteDuration, SECONDS}
 
 // $COVERAGE-OFF$
 @Lenses
@@ -49,7 +49,16 @@ object ApplicationConfig {
       networkProperties: NetworkProperties
     )
 
-    case class NetworkProperties(legacyNetwork: Boolean, pingPongInterval: FiniteDuration)
+    case class NetworkProperties(
+      legacyNetwork:                        Boolean = false,
+      pingPongInterval:                     FiniteDuration = FiniteDuration(90, SECONDS),
+      expectedSlotsPerBlock:                Double = 5.0, // TODO shall be calculated?
+      maxPerformanceDelayInSlots:           Double = 2.0,
+      remotePeerNoveltyInExpectedBlocks:    Double = 2.0,
+      minimumBlockProvidingReputationPeers: Int = 2,
+      minimumRequiredReputation:            Double = 0.66,
+      minimumHotConnections:                Int = 3
+    )
 
     case class KnownPeer(host: String, port: Int)
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -5,7 +5,7 @@ import cats.effect.Resource
 import cats.effect.kernel.Concurrent
 import cats.effect.implicits._
 import cats.implicits._
-import co.topl.algebras.Store
+import co.topl.algebras.{ClockAlgebra, Store}
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.config.ApplicationConfig.Bifrost.NetworkProperties
@@ -36,7 +36,8 @@ object ActorPeerHandlerBridgeAlgebra {
     bodyStore:                   Store[F, BlockId, BlockBody],
     transactionStore:            Store[F, TransactionId, IoTransaction],
     blockIdTree:                 ParentChildTree[F, BlockId],
-    networkProperties:           NetworkProperties
+    networkProperties:           NetworkProperties,
+    clockAlgebra:                ClockAlgebra[F]
   ): Resource[F, BlockchainPeerHandlerAlgebra[F]] = {
     val networkAlgebra = new NetworkAlgebraImpl[F]()
     val networkManager =
@@ -55,7 +56,8 @@ object ActorPeerHandlerBridgeAlgebra {
         blockIdTree,
         networkAlgebra,
         List.empty,
-        networkProperties
+        networkProperties,
+        clockAlgebra
       )
 
     networkManager.map(makeAlgebra(_))

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
@@ -159,7 +159,7 @@ object RequestsProxy {
       }
 
     val sendMessage: NonEmptyChain[(HostId, Long)] => F[Unit] =
-      d => state.reputationAggregator.sendNoWait(ReputationAggregator.Message.HostsNoveltyProviding(d))
+      d => state.reputationAggregator.sendNoWait(ReputationAggregator.Message.BlockProvidingReputationUpdate(d))
 
     NonEmptyChain.fromSeq(toSend).map(sendMessage).getOrElse(().pure[F]) >> (state, state).pure[F]
   }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -5,6 +5,7 @@ import cats.effect.Async
 import cats.implicits._
 import cats.{Monad, MonadThrow, Show}
 import co.topl.algebras.Store
+import co.topl.config.ApplicationConfig.Bifrost.NetworkProperties
 import co.topl.consensus.models._
 import co.topl.ledger.models.{BodyAuthorizationError, BodySemanticError, BodySyntaxError, BodyValidationError}
 import co.topl.networking.fsnetwork.NetworkQualityError.{IncorrectPongMessage, NoPongMessage}
@@ -12,6 +13,8 @@ import co.topl.networking.fsnetwork.ReputationAggregator.Message.PingPongMessage
 import co.topl.node.models.BlockBody
 import co.topl.typeclasses.implicits._
 import com.github.benmanes.caffeine.cache.Cache
+
+import scala.concurrent.duration.FiniteDuration
 
 package object fsnetwork {
 
@@ -156,4 +159,47 @@ package object fsnetwork {
     downloadTimeTxMs: Seq[Long] = Seq.empty
   )
 
+  case class P2PNetworkConfig(networkProperties: NetworkProperties, slotDuration: FiniteDuration) {
+
+    /**
+     * Block providing novelty reputation if new unknown block is received in current slot.
+     * Shall be always equal one.
+     */
+    val blockNoveltyInitialValue: Double = 1
+
+    /**
+     * Reducing block novelty reputation for each already known source, i.e:
+     * blockNoveltyReputation = 1 - knewSourceForThatBlockId * blockNoveltyReputationStep
+     */
+    val blockNoveltyReputationStep: Double = 0.2
+
+    /**
+     * Block novelty reputation shall be reducing every slot by X number.
+     * If we have reputation of "blockNoveltyInitialValue" then after "expectedSlotsPerBlock" slots that
+     * reputation shall be equal to "blockNoveltyInitialValue" - "blockNoveltyReputationStep".
+     * Thus we need such X number where:
+     *  pow(X, expectedSlotsPerBlock - 1) == "blockNoveltyInitialValue" - blockNoveltyReputationStep,
+     * then:
+     *  X = root of (1 - blockNoveltyReputationStep) with index (expectedSlotsPerBlock - 1)
+     */
+    val blockNoveltyDecoy: Double =
+      Math.pow(blockNoveltyInitialValue - blockNoveltyReputationStep, 1 / (networkProperties.expectedSlotsPerBlock - 1))
+
+    /**
+     * Maximum possible performance reputation, i.e. reputation for host with delay in 0 ms
+     */
+    val performanceReputationInitialValue: Double = 1
+
+    /**
+     * Any remote peer with "ping" equal or more than performanceReputationMaxDelay will have 0 performance reputation
+     */
+    val performanceReputationMaxDelay: Double = slotDuration.toMillis * networkProperties.maxPerformanceDelayInSlots
+
+    /**
+     * New remote peer will not be closed during "remotePeerNoveltyInSlots" slots even if reputation is low.
+     * It gives a chance to build-up reputation for remote peer
+     */
+    val remotePeerNoveltyInSlots: Long =
+      Math.ceil(networkProperties.expectedSlotsPerBlock * networkProperties.remotePeerNoveltyInExpectedBlocks).toLong
+  }
 }

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
@@ -1,12 +1,15 @@
 package co.topl.networking.fsnetwork
 
+import cats.data.NonEmptyChain
 import cats.effect.IO
+import cats.effect.kernel.Async
 import cats.implicits._
 import co.topl.brambl.generators.TransactionGenerator
+import co.topl.config.ApplicationConfig.Bifrost.NetworkProperties
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.networking.fsnetwork.NetworkQualityError.{IncorrectPongMessage, NoPongMessage}
 import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
-import co.topl.networking.fsnetwork.ReputationAggregatorTest.F
+import co.topl.networking.fsnetwork.ReputationAggregatorTest.{defaultP2PConfig, F}
 import co.topl.networking.fsnetwork.TestHelper.arbitraryHost
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
@@ -14,8 +17,14 @@ import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
+import scala.concurrent.duration.{FiniteDuration, MILLISECONDS, SECONDS}
+
 object ReputationAggregatorTest {
   type F[A] = IO[A]
+  val defaultSlotDuration: FiniteDuration = FiniteDuration(1, SECONDS)
+
+  val defaultP2PConfig: P2PNetworkConfig =
+    P2PNetworkConfig(NetworkProperties(), defaultSlotDuration)
 }
 
 class ReputationAggregatorTest
@@ -32,19 +41,19 @@ class ReputationAggregatorTest
 
       val initialPerfMap = Map(hostToRemove -> 0.5, arbitraryHost.arbitrary.first -> 0.1)
       val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, hostToRemove -> 0.7)
-      val initialNewMap = Map(hostToRemove -> 0.5)
+      val initialNewMap = Map(hostToRemove -> 1L)
       ReputationAggregator
-        .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+        .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
         .use { actor =>
           for {
-            newState <- actor.send(ReputationAggregator.Message.RemoveReputationForHost(hostToRemove))
+            newState <- actor.send(ReputationAggregator.Message.StopTrackingReputationForHost(hostToRemove))
             _ = assert(!newState.performanceReputation.contains(hostToRemove))
             _ = assert(!newState.blockProvidingReputation.contains(hostToRemove))
-            _ = assert(!newState.newnessReputation.contains(hostToRemove))
-            newState2 <- actor.send(ReputationAggregator.Message.RemoveReputationForHost(hostToRemove))
+            _ = assert(!newState.noveltyReputation.contains(hostToRemove))
+            newState2 <- actor.send(ReputationAggregator.Message.StopTrackingReputationForHost(hostToRemove))
             _ = assert(!newState2.performanceReputation.contains(hostToRemove))
             _ = assert(!newState2.blockProvidingReputation.contains(hostToRemove))
-            _ = assert(!newState2.newnessReputation.contains(hostToRemove))
+            _ = assert(!newState2.noveltyReputation.contains(hostToRemove))
           } yield ()
         }
     }
@@ -57,17 +66,19 @@ class ReputationAggregatorTest
 
       val initialPerfMap = Map(host -> 0.5, arbitraryHost.arbitrary.first -> 0.1)
       val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
-      val initialNewMap = Map(host -> 0.5)
+      val initialNewMap = Map(host -> 1L)
 
-      val delay = 230
+      val delay = 230L
       ReputationAggregator
-        .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+        .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
         .use { actor =>
           for {
             newState <- actor.send(ReputationAggregator.Message.PingPongMessagePing(host, Right(delay)))
-            _ = assert(newState.performanceReputation(host) == ReputationAggregator.delayToReputation(delay))
+            _ = assert(
+              newState.performanceReputation(host) == ReputationAggregator.delayToReputation(defaultP2PConfig, delay)
+            )
             _ = assert(newState.blockProvidingReputation == initialBlockMap)
-            _ = assert(newState.newnessReputation == initialNewMap)
+            _ = assert(newState.noveltyReputation == initialNewMap)
           } yield ()
         }
     }
@@ -80,19 +91,19 @@ class ReputationAggregatorTest
 
       val initialPerfMap = Map(host -> 0.5, arbitraryHost.arbitrary.first -> 0.1)
       val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
-      val initialNewMap = Map(host -> 0.5)
+      val initialNewMap = Map(host -> 1L)
 
       (peersManager.sendNoWait _)
         .expects(PeersManager.Message.UpdatePeerStatus(host, PeerState.Banned))
         .returns(().pure[F])
       ReputationAggregator
-        .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+        .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
         .use { actor =>
           for {
             newState <- actor.send(ReputationAggregator.Message.PingPongMessagePing(host, Left(NoPongMessage)))
             _ = assert(newState.performanceReputation == initialPerfMap)
             _ = assert(newState.blockProvidingReputation == initialBlockMap)
-            _ = assert(newState.newnessReputation == initialNewMap)
+            _ = assert(newState.noveltyReputation == initialNewMap)
           } yield ()
         }
     }
@@ -105,19 +116,19 @@ class ReputationAggregatorTest
 
       val initialPerfMap = Map(host -> 0.5, arbitraryHost.arbitrary.first -> 0.1)
       val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
-      val initialNewMap = Map(host -> 0.5)
+      val initialNewMap = Map(host -> 1L)
 
       (peersManager.sendNoWait _)
         .expects(PeersManager.Message.UpdatePeerStatus(host, PeerState.Banned))
         .returns(().pure[F])
       ReputationAggregator
-        .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+        .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
         .use { actor =>
           for {
             newState <- actor.send(ReputationAggregator.Message.PingPongMessagePing(host, Left(IncorrectPongMessage)))
             _ = assert(newState.performanceReputation == initialPerfMap)
             _ = assert(newState.blockProvidingReputation == initialBlockMap)
-            _ = assert(newState.newnessReputation == initialNewMap)
+            _ = assert(newState.noveltyReputation == initialNewMap)
           } yield ()
         }
     }
@@ -130,19 +141,19 @@ class ReputationAggregatorTest
 
       val initialPerfMap = Map(host -> 0.5, arbitraryHost.arbitrary.first -> 0.1)
       val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
-      val initialNewMap = Map(host -> 0.5)
+      val initialNewMap = Map(host -> 1L)
 
       (peersManager.sendNoWait _)
         .expects(PeersManager.Message.UpdatePeerStatus(host, PeerState.Banned))
         .returns(().pure[F])
       ReputationAggregator
-        .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+        .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
         .use { actor =>
           for {
             newState <- actor.send(ReputationAggregator.Message.HostProvideIncorrectBlock(host))
             _ = assert(newState.performanceReputation == initialPerfMap)
             _ = assert(newState.blockProvidingReputation == initialBlockMap)
-            _ = assert(newState.newnessReputation == initialNewMap)
+            _ = assert(newState.noveltyReputation == initialNewMap)
           } yield ()
         }
     }
@@ -156,49 +167,201 @@ class ReputationAggregatorTest
       val initialReputation = 0.5
       val initialPerfMap = Map(host -> initialReputation, arbitraryHost.arbitrary.first -> 0.1)
       val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
-      val initialNewMap = Map(host -> 0.5)
+      val initialNewMap = Map(host -> 1L)
 
       val downloadTime = 120
-      val reputation = ReputationAggregator.delayToReputation(downloadTime)
+      val reputation = ReputationAggregator.delayToReputation(defaultP2PConfig, downloadTime)
 
       ReputationAggregator
-        .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+        .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
         .use { actor =>
           for {
             newState <- actor.send(ReputationAggregator.Message.DownloadTimeHeader(host, downloadTime))
             _ = assert(newState.performanceReputation(host) == (initialReputation * 2 + reputation) / 3.0)
             _ = assert(newState.blockProvidingReputation == initialBlockMap)
-            _ = assert(newState.newnessReputation == initialNewMap)
+            _ = assert(newState.noveltyReputation == initialNewMap)
           } yield ()
         }
     }
   }
 
   test("Performance reputation after body downloading shall be updated") {
-    PropF.forAllF { (txDownloadTime: Seq[Long]) =>
+    PropF.forAllF { (txTimes: Seq[Long]) =>
       withMock {
         val peersManager = mock[PeersManagerActor[F]]
         val host = arbitraryHost.arbitrary.first
+        val txDownloadTime: Seq[Long] = txTimes.filter(_ > 0)
 
         val initialReputation = 0.5
         val initialPerfMap = Map(host -> initialReputation, arbitraryHost.arbitrary.first -> 0.1)
         val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
-        val initialNewMap = Map(host -> 0.5)
+        val initialNewMap = Map(host -> 1L)
 
         val downloadTime: Long = 120
-        val reputation = ReputationAggregator.delayToReputation((txDownloadTime.filter(_ > 0) :+ downloadTime).max)
+        val reputation = ReputationAggregator.delayToReputation(defaultP2PConfig, (txDownloadTime :+ downloadTime).max)
 
         ReputationAggregator
-          .makeActor(peersManager, initialPerfMap, initialBlockMap, initialNewMap)
+          .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
           .use { actor =>
             for {
               newState <- actor.send(ReputationAggregator.Message.DownloadTimeBody(host, downloadTime, txDownloadTime))
               _ = assert(newState.performanceReputation(host) == (initialReputation * 2 + reputation) / 3.0)
               _ = assert(newState.blockProvidingReputation == initialBlockMap)
-              _ = assert(newState.newnessReputation == initialNewMap)
+              _ = assert(newState.noveltyReputation == initialNewMap)
             } yield ()
           }
       }
+    }
+  }
+
+  test("Reputation update fiber shall be started and running after actor starting") {
+    withMock {
+      val peersManager = mock[PeersManagerActor[F]]
+      val host = arbitraryHost.arbitrary.first
+
+      val initialReputation = 0.5
+      val initialPerfMap = Map(host -> initialReputation, arbitraryHost.arbitrary.first -> 0.1)
+      val initialBlockMap = Map(arbitraryHost.arbitrary.first -> 0.1, host -> 0.7)
+      val initialNewMap = Map(host -> 2L)
+
+      val slotDuration = FiniteDuration(100, MILLISECONDS)
+      val waitDuration = FiniteDuration(slotDuration.toMillis * 3, MILLISECONDS)
+      val config = P2PNetworkConfig(NetworkProperties(), slotDuration)
+
+      val blockProvidingReputation1 = initialBlockMap.view.mapValues(_ * config.blockNoveltyDecoy).toMap
+      val noveltyReputation1 = initialNewMap.view.mapValues(_ - 1).toMap
+      val expectedMessage1 =
+        PeersManager.Message.UpdatedReputation(initialPerfMap, blockProvidingReputation1, noveltyReputation1)
+      (peersManager.sendNoWait _).expects(expectedMessage1).once().returns(().pure[F])
+
+      val blockProvidingReputation2 = blockProvidingReputation1.view.mapValues(_ * config.blockNoveltyDecoy).toMap
+      val noveltyReputation2 = noveltyReputation1.view.mapValues(_ - 1).toMap
+      val expectedMessage2 =
+        PeersManager.Message.UpdatedReputation(initialPerfMap, blockProvidingReputation2, noveltyReputation2)
+      (peersManager.sendNoWait _).expects(expectedMessage2).once().returns(().pure[F])
+
+      val blockProvidingReputation3 = blockProvidingReputation2.view.mapValues(_ * config.blockNoveltyDecoy).toMap
+      val noveltyReputation3 = Map(host -> 0L) // Novelty reputation never is less than 0
+      val expectedMessage3 =
+        PeersManager.Message.UpdatedReputation(initialPerfMap, blockProvidingReputation3, noveltyReputation3)
+      (peersManager.sendNoWait _).expects(expectedMessage3).once().returns(().pure[F])
+
+      ReputationAggregator
+        .makeActor(peersManager, config, initialPerfMap, initialBlockMap, initialNewMap)
+        .use { actor =>
+          for {
+            newState <- Async[F].andWait(actor.send(ReputationAggregator.Message.StartReputationUpdate), waitDuration)
+            _ = assert(newState.reputationUpdateFiber.isDefined)
+
+          } yield ()
+        }
+    }
+  }
+
+  test("Reputation shall be updated after added new host") {
+    withMock {
+      val peersManager = mock[PeersManagerActor[F]]
+      val host = arbitraryHost.arbitrary.first
+
+      val initialReputation = 0.5
+      val initialPerfMap =
+        Map(arbitraryHost.arbitrary.first -> initialReputation, arbitraryHost.arbitrary.first -> 0.1)
+      val initialBlockMap =
+        Map(arbitraryHost.arbitrary.first -> 0.1, arbitraryHost.arbitrary.first -> 0.7)
+      val initialNewMap =
+        Map(arbitraryHost.arbitrary.first -> 1L)
+
+      val reputation = defaultP2PConfig.remotePeerNoveltyInSlots
+
+      ReputationAggregator
+        .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
+        .use { actor =>
+          for {
+            newState <- actor.send(ReputationAggregator.Message.NewRemoteHost(host))
+            _ = assert(newState.performanceReputation == (initialPerfMap + (host -> 0.0)))
+            _ = assert(newState.blockProvidingReputation == (initialBlockMap + (host -> 0.0)))
+            _ = assert(newState.noveltyReputation == (initialNewMap + (host -> reputation)))
+          } yield ()
+        }
+    }
+  }
+
+  test("Block providing reputation: take better value from update and current value") {
+    withMock {
+      val peersManager = mock[PeersManagerActor[F]]
+      val host1 = arbitraryHost.arbitrary.first
+      val host2 = arbitraryHost.arbitrary.first
+      val host3 = arbitraryHost.arbitrary.first
+      val host4 = arbitraryHost.arbitrary.first
+
+      val worstKnownSources = 3L
+      val worstReputation = ReputationAggregator.knownSourcesToReputation(defaultP2PConfig, worstKnownSources)
+
+      val okKnownSources = 2L
+      val okReputation = ReputationAggregator.knownSourcesToReputation(defaultP2PConfig, okKnownSources)
+
+      val bestKnownSources = 1L
+      val bestReputation = ReputationAggregator.knownSourcesToReputation(defaultP2PConfig, bestKnownSources)
+      assert(bestReputation == 1)
+
+      val initialBlockMap =
+        Map(host1 -> worstReputation, host2 -> okReputation, host3 -> bestReputation)
+      val update = List(
+        host1 -> okKnownSources,
+        host1 -> bestKnownSources,
+        host2 -> worstKnownSources,
+        host2 -> bestKnownSources,
+        host3 -> worstKnownSources,
+        host3 -> okKnownSources,
+        host4 -> worstKnownSources
+      )
+
+      val blockProvidingUpdate =
+        ReputationAggregator.Message.BlockProvidingReputationUpdate(NonEmptyChain.fromSeq(update).get)
+
+      val initialPerfMap =
+        Map(arbitraryHost.arbitrary.first -> 0.4, arbitraryHost.arbitrary.first -> 0.1)
+      val initialNewMap =
+        Map(arbitraryHost.arbitrary.first -> 1L)
+
+      val expectedBlockProvidingReputation =
+        Map(host1 -> bestReputation, host2 -> bestReputation, host3 -> bestReputation, host4 -> worstReputation)
+      ReputationAggregator
+        .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
+        .use { actor =>
+          for {
+            newState <- actor.send(blockProvidingUpdate)
+            _ = assert(newState.performanceReputation == initialPerfMap)
+            _ = assert(newState.noveltyReputation == initialNewMap)
+            _ = assert(newState.blockProvidingReputation == expectedBlockProvidingReputation)
+          } yield ()
+        }
+    }
+  }
+
+  test("Reputation shall be set to zero if remote host provide bad k lookback slot data") {
+    withMock {
+      val peersManager = mock[PeersManagerActor[F]]
+      val host = arbitraryHost.arbitrary.first
+
+      val initialReputation = 0.5
+      val initialPerfMap =
+        Map(arbitraryHost.arbitrary.first -> initialReputation, arbitraryHost.arbitrary.first -> 0.1)
+      val initialBlockMap =
+        Map(arbitraryHost.arbitrary.first -> 0.1, arbitraryHost.arbitrary.first -> 0.7)
+      val initialNewMap =
+        Map(arbitraryHost.arbitrary.first -> 1L)
+
+      ReputationAggregator
+        .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap + (host -> 1.0), initialNewMap)
+        .use { actor =>
+          for {
+            newState <- actor.send(ReputationAggregator.Message.BadKLookbackSlotData(host))
+            _ = assert(newState.performanceReputation == initialPerfMap)
+            _ = assert(newState.blockProvidingReputation == (initialBlockMap + (host -> 0.0)))
+            _ = assert(newState.noveltyReputation == initialNewMap)
+          } yield ()
+        }
     }
   }
 }

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
@@ -480,7 +480,7 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
           }
 
           (reputationAggregator.sendNoWait _)
-            .expects(ReputationAggregator.Message.HostsNoveltyProviding(expectedData))
+            .expects(ReputationAggregator.Message.BlockProvidingReputationUpdate(expectedData))
             .once()
             .returns(().pure[F])
 


### PR DESCRIPTION
## Purpose
Block-providing reputation is used for calculation overall reputation calculation for network discovery

## Approach
Calculate it in ReputationAggregator

## Testing
Unit test + integration tests

## Tickets
closes #BN-1070