### PR TITLE
Bn 1129 p 2 p do additional check before sending bad k look back message

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -248,7 +248,7 @@ object PeerBlockHeaderFetcher {
               .couldBeWorse(slotData.last)
               .ifM(
                 ifTrue = Logger[F].info(show"Ignoring tip $bestBlockId because of density rule") >>
-                  state.requestsProxy.sendNoWait(RequestsProxy.Message.BadKLoopbackSlotData(state.hostId)),
+                  state.requestsProxy.sendNoWait(RequestsProxy.Message.BadKLookbackSlotData(state.hostId)),
                 ifFalse =
                   Logger[F].info(show"Ignoring tip $bestBlockId because other better or equal block had been adopted")
               ) >>

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -101,13 +101,13 @@ object PeerBlockHeaderFetcher {
   private def getRemoteSlotDataByBlockId[F[_]: Async: Logger](state: State[F], blockId: BlockId): F[Unit] =
     for {
       _                 <- Logger[F].info(show"Got blockId: $blockId from remote peer ${state.hostId}")
-      newSlotDataOpt    <- getNewSlotDataChain(state, blockId).value
+      newSlotDataOpt    <- getRemoteBetterSlotDataChain(state, blockId).value
       _                 <- Logger[F].info(show"Build slot data chain from tip $blockId is ${newSlotDataOpt.isDefined}")
       newBlockSourceOpt <- buildBlockSource(state, blockId, newSlotDataOpt)
       _                 <- sendMessagesToProxy(state, newSlotDataOpt, newBlockSourceOpt)
     } yield ()
 
-  private def getNewSlotDataChain[F[_]: Async: Logger](
+  private def getRemoteBetterSlotDataChain[F[_]: Async: Logger](
     state:   State[F],
     blockId: BlockId
   ): OptionT[F, NonEmptyChain[SlotData]] =
@@ -244,8 +244,14 @@ object PeerBlockHeaderFetcher {
             Logger[F].debug(show"Received tip $bestBlockId is better than current block") >>
             Option(slotData).pure[F]
           case false =>
-            Logger[F].info(show"Ignoring tip because of density rule which id=$bestBlockId") >>
-            state.requestsProxy.sendNoWait(RequestsProxy.Message.BadKLoopbackSlotData(state.hostId)) >>
+            state.localChain
+              .couldBeWorse(slotData.last)
+              .ifM(
+                ifTrue = Logger[F].info(show"Ignoring tip $bestBlockId because of density rule") >>
+                  state.requestsProxy.sendNoWait(RequestsProxy.Message.BadKLoopbackSlotData(state.hostId)),
+                ifFalse =
+                  Logger[F].info(show"Ignoring tip $bestBlockId because other better or equal block had been adopted")
+              ) >>
             Option.empty[NonEmptyChain[SlotData]].pure[F]
         }
     )
@@ -256,7 +262,7 @@ object PeerBlockHeaderFetcher {
       _   <- OptionT.liftF(Logger[F].info(show"Requested current tip from peer ${state.hostId}"))
       tip <- OptionT(state.client.remoteCurrentTip())
       _   <- OptionT.liftF(getRemoteSlotDataByBlockId(state, tip))
-      _   <- OptionT.liftF(Logger[F].info(show"Received current tip $tip from peer ${state.hostId}"))
+      _   <- OptionT.liftF(Logger[F].info(show"Processed current tip $tip from peer ${state.hostId}"))
     } yield (state, state)
   }.getOrElse((state, state))
     .handleErrorWith(Logger[F].error(_)("Get tip from remote host return error") >> (state, state).pure[F])

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
@@ -290,8 +290,7 @@ object ReputationAggregator {
   }
 
   private def badKLoopbackSlotData[F[_]: Async](state: State[F], hostId: HostId): F[(State[F], Response[F])] = {
-    // shall be enable after fix BN-1129
-    val newBlockProvidingMap = state.blockProvidingReputation // + (hostId -> 0.0)
+    val newBlockProvidingMap = state.blockProvidingReputation + (hostId -> 0.0)
     val newState = state.copy(blockProvidingReputation = newBlockProvidingMap)
     (newState, newState).pure[F]
   }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
@@ -114,7 +114,7 @@ object ReputationAggregator {
       case (state, DownloadTimeBody(hostId, delay, txDelays)) => blockDownloadTime(state, hostId, delay, txDelays)
       case (state, BlockProvidingReputationUpdate(data))      => blockProvidingReputationUpdate(state, data)
 
-      case (state, BadKLookbackSlotData(hostId))      => badKLoopbackSlotData(state, hostId)
+      case (state, BadKLookbackSlotData(hostId))      => badKLookbackSlotData(state, hostId)
       case (state, HostProvideIncorrectBlock(hostId)) => incorrectBlockReceived(state, hostId)
 
       case (state, ReputationUpdateTick) => processReputationUpdateTick(state)
@@ -289,7 +289,7 @@ object ReputationAggregator {
     (newState, newState).pure[F]
   }
 
-  private def badKLoopbackSlotData[F[_]: Async](state: State[F], hostId: HostId): F[(State[F], Response[F])] = {
+  private def badKLookbackSlotData[F[_]: Async](state: State[F], hostId: HostId): F[(State[F], Response[F])] = {
     val newBlockProvidingMap = state.blockProvidingReputation + (hostId -> 0.0)
     val newState = state.copy(blockProvidingReputation = newBlockProvidingMap)
     (newState, newState).pure[F]

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
@@ -29,7 +29,7 @@ object RequestsProxy {
 
     case class BlocksSource(sources: NonEmptyChain[(HostId, BlockId)]) extends Message
 
-    case class BadKLoopbackSlotData(hostId: HostId) extends Message
+    case class BadKLookbackSlotData(hostId: HostId) extends Message
 
     // blockIds shall contains chain of linked blocks, for example if we have chain A -> B -> C
     // then A is parent of B and B is parent of C
@@ -76,7 +76,7 @@ object RequestsProxy {
       case (state, message: SetupBlockChecker[F] @unchecked)    => setupBlockChecker(state, message.blockCheckerActor)
       case (state, GetCurrentTips)                              => getCurrentTips(state)
       case (state, RemoteSlotData(hostId, slotData))            => processRemoteSlotData(state, hostId, slotData)
-      case (state, BadKLoopbackSlotData(hostId))                => resendBadKLoopbackSlotData(state, hostId)
+      case (state, BadKLookbackSlotData(hostId))                => resendBadKLookbackSlotData(state, hostId)
       case (state, BlocksSource(sources))                       => blocksSourceProcessing(state, sources)
       case (state, DownloadHeadersRequest(hostId, blockIds))    => downloadHeadersRequest(state, hostId, blockIds)
       case (state, DownloadHeadersResponse(source, response))   => downloadHeadersResponse(state, source, response)
@@ -134,7 +134,7 @@ object RequestsProxy {
     (state, state).pure[F]
   }
 
-  private def resendBadKLoopbackSlotData[F[_]: Async: Logger](
+  private def resendBadKLookbackSlotData[F[_]: Async: Logger](
     state:  State[F],
     source: HostId
   ): F[(State[F], Response[F])] =

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
@@ -530,7 +530,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val requestsProxy = mock[RequestsProxyActor[F]]
       val expectedSourceMessage: RequestsProxy.Message =
-        RequestsProxy.Message.BadKLoopbackSlotData(hostId)
+        RequestsProxy.Message.BadKLookbackSlotData(hostId)
       (requestsProxy.sendNoWait _).expects(expectedSourceMessage).once().returning(().pure[F])
 
       val localChain = mock[LocalChainAlgebra[F]]
@@ -596,7 +596,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val requestsProxy = mock[RequestsProxyActor[F]]
       val expectedSourceMessage: RequestsProxy.Message =
-        RequestsProxy.Message.BadKLoopbackSlotData(hostId)
+        RequestsProxy.Message.BadKLookbackSlotData(hostId)
       (requestsProxy.sendNoWait _).expects(expectedSourceMessage).never().returning(().pure[F])
 
       val localChain = mock[LocalChainAlgebra[F]]

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
@@ -313,9 +313,7 @@ class ReputationAggregatorTest
           for {
             newState <- actor.send(ReputationAggregator.Message.BadKLookbackSlotData(host))
             _ = assert(newState.performanceReputation == initialPerfMap)
-            _ = assert(
-              newState.blockProvidingReputation == initialBlockMap + (host -> 1.0)
-            ) /*+ (host -> 0.0))*/ // enable after BN-1129
+            _ = assert(newState.blockProvidingReputation == initialBlockMap + (host -> 0.0))
             _ = assert(newState.noveltyReputation == initialNewMap)
           } yield ()
         }

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
@@ -430,7 +430,7 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
     }
   }
 
-  test("BadKLoopbackSlotData shall be resent to reputation aggregator") {
+  test("BadKLookbackSlotData shall be resent to reputation aggregator") {
     withMock {
       val reputationAggregator = mock[ReputationAggregatorActor[F]]
       val peersManager = mock[PeersManagerActor[F]]
@@ -445,7 +445,7 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
         .makeActor(reputationAggregator, peersManager, headerStore, bodyStore)
         .use { actor =>
           for {
-            _ <- actor.send(RequestsProxy.Message.BadKLoopbackSlotData(hostId))
+            _ <- actor.send(RequestsProxy.Message.BadKLookbackSlotData(hostId))
           } yield ()
         }
 


### PR DESCRIPTION
## Purpose
BadKLookback message could be false positive detected in case if during remote data fetching new block had been successfully adopted. 

## Approach
Do additional check `couldBeWorse` debfore sending badKlookback message
## Testing

## Tickets
closes #BN-1129