### PR TITLE
More updates for ExperimentCompiler

### DIFF
--- a/docs/scripts/experiment-definitions/ExperimentCompiler.py
+++ b/docs/scripts/experiment-definitions/ExperimentCompiler.py
@@ -17,7 +17,7 @@ import yaml
                 type=click.Path(exists=True, readable=True, path_type=pathlib.Path),
                 required=True)
 @click.argument('output_dir',
-                type=click.Path(exists=True, writable=True, file_okay=False, path_type=pathlib.Path),
+                type=click.Path(exists=False, writable=True, file_okay=False, path_type=pathlib.Path),
                 required=False)
 def main(experiment_file: pathlib.Path, output_dir: pathlib.Path = None) -> None:
     # ensure that the output directory exists

--- a/docs/scripts/experiment-definitions/example-experiment.yaml
+++ b/docs/scripts/experiment-definitions/example-experiment.yaml
@@ -23,6 +23,7 @@
 
 # override specific settings at these dict-key-paths
 "scenario/transactionsPerSecond": [ 2.5 ]
+"shared-config/bifrost/big-bang/staker-count": [ 2 ]
 "shared-config/bifrost/protocols/0/slot-duration": { "min": 250, "max": 250, "step": 1, "suffix": " milli" }
 "scenario/scenarioTimeout": [ 600 ]
 "scenario/targetHeight": [ 30 ]

--- a/docs/scripts/experiment-definitions/experiment-templates/template-1.yaml
+++ b/docs/scripts/experiment-definitions/experiment-templates/template-1.yaml
@@ -1,7 +1,21 @@
+# These settings configure the images that will be used to run the experiment
+image:
+  name: localhost:5000/topl/bifrost-node
+  tag: latest
+
+delayerImage:
+  name: localhost:5000/topl/network-delayer
+  tag: latest
+
+orchestratorImage:
+  name: localhost:5000/topl/testnet-simulation-orchestrator
+  tag: latest
+
+
 # These settings control where the results are published
 results:
   # The Storage Bucket on Google Cloud
-  bucket: bifrost-topl-testnet-scenario-results
+  bucket: bifrost-topl-labs-testnet-scenario-results
   # The prefix to apply to each uploaded file.  The scenario name is automatically applied as a suffix to this prefix.
   prefix: /simulation/results/
 
@@ -21,7 +35,7 @@ shared-config:
   # Define custom application.conf overrides
   bifrost:
     big-bang:
-      staker-count: 500
+      staker-count: 2
     protocols:
       0:
         slot-duration: 1 milli


### PR DESCRIPTION
## Purpose
Minor update to the experiment compiler in order to generate valid Helm charts for running the testnet cluster

## Approach
- Included the image names and locations in the template helm file that is modified by the script
- Updated ExperimentCompiler input args to allow the output directory to be created at runtime

## Testing
- able to read the experiment file and template via ExperimentCompiler to output a job chart
- used job chart from output in a testnet scenario and successfully uploaded data to the public bucket

## Tickets
* N/A