### PR TITLE
Support Loading Staker From Disk

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/UnsafeResource.scala
+++ b/algebras/src/main/scala/co/topl/algebras/UnsafeResource.scala
@@ -1,5 +1,7 @@
 package co.topl.algebras
 
+import cats.effect.Sync
+
 /**
  * Wraps some entity of type T that is deemed to not be thread-safe.
  */
@@ -9,4 +11,9 @@ trait UnsafeResource[F[_], T] {
    * Use the thread-unsafe resource in a thread-safe manner
    */
   def use[Res](f: T => F[Res]): F[Res]
+
+  /**
+   * Convenience method to execute the function using cats-effect Sync
+   */
+  def useSync[Res](f: T => Res)(implicit SyncF: Sync[F]): F[Res] = use(v => SyncF.delay(f(v)))
 }

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val dockerSettings = Seq(
 lazy val nodeDockerSettings =
   dockerSettings ++ Seq(
     dockerExposedPorts := Seq(9084, 9085),
-    dockerExposedVolumes += "/opt/docker/.bifrost",
+    dockerExposedVolumes ++= Seq("/bifrost-data", "/bifrost-staking", "/bifrost-config"),
     Docker / packageName := "bifrost-node"
   )
 

--- a/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
@@ -1,11 +1,15 @@
 package co.topl.byzantine
 
+import cats.data.OptionT
 import cats.effect.IO
 import cats.effect.implicits._
 import cats.effect.kernel.Sync
 import cats.implicits._
+import co.topl.algebras.NodeRpc
 import co.topl.blockchain.{PrivateTestnet, StakerInitializers}
-import co.topl.brambl.models.box.Value
+import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
+import co.topl.brambl.common.ContainsSignable.instances.ioTransactionSignable
+import co.topl.brambl.models.box.{Attestation, Value}
 import co.topl.brambl.models.{Datum, Event, TransactionOutputAddress}
 import co.topl.brambl.models.transaction.{IoTransaction, Schedule, SpentTransactionOutput, UnspentTransactionOutput}
 import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
@@ -21,8 +25,9 @@ import co.topl.interpreters.NodeRpcOps._
 import co.topl.node.StakingInit
 import com.google.protobuf.ByteString
 import fs2.Chunk
-import fs2.io.file.Files
+import fs2.io.file.{Files, Path}
 import co.topl.numerics.implicits._
+import co.topl.quivr.api.Prover
 
 import java.security.SecureRandom
 import java.time.Instant
@@ -46,32 +51,57 @@ class MultiNodeTest extends IntegrationSuite {
         node0 <- dockerSupport.createNode("MultiNodeTest-node0", "MultiNodeTest", config0)
         node1 <- dockerSupport.createNode("MultiNodeTest-node1", "MultiNodeTest", config1)
         node2 <- dockerSupport.createNode("MultiNodeTest-node2", "MultiNodeTest", config2)
-        nodes = List(node0, node1, node2)
-        _ <- nodes.parTraverse(_.startContainer[F]).toResource
-        _ <- nodes
-          .parTraverse(node => node.rpcClient[F](node.config.rpcPort, tls = false).use(_.waitForRpcStartUp))
+        // Node 3 is a delayed staker.  It will register in epoch 0, but the container won't launch until epoch 2.
+        node3 <- dockerSupport.createNode("MultiNodeTest-node3", "MultiNodeTest", config3)
+        initialNodes = List(node0, node1, node2)
+        allNodes = List(node0, node1, node2, node3)
+        _ <- initialNodes.parTraverse(_.startContainer[F]).toResource
+        _ <- initialNodes
+          .parTraverse(node => node.rpcClient[F](node.config.rpcPort).use(_.waitForRpcStartUp))
+          .toResource
+        genesisTransaction <- node0
+          .rpcClient[F](node0.config.rpcPort)
+          .use(client =>
+            OptionT(client.blockIdAtHeight(1))
+              .flatMapF(client.fetchBlockBody)
+              .map(_.transactionIds.head)
+              .flatMapF(client.fetchTransaction)
+              .getOrRaise(new IllegalStateException)
+          )
+          .toResource
+        _ <- Logger[F].info("Registering node3").toResource
+        node3StakingAddress <- node2
+          .rpcClient[F](node2.config.rpcPort)
+          // Take stake from node0 and transfer it to node3
+          .use(registerStaker(genesisTransaction, 0)(_, node3))
           .toResource
         _ <- Logger[F].info("Waiting for nodes to reach target epoch.  This may take several minutes.").toResource
-        thirdEpochHeads <- nodes
+        thirdEpochHeads <- initialNodes
           .parTraverse(node =>
             node
-              .rpcClient[F](node.config.rpcPort, tls = false)
+              .rpcClient[F](node.config.rpcPort)
               .use(_.adoptedHeaders.takeWhile(_.slot < (epochSlotLength * 3)).timeout(9.minutes).compile.lastOrError)
           )
           .toResource
-        _     <- Logger[F].info("Nodes have reached target epoch").toResource
-        node3 <- dockerSupport.createNode("MultiNodeTest-node3", "MultiNodeTest", config3)
+        _ <- Logger[F].info("Nodes have reached target epoch").toResource
+        // node3's registration should now be active, so node3 can launch and start producing blocks
+        _ <- Logger[F].info("Starting node3").toResource
+        _ <- node3.startContainer[F].toResource
+        // node3's blocks should be valid on other nodes (like node0), so search node0 for adoptions of a block produced
+        // by node3's staking address
+        _ <- node0
+          .rpcClient[F](node0.config.rpcPort)
+          .use(_.adoptedHeaders.find(_.address == node3StakingAddress).timeout(1.minutes).compile.lastOrError)
+          .toResource
         heights = thirdEpochHeads.map(_.height)
         // All nodes should be at _roughly_ equal height
         _ <- IO(heights.max - heights.min <= 5).assert.toResource
         // All nodes should have a shared common ancestor near the tip of the chain
-        _ <- nodes
+        _ <- allNodes
           .parTraverse(node =>
             node
-              .rpcClient[F](node.config.rpcPort, tls = false)
-              .use(
-                _.blockIdAtHeight(heights.min - 5)
-              )
+              .rpcClient[F](node.config.rpcPort)
+              .use(_.blockIdAtHeight(heights.min - 5))
           )
           .map(_.toSet.size)
           .assertEquals(1)
@@ -82,28 +112,24 @@ class MultiNodeTest extends IntegrationSuite {
 
   }
 
-  private def registerStaker(inputTransaction: IoTransaction, inputIndex: Int)(node: BifrostDockerNode) =
+  private def registerStaker(inputTransaction: IoTransaction, inputIndex: Int)(
+    rpcClient:   NodeRpc[F, fs2.Stream[F, *]],
+    stakingNode: BifrostDockerNode
+  )(implicit dockerClient: DockerClient) =
     Files
       .forAsync[F]
       .tempDirectory
       .use(localTmpDir =>
         for {
+          _ <- Logger[F].info("Generating new staker keys")
           kesKey <- Sync[F]
             .delay(new KesProduct().createKeyPair(SecureRandom.getInstanceStrong.generateSeed(32), (9, 9), 0))
           operatorKey <- Sync[F].delay(new Ed25519().deriveKeyPairFromEntropy(Entropy.generate(), None))
           vrfKey      <- Sync[F].delay(Ed25519VRF.precomputed().generateRandom)
           writeFile = (name: String, data: Array[Byte]) =>
-            fs2.Stream
-              .chunk(Chunk.array(data))
-              .through(
-                Files
-                  .forAsync[F]
-                  .writeAll(
-                    localTmpDir / name
-                  )
-              )
-              .compile
-              .drain
+            fs2.Stream.chunk(Chunk.array(data)).through(Files.forAsync[F].writeAll(localTmpDir / name)).compile.drain
+          _ <- Logger[F].info("Saving new staker keys to temp directory")
+          _ <- Files[F].createDirectories(localTmpDir / StakingInit.KesDirectoryName)
           _ <- writeFile(
             StakingInit.KesDirectoryName + "/0",
             Persistable[SecretKeyKesProduct].persistedBytes(kesKey._1).toByteArray
@@ -118,9 +144,10 @@ class MultiNodeTest extends IntegrationSuite {
               kesKey._1
             )
           spendableOutput = inputTransaction.outputs(inputIndex)
-          input = SpentTransactionOutput(
+          unprovenPredicateAttestation = Attestation.Predicate(PrivateTestnet.HeightLockOneLock.getPredicate, Nil)
+          unprovenInput = SpentTransactionOutput(
             TransactionOutputAddress(0, 0, inputIndex, inputTransaction.id),
-            ???,
+            Attestation.defaultInstance.withPredicate(unprovenPredicateAttestation),
             spendableOutput.value
           )
           spendableTopl = spendableOutput.value.value.topl.get
@@ -135,15 +162,28 @@ class MultiNodeTest extends IntegrationSuite {
               )
             )
           )
-          transaction = IoTransaction(datum =
+          unprovenTransaction = IoTransaction(datum =
             Datum.IoTransaction(
               Event.IoTransaction.defaultInstance.withSchedule(
                 Schedule(0L, Long.MaxValue, System.currentTimeMillis())
               )
             )
           )
-            .withInputs(List(input))
+            .withInputs(List(unprovenInput))
             .withOutputs(registrationOutputs :+ changeOutput)
-        } yield ()
+
+          proof <- Prover.heightProver[F].prove((), unprovenTransaction.signable)
+          provenPredicateAttestation = unprovenPredicateAttestation.copy(responses = List(proof))
+          transaction = unprovenTransaction.copy(
+            inputs = unprovenTransaction.inputs.map(
+              _.copy(attestation = Attestation(Attestation.Value.Predicate(provenPredicateAttestation)))
+            )
+          )
+          _ <- Logger[F].info("Broadcasting registration transaction")
+          _ <- rpcClient.broadcastTransaction(transaction)
+          _ <- writeFile(StakingInit.RegistrationTxName, transaction.toByteArray)
+          _ <- Logger[F].info("Copying temporary registration files into staking node container")
+          _ <- stakingNode.copyDirectoryIntoContainer[F](localTmpDir, Path("/bifrost-staking"))
+        } yield stakerInitializer.stakingAddress
       )
 }

--- a/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
@@ -91,7 +91,7 @@ class MultiNodeTest extends IntegrationSuite {
         // by node3's staking address
         _ <- node0
           .rpcClient[F](node0.config.rpcPort)
-          .use(_.adoptedHeaders.find(_.address == node3StakingAddress).timeout(1.minutes).compile.lastOrError)
+          .use(_.adoptedHeaders.find(_.address == node3StakingAddress).timeout(2.minutes).compile.lastOrError)
           .toResource
         heights = thirdEpochHeads.map(_.height)
         // All nodes should be at _roughly_ equal height

--- a/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
@@ -1,7 +1,7 @@
 package co.topl.byzantine
 
 import cats.data.OptionT
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import cats.effect.implicits._
 import cats.effect.kernel.Sync
 import cats.implicits._
@@ -44,7 +44,6 @@ class MultiNodeTest extends IntegrationSuite {
     val config0 = TestNodeConfig(bigBang, 3, 0, Nil)
     val config1 = TestNodeConfig(bigBang, 3, 1, List("MultiNodeTest-node0"))
     val config2 = TestNodeConfig(bigBang, 3, 2, List("MultiNodeTest-node1"))
-    val config3 = TestNodeConfig(bigBang, 3, -1, List("MultiNodeTest-node2"))
     val resource =
       for {
         (dockerSupport, _dockerClient) <- DockerSupport.make[F]()
@@ -52,10 +51,7 @@ class MultiNodeTest extends IntegrationSuite {
         node0 <- dockerSupport.createNode("MultiNodeTest-node0", "MultiNodeTest", config0)
         node1 <- dockerSupport.createNode("MultiNodeTest-node1", "MultiNodeTest", config1)
         node2 <- dockerSupport.createNode("MultiNodeTest-node2", "MultiNodeTest", config2)
-        // Node 3 is a delayed staker.  It will register in epoch 0, but the container won't launch until epoch 2.
-        node3 <- dockerSupport.createNode("MultiNodeTest-node3", "MultiNodeTest", config3)
         initialNodes = List(node0, node1, node2)
-        allNodes = List(node0, node1, node2, node3)
         _ <- initialNodes.parTraverse(_.startContainer[F]).toResource
         _ <- initialNodes
           .parTraverse(node => node.rpcClient[F](node.config.rpcPort).use(_.waitForRpcStartUp))
@@ -70,12 +66,23 @@ class MultiNodeTest extends IntegrationSuite {
               .getOrRaise(new IllegalStateException)
           )
           .toResource
+        // Node 3 is a delayed staker.  It will register in epoch 0, but the container won't launch until epoch 2.
+        tempHostStakingDirectory <- Files.forAsync[F].tempDirectory
+        _ <- Files.forAsync[F].setPosixPermissions(tempHostStakingDirectory, posixOtherWritePermissions).toResource
+        config3 = TestNodeConfig(
+          bigBang,
+          3,
+          -1,
+          List("MultiNodeTest-node2"),
+          stakingBindSourceDir = tempHostStakingDirectory.toString.some
+        )
+        node3 <- dockerSupport.createNode("MultiNodeTest-node3", "MultiNodeTest", config3)
+        allNodes = List(node0, node1, node2, node3)
         _ <- Logger[F].info("Registering node3").toResource
         node3StakingAddress <- node2
           .rpcClient[F](node2.config.rpcPort)
           // Take stake from node0 and transfer it to node3
-          .use(registerStaker(genesisTransaction, 0)(_, node3))
-          .toResource
+          .evalMap(registerStaker(genesisTransaction, 0)(_, tempHostStakingDirectory))
         _ <- Logger[F].info("Waiting for nodes to reach target epoch.  This may take several minutes.").toResource
         thirdEpochHeads <- initialNodes
           .parTraverse(node =>
@@ -120,10 +127,13 @@ class MultiNodeTest extends IntegrationSuite {
     PosixPermissions(
       PosixPermission.OwnerRead,
       PosixPermission.OwnerWrite,
+      PosixPermission.OwnerExecute,
       PosixPermission.GroupRead,
       PosixPermission.GroupWrite,
+      PosixPermission.GroupExecute,
       PosixPermission.OthersRead,
-      PosixPermission.OthersWrite
+      PosixPermission.OthersWrite,
+      PosixPermission.OthersExecute
     )
 
   /**
@@ -133,82 +143,78 @@ class MultiNodeTest extends IntegrationSuite {
    * @param inputTransaction A transaction containing funds to split
    * @param inputIndex The UTxO index at which the funds currently exist
    * @param rpcClient the RPC client to receive the broadcasted transaction
-   * @param stakingNode the docker container/node to which the keys will be copied
    * @return the new staker's StakingAddress
    */
   private def registerStaker(inputTransaction: IoTransaction, inputIndex: Int)(
     rpcClient:   NodeRpc[F, fs2.Stream[F, *]],
-    stakingNode: BifrostDockerNode
-  )(implicit dockerClient: DockerClient): F[StakingAddress] =
-    Files
-      .forAsync[F]
-      .tempDirectory
-      .use(localTmpDir =>
-        for {
-          _ <- Logger[F].info("Generating new staker keys")
-          kesKey <- Sync[F]
-            .delay(new KesProduct().createKeyPair(SecureRandom.getInstanceStrong.generateSeed(32), (9, 9), 0))
-          operatorKey <- Sync[F].delay(new Ed25519().deriveKeyPairFromEntropy(Entropy.generate(), None))
-          vrfKey      <- Sync[F].delay(Ed25519VRF.precomputed().generateRandom)
-          writeFile = (name: String, data: Array[Byte]) =>
-            fs2.Stream.chunk(Chunk.array(data)).through(Files.forAsync[F].writeAll(localTmpDir / name)).compile.drain
-          _ <- Logger[F].info("Saving new staker keys to temp directory")
-          _ <- Files[F].createDirectories(localTmpDir / StakingInit.KesDirectoryName)
-          _ <- Files[F].createFile(localTmpDir / StakingInit.KesDirectoryName / "0", Some(posixOtherWritePermissions))
-          _ <- writeFile(
-            StakingInit.KesDirectoryName + "/0",
-            Persistable[SecretKeyKesProduct].persistedBytes(kesKey._1).toByteArray
-          )
-          _ <- writeFile(StakingInit.OperatorKeyName, operatorKey.signingKey.bytes)
-          _ <- writeFile(StakingInit.VrfKeyName, vrfKey._1)
-          stakerInitializer =
-            StakerInitializers.Operator(
-              ByteString.copyFrom(operatorKey.signingKey.bytes),
-              PrivateTestnet.HeightLockOneSpendingAddress,
-              ByteString.copyFrom(vrfKey._1),
-              kesKey._1
-            )
-          spendableOutput = inputTransaction.outputs(inputIndex)
-          unprovenPredicateAttestation = Attestation.Predicate(PrivateTestnet.HeightLockOneLock.getPredicate, Nil)
-          unprovenInput = SpentTransactionOutput(
-            TransactionOutputAddress(0, 0, inputIndex, inputTransaction.id),
-            Attestation.defaultInstance.withPredicate(unprovenPredicateAttestation),
-            spendableOutput.value
-          )
-          spendableTopl = spendableOutput.value.value.topl.get
-          spendableQuantity = spendableTopl.quantity: BigInt
-          registrationOutputs = stakerInitializer.registrationOutputs(spendableQuantity / 2)
-          changeOutput = UnspentTransactionOutput(
-            PrivateTestnet.HeightLockOneSpendingAddress,
-            Value.defaultInstance.withTopl(
-              Value.TOPL(
-                spendableQuantity - (spendableQuantity / 2),
-                spendableTopl.registration
-              )
-            )
-          )
-          unprovenTransaction = IoTransaction(datum =
-            Datum.IoTransaction(
-              Event.IoTransaction.defaultInstance.withSchedule(
-                Schedule(0L, Long.MaxValue, System.currentTimeMillis())
-              )
-            )
-          )
-            .withInputs(List(unprovenInput))
-            .withOutputs(registrationOutputs :+ changeOutput)
-
-          proof <- Prover.heightProver[F].prove((), unprovenTransaction.signable)
-          provenPredicateAttestation = unprovenPredicateAttestation.copy(responses = List(proof))
-          transaction = unprovenTransaction.copy(
-            inputs = unprovenTransaction.inputs.map(
-              _.copy(attestation = Attestation(Attestation.Value.Predicate(provenPredicateAttestation)))
-            )
-          )
-          _ <- Logger[F].info("Broadcasting registration transaction")
-          _ <- rpcClient.broadcastTransaction(transaction)
-          _ <- writeFile(StakingInit.RegistrationTxName, transaction.toByteArray)
-          _ <- Logger[F].info("Copying temporary registration files into staking node container")
-          _ <- stakingNode.copyDirectoryIntoContainer[F](localTmpDir, Path("/bifrost-staking"))
-        } yield stakerInitializer.stakingAddress
+    localTmpDir: Path
+  ): F[StakingAddress] =
+    for {
+      _ <- Logger[F].info("Generating new staker keys")
+      kesKey <- Sync[F]
+        .delay(new KesProduct().createKeyPair(SecureRandom.getInstanceStrong.generateSeed(32), (9, 9), 0))
+      operatorKey <- Sync[F].delay(new Ed25519().deriveKeyPairFromEntropy(Entropy.generate(), None))
+      vrfKey      <- Sync[F].delay(Ed25519VRF.precomputed().generateRandom)
+      writeFile = (name: String, data: Array[Byte]) =>
+        fs2.Stream.chunk(Chunk.array(data)).through(Files.forAsync[F].writeAll(localTmpDir / name)).compile.drain
+      _ <- Logger[F].info("Saving new staker keys to temp directory")
+      _ <- Files[F].createDirectory(localTmpDir / StakingInit.KesDirectoryName)
+      _ <- Files.forAsync[F].setPosixPermissions(localTmpDir / StakingInit.KesDirectoryName, posixOtherWritePermissions)
+      _ <- Files[F].createFile(localTmpDir / StakingInit.KesDirectoryName / "0", Some(posixOtherWritePermissions))
+      _ <- Files
+        .forAsync[F]
+        .setPosixPermissions(localTmpDir / StakingInit.KesDirectoryName / "0", posixOtherWritePermissions)
+      _ <- writeFile(
+        StakingInit.KesDirectoryName + "/0",
+        Persistable[SecretKeyKesProduct].persistedBytes(kesKey._1).toByteArray
       )
+      _ <- writeFile(StakingInit.OperatorKeyName, operatorKey.signingKey.bytes)
+      _ <- writeFile(StakingInit.VrfKeyName, vrfKey._1)
+      stakerInitializer =
+        StakerInitializers.Operator(
+          ByteString.copyFrom(operatorKey.signingKey.bytes),
+          PrivateTestnet.HeightLockOneSpendingAddress,
+          ByteString.copyFrom(vrfKey._1),
+          kesKey._1
+        )
+      spendableOutput = inputTransaction.outputs(inputIndex)
+      unprovenPredicateAttestation = Attestation.Predicate(PrivateTestnet.HeightLockOneLock.getPredicate, Nil)
+      unprovenInput = SpentTransactionOutput(
+        TransactionOutputAddress(0, 0, inputIndex, inputTransaction.id),
+        Attestation.defaultInstance.withPredicate(unprovenPredicateAttestation),
+        spendableOutput.value
+      )
+      spendableTopl = spendableOutput.value.value.topl.get
+      spendableQuantity = spendableTopl.quantity: BigInt
+      registrationOutputs = stakerInitializer.registrationOutputs(spendableQuantity / 2)
+      changeOutput = UnspentTransactionOutput(
+        PrivateTestnet.HeightLockOneSpendingAddress,
+        Value.defaultInstance.withTopl(
+          Value.TOPL(
+            spendableQuantity - (spendableQuantity / 2),
+            spendableTopl.registration
+          )
+        )
+      )
+      unprovenTransaction = IoTransaction(datum =
+        Datum.IoTransaction(
+          Event.IoTransaction.defaultInstance.withSchedule(
+            Schedule(0L, Long.MaxValue, System.currentTimeMillis())
+          )
+        )
+      )
+        .withInputs(List(unprovenInput))
+        .withOutputs(registrationOutputs :+ changeOutput)
+
+      proof <- Prover.heightProver[F].prove((), unprovenTransaction.signable)
+      provenPredicateAttestation = unprovenPredicateAttestation.copy(responses = List(proof))
+      transaction = unprovenTransaction.copy(
+        inputs = unprovenTransaction.inputs.map(
+          _.copy(attestation = Attestation(Attestation.Value.Predicate(provenPredicateAttestation)))
+        )
+      )
+      _ <- Logger[F].info("Broadcasting registration transaction")
+      _ <- rpcClient.broadcastTransaction(transaction)
+      _ <- writeFile(StakingInit.RegistrationTxName, transaction.toByteArray)
+    } yield stakerInitializer.stakingAddress
 }

--- a/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
@@ -2,12 +2,29 @@ package co.topl.byzantine
 
 import cats.effect.IO
 import cats.effect.implicits._
+import cats.effect.kernel.Sync
 import cats.implicits._
+import co.topl.blockchain.{PrivateTestnet, StakerInitializers}
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.{Datum, Event, TransactionOutputAddress}
+import co.topl.brambl.models.transaction.{IoTransaction, Schedule, SpentTransactionOutput, UnspentTransactionOutput}
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
 import co.topl.byzantine.util._
+import co.topl.codecs.bytes.tetra.instances.persistableKesProductSecretKey
+import co.topl.codecs.bytes.typeclasses.Persistable
+import co.topl.crypto.generation.mnemonic.Entropy
+import co.topl.crypto.models.SecretKeyKesProduct
+import co.topl.crypto.signing.{Ed25519, Ed25519VRF, KesProduct}
 import com.spotify.docker.client.DockerClient
 import org.typelevel.log4cats.Logger
 import co.topl.interpreters.NodeRpcOps._
+import co.topl.node.StakingInit
+import com.google.protobuf.ByteString
+import fs2.Chunk
+import fs2.io.file.Files
+import co.topl.numerics.implicits._
 
+import java.security.SecureRandom
 import java.time.Instant
 import scala.concurrent.duration._
 
@@ -21,14 +38,15 @@ class MultiNodeTest extends IntegrationSuite {
     val config0 = TestNodeConfig(bigBang, 3, 0, Nil)
     val config1 = TestNodeConfig(bigBang, 3, 1, List("MultiNodeTest-node0"))
     val config2 = TestNodeConfig(bigBang, 3, 2, List("MultiNodeTest-node1"))
+    val config3 = TestNodeConfig(bigBang, 3, -1, List("MultiNodeTest-node2"))
     val resource =
       for {
         (dockerSupport, _dockerClient) <- DockerSupport.make[F]()
         implicit0(dockerClient: DockerClient) = _dockerClient
-        node1 <- dockerSupport.createNode("MultiNodeTest-node0", "MultiNodeTest", config0)
-        node2 <- dockerSupport.createNode("MultiNodeTest-node1", "MultiNodeTest", config1)
-        node3 <- dockerSupport.createNode("MultiNodeTest-node2", "MultiNodeTest", config2)
-        nodes = List(node1, node2, node3)
+        node0 <- dockerSupport.createNode("MultiNodeTest-node0", "MultiNodeTest", config0)
+        node1 <- dockerSupport.createNode("MultiNodeTest-node1", "MultiNodeTest", config1)
+        node2 <- dockerSupport.createNode("MultiNodeTest-node2", "MultiNodeTest", config2)
+        nodes = List(node0, node1, node2)
         _ <- nodes.parTraverse(_.startContainer[F]).toResource
         _ <- nodes
           .parTraverse(node => node.rpcClient[F](node.config.rpcPort, tls = false).use(_.waitForRpcStartUp))
@@ -41,7 +59,8 @@ class MultiNodeTest extends IntegrationSuite {
               .use(_.adoptedHeaders.takeWhile(_.slot < (epochSlotLength * 3)).timeout(9.minutes).compile.lastOrError)
           )
           .toResource
-        _ <- Logger[F].info("Nodes have reached target epoch").toResource
+        _     <- Logger[F].info("Nodes have reached target epoch").toResource
+        node3 <- dockerSupport.createNode("MultiNodeTest-node3", "MultiNodeTest", config3)
         heights = thirdEpochHeads.map(_.height)
         // All nodes should be at _roughly_ equal height
         _ <- IO(heights.max - heights.min <= 5).assert.toResource
@@ -62,4 +81,69 @@ class MultiNodeTest extends IntegrationSuite {
     resource.use_
 
   }
+
+  private def registerStaker(inputTransaction: IoTransaction, inputIndex: Int)(node: BifrostDockerNode) =
+    Files
+      .forAsync[F]
+      .tempDirectory
+      .use(localTmpDir =>
+        for {
+          kesKey <- Sync[F]
+            .delay(new KesProduct().createKeyPair(SecureRandom.getInstanceStrong.generateSeed(32), (9, 9), 0))
+          operatorKey <- Sync[F].delay(new Ed25519().deriveKeyPairFromEntropy(Entropy.generate(), None))
+          vrfKey      <- Sync[F].delay(Ed25519VRF.precomputed().generateRandom)
+          writeFile = (name: String, data: Array[Byte]) =>
+            fs2.Stream
+              .chunk(Chunk.array(data))
+              .through(
+                Files
+                  .forAsync[F]
+                  .writeAll(
+                    localTmpDir / name
+                  )
+              )
+              .compile
+              .drain
+          _ <- writeFile(
+            StakingInit.KesDirectoryName + "/0",
+            Persistable[SecretKeyKesProduct].persistedBytes(kesKey._1).toByteArray
+          )
+          _ <- writeFile(StakingInit.OperatorKeyName, operatorKey.signingKey.bytes)
+          _ <- writeFile(StakingInit.VrfKeyName, vrfKey._1)
+          stakerInitializer =
+            StakerInitializers.Operator(
+              ByteString.copyFrom(operatorKey.signingKey.bytes),
+              PrivateTestnet.HeightLockOneSpendingAddress,
+              ByteString.copyFrom(vrfKey._1),
+              kesKey._1
+            )
+          spendableOutput = inputTransaction.outputs(inputIndex)
+          input = SpentTransactionOutput(
+            TransactionOutputAddress(0, 0, inputIndex, inputTransaction.id),
+            ???,
+            spendableOutput.value
+          )
+          spendableTopl = spendableOutput.value.value.topl.get
+          spendableQuantity = spendableTopl.quantity: BigInt
+          registrationOutputs = stakerInitializer.registrationOutputs(spendableQuantity / 2)
+          changeOutput = UnspentTransactionOutput(
+            PrivateTestnet.HeightLockOneSpendingAddress,
+            Value.defaultInstance.withTopl(
+              Value.TOPL(
+                spendableQuantity - (spendableQuantity / 2),
+                spendableTopl.registration
+              )
+            )
+          )
+          transaction = IoTransaction(datum =
+            Datum.IoTransaction(
+              Event.IoTransaction.defaultInstance.withSchedule(
+                Schedule(0L, Long.MaxValue, System.currentTimeMillis())
+              )
+            )
+          )
+            .withInputs(List(input))
+            .withOutputs(registrationOutputs :+ changeOutput)
+        } yield ()
+      )
 }

--- a/byzantine-it/src/test/scala/co/topl/byzantine/util/DockerSupport.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/util/DockerSupport.scala
@@ -146,7 +146,7 @@ object DockerSupport {
         )
 
       val hostConfig =
-        HostConfig.builder().build()
+        HostConfig.builder().privileged(true).build()
 
       ContainerConfig
         .builder()

--- a/byzantine-it/src/test/scala/co/topl/byzantine/util/DockerSupport.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/util/DockerSupport.scala
@@ -123,7 +123,9 @@ object DockerSupport {
       environment: Map[String, String],
       config:      TestNodeConfig
     ): ContainerConfig = {
-      val configDirectory = "/opt/docker/config"
+      val configDirectory = "/bifrost-config"
+      val stakingDirectory = "/bifrost-staking"
+      val dataDirectory = "/bifrost-data"
       val bifrostImage: String = s"toplprotocol/bifrost-node:${BuildInfo.version}"
       val exposedPorts: Seq[String] = List(config.rpcPort, config.p2pPort, config.jmxRemotePort).map(_.toString)
       val env =
@@ -137,9 +139,9 @@ object DockerSupport {
           "-Dcom.sun.management.jmxremote.local.only=false",
           "-Dcom.sun.management.jmxremote.authenticate=false",
           "--config",
-          "/opt/docker/config/node.yaml",
+          "/bifrost-config/node.yaml",
           "--logbackFile",
-          "/opt/docker/config/logback.xml",
+          "/bifrost-config/logback.xml",
           "--debug"
         )
 
@@ -150,7 +152,7 @@ object DockerSupport {
         .builder()
         .image(bifrostImage)
         .env(env: _*)
-        .volumes(configDirectory)
+        .volumes(configDirectory, stakingDirectory, dataDirectory)
         .cmd(cmd: _*)
         .hostname(name)
         .hostConfig(hostConfig)
@@ -178,6 +180,10 @@ case class TestNodeConfig(
     )
     s"""
        |bifrost:
+       |  data:
+       |    directory: /bifrost-data
+       |  staking:
+       |    directory: /bifrost-staking
        |  rpc:
        |    bind-host: 0.0.0.0
        |    port: "$rpcPort"

--- a/byzantine-it/src/test/scala/co/topl/byzantine/util/NodeDockerApi.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/util/NodeDockerApi.scala
@@ -47,10 +47,10 @@ class NodeDockerApi(containerId: String)(implicit dockerClient: DockerClient) {
   def ipAddress[F[_]: Sync]: F[String] =
     Sync[F].blocking(dockerClient.inspectContainer(containerId).networkSettings().ipAddress())
 
-  def rpcClient[F[_]: Async](port: Int, tls: Boolean): Resource[F, NodeRpc[F, Stream[F, *]]] =
+  def rpcClient[F[_]: Async](port: Int, tls: Boolean = false): Resource[F, NodeRpc[F, Stream[F, *]]] =
     ipAddress.toResource.flatMap(NodeGrpc.Client.make[F](_, port, tls))
 
-  def rpcGenusClient[F[_]: Async](port: Int, tls: Boolean): Resource[F, ToplGenusRpc[F]] =
+  def rpcGenusClient[F[_]: Async](port: Int, tls: Boolean = false): Resource[F, ToplGenusRpc[F]] =
     ipAddress.toResource.flatMap(GenusGrpc.Client.make[F](_, port, tls))
 
   def configure[F[_]: Async](configYaml: String): F[Unit] =
@@ -75,7 +75,7 @@ class NodeDockerApi(containerId: String)(implicit dockerClient: DockerClient) {
             .through(Files[F].writeAll(tmpLogFile))
             .compile
             .drain
-          _ <- copyDirectoryIntoContainer(tmpConfigDir, Path("/opt/docker/config"))
+          _ <- copyDirectoryIntoContainer(tmpConfigDir, Path("/bifrost-config"))
         } yield ()
       )
     } yield ()

--- a/common-interpreters/src/main/scala/co/topl/interpreters/CatsSecureStore.scala
+++ b/common-interpreters/src/main/scala/co/topl/interpreters/CatsSecureStore.scala
@@ -66,7 +66,7 @@ object CatsSecureStore {
    */
   private[interpreters] def eraseImplNoCheck(path: Path): Unit = {
     val size = Files.size(path).toInt
-    Files.write(path, Array.fill[Byte](size)(0), StandardOpenOption.TRUNCATE_EXISTING)
+    Files.write(path, Array.fill[Byte](size)(0), StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)
     Files.delete(path)
   }
 

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -1,12 +1,14 @@
 bifrost {
   // Settings for blockchain data
   data {
-    // The _base_ directory in which blockchain data is stored
+    // The _base_ directory in which blockchain data is stored.
+    // Use {genesisBlockId} to interpolate the Genesis Block ID in the path.
     directory = "/tmp/bifrost/data/{genesisBlockId}"
   }
   // Settings for staking
   staking {
-    // The _base_ directory in which staking data/keys are stored
+    // The directory in which staking data/keys are stored.
+    // Use {genesisBlockId} to interpolate the Genesis Block ID in the path.
     directory = "/tmp/bifrost/staking/{genesisBlockId}"
     // The string-encoded address to which any rewards should be paid
     // Default: HeightLock=1

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -2,12 +2,12 @@ bifrost {
   // Settings for blockchain data
   data {
     // The _base_ directory in which blockchain data is stored
-    directory = "/tmp/bifrost/data"
+    directory = "/tmp/bifrost/data/{genesisBlockId}"
   }
   // Settings for staking
   staking {
     // The _base_ directory in which staking data/keys are stored
-    directory = "/tmp/bifrost/staking"
+    directory = "/tmp/bifrost/staking/{genesisBlockId}"
     // The string-encoded address to which any rewards should be paid
     // Default: HeightLock=1
     reward-address = "ptetP7jshHTwEg9Fz9Xa1AmmzhYHDHo1zZRde7mnw3fddcXPjV14RPcgVgy7"

--- a/node/src/main/scala/co/topl/node/DataStoresInit.scala
+++ b/node/src/main/scala/co/topl/node/DataStoresInit.scala
@@ -19,7 +19,6 @@ import co.topl.interpreters.CacheStore
 import co.topl.models.utility._
 import co.topl.node.models._
 import co.topl.proto.node.EpochData
-import co.topl.typeclasses.implicits._
 import com.google.protobuf.ByteString
 import fs2.io.file.{Files, Path}
 import org.typelevel.log4cats.Logger
@@ -29,7 +28,7 @@ object DataStoresInit {
   def init[F[_]: Async: Logger](appConfig: ApplicationConfig)(bigBangBlock: FullBlock): Resource[F, DataStores[F]] =
     for {
       dataDir <- Resource.pure[F, Path](
-        Path(appConfig.bifrost.data.directory) / bigBangBlock.header.id.show
+        Path(interpolateBlockId(bigBangBlock.header.id)(appConfig.bifrost.data.directory))
       )
       _ <- Resource.eval(Files.forAsync[F].createDirectories(dataDir))
       _ <- Resource.eval(Logger[F].info(show"Using dataDir=$dataDir"))

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -31,7 +31,6 @@ import co.topl.typeclasses.implicits._
 import co.topl.node.ApplicationConfigOps._
 import co.topl.node.cli.ConfiguredCliApp
 
-// Hide `io` from fs2 because it conflicts with `io.grpc` down below
 import fs2.io.file.{Files, Path}
 import kamon.Kamon
 import org.typelevel.log4cats.Logger

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -1,6 +1,5 @@
 package co.topl.node
 
-import cats.Applicative
 import cats.effect.implicits._
 import cats.effect.std.Random
 import cats.effect.std.SecureRandom
@@ -16,17 +15,14 @@ import co.topl.config.ApplicationConfig
 import co.topl.consensus.algebras._
 import co.topl.consensus.interpreters.ConsensusDataEventSourcedState.ConsensusData
 import co.topl.consensus.interpreters.EpochBoundariesEventSourcedState.EpochBoundaries
-import co.topl.consensus.models.{BlockId, ProtocolVersion, VrfConfig}
+import co.topl.consensus.models.{BlockId, VrfConfig}
 import co.topl.consensus.interpreters._
-import co.topl.crypto.hash.Blake2b256
 import co.topl.crypto.hash.Blake2b512
-import co.topl.crypto.signing._
 import co.topl.eventtree.{EventSourcedState, ParentChildTree}
 import co.topl.genus._
 import co.topl.interpreters._
 import co.topl.ledger.interpreters._
 import co.topl.minting.algebras.StakingAlgebra
-import co.topl.minting.interpreters.{OperationalKeyMaker, Staking, VrfCalculator}
 import co.topl.models._
 import co.topl.models.utility.HasLength.instances.byteStringLength
 import co.topl.models.utility._
@@ -84,7 +80,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
       implicit0(networkPrefix: NetworkPrefix) = NetworkPrefix(1: Byte)
       privateBigBang = appConfig.bifrost.bigBang.asInstanceOf[ApplicationConfig.Bifrost.BigBangs.Private]
       protocolVersion = ProtocolVersioner.apply(appConfig.bifrost.protocols).appVersion.asProtocolVersion
-      stakerInitializers <- Sync[F]
+      testnetStakerInitializers <- Sync[F]
         .delay(
           PrivateTestnet.stakerInitializers(
             privateBigBang.timestamp,
@@ -96,7 +92,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
         .delay(
           PrivateTestnet.config(
             privateBigBang.timestamp,
-            stakerInitializers,
+            testnetStakerInitializers,
             privateBigBang.stakes,
             protocolVersion
           )
@@ -223,24 +219,46 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
         appConfig.bifrost.mempool.defaultExpirationSlots
       )
       staking <- privateBigBang.localStakerIndex
-        .flatMap(stakerInitializers.get(_))
-        .fold(Resource.pure[F, Option[StakingAlgebra[F]]](none))(initializer =>
-          makeStaking(
-            stakingDir,
-            initializer,
-            clock,
-            etaCalculation,
-            consensusValidationState,
-            leaderElectionThreshold,
-            cryptoResources.ed25519,
-            cryptoResources.blake2b256,
-            cryptoResources.ed25519VRF,
-            cryptoResources.kesProduct,
-            bigBangProtocol,
-            vrfConfig,
-            protocolVersion,
-            appConfig.bifrost.staking.rewardAddress
-          ).map(_.some)
+        .flatMap(testnetStakerInitializers.get(_))
+        .fold(
+          Files[F]
+            .list(stakingDir)
+            .compile
+            .toList
+            .toResource
+            .flatMap(files =>
+              if (files.nonEmpty)
+                StakingInit
+                  .makeStakingFromDisk(
+                    stakingDir,
+                    clock,
+                    etaCalculation,
+                    consensusValidationState,
+                    leaderElectionThreshold,
+                    cryptoResources,
+                    bigBangProtocol,
+                    vrfConfig,
+                    protocolVersion
+                  )
+                  .map(_.some)
+              else
+                Resource.pure[F, Option[StakingAlgebra[F]]](none)
+            )
+        )(initializer =>
+          StakingInit
+            .makeStakingFromGenesis(
+              stakingDir,
+              initializer,
+              clock,
+              etaCalculation,
+              consensusValidationState,
+              leaderElectionThreshold,
+              cryptoResources,
+              bigBangProtocol,
+              vrfConfig,
+              protocolVersion
+            )
+            .map(_.some)
         )
 
       eligibilityCache <-
@@ -345,71 +363,6 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
           appConfig.bifrost.p2p.networkProperties
         )
     } yield ()
-
-  private def makeStaking(
-    stakingDir:               Path,
-    initializer:              StakerInitializers.Operator,
-    clock:                    ClockAlgebra[F],
-    etaCalculation:           EtaCalculationAlgebra[F],
-    consensusValidationState: ConsensusValidationStateAlgebra[F],
-    leaderElectionThreshold:  LeaderElectionValidationAlgebra[F],
-    ed25519Resource:          UnsafeResource[F, Ed25519],
-    blake2b256Resource:       UnsafeResource[F, Blake2b256],
-    ed25519VRFResource:       UnsafeResource[F, Ed25519VRF],
-    kesProductResource:       UnsafeResource[F, KesProduct],
-    protocol:                 ApplicationConfig.Bifrost.Protocol,
-    vrfConfig:                VrfConfig,
-    protocolVersion:          ProtocolVersion,
-    rewardAddress:            LockAddress
-  ) =
-    for {
-      // Initialize a persistent secure store
-      kesPath     <- Sync[F].delay(stakingDir / "kes").toResource
-      _           <- Files[F].createDirectories(kesPath).toResource
-      secureStore <- CatsSecureStore.make[F](kesPath.toNioPath)
-      // Determine if a key has already been initialized
-      _ <- secureStore.list
-        .map(_.isEmpty)
-        // If uninitialized, generate a new key.  Otherwise, move on.
-        .ifM(secureStore.write(UUID.randomUUID().toString, initializer.kesSK), Applicative[F].unit)
-        .toResource
-
-      vrfCalculator <- VrfCalculator.make[F](
-        initializer.vrfSK,
-        ed25519VRFResource,
-        protocol.vrfCacheSize
-      )
-
-      operationalKeys <- OperationalKeyMaker
-        .make[F](
-          operationalPeriodLength = protocol.operationalPeriodLength,
-          activationOperationalPeriod = 0L, // TODO: Accept registration block as `make` parameter?
-          initializer.stakingAddress,
-          vrfConfig,
-          secureStore = secureStore,
-          clock = clock,
-          vrfCalculator = vrfCalculator,
-          leaderElectionThreshold,
-          etaCalculation,
-          consensusValidationState,
-          kesProductResource,
-          ed25519Resource
-        )
-
-      staking <- Staking.make(
-        initializer.stakingAddress,
-        rewardAddress,
-        initializer.vrfVK,
-        operationalKeys,
-        consensusValidationState,
-        etaCalculation,
-        ed25519Resource,
-        blake2b256Resource,
-        vrfCalculator,
-        leaderElectionThreshold,
-        protocolVersion
-      )
-    } yield staking
 
   private def makeEpochBoundariesState(
     clock:                       ClockAlgebra[F],

--- a/node/src/main/scala/co/topl/node/StakingInit.scala
+++ b/node/src/main/scala/co/topl/node/StakingInit.scala
@@ -35,6 +35,21 @@ object StakingInit {
   final val RegistrationTxName = "registration.transaction.pbuf"
 
   /**
+   * Inspects the given stakingDir for the expected keys/files.  If the expected files exist, `true` is returned.
+   */
+  def stakingIsInitialized[F[_]: Async](stakingDir: Path): F[Boolean] =
+    Files
+      .forAsync[F]
+      .list(stakingDir)
+      .compile
+      .toList
+      .map(files =>
+        files.exists(_.endsWith(KesDirectoryName)) &&
+        files.exists(_.endsWith(VrfKeyName)) &&
+        files.exists(_.endsWith(RegistrationTxName))
+      )
+
+  /**
    * Initializes a Staking object from a private genesis configuration.
    */
   def makeStakingFromGenesis[F[_]: Async: Logger](
@@ -78,21 +93,6 @@ object StakingInit {
         protocolVersion
       )
     } yield staking
-
-  /**
-   * Inspects the given stakingDir for the expected keys/files.  If the expected files exist, `true` is returned.
-   */
-  def stakingIsInitialized[F[_]: Async](stakingDir: Path): F[Boolean] =
-    Files
-      .forAsync[F]
-      .list(stakingDir)
-      .compile
-      .toList
-      .map(files =>
-        files.exists(_.endsWith(KesDirectoryName)) &&
-        files.exists(_.endsWith(VrfKeyName)) &&
-        files.exists(_.endsWith(RegistrationTxName))
-      )
 
   /**
    * Initializes a Staking object from existing files on disk.  The files are expected to be in the format created

--- a/node/src/main/scala/co/topl/node/StakingInit.scala
+++ b/node/src/main/scala/co/topl/node/StakingInit.scala
@@ -7,6 +7,7 @@ import cats.effect.implicits._
 import cats.effect._
 import co.topl.algebras.ClockAlgebra
 import co.topl.blockchain.{CryptoResources, StakerInitializers}
+import co.topl.brambl.models.LockAddress
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.codecs.bytes.tetra.instances.persistableKesProductSecretKey
 import co.topl.codecs.bytes.typeclasses.Persistable
@@ -39,6 +40,7 @@ object StakingInit {
   def makeStakingFromGenesis[F[_]: Async: Logger](
     stakingDir:               Path,
     initializer:              StakerInitializers.Operator,
+    rewardAddress:            LockAddress,
     clock:                    ClockAlgebra[F],
     etaCalculation:           EtaCalculationAlgebra[F],
     consensusValidationState: ConsensusValidationStateAlgebra[F],
@@ -65,6 +67,7 @@ object StakingInit {
         initializer.vrfSK,
         initializer.vrfVK,
         initializer.stakingAddress,
+        rewardAddress,
         clock,
         etaCalculation,
         consensusValidationState,
@@ -82,6 +85,7 @@ object StakingInit {
    */
   def makeStakingFromDisk[F[_]: Async: Logger](
     stakingDir:               Path,
+    rewardAddress:            LockAddress,
     clock:                    ClockAlgebra[F],
     etaCalculation:           EtaCalculationAlgebra[F],
     consensusValidationState: ConsensusValidationStateAlgebra[F],
@@ -115,6 +119,7 @@ object StakingInit {
         ByteString.copyFrom(vrfSK),
         ByteString.copyFrom(vrfVK),
         registration.address,
+        rewardAddress,
         clock,
         etaCalculation,
         consensusValidationState,
@@ -134,6 +139,7 @@ object StakingInit {
     vrfSK:                    ByteString,
     vrfVK:                    ByteString,
     stakingAddress:           StakingAddress,
+    rewardAddress:            LockAddress,
     clock:                    ClockAlgebra[F],
     etaCalculation:           EtaCalculationAlgebra[F],
     consensusValidationState: ConsensusValidationStateAlgebra[F],
@@ -170,6 +176,7 @@ object StakingInit {
 
       staking <- Staking.make(
         stakingAddress,
+        rewardAddress,
         vrfVK,
         operationalKeys,
         consensusValidationState,

--- a/node/src/main/scala/co/topl/node/StakingInit.scala
+++ b/node/src/main/scala/co/topl/node/StakingInit.scala
@@ -33,6 +33,9 @@ object StakingInit {
   final val VrfKeyName = "vrf-key.ed25519vrf.sk"
   final val RegistrationTxName = "registration.transaction.pbuf"
 
+  /**
+   * Initializes a Staking object from a private genesis configuration.
+   */
   def makeStakingFromGenesis[F[_]: Async: Logger](
     stakingDir:               Path,
     initializer:              StakerInitializers.Operator,
@@ -73,6 +76,10 @@ object StakingInit {
       )
     } yield staking
 
+  /**
+   * Initializes a Staking object from existing files on disk.  The files are expected to be in the format created
+   * by the "Registration" CLI process.
+   */
   def makeStakingFromDisk[F[_]: Async: Logger](
     stakingDir:               Path,
     clock:                    ClockAlgebra[F],
@@ -119,6 +126,9 @@ object StakingInit {
       )
     } yield staking
 
+  /**
+   * Initializes a Staking object from the given raw VRF and staking address information
+   */
   def makeStaking[F[_]: Async: Logger](
     stakingDir:               Path,
     vrfSK:                    ByteString,

--- a/node/src/main/scala/co/topl/node/StakingInit.scala
+++ b/node/src/main/scala/co/topl/node/StakingInit.scala
@@ -1,0 +1,175 @@
+package co.topl.node
+
+import cats._
+import cats.data.OptionT
+import cats.implicits._
+import cats.effect.implicits._
+import cats.effect._
+import co.topl.algebras.ClockAlgebra
+import co.topl.blockchain.{CryptoResources, StakerInitializers}
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.codecs.bytes.tetra.instances.persistableKesProductSecretKey
+import co.topl.codecs.bytes.typeclasses.Persistable
+import co.topl.config.ApplicationConfig
+import co.topl.consensus.algebras.{
+  ConsensusValidationStateAlgebra,
+  EtaCalculationAlgebra,
+  LeaderElectionValidationAlgebra
+}
+import co.topl.consensus.models.{ProtocolVersion, StakingAddress, VrfConfig}
+import co.topl.crypto.models.SecretKeyKesProduct
+import co.topl.interpreters.CatsSecureStore
+import co.topl.minting.algebras.StakingAlgebra
+import co.topl.minting.interpreters.{OperationalKeyMaker, Staking, VrfCalculator}
+import com.google.protobuf.ByteString
+import fs2.Chunk
+import fs2.io.file.{Files, Path}
+import org.typelevel.log4cats.Logger
+
+object StakingInit {
+
+  final val KesDirectoryName = "kes"
+  final val OperatorKeyName = "operator-key.ed25519.sk"
+  final val VrfKeyName = "vrf-key.ed25519vrf.sk"
+  final val RegistrationTxName = "registration.transaction.pbuf"
+
+  def makeStakingFromGenesis[F[_]: Async: Logger](
+    stakingDir:               Path,
+    initializer:              StakerInitializers.Operator,
+    clock:                    ClockAlgebra[F],
+    etaCalculation:           EtaCalculationAlgebra[F],
+    consensusValidationState: ConsensusValidationStateAlgebra[F],
+    leaderElectionThreshold:  LeaderElectionValidationAlgebra[F],
+    cryptoResources:          CryptoResources[F],
+    protocol:                 ApplicationConfig.Bifrost.Protocol,
+    vrfConfig:                VrfConfig,
+    protocolVersion:          ProtocolVersion
+  ): Resource[F, StakingAlgebra[F]] =
+    for {
+      // Initialize a persistent secure store
+      kesPath <- Sync[F].delay(stakingDir / "kes").toResource
+      _       <- Files[F].createDirectories(kesPath).toResource
+      _ <- fs2.Stream
+        .chunk(
+          Chunk.byteBuffer(Persistable[SecretKeyKesProduct].persistedBytes(initializer.kesSK).asReadOnlyByteBuffer())
+        )
+        .through(Files[F].writeAll(kesPath / "0"))
+        .compile
+        .drain
+        .toResource
+      staking <- makeStaking(
+        stakingDir,
+        initializer.vrfSK,
+        initializer.vrfVK,
+        initializer.stakingAddress,
+        clock,
+        etaCalculation,
+        consensusValidationState,
+        leaderElectionThreshold,
+        cryptoResources,
+        protocol,
+        vrfConfig,
+        protocolVersion
+      )
+    } yield staking
+
+  def makeStakingFromDisk[F[_]: Async: Logger](
+    stakingDir:               Path,
+    clock:                    ClockAlgebra[F],
+    etaCalculation:           EtaCalculationAlgebra[F],
+    consensusValidationState: ConsensusValidationStateAlgebra[F],
+    leaderElectionThreshold:  LeaderElectionValidationAlgebra[F],
+    cryptoResources:          CryptoResources[F],
+    protocol:                 ApplicationConfig.Bifrost.Protocol,
+    vrfConfig:                VrfConfig,
+    protocolVersion:          ProtocolVersion
+  ): Resource[F, StakingAlgebra[F]] =
+    for {
+      kesPath <- Sync[F].delay(stakingDir / "kes").toResource
+      _ <- Files[F]
+        .list(kesPath)
+        .compile
+        .toList
+        .flatMap(files =>
+          MonadThrow[F]
+            .raiseWhen(files.length != 1)(new IllegalArgumentException("Expected exactly one KES key in secure store."))
+        )
+        .toResource
+      readFile = (p: Path) => Files[F].readAll(p).compile.to(Chunk)
+      vrfSK       <- readFile(stakingDir / VrfKeyName).map(_.toArray).toResource
+      vrfVK       <- cryptoResources.ed25519VRF.useSync(_.getVerificationKey(vrfSK)).toResource
+      transaction <- readFile(stakingDir / RegistrationTxName).map(_.toArray).map(IoTransaction.parseFrom).toResource
+      registration <- OptionT
+        .fromOption[F](transaction.outputs.headOption.flatMap(_.value.value.topl.flatMap(_.registration)))
+        .getOrRaise(new IllegalArgumentException("Registration Transaction is invalid"))
+        .toResource
+      staking <- makeStaking(
+        stakingDir,
+        ByteString.copyFrom(vrfSK),
+        ByteString.copyFrom(vrfVK),
+        registration.address,
+        clock,
+        etaCalculation,
+        consensusValidationState,
+        leaderElectionThreshold,
+        cryptoResources,
+        protocol,
+        vrfConfig,
+        protocolVersion
+      )
+    } yield staking
+
+  def makeStaking[F[_]: Async: Logger](
+    stakingDir:               Path,
+    vrfSK:                    ByteString,
+    vrfVK:                    ByteString,
+    stakingAddress:           StakingAddress,
+    clock:                    ClockAlgebra[F],
+    etaCalculation:           EtaCalculationAlgebra[F],
+    consensusValidationState: ConsensusValidationStateAlgebra[F],
+    leaderElectionThreshold:  LeaderElectionValidationAlgebra[F],
+    cryptoResources:          CryptoResources[F],
+    protocol:                 ApplicationConfig.Bifrost.Protocol,
+    vrfConfig:                VrfConfig,
+    protocolVersion:          ProtocolVersion
+  ): Resource[F, StakingAlgebra[F]] =
+    for {
+      kesPath     <- Sync[F].delay(stakingDir / "kes").toResource
+      secureStore <- CatsSecureStore.make[F](kesPath.toNioPath)
+      vrfCalculator <- VrfCalculator.make[F](
+        vrfSK,
+        cryptoResources.ed25519VRF,
+        protocol.vrfCacheSize
+      )
+
+      operationalKeys <- OperationalKeyMaker
+        .make[F](
+          operationalPeriodLength = protocol.operationalPeriodLength,
+          activationOperationalPeriod = 0L, // TODO: Accept registration block as `make` parameter?
+          stakingAddress,
+          vrfConfig,
+          secureStore = secureStore,
+          clock = clock,
+          vrfCalculator = vrfCalculator,
+          leaderElectionThreshold,
+          etaCalculation,
+          consensusValidationState,
+          cryptoResources.kesProduct,
+          cryptoResources.ed25519
+        )
+
+      staking <- Staking.make(
+        stakingAddress,
+        vrfVK,
+        operationalKeys,
+        consensusValidationState,
+        etaCalculation,
+        cryptoResources.ed25519,
+        cryptoResources.blake2b256,
+        vrfCalculator,
+        leaderElectionThreshold,
+        protocolVersion
+      )
+    } yield staking
+
+}

--- a/node/src/main/scala/co/topl/node/StakingInit.scala
+++ b/node/src/main/scala/co/topl/node/StakingInit.scala
@@ -51,7 +51,7 @@ object StakingInit {
     protocolVersion:          ProtocolVersion
   ): Resource[F, StakingAlgebra[F]] =
     for {
-      // Initialize a persistent secure store
+      _       <- Logger[F].info("Generating a private testnet genesis staker").toResource
       kesPath <- Sync[F].delay(stakingDir / "kes").toResource
       _       <- Files.forAsync[F].createDirectories(kesPath).toResource
       _ <- fs2.Stream
@@ -111,6 +111,7 @@ object StakingInit {
     protocolVersion:          ProtocolVersion
   ): Resource[F, StakingAlgebra[F]] =
     for {
+      _       <- Logger[F].info("Loading registered staker from disk").toResource
       kesPath <- Sync[F].delay(stakingDir / KesDirectoryName).toResource
       _ <- Files
         .forAsync[F]

--- a/node/src/main/scala/co/topl/node/cli/CliApp.scala
+++ b/node/src/main/scala/co/topl/node/cli/CliApp.scala
@@ -11,6 +11,7 @@ import co.topl.config.ApplicationConfig
 import co.topl.crypto.generation.EntropyToSeed
 import co.topl.crypto.generation.mnemonic.Entropy
 import co.topl.crypto.signing.{Ed25519, Ed25519VRF, KesProduct}
+import co.topl.node.StakingInit
 import co.topl.typeclasses.implicits._
 import com.google.protobuf.ByteString
 import fs2.Chunk
@@ -92,7 +93,7 @@ class ConfiguredCliApp(appConfig: ApplicationConfig) {
         )
       )
         .withOutputs(transactionOutputs)
-      _ <- write(transaction.toByteArray)("Registration Transaction", "registration.transaction.pbuf")
+      _ <- write(transaction.toByteArray)("Registration Transaction", StakingInit.RegistrationTxName)
       _ <- finalInstructions(isExistingNetwork)
     } yield StageResult.Menu
 
@@ -196,7 +197,7 @@ class ConfiguredCliApp(appConfig: ApplicationConfig) {
     ) >>
     createSeed
       .map(new Ed25519().deriveSecretKeyFromSeed)
-      .flatTap(key => write(key.bytes)("Operator SK", "operator-key.ed25519.sk"))
+      .flatTap(key => write(key.bytes)("Operator SK", StakingInit.OperatorKeyName))
 
   /**
    * Generate and save a VRF key.
@@ -207,7 +208,7 @@ class ConfiguredCliApp(appConfig: ApplicationConfig) {
     ) >>
     createSeed
       .map(Ed25519VRF.precomputed().deriveKeyPairFromSeed)
-      .flatTap(key => write(key._1)("VRF SK", "vrf-key.ed25519vrf.sk"))
+      .flatTap(key => write(key._1)("VRF SK", StakingInit.VrfKeyName))
 
   /**
    * Generate and save a KES key.
@@ -227,7 +228,7 @@ class ConfiguredCliApp(appConfig: ApplicationConfig) {
       .flatTap(key =>
         write(co.topl.codecs.bytes.tetra.instances.persistableKesProductSecretKey.persistedBytes(key._1).toByteArray)(
           "KES SK",
-          "kes/0"
+          s"${StakingInit.KesDirectoryName}/0"
         )
       )
 

--- a/node/src/main/scala/co/topl/node/package.scala
+++ b/node/src/main/scala/co/topl/node/package.scala
@@ -1,0 +1,16 @@
+package co.topl
+
+import cats.implicits.toShow
+import co.topl.consensus.models.BlockId
+import co.topl.typeclasses.implicits.showBlockId
+
+package object node {
+
+  /**
+   * For private testnets, it is convenient to run each network from its own directory, rather than re-using
+   * a single directory over and over.  This method helps interpolate a directory
+   * (i.e. /tmp/bifrost/data/{genesisBlockId}) with the genesis block ID.
+   */
+  def interpolateBlockId(genesisBlockId: BlockId)(path: String): String =
+    path.replace("{genesisBlockId}", genesisBlockId.show)
+}


### PR DESCRIPTION
## Purpose
- In real world blockchain networks, the staking keys are owned by a human rather than generated at runtime
- We need the ability to load staking information from disk and use it during the staking process
## Approach
- Create a `StakingInit` helper object which can generate private testnet staking (existing behavior) or load information from disk (new behavior)
## Testing
- Modify MultiNodeTest to register a new staker and launch a 4th node with the new staking information
## Tickets
- #BN-1128
## Note
- I would like to do follow-up work which searches the chain for the staker's registration transaction and delays staker initialization until the registration is active