### PR TITLE
BN-1143: Improve Testnet Orchestrator Docs

### DIFF
--- a/docs/DevContainerSimulatorGuide.md
+++ b/docs/DevContainerSimulatorGuide.md
@@ -1,6 +1,25 @@
 # DevContainer Testnet Simulator Guide
 Instructions for running a testnet simulation in a Devcontainer environment (i.e. GitHub Codespaces).
 
+## Devcontainer
+Devcontainers are a way to package your dev enviornment and run it from a Docker container (or remotely via GitHub Codespaces).
+
+The configuration is stored in the `.devcontainer` folder which contains a `devcontainer.json` file as well as a few install scripts. 
+
+Our devcontainer setup installs:
+* Docker (in Docker)
+* Minikube
+* SDKMan
+
+### Use Devcontainer locally
+To use devcontainers locally, you will need:
+
+* Docker
+* VSCode
+* Devcontainer plugin for VSCode
+
+Once these are installed, you can open the folder in VSCode, and it will prompt you to open the devcontainer environment. From there, you will be able to run the commands below.
+
 ## Installation
 All pre-requisites should be automatically installed, including: Java, SBT, Docker, minikube, kubectl, helm, and k9s
 
@@ -10,7 +29,7 @@ All pre-requisites should be automatically installed, including: Java, SBT, Dock
 
 ### Helm Charts
 1. Run `cd /workspaces`
-1. Run `git clone https://github.com/Topl/helm-charts.git`
+1. Run `sudo git clone https://github.com/Topl/helm-charts.git`
 
 ## Run Simulation
 1. From terminal, run (modify `my-testnet-name` accordingly)
@@ -27,3 +46,9 @@ All pre-requisites should be automatically installed, including: Java, SBT, Dock
     ```
     Note: You can specify a different configuration file by changing the `-f` argument.
 1. View the [results](https://console.cloud.google.com/storage/browser/bifrost-topl-labs-testnet-scenario-results/%2Fsimulation/results)
+
+### Issues
+
+> StatefulSet.apps "DEMO_NAME" is invalid: metadata.name: Invalid value: "DEMO_NAME": must be no more than 63 characters
+
+To fix, make sure that `DEMO_NAME` is less that 63 characters.


### PR DESCRIPTION
## Purpose
Recent usage of the testnet orchestrator demo has shown the docs to be a bit lacking, This PR aims to improve the documentation. 

## Approach
Update the markdown docs to add:
* More information about the purpose of devcontainers and what they achieve
* Information related to a common issue

## Testing
n/a

## Tickets
*


