### PR TITLE
BN-1116 Remote peer state changes

### DIFF
--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -56,8 +56,10 @@ object ApplicationConfig {
       maxPerformanceDelayInSlots:           Double = 2.0,
       remotePeerNoveltyInExpectedBlocks:    Double = 2.0,
       minimumBlockProvidingReputationPeers: Int = 2,
+      minimumPerformanceReputationPeers:    Int = 1,
       minimumRequiredReputation:            Double = 0.66,
       minimumHotConnections:                Int = 3,
+      minimumWarmConnections:               Int = 3,
       warmHostsUpdateEveryNBlock:           Double = 4.0
     )
 

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainNetwork.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainNetwork.scala
@@ -2,7 +2,7 @@ package co.topl.networking.blockchain
 
 import cats.effect._
 import cats.effect.implicits._
-import cats.effect.std.Random
+import cats.effect.std.{Queue, Random}
 import co.topl.networking.p2p._
 import fs2._
 import org.typelevel.log4cats.Logger
@@ -28,7 +28,8 @@ object BlockchainNetwork {
     localPeer:     LocalPeer,
     remotePeers:   Stream[F, DisconnectedPeer],
     clientHandler: BlockchainPeerHandlerAlgebra[F],
-    serverF:       ConnectedPeer => Resource[F, BlockchainPeerServerAlgebra[F]]
+    serverF:       ConnectedPeer => Resource[F, BlockchainPeerServerAlgebra[F]],
+    closedPeers:   Queue[F, ConnectedPeer]
   ): Resource[F, P2PServer[F]] =
     for {
       implicit0(logger: Logger[F]) <- Slf4jLogger.fromName("Bifrost.P2P.Blockchain").toResource
@@ -45,7 +46,8 @@ object BlockchainNetwork {
             .flatMap(connectionLeader =>
               BlockchainSocketHandler
                 .make[F](serverF, clientHandler.usePeer)(peer, connectionLeader, socket.reads, socket.writes)
-            )
+            ),
+        closedPeers
       )
     } yield p2pServer
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -71,7 +71,6 @@ object ActorPeerHandlerBridgeAlgebra {
       for {
         hostId <- client.remotePeer.map(_.remoteAddress).toResource
         _      <- peersManager.sendNoWait(PeersManager.Message.OpenedPeerConnection(hostId, client)).toResource
-        _      <- Resource.onFinalize(peersManager.sendNoWait(PeersManager.Message.ClosePeer(hostId)))
       } yield ()
   }
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/Notifier.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/Notifier.scala
@@ -48,6 +48,7 @@ object Notifier {
   }
 
   private def startSendingNotifications[F[_]: Async: Logger](state: State[F]): F[(State[F], Response[F])] =
+    Logger[F].info(s"Start notifier with config ${state.networkConfig}") >>
     startSlotNotification[F](state)
       .flatMap(startNetworkQualityFiber[F])
       .flatMap(startWarmHostsUpdateFiber[F])
@@ -98,7 +99,7 @@ object Notifier {
 
     val warmHostsUpdateStream =
       Stream.awakeEvery(warmPeersUpdate).evalMap { _ =>
-        state.peersManager.sendNoWait(PeersManager.Message.UpdateWarmHosts)
+        state.reputationAggregator.sendNoWait(ReputationAggregator.Message.UpdateWarmHosts)
       }
 
     if (state.warmHostsUpdateFiber.isEmpty && warmPeersUpdate.toMillis > 0) {

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -26,9 +26,10 @@ object PeerActor {
 
     /**
      * Update peer state
-     * @param newState new state
+     * @param networkLevel do we run network level data exchange like measuring metwork quality
+     * @param applicationLevel do we run application level data exchange
      */
-    case class UpdateState(newState: PeerState) extends Message
+    case class UpdateState(networkLevel: Boolean, applicationLevel: Boolean) extends Message
 
     /**
      * Request to download block headers from peer, downloaded headers will be sent to block checker directly
@@ -51,6 +52,11 @@ object PeerActor {
      * Request network quality measure
      */
     case object GetNetworkQuality extends Message
+
+    /**
+     * Request to get remote host's hot connections
+     */
+    case object GetHotPeersFromPeer extends Message
   }
 
   case class State[F[_]](
@@ -59,18 +65,20 @@ object PeerActor {
     blockHeaderActor:    PeerBlockHeaderFetcherActor[F],
     blockBodyActor:      PeerBlockBodyFetcherActor[F],
     networkQualityActor: PeerNetworkQualityActor[F],
-    currentPeerState:    PeerState
+    networkLevel:        Boolean,
+    applicationLevel:    Boolean
   )
 
   type Response[F[_]] = State[F]
   type PeerActor[F[_]] = Actor[F, Message, Response[F]]
 
   def getFsm[F[_]: Concurrent: Logger]: Fsm[F, State[F], Message, Response[F]] = Fsm {
-    case (state, UpdateState(newState))             => updateState(state, newState)
-    case (state, DownloadBlockHeaders(blockIds))    => downloadHeaders(state, blockIds)
-    case (state, DownloadBlockBodies(blockHeaders)) => downloadBodies(state, blockHeaders)
-    case (state, GetCurrentTip)                     => getCurrentTip(state)
-    case (state, GetNetworkQuality)                 => getNetworkQuality(state)
+    case (state, UpdateState(networkLevel, applicationLevel)) => updateState(state, networkLevel, applicationLevel)
+    case (state, DownloadBlockHeaders(blockIds))              => downloadHeaders(state, blockIds)
+    case (state, DownloadBlockBodies(blockHeaders))           => downloadBodies(state, blockHeaders)
+    case (state, GetCurrentTip)                               => getCurrentTip(state)
+    case (state, GetNetworkQuality)                           => getNetworkQuality(state)
+    case (state, GetHotPeersFromPeer)                         => getHotPeers(state)
   }
 
   def makeActor[F[_]: Async: Logger](
@@ -95,30 +103,35 @@ object PeerActor {
       )
       body <- PeerBlockBodyFetcher.makeActor(hostId, client, requestsProxy, transactionStore, headerToBodyValidation)
       networkQuality <- PeerNetworkQuality.makeActor(hostId, client, reputationAggregator)
-      initialState = State(hostId, client, header, body, networkQuality, PeerState.Cold)
-      actor <- Actor.make(initialState, getFsm[F])
-
+      initialState = State(hostId, client, header, body, networkQuality, networkLevel = false, applicationLevel = false)
+      actor <- Actor.makeWithFinalize(initialState, getFsm[F], finalizer[F])
     } yield actor
 
+  private def finalizer[F[_]: Concurrent: Logger](state: State[F]): F[Unit] =
+    Logger[F].info(show"Finishing actor for peer ${state.hostId}") >>
+    stopApplicationLevel(state) >>
+    stopNetworkLevel(state)
+
   private def updateState[F[_]: Concurrent: Logger](
-    state:        State[F],
-    newPeerState: PeerState
+    state:               State[F],
+    newNetworkLevel:     Boolean,
+    newApplicationLevel: Boolean
   ): F[(State[F], Response[F])] = {
     val networkLevel: F[Unit] =
-      (state.currentPeerState.networkLevel != newPeerState.networkLevel, newPeerState.networkLevel) match {
+      (state.networkLevel != newNetworkLevel, newNetworkLevel) match {
         case (true, true)  => startNetworkLevel(state)
         case (true, false) => stopNetworkLevel(state)
         case (false, _)    => ().pure[F]
       }
 
     val applicationLevel: F[Unit] =
-      (state.currentPeerState.applicationLevel != newPeerState.applicationLevel, newPeerState.applicationLevel) match {
+      (state.applicationLevel != newApplicationLevel, newApplicationLevel) match {
         case (true, true)  => startApplicationLevel(state)
         case (true, false) => stopApplicationLevel(state)
         case (false, _)    => ().pure[F]
       }
 
-    val newState: State[F] = state.copy(currentPeerState = newPeerState)
+    val newState: State[F] = state.copy(applicationLevel = newApplicationLevel, networkLevel = newNetworkLevel)
     applicationLevel >> networkLevel >> (newState, newState).pure[F]
   }
 
@@ -133,10 +146,12 @@ object PeerActor {
     state.blockBodyActor.sendNoWait(PeerBlockBodyFetcher.Message.StopActor)
 
   private def startNetworkLevel[F[_]: Concurrent: Logger](state: State[F]): F[Unit] =
-    Logger[F].info(show"Network level is enabled for ${state.hostId}")
+    Logger[F].info(show"Network level is started for ${state.hostId}") >>
+    state.networkQualityActor.sendNoWait(PeerNetworkQuality.Message.StartActor)
 
   private def stopNetworkLevel[F[_]: Concurrent: Logger](state: State[F]): F[Unit] =
-    Logger[F].info(show"Network level is disabled for ${state.hostId}")
+    Logger[F].info(show"Network level is stop for ${state.hostId}") >>
+    state.networkQualityActor.sendNoWait(PeerNetworkQuality.Message.StopActor)
 
   private def downloadHeaders[F[_]: Concurrent](
     state:    State[F],
@@ -158,5 +173,8 @@ object PeerActor {
 
   private def getNetworkQuality[F[_]: Concurrent](state: State[F]): F[(State[F], Response[F])] =
     state.networkQualityActor.sendNoWait(PeerNetworkQuality.Message.GetNetworkQuality) >>
+    (state, state).pure[F]
+
+  private def getHotPeers[F[_]: Concurrent](state: State[F]): F[(State[F], Response[F])] =
     (state, state).pure[F]
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -118,7 +118,7 @@ object PeerBlockHeaderFetcher {
       betterSlotData         <- compareSlotDataWithLocal(savedSlotData, state)
     } yield betterSlotData
 
-  private def buildBlockSource[F[_]: Async: Logger](
+  private def buildBlockSource[F[_]: Async](
     state:          State[F],
     blockId:        BlockId,
     newSlotDataOpt: Option[NonEmptyChain[SlotData]]

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerCreationRequestAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerCreationRequestAlgebra.scala
@@ -1,0 +1,13 @@
+package co.topl.networking.fsnetwork
+
+import co.topl.networking.p2p.DisconnectedPeer
+
+abstract class PeerCreationRequestAlgebra[F[_]] {
+  def requestNewPeerCreation(peer: HostId): F[Unit]
+}
+
+object PeerCreationRequestAlgebra {
+
+  def apply[F[_]](peerCreationFun: DisconnectedPeer => F[Unit]): PeerCreationRequestAlgebra[F] =
+    (peer: HostId) => peerCreationFun(DisconnectedPeer(peer, (0, 0)))
+}

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerState.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerState.scala
@@ -22,6 +22,12 @@ object PeerState {
     override def applicationLevel: Boolean = false
   }
 
+  case object PreWarm extends PeerState {
+    override def networkLevel: Boolean = false
+
+    override def applicationLevel: Boolean = false
+  }
+
   case object Warm extends PeerState {
     override def networkLevel: Boolean = true
 
@@ -33,4 +39,5 @@ object PeerState {
 
     override def applicationLevel: Boolean = true
   }
+
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -3,22 +3,25 @@ package co.topl.networking
 import cats.data.{NonEmptyChain, OptionT}
 import cats.effect.Async
 import cats.implicits._
-import cats.{Monad, MonadThrow, Show}
+import cats.{Applicative, Monad, MonadThrow, Show}
 import co.topl.algebras.Store
 import co.topl.config.ApplicationConfig.Bifrost.NetworkProperties
 import co.topl.consensus.models._
 import co.topl.ledger.models.{BodyAuthorizationError, BodySemanticError, BodySyntaxError, BodyValidationError}
 import co.topl.networking.fsnetwork.NetworkQualityError.{IncorrectPongMessage, NoPongMessage}
 import co.topl.networking.fsnetwork.ReputationAggregator.Message.PingPongMessagePing
+import co.topl.networking.p2p.RemoteAddress
 import co.topl.node.models.BlockBody
 import co.topl.typeclasses.implicits._
 import com.github.benmanes.caffeine.cache.Cache
+import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
+import scala.util.Random
 
 package object fsnetwork {
 
-  type HostId = String // IP address? IP address could be changed and bad for identify good peer
+  type HostId = RemoteAddress // IP address? IP address could be changed and bad for identify good peer
 
   type HostReputationValue =
     Double // will be more complex, to get high reputation host shall fulfill different criteria
@@ -207,5 +210,21 @@ package object fsnetwork {
      */
     val warmHostsUpdateInterval: FiniteDuration =
       FiniteDuration(Math.round(networkProperties.warmHostsUpdateEveryNBlock * slotDuration.toMillis), MILLISECONDS)
+  }
+
+  trait ColdToWarmSelector {
+    def select(coldHosts: Set[HostId], countToReceive: Int): Set[HostId]
+  }
+
+  val RandomColdToWarmSelector: ColdToWarmSelector =
+    (coldHosts: Set[HostId], countToReceive: Int) => Random.shuffle(coldHosts).take(countToReceive)
+
+  implicit class LoggerOps[F[_]: Applicative](logger: Logger[F]) {
+
+    def infoIf(predicate: => Boolean, message: => String): F[Unit] =
+      if (predicate)
+        logger.info(message)
+      else
+        Applicative[F].unit
   }
 }

--- a/networking/src/main/scala/co/topl/networking/p2p/FS2P2PServer.scala
+++ b/networking/src/main/scala/co/topl/networking/p2p/FS2P2PServer.scala
@@ -4,6 +4,7 @@ import cats.data.OptionT
 import cats.effect.Async
 import cats.effect.Resource
 import cats.effect.implicits._
+import cats.effect.std.Queue
 import cats.implicits._
 import com.comcast.ip4s._
 import fs2.Stream
@@ -19,12 +20,13 @@ object FS2P2PServer {
     port:        Int,
     localPeer:   LocalPeer,
     remotePeers: Stream[F, DisconnectedPeer],
-    peerHandler: (ConnectedPeer, Socket[F]) => Resource[F, Unit]
+    peerHandler: (ConnectedPeer, Socket[F]) => Resource[F, Unit],
+    closedPeers: Queue[F, ConnectedPeer]
   ): Resource[F, P2PServer[F]] =
     for {
       implicit0(logger: Logger[F]) <- Slf4jLogger.fromName("Bifrost.P2P").toResource
       topic                        <- Resource.make(Topic[F, PeerConnectionChange])(_.close.void)
-      _                            <- eventProcessor(topic)
+      _                            <- eventProcessor(topic, closedPeers)
       sockets                      <- socketsStream[F](host, port)
       _                            <- server(sockets)(topic, peerHandler)
       _                            <- client(remotePeers, localPeer)(topic, peerHandler)
@@ -103,10 +105,14 @@ object FS2P2PServer {
               .fromOption[F](Port.fromInt(disconnected.remoteAddress.port))
               .getOrRaise(new IllegalArgumentException("Invalid destinationPort"))
               .toResource
-            socket <- Network.forAsync[F].client(SocketAddress(host, port))
+            socketEither <- Network.forAsync[F].client(SocketAddress(host, port)).attempt
             connected = ConnectedPeer(disconnected.remoteAddress, disconnected.coordinate)
-            _      <- peerChangesTopic.publish1(PeerConnectionChanges.ConnectionEstablished(connected)).toResource
-            result <- peerHandler(connected, socket).attempt
+            result <- socketEither match {
+              case Left(error) => Resource.pure[F, Either[Throwable, Unit]](Either.left[Throwable, Unit](error))
+              case Right(socket) =>
+                peerChangesTopic.publish1(PeerConnectionChanges.ConnectionEstablished(connected)).toResource >>
+                peerHandler(connected, socket).attempt
+            }
             _ <- peerChangesTopic
               .publish1(PeerConnectionChanges.ConnectionClosed(connected, result.swap.toOption))
               .toResource
@@ -119,17 +125,20 @@ object FS2P2PServer {
       .background
 
   private def eventProcessor[F[_]: Async: Logger](
-    peerChangesTopic: Topic[F, PeerConnectionChange]
+    peerChangesTopic: Topic[F, PeerConnectionChange],
+    closedPeers:      Queue[F, ConnectedPeer]
   ) =
     peerChangesTopic.subscribeUnbounded
       .evalTap {
         case PeerConnectionChanges.ConnectionEstablished(peer) =>
           Logger[F].info(s"Connection established with peer=$peer")
         case PeerConnectionChanges.ConnectionClosed(peer, reason) =>
-          reason match {
-            case Some(error) => Logger[F].warn(error)(s"Connection closed with peer=$peer")
-            case _           => Logger[F].info(s"Connection closed with peer=$peer")
-          }
+          {
+            reason match {
+              case Some(error) => Logger[F].warn(error)(s"Connection closed with peer=$peer")
+              case _           => Logger[F].info(s"Connection closed with peer=$peer")
+            }
+          } >> closedPeers.offer(peer)
         case PeerConnectionChanges.InboundConnectionInitializing(peer) =>
           Logger[F].info(s"Inbound connection initializing with peer=$peer")
         case PeerConnectionChanges.OutboundConnectionInitializing(peer) =>

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
@@ -24,6 +24,7 @@ import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
 import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
 import co.topl.networking.fsnetwork.TestHelper._
+import co.topl.networking.p2p.RemoteAddress
 import co.topl.node.models.{Block, BlockBody}
 import co.topl.quivr.runtime.DynamicContext
 import co.topl.typeclasses.implicits._
@@ -43,7 +44,7 @@ object BlockCheckerTest {
 
 class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
-  val hostId: HostId = "127.0.0.1"
+  val hostId: HostId = RemoteAddress("127.0.0.1", 0)
   val maxChainSize = 99
 
   test("RemoteSlotData: Request no headers if new slot data is worse") {

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/NotifierTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/NotifierTest.scala
@@ -32,11 +32,14 @@ class NotifierTest extends CatsEffectSuite with ScalaCheckEffectSuite with Async
         .expects(PeersManager.Message.GetNetworkQualityForWarmHosts)
         .atLeastOnce()
         .returns(().pure[F])
-      (peersManager.sendNoWait _).expects(PeersManager.Message.UpdateWarmHosts).atLeastOnce().returns(().pure[F])
 
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       (reputationAggregator.sendNoWait _)
         .expects(ReputationAggregator.Message.ReputationUpdateTick)
+        .atLeastOnce()
+        .returns(().pure[F])
+      (reputationAggregator.sendNoWait _)
+        .expects(ReputationAggregator.Message.UpdateWarmHosts)
         .atLeastOnce()
         .returns(().pure[F])
 
@@ -67,11 +70,14 @@ class NotifierTest extends CatsEffectSuite with ScalaCheckEffectSuite with Async
         .expects(PeersManager.Message.GetNetworkQualityForWarmHosts)
         .anyNumberOfTimes()
         .returns(().pure[F])
-      (peersManager.sendNoWait _).expects(PeersManager.Message.UpdateWarmHosts).anyNumberOfTimes().returns(().pure[F])
 
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       (reputationAggregator.sendNoWait _)
         .expects(ReputationAggregator.Message.ReputationUpdateTick)
+        .anyNumberOfTimes()
+        .returns(().pure[F])
+      (reputationAggregator.sendNoWait _)
+        .expects(ReputationAggregator.Message.UpdateWarmHosts)
         .anyNumberOfTimes()
         .returns(().pure[F])
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
@@ -15,6 +15,7 @@ import co.topl.networking.fsnetwork.PeerActorTest.F
 import co.topl.networking.fsnetwork.ReputationAggregator.Message.PingPongMessagePing
 import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
 import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
+import co.topl.networking.p2p.RemoteAddress
 import co.topl.node.models.{PingMessage, PongMessage}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalamock.munit.AsyncMockFactory
@@ -30,7 +31,7 @@ object PeerActorTest {
 class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory with TransactionGenerator {
   implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
 
-  val hostId: HostId = "127.0.0.1"
+  val hostId: HostId = RemoteAddress("127.0.0.1", 0)
 
   test("Ping shall be started for warm hosts and sent result to reputation aggregator") {
     withMock {
@@ -71,7 +72,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
         )
         .use { actor =>
           for {
-            _ <- actor.send(PeerActor.Message.UpdateState(PeerState.Warm))
+            _ <- actor.send(PeerActor.Message.UpdateState(networkLevel = true, applicationLevel = false))
             _ <- Async[F].andWait(actor.send(PeerActor.Message.GetNetworkQuality), pingDelay * 5)
           } yield ()
         }

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
@@ -17,6 +17,7 @@ import co.topl.networking.fsnetwork.BlockDownloadError.BlockHeaderDownloadError.
 import co.topl.networking.fsnetwork.PeerBlockHeaderFetcherTest.{BlockHeaderDownloadErrorByName, F}
 import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
 import co.topl.networking.fsnetwork.TestHelper._
+import co.topl.networking.p2p.RemoteAddress
 import co.topl.typeclasses.implicits._
 import fs2.Stream
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -37,7 +38,7 @@ object PeerBlockHeaderFetcherTest {
 class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
 
-  val hostId: HostId = "127.0.0.1"
+  val hostId: HostId = RemoteAddress("127.0.0.1", 0)
   val maxChainSize = 99
 
   private def compareWithoutDownloadTimeMatcher(
@@ -55,6 +56,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
                 (header, res.map(b => b.copy(downloadTimeMs = 0)))
               }
             expectedMessage == actualMessage.copy(response = newResp)
+          case (_, _) => throw new IllegalStateException()
         }
     new FunctionAdapter1[RequestsProxy.Message, Boolean](matchingFunction)
   }
@@ -113,7 +115,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       (client
         .getHeaderOrError(_: BlockId, _: Throwable)(_: MonadThrow[F]))
         .expects(header.id, *, *)
-        .once
+        .once()
         .returns(Async[F].delayBy(header.pure[F], FiniteDuration(pingDelay, MILLISECONDS)))
 
       val requestsProxy = mock[RequestsProxyActor[F]]
@@ -350,7 +352,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val localChain = mock[LocalChainAlgebra[F]]
       (localChain.couldBeWorse _).expects(bestSlotData).once().returning(false.pure[F])
-      (localChain.head _).expects().once().returning(knownSlotData.pure[F])
+      (() => localChain.head).expects().once().returning(knownSlotData.pure[F])
 
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
@@ -406,7 +408,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val localChain = mock[LocalChainAlgebra[F]]
       (localChain.couldBeWorse _).expects(bestSlotData).once().returning(false.pure[F])
-      (localChain.head _).expects().once().returning(knownSlotData.pure[F])
+      (() => localChain.head).expects().once().returning(knownSlotData.pure[F])
 
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
@@ -533,7 +535,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val localChain = mock[LocalChainAlgebra[F]]
       (localChain.couldBeWorse _).expects(bestTip).once().returning(false.pure[F])
-      (localChain.head _).expects().once().returning(knownSlotData.pure[F])
+      (() => localChain.head).expects().once().returning(knownSlotData.pure[F])
 
       val slotDataStoreMap = mutable.Map.empty[BlockId, SlotData]
       slotDataStoreMap.put(knownId, knownSlotData)

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerNetworkQualityTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerNetworkQualityTest.scala
@@ -9,6 +9,7 @@ import co.topl.networking.fsnetwork.NetworkQualityError.{IncorrectPongMessage, N
 import co.topl.networking.fsnetwork.PeerNetworkQualityTest.{pingDelay, F}
 import co.topl.networking.fsnetwork.ReputationAggregator.Message.PingPongMessagePing
 import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
+import co.topl.networking.p2p.RemoteAddress
 import co.topl.node.models.{PingMessage, PongMessage}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalamock.munit.AsyncMockFactory
@@ -29,7 +30,7 @@ class PeerNetworkQualityTest
     with TransactionGenerator {
   implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
 
-  val hostId: HostId = "127.0.0.1"
+  val hostId: HostId = RemoteAddress("127.0.0.1", 0)
 
   test("Ping shall be sent to reputation aggregator") {
     withMock {

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
@@ -1,0 +1,432 @@
+package co.topl.networking.fsnetwork
+
+import cats.data.NonEmptyChain
+import cats.effect.{IO, Resource}
+import cats.implicits._
+import co.topl.algebras.Store
+import co.topl.brambl.generators.TransactionGenerator
+import co.topl.brambl.models.TransactionId
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.config.ApplicationConfig.Bifrost.NetworkProperties
+import co.topl.consensus.algebras.{BlockHeaderToBodyValidationAlgebra, LocalChainAlgebra}
+import co.topl.consensus.models.{BlockId, SlotData}
+import co.topl.eventtree.ParentChildTree
+import co.topl.networking.blockchain.BlockchainPeerClient
+import co.topl.networking.fsnetwork.BlockChecker.BlockCheckerActor
+import co.topl.networking.fsnetwork.PeerActor.PeerActor
+import co.topl.networking.fsnetwork.PeersManager.Peer
+import co.topl.networking.fsnetwork.PeersManagerTest.F
+import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
+import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
+import co.topl.networking.p2p.RemoteAddress
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalamock.munit.AsyncMockFactory
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import scala.concurrent.duration.{FiniteDuration, SECONDS}
+
+object PeersManagerTest {
+  type F[A] = IO[A]
+}
+
+class PeersManagerTest
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with AsyncMockFactory
+    with TransactionGenerator {
+  implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
+
+  val hostId: HostId = RemoteAddress("127.0.0.1", 0)
+
+  val coldToWarmSelector: ColdToWarmSelector = (coldHosts: Set[HostId], countToReceive: Int) =>
+    coldHosts.toSeq.sortBy(_.port).take(countToReceive).toSet
+
+  test("Banned peer shall be stopped and appropriate state shall be set") {
+    withMock {
+
+      val networkAlgebra: NetworkAlgebra[F] = mock[NetworkAlgebra[F]]
+      val localChain: LocalChainAlgebra[F] = mock[LocalChainAlgebra[F]]
+      val slotDataStore: Store[F, BlockId, SlotData] = mock[Store[F, BlockId, SlotData]]
+      val transactionStore: Store[F, TransactionId, IoTransaction] = mock[Store[F, TransactionId, IoTransaction]]
+      val blockIdTree: ParentChildTree[F, BlockId] = mock[ParentChildTree[F, BlockId]]
+      val headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F] = mock[BlockHeaderToBodyValidationAlgebra[F]]
+      val newPeerCreationAlgebra: PeerCreationRequestAlgebra[F] = mock[PeerCreationRequestAlgebra[F]]
+      val p2pConfig: P2PNetworkConfig = P2PNetworkConfig(NetworkProperties(), FiniteDuration(1, SECONDS))
+
+      val peerActor = mock[PeerActor[F]]
+      (peerActor.sendNoWait _)
+        .expects(PeerActor.Message.UpdateState(networkLevel = false, applicationLevel = false))
+        .returns(().pure[F])
+      (() => peerActor.id).expects().anyNumberOfTimes().returns(1) // used in release actor function
+
+      val reputationAggregator = mock[ReputationAggregatorActor[F]]
+      (reputationAggregator.sendNoWait _)
+        .expects(ReputationAggregator.Message.PeerIsCold(hostId))
+        .returns(().pure[F])
+
+      val initialPeersMap =
+        Map.empty[HostId, Peer[F]] + (hostId -> Peer(PeerState.Hot, Option(peerActor)))
+
+      PeersManager
+        .makeActor(
+          networkAlgebra,
+          localChain,
+          slotDataStore,
+          transactionStore,
+          blockIdTree,
+          headerToBodyValidation,
+          newPeerCreationAlgebra,
+          p2pConfig,
+          initialPeers = initialPeersMap
+        )
+        .use { actor =>
+          for {
+            _        <- actor.send(PeersManager.Message.SetupReputationAggregator(reputationAggregator))
+            endState <- actor.send(PeersManager.Message.BanPeer(hostId))
+            _ = assert(endState.peers(hostId).state == PeerState.Banned)
+          } yield ()
+        }
+    }
+  }
+
+  test("Peer moved to cold state shall be stopped and appropriate state shall be set") {
+    withMock {
+
+      val networkAlgebra: NetworkAlgebra[F] = mock[NetworkAlgebra[F]]
+      val localChain: LocalChainAlgebra[F] = mock[LocalChainAlgebra[F]]
+      val slotDataStore: Store[F, BlockId, SlotData] = mock[Store[F, BlockId, SlotData]]
+      val transactionStore: Store[F, TransactionId, IoTransaction] = mock[Store[F, TransactionId, IoTransaction]]
+      val blockIdTree: ParentChildTree[F, BlockId] = mock[ParentChildTree[F, BlockId]]
+      val headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F] = mock[BlockHeaderToBodyValidationAlgebra[F]]
+      val newPeerCreationAlgebra: PeerCreationRequestAlgebra[F] = mock[PeerCreationRequestAlgebra[F]]
+      val p2pConfig: P2PNetworkConfig = P2PNetworkConfig(NetworkProperties(), FiniteDuration(1, SECONDS))
+
+      val peerActor = mock[PeerActor[F]]
+      (peerActor.sendNoWait _)
+        .expects(PeerActor.Message.UpdateState(networkLevel = false, applicationLevel = false))
+        .returns(().pure[F])
+      (() => peerActor.id).expects().anyNumberOfTimes().returns(1) // used in release actor function
+
+      val reputationAggregator = mock[ReputationAggregatorActor[F]]
+      (reputationAggregator.sendNoWait _)
+        .expects(ReputationAggregator.Message.PeerIsCold(hostId))
+        .returns(().pure[F])
+
+      val initialPeersMap =
+        Map.empty[HostId, Peer[F]] + (hostId -> Peer(PeerState.Hot, Option(peerActor)))
+
+      PeersManager
+        .makeActor(
+          networkAlgebra,
+          localChain,
+          slotDataStore,
+          transactionStore,
+          blockIdTree,
+          headerToBodyValidation,
+          newPeerCreationAlgebra,
+          p2pConfig,
+          initialPeers = initialPeersMap
+        )
+        .use { actor =>
+          for {
+            _        <- actor.send(PeersManager.Message.SetupReputationAggregator(reputationAggregator))
+            endState <- actor.send(PeersManager.Message.ClosePeer(hostId))
+            _ = assert(endState.peers(hostId).state == PeerState.Cold)
+          } yield ()
+        }
+    }
+  }
+
+  test("Reputation update: If no warm peer then move cold peer(s) to prewarm") {
+    withMock {
+      val networkAlgebra: NetworkAlgebra[F] = mock[NetworkAlgebra[F]]
+      val localChain: LocalChainAlgebra[F] = mock[LocalChainAlgebra[F]]
+      val slotDataStore: Store[F, BlockId, SlotData] = mock[Store[F, BlockId, SlotData]]
+      val transactionStore: Store[F, TransactionId, IoTransaction] = mock[Store[F, TransactionId, IoTransaction]]
+      val blockIdTree: ParentChildTree[F, BlockId] = mock[ParentChildTree[F, BlockId]]
+      val headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F] = mock[BlockHeaderToBodyValidationAlgebra[F]]
+      val newPeerCreationAlgebra: PeerCreationRequestAlgebra[F] = mock[PeerCreationRequestAlgebra[F]]
+      val p2pConfig: P2PNetworkConfig =
+        P2PNetworkConfig(NetworkProperties(minimumWarmConnections = 2), FiniteDuration(1, SECONDS))
+      val reputationAggregator = mock[ReputationAggregatorActor[F]]
+
+      val host1 = RemoteAddress("first", 0)
+      val host2 = RemoteAddress("second", 1)
+      val host3 = RemoteAddress("third", 2)
+
+      (newPeerCreationAlgebra.requestNewPeerCreation _).expects(host1).returns(().pure[F])
+      (newPeerCreationAlgebra.requestNewPeerCreation _).expects(host2).returns(().pure[F])
+
+      PeersManager
+        .makeActor(
+          networkAlgebra,
+          localChain,
+          slotDataStore,
+          transactionStore,
+          blockIdTree,
+          headerToBodyValidation,
+          newPeerCreationAlgebra,
+          p2pConfig,
+          coldToWarmSelector = coldToWarmSelector
+        )
+        .use { actor =>
+          for {
+            _            <- actor.send(PeersManager.Message.SetupReputationAggregator(reputationAggregator))
+            withColdPeer <- actor.send(PeersManager.Message.AddKnownPeers(NonEmptyChain(host1, host2, host3)))
+            _ = assert(withColdPeer.peers(host1).state == PeerState.Cold)
+            _ = assert(withColdPeer.peers(host2).state == PeerState.Cold)
+            _ = assert(withColdPeer.peers(host3).state == PeerState.Cold)
+
+            withUpdate <- actor.send(PeersManager.Message.UpdatedReputation(Map.empty, Map.empty, Map.empty))
+            _ = assert(withUpdate.peers(host1).state == PeerState.PreWarm)
+            _ = assert(withUpdate.peers(host2).state == PeerState.PreWarm)
+            _ = assert(withUpdate.peers(host3).state == PeerState.Cold)
+          } yield ()
+        }
+    }
+  }
+
+  test("Reputation update: close opened hot connections") {
+    withMock {
+      val networkAlgebra: NetworkAlgebra[F] = mock[NetworkAlgebra[F]]
+      val localChain: LocalChainAlgebra[F] = mock[LocalChainAlgebra[F]]
+      val slotDataStore: Store[F, BlockId, SlotData] = mock[Store[F, BlockId, SlotData]]
+      val transactionStore: Store[F, TransactionId, IoTransaction] = mock[Store[F, TransactionId, IoTransaction]]
+      val blockIdTree: ParentChildTree[F, BlockId] = mock[ParentChildTree[F, BlockId]]
+      val headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F] = mock[BlockHeaderToBodyValidationAlgebra[F]]
+      val newPeerCreationAlgebra: PeerCreationRequestAlgebra[F] = mock[PeerCreationRequestAlgebra[F]]
+      val p2pConfig: P2PNetworkConfig = P2PNetworkConfig(NetworkProperties(), FiniteDuration(1, SECONDS))
+      val reputationAggregator = mock[ReputationAggregatorActor[F]]
+
+      val host1 = RemoteAddress("first", 1)
+      val peer1 = mock[PeerActor[F]]
+
+      val host2 = RemoteAddress("second", 2)
+      val peer2 = mock[PeerActor[F]]
+
+      val host3 = RemoteAddress("third", 3)
+      val peer3 = mock[PeerActor[F]]
+
+      val host4 = RemoteAddress("fourth", 4)
+      val peer4 = mock[PeerActor[F]]
+
+      val host5 = RemoteAddress("five", 5)
+      val peer5 = mock[PeerActor[F]]
+      (peer5.sendNoWait _)
+        .expects(PeerActor.Message.UpdateState(networkLevel = false, applicationLevel = false))
+        .returns(().pure[F])
+      (() => peer5.id).expects().anyNumberOfTimes().returns(5) // used in release actor function
+      (reputationAggregator.sendNoWait _)
+        .expects(ReputationAggregator.Message.PeerIsCold(host5))
+        .returns(().pure[F])
+
+      val host6 = RemoteAddress("six", 6)
+      val peer6 = mock[PeerActor[F]]
+      (peer6.sendNoWait _)
+        .expects(PeerActor.Message.UpdateState(networkLevel = false, applicationLevel = false))
+        .returns(().pure[F])
+      (() => peer6.id).expects().anyNumberOfTimes().returns(6) // used in release actor function
+      (reputationAggregator.sendNoWait _)
+        .expects(ReputationAggregator.Message.PeerIsCold(host6))
+        .returns(().pure[F])
+
+      val initialPeersMap: Map[HostId, Peer[F]] =
+        Map(
+          host1 -> Peer(PeerState.Hot, Option(peer1)),
+          host2 -> Peer(PeerState.Hot, Option(peer2)),
+          host3 -> Peer(PeerState.Hot, Option(peer3)),
+          host4 -> Peer(PeerState.Hot, Option(peer4)),
+          host5 -> Peer(PeerState.Hot, Option(peer5)),
+          host6 -> Peer(PeerState.Hot, Option(peer6))
+        )
+
+      val performanceRep: Map[HostId, HostReputationValue] =
+        Map(
+          host1 -> 1.0,
+          host3 -> p2pConfig.networkProperties.minimumRequiredReputation * 1.05
+        )
+
+      val blockRep: Map[HostId, HostReputationValue] =
+        Map(
+          host2 -> 1.0,
+          host3 -> p2pConfig.networkProperties.minimumRequiredReputation * 1.05
+        )
+
+      val noveltyRep: Map[HostId, Long] =
+        Map(
+          host4 -> 1
+        )
+
+      PeersManager
+        .makeActor(
+          networkAlgebra,
+          localChain,
+          slotDataStore,
+          transactionStore,
+          blockIdTree,
+          headerToBodyValidation,
+          newPeerCreationAlgebra,
+          p2pConfig,
+          coldToWarmSelector = coldToWarmSelector,
+          initialPeers = initialPeersMap
+        )
+        .use { actor =>
+          for {
+            _          <- actor.send(PeersManager.Message.SetupReputationAggregator(reputationAggregator))
+            withUpdate <- actor.send(PeersManager.Message.UpdatedReputation(performanceRep, blockRep, noveltyRep))
+            _ = assert(withUpdate.peers(host1).state == PeerState.Hot)
+            _ = assert(withUpdate.peers(host2).state == PeerState.Hot)
+            _ = assert(withUpdate.peers(host3).state == PeerState.Hot)
+            _ = assert(withUpdate.peers(host4).state == PeerState.Hot)
+            _ = assert(withUpdate.peers(host5).state == PeerState.Cold)
+            _ = assert(withUpdate.peers(host6).state == PeerState.Cold)
+          } yield ()
+        }
+    }
+  }
+
+  test("Reputation update: move warm to hot") {
+    withMock {
+      val networkAlgebra: NetworkAlgebra[F] = mock[NetworkAlgebra[F]]
+      val localChain: LocalChainAlgebra[F] = mock[LocalChainAlgebra[F]]
+      val slotDataStore: Store[F, BlockId, SlotData] = mock[Store[F, BlockId, SlotData]]
+      val transactionStore: Store[F, TransactionId, IoTransaction] = mock[Store[F, TransactionId, IoTransaction]]
+      val blockIdTree: ParentChildTree[F, BlockId] = mock[ParentChildTree[F, BlockId]]
+      val headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F] = mock[BlockHeaderToBodyValidationAlgebra[F]]
+      val newPeerCreationAlgebra: PeerCreationRequestAlgebra[F] = mock[PeerCreationRequestAlgebra[F]]
+      val p2pConfig: P2PNetworkConfig =
+        P2PNetworkConfig(NetworkProperties(minimumHotConnections = 2), FiniteDuration(1, SECONDS))
+      val reputationAggregator = mock[ReputationAggregatorActor[F]]
+
+      val host1 = RemoteAddress("first", 1)
+      val peer1 = mock[PeerActor[F]]
+      (peer1.sendNoWait _)
+        .expects(PeerActor.Message.UpdateState(networkLevel = true, applicationLevel = true))
+        .returns(().pure[F])
+
+      val host2 = RemoteAddress("second", 2)
+      val peer2 = mock[PeerActor[F]]
+      (peer2.sendNoWait _)
+        .expects(PeerActor.Message.UpdateState(networkLevel = true, applicationLevel = true))
+        .returns(().pure[F])
+
+      val host3 = RemoteAddress("third", 3)
+      val peer3 = mock[PeerActor[F]]
+
+      val host4 = RemoteAddress("fourth", 4)
+      val peer4 = mock[PeerActor[F]]
+
+      val initialPeersMap: Map[HostId, Peer[F]] =
+        Map(
+          host1 -> Peer(PeerState.Warm, Option(peer1)),
+          host2 -> Peer(PeerState.Warm, Option(peer2)),
+          host3 -> Peer(PeerState.Warm, Option(peer3)),
+          host4 -> Peer(PeerState.Warm, Option(peer4))
+        )
+
+      (reputationAggregator.sendNoWait _)
+        .expects(ReputationAggregator.Message.NewHotPeer(NonEmptyChain(host2, host1)))
+        .once()
+        .returns(().pure[F])
+
+      val performanceRep: Map[HostId, HostReputationValue] =
+        Map(
+          host1 -> 1.0,
+          host2 -> 0.9,
+          host3 -> 0.8,
+          host4 -> 0.7
+        )
+
+      PeersManager
+        .makeActor(
+          networkAlgebra,
+          localChain,
+          slotDataStore,
+          transactionStore,
+          blockIdTree,
+          headerToBodyValidation,
+          newPeerCreationAlgebra,
+          p2pConfig,
+          coldToWarmSelector = coldToWarmSelector,
+          initialPeers = initialPeersMap
+        )
+        .use { actor =>
+          for {
+            _          <- actor.send(PeersManager.Message.SetupReputationAggregator(reputationAggregator))
+            withUpdate <- actor.send(PeersManager.Message.UpdatedReputation(performanceRep, Map.empty, Map.empty))
+            _ = assert(withUpdate.peers(host1).state == PeerState.Hot)
+            _ = assert(withUpdate.peers(host2).state == PeerState.Hot)
+            _ = assert(withUpdate.peers(host3).state == PeerState.Warm)
+            _ = assert(withUpdate.peers(host4).state == PeerState.Warm)
+          } yield ()
+        }
+    }
+  }
+
+  test("Peer moved to warm state after received new opened peer message") {
+    withMock {
+
+      val networkAlgebra: NetworkAlgebra[F] = mock[NetworkAlgebra[F]]
+      val localChain: LocalChainAlgebra[F] = mock[LocalChainAlgebra[F]]
+      val slotDataStore: Store[F, BlockId, SlotData] = mock[Store[F, BlockId, SlotData]]
+      val transactionStore: Store[F, TransactionId, IoTransaction] = mock[Store[F, TransactionId, IoTransaction]]
+      val blockIdTree: ParentChildTree[F, BlockId] = mock[ParentChildTree[F, BlockId]]
+      val headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F] = mock[BlockHeaderToBodyValidationAlgebra[F]]
+      val newPeerCreationAlgebra: PeerCreationRequestAlgebra[F] = mock[PeerCreationRequestAlgebra[F]]
+      val p2pConfig: P2PNetworkConfig = P2PNetworkConfig(NetworkProperties(), FiniteDuration(1, SECONDS))
+      val blockChecker = mock[BlockCheckerActor[F]]
+      val reputationAggregator = mock[ReputationAggregatorActor[F]]
+      val requestProxy = mock[RequestsProxyActor[F]]
+
+      val host1 = RemoteAddress("first", 1)
+      val peer1 = mock[PeerActor[F]]
+      (networkAlgebra.makePeer _).expects(host1, *, *, *, *, *, *, *, *).once().returns(Resource.pure(peer1))
+      (() => peer1.id).expects().anyNumberOfTimes().returns(1)
+      (peer1.sendNoWait _)
+        .expects(PeerActor.Message.GetNetworkQuality)
+        .returns(().pure[F])
+      (peer1.sendNoWait _)
+        .expects(PeerActor.Message.UpdateState(true, false))
+        .returns(().pure[F])
+
+      val host2 = RemoteAddress("second", 2)
+      val peer2 = mock[PeerActor[F]]
+      (networkAlgebra.makePeer _).expects(host2, *, *, *, *, *, *, *, *).once().returns(Resource.pure(peer2))
+      (() => peer2.id).expects().anyNumberOfTimes().returns(2)
+      (peer2.sendNoWait _)
+        .expects(PeerActor.Message.GetNetworkQuality)
+        .returns(().pure[F])
+      (peer2.sendNoWait _)
+        .expects(PeerActor.Message.UpdateState(true, false))
+        .returns(().pure[F])
+
+      val initialPeersMap = Map(host1 -> Peer(PeerState.PreWarm, None))
+
+      PeersManager
+        .makeActor(
+          networkAlgebra,
+          localChain,
+          slotDataStore,
+          transactionStore,
+          blockIdTree,
+          headerToBodyValidation,
+          newPeerCreationAlgebra,
+          p2pConfig,
+          initialPeers = initialPeersMap
+        )
+        .use { actor =>
+          for {
+            _          <- actor.send(PeersManager.Message.SetupReputationAggregator(reputationAggregator))
+            _          <- actor.send(PeersManager.Message.SetupBlockChecker(blockChecker))
+            _          <- actor.send(PeersManager.Message.SetupRequestsProxy(requestProxy))
+            stateHost1 <- actor.send(PeersManager.Message.OpenedPeerConnection(host1, mock[BlockchainPeerClient[F]]))
+            _ = assert(stateHost1.peers(host1).state == PeerState.Warm)
+            stateHost2 <- actor.send(PeersManager.Message.OpenedPeerConnection(host2, mock[BlockchainPeerClient[F]]))
+            _ = assert(stateHost2.peers(host2).state == PeerState.Warm)
+          } yield ()
+        }
+    }
+  }
+
+}

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
@@ -28,6 +28,7 @@ import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.networking.fsnetwork.TestHelper.arbitraryHostBlockId
+import co.topl.networking.p2p.RemoteAddress
 
 import scala.jdk.CollectionConverters._
 import scala.collection.immutable.ListMap
@@ -67,7 +68,7 @@ object RequestsProxyTest {
 class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory with ModelGenerators {
   implicit val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
 
-  val hostId: HostId = "127.0.0.1"
+  val hostId: HostId = RemoteAddress("127.0.0.1", 0)
   val maxChainSize = 99
 
   test("Block header download request: downloaded prefix sent back, request for new block header shall be sent") {
@@ -466,7 +467,7 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
               .map(d => d._2)
               .zipWithIndex
               .map { case (block, index) =>
-                val sourcesForBlock = (1 to index).map(i => i.toString).toSet
+                val sourcesForBlock = (1 to index).map(i => RemoteAddress(i.toString, 0)).toSet
                 (block, sourcesForBlock)
               }
               .toMap

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/TestHelper.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/TestHelper.scala
@@ -10,6 +10,7 @@ import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.models.generators.consensus.ModelGenerators
 import co.topl.models.generators.consensus.ModelGenerators._
+import co.topl.networking.p2p.RemoteAddress
 import co.topl.node.models.BlockBody
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalamock.handlers.{CallHandler1, CallHandler2, CallHandler3}
@@ -44,7 +45,12 @@ object TestHelper extends TransactionGenerator {
         addHeaderToChain(headers.append(gen.sample.get.copy(parentHeaderId = parentId)), gen, count - 1)
     }
 
-  val arbitraryHost: Arbitrary[HostId] = Arbitrary(Arbitrary.arbitrary[String])
+  val arbitraryHost: Arbitrary[HostId] = Arbitrary(
+    for {
+      host <- Arbitrary.arbitrary[String]
+      port <- Arbitrary.arbitrary[Byte]
+    } yield RemoteAddress(host, port)
+  )
 
   val arbitraryHostBlockId: Arbitrary[(HostId, BlockId)] = Arbitrary(
     for {

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -30,14 +30,14 @@ import co.topl.minting.interpreters.{OperationalKeyMaker, Staking, VrfCalculator
 import co.topl.models._
 import co.topl.models.utility.HasLength.instances.byteStringLength
 import co.topl.models.utility._
-import co.topl.networking.p2p.{DisconnectedPeer, LocalPeer, RemoteAddress}
+import co.topl.networking.p2p.{LocalPeer, RemoteAddress}
 import co.topl.numerics.interpreters.{ExpInterpreter, Log1pInterpreter}
 import co.topl.typeclasses.implicits._
 import co.topl.node.ApplicationConfigOps._
 import co.topl.node.cli.ConfiguredCliApp
 
 // Hide `io` from fs2 because it conflicts with `io.grpc` down below
-import fs2.{io => _, _}
+import fs2.{io => _}
 import fs2.io.file.{Files, Path}
 import kamon.Kamon
 import org.typelevel.log4cats.Logger
@@ -332,10 +332,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
           mempool,
           cryptoResources.ed25519VRF,
           localPeer,
-          Stream.eval(clock.delayedUntilSlot(canonicalHeadSlotData.slotId.slot)) >>
-          Stream.iterable[F, DisconnectedPeer](
-            appConfig.bifrost.p2p.knownPeers.map(kp => DisconnectedPeer(RemoteAddress(kp.host, kp.port), (0, 0)))
-          ) ++ Stream.never[F],
+          appConfig.bifrost.p2p.knownPeers,
           appConfig.bifrost.rpc.bindHost,
           appConfig.bifrost.rpc.bindPort,
           protocolConfig,


### PR DESCRIPTION
## Purpose
Remote peer state changes based on their reputation including open/close connections

## Approach
A reputation update is sent to Peers manager every slot, thus we could change the state of the remote peer every slot.

## Testing
Unit test + Integration tests 

## Tickets
closes #BN-1116