### PR TITLE
BN-1132 Node now could save/reload known hosts to/from the disk

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -115,6 +115,7 @@ object Blockchain {
             dataStores.headers,
             dataStores.bodies,
             dataStores.transactions,
+            dataStores.knownHosts,
             blockIdTree,
             networkProperties,
             clock,

--- a/blockchain/src/main/scala/co/topl/blockchain/DataStores.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/DataStores.scala
@@ -28,7 +28,8 @@ case class DataStores[F[_]](
   registrations:           Store[F, StakingAddress, ActiveStaker],
   blockHeightTree:         Store[F, Long, BlockId],
   epochData:               Store[F, Epoch, EpochData],
-  registrationAccumulator: Store[F, StakingAddress, Unit]
+  registrationAccumulator: Store[F, StakingAddress, Unit],
+  knownHosts:              Store[F, Unit, Seq[KnownHost]]
 )
 
 class CurrentEventIdGetterSetters[F[_]: MonadThrow](store: Store[F, Byte, BlockId]) {

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -15,7 +15,7 @@ import co.topl.ledger.algebras._
 import co.topl.networking.blockchain.{BlockchainPeerClient, BlockchainPeerHandlerAlgebra}
 import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.networking.p2p.{ConnectedPeer, DisconnectedPeer, RemoteAddress}
-import co.topl.node.models.BlockBody
+import co.topl.node.models.{BlockBody, KnownHost}
 import com.comcast.ip4s.Dns
 import fs2.Stream
 import org.typelevel.log4cats.Logger
@@ -35,6 +35,7 @@ object ActorPeerHandlerBridgeAlgebra {
     headerStore:                 Store[F, BlockId, BlockHeader],
     bodyStore:                   Store[F, BlockId, BlockBody],
     transactionStore:            Store[F, TransactionId, IoTransaction],
+    knownHostsStore:             Store[F, Unit, Seq[KnownHost]],
     blockIdTree:                 ParentChildTree[F, BlockId],
     networkProperties:           NetworkProperties,
     clockAlgebra:                ClockAlgebra[F],
@@ -60,6 +61,7 @@ object ActorPeerHandlerBridgeAlgebra {
         headerStore,
         bodyStore,
         transactionStore,
+        knownHostsStore,
         blockIdTree,
         networkAlgebra,
         remotePeers.map(_.remoteAddress),

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
@@ -31,7 +31,8 @@ trait NetworkAlgebra[F[_]] {
     headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F],
     newPeerCreationAlgebra: PeerCreationRequestAlgebra[F],
     p2pNetworkConfig:       P2PNetworkConfig,
-    hotPeersUpdate:         Set[RemoteAddress] => F[Unit]
+    hotPeersUpdate:         Set[RemoteAddress] => F[Unit],
+    savePeersFunction:      Set[RemoteAddress] => F[Unit]
   ): Resource[F, PeersManagerActor[F]]
 
   def makeReputationAggregation(
@@ -92,7 +93,8 @@ class NetworkAlgebraImpl[F[_]: Async: Logger: DnsResolver] extends NetworkAlgebr
     headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F],
     newPeerCreationAlgebra: PeerCreationRequestAlgebra[F],
     p2pNetworkConfig:       P2PNetworkConfig,
-    hotPeersUpdate:         Set[RemoteAddress] => F[Unit]
+    hotPeersUpdate:         Set[RemoteAddress] => F[Unit],
+    savePeersFunction:      Set[RemoteAddress] => F[Unit]
   ): Resource[F, PeersManagerActor[F]] =
     PeersManager.makeActor(
       thisHostId,
@@ -104,7 +106,8 @@ class NetworkAlgebraImpl[F[_]: Async: Logger: DnsResolver] extends NetworkAlgebr
       headerToBodyValidation,
       newPeerCreationAlgebra,
       p2pNetworkConfig,
-      hotPeersUpdate
+      hotPeersUpdate,
+      savePeersFunction
     )
 
   override def makeReputationAggregation(

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
@@ -13,15 +13,16 @@ import co.topl.consensus.algebras._
 import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
 import co.topl.eventtree.ParentChildTree
 import co.topl.ledger.algebras._
+import co.topl.networking.KnownHostOps
 import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.networking.p2p.{ConnectedPeer, RemoteAddress}
-import co.topl.node.models.BlockBody
+import co.topl.node.models.{BlockBody, KnownHost}
 import fs2.Stream
 import org.typelevel.log4cats.Logger
 
 object NetworkManager {
 
-  def startNetwork[F[_]: Async: Logger: DnsResolver](
+  def startNetwork[F[_]: Async: Logger](
     thisHostId:                  HostId,
     localChain:                  LocalChainAlgebra[F],
     chainSelectionAlgebra:       ChainSelectionAlgebra[F, SlotData],
@@ -34,6 +35,7 @@ object NetworkManager {
     headerStore:                 Store[F, BlockId, BlockHeader],
     bodyStore:                   Store[F, BlockId, BlockBody],
     transactionStore:            Store[F, TransactionId, IoTransaction],
+    knownHostsStore:             Store[F, Unit, Seq[KnownHost]],
     blockIdTree:                 ParentChildTree[F, BlockId],
     networkAlgebra:              NetworkAlgebra[F],
     initialHosts:                List[RemoteAddress],
@@ -44,10 +46,12 @@ object NetworkManager {
     hotPeersUpdate:              Set[RemoteAddress] => F[Unit]
   ): Resource[F, PeersManagerActor[F]] =
     for {
-      _            <- Resource.liftK(Logger[F].info(s"Start actors network with list of known peers: $initialHosts"))
+      _            <- Resource.liftK(Logger[F].info(s"Start actors network with list of peers: $initialHosts"))
       slotDuration <- Resource.liftK(clock.slotLength)
       p2pNetworkConfig = P2PNetworkConfig(networkProperties, slotDuration)
 
+      peersFromStorage <- Resource.liftK(knownHostsStore.get(()).map(_.getOrElse(Seq.empty).map(_.asRemoteAddress)))
+      _                <- Resource.liftK(Logger[F].info(s"Loaded from storage next known hosts: $peersFromStorage"))
       peerManager <- networkAlgebra.makePeerManger(
         thisHostId,
         networkAlgebra,
@@ -58,7 +62,8 @@ object NetworkManager {
         headerToBodyValidation,
         addRemotePeerAlgebra,
         p2pNetworkConfig,
-        hotPeersUpdate
+        hotPeersUpdate,
+        buildSaveRemotePeersFunction(knownHostsStore)
       )
 
       reputationAggregator <- networkAlgebra.makeReputationAggregation(peerManager, p2pNetworkConfig)
@@ -85,7 +90,7 @@ object NetworkManager {
 
       _ <- Resource.liftK(
         NonEmptyChain
-          .fromSeq(initialHosts)
+          .fromSeq(initialHosts ++ peersFromStorage)
           .map { initialPeers =>
             peerManager.sendNoWait(PeersManager.Message.AddKnownPeers(initialPeers))
           }
@@ -116,4 +121,11 @@ object NetworkManager {
       .compile
       .drain
       .background
+
+  private def buildSaveRemotePeersFunction[F[_]: Async: Logger](
+    knownHostsStore: Store[F, Unit, Seq[KnownHost]]
+  ): Set[RemoteAddress] => F[Unit] = { peers: Set[RemoteAddress] =>
+    Logger[F].info(s"Going to save known hosts $peers to local data storage") >>
+    knownHostsStore.put((), peers.map(_.asKnownHost).toList)
+  }
 }

--- a/networking/src/main/scala/co/topl/networking/package.scala
+++ b/networking/src/main/scala/co/topl/networking/package.scala
@@ -16,4 +16,8 @@ package object networking {
   implicit class KnownHostOps(knownHost: KnownHost) {
     def asRemoteAddress: RemoteAddress = RemoteAddress(knownHost.host, knownHost.port)
   }
+
+  implicit class RemoteAddressOps(remoteAddress: RemoteAddress) {
+    def asKnownHost: KnownHost = KnownHost(remoteAddress.host, remoteAddress.port)
+  }
 }

--- a/node/src/main/scala/co/topl/node/DataStoresInit.scala
+++ b/node/src/main/scala/co/topl/node/DataStoresInit.scala
@@ -9,7 +9,6 @@ import co.topl.blockchain.{CurrentEventIdGetterSetters, DataStores}
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.syntax._
-import co.topl.codecs.bytes.tetra.TetraScodecCodecs
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.Persistable
 import co.topl.config.ApplicationConfig
@@ -23,8 +22,9 @@ import co.topl.proto.node.EpochData
 import com.google.protobuf.ByteString
 import fs2.io.file.{Files, Path}
 import org.typelevel.log4cats.Logger
+import co.topl.codecs.bytes.tetra.TetraScodecCodecs._
 
-object DataStoresInit extends TetraScodecCodecs {
+object DataStoresInit {
 
   def init[F[_]: Async: Logger](appConfig: ApplicationConfig)(bigBangBlock: FullBlock): Resource[F, DataStores[F]] =
     for {

--- a/node/src/main/scala/co/topl/node/DataStoresInit.scala
+++ b/node/src/main/scala/co/topl/node/DataStoresInit.scala
@@ -9,6 +9,7 @@ import co.topl.blockchain.{CurrentEventIdGetterSetters, DataStores}
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.syntax._
+import co.topl.codecs.bytes.tetra.TetraScodecCodecs
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.Persistable
 import co.topl.config.ApplicationConfig
@@ -23,7 +24,7 @@ import com.google.protobuf.ByteString
 import fs2.io.file.{Files, Path}
 import org.typelevel.log4cats.Logger
 
-object DataStoresInit {
+object DataStoresInit extends TetraScodecCodecs {
 
   def init[F[_]: Async: Logger](appConfig: ApplicationConfig)(bigBangBlock: FullBlock): Resource[F, DataStores[F]] =
     for {
@@ -105,6 +106,9 @@ object DataStoresInit {
         appConfig.bifrost.cache.registrationAccumulator,
         identity
       )
+
+      knownRemotePeersStore <- makeDb[F, Unit, Seq[KnownHost]](dataDir)("known-remote-peers")
+
       dataStores = DataStores(
         dataDir,
         parentChildTree,
@@ -121,7 +125,8 @@ object DataStoresInit {
         registrationsStore,
         blockHeightTreeStore,
         epochDataStore,
-        registrationAccumulatorStore
+        registrationAccumulatorStore,
+        knownRemotePeersStore
       )
       _ <- Resource.eval(initialize(dataStores, bigBangBlock))
     } yield dataStores

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraPersistableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraPersistableCodecs.scala
@@ -7,8 +7,8 @@ import co.topl.codecs.bytes.typeclasses.Persistable
 import co.topl.consensus.models.BlockId
 import co.topl.crypto.models.SecretKeyKesProduct
 import com.google.protobuf.ByteString
-import scalapb.GeneratedMessage
-import scalapb.GeneratedMessageCompanion
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
+import scodec.Codec
 
 import scala.collection.immutable.SortedSet
 import scala.util.Try
@@ -24,6 +24,9 @@ trait TetraPersistableCodecs {
         Try(implicitly[GeneratedMessageCompanion[T]].parseFrom(bytes.newCodedInput())).toEither
           .leftMap(_.getMessage)
     }
+
+  implicit def persistableSeq[T: Codec]: Persistable[Seq[T]] =
+    Persistable.instanceFromCodec(seqCodec[T])
 
   implicit val persistableTransactionOutputIndices: Persistable[NonEmptySet[Short]] =
     Persistable.instanceFromCodec(

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -5,12 +5,10 @@ import co.topl.consensus.models._
 import co.topl.crypto.{models => nodeCryptoModels}
 import co.topl.models._
 import co.topl.models.utility._
-import scodec.codecs.discriminated
-import scodec.codecs.lazily
+import co.topl.node.models.KnownHost
 import scodec.Codec
-import shapeless.::
-import shapeless.HList
-import shapeless.HNil
+import scodec.codecs.{discriminated, lazily, utf8_32}
+import shapeless.{::, HList, HNil}
 
 /**
  * Use this object or the package object to access all of the codecs from outside of this package.
@@ -154,4 +152,10 @@ trait TetraScodecCodecs {
       byteStringCodec :: // metadata
       stakingAddressCodec // address
   ).as[UnsignedBlockHeader]
+
+  implicit val knownHostCodec: Codec[KnownHost] = (
+    utf8_32 ::
+      intCodec ::
+      unknownFieldSetCodec
+  ).as[KnownHost]
 }


### PR DESCRIPTION
## Purpose
Node shall be able to save/load known peers to disk, which allows us to not bootstrap network connections every launch from scratch

## Approach
Use data storage to save known peers after peers manager actor shutdown

## Testing
Unit test + multinode test + manual changed multinode test

## Tickets
closes #BN-1132