### PR TITLE
Bn 1145 remove peer from cold peer list if n connections was not successfull

### DIFF
--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -62,7 +62,11 @@ object ApplicationConfig {
       minimumHotConnections:                Int = 3,
       minimumWarmConnections:               Int = 6,
       maximumWarmConnections:               Int = 12,
-      warmHostsUpdateEveryNBlock:           Double = 4.0
+      warmHostsUpdateEveryNBlock:           Double = 4.0,
+      // we could try to connect to remote peer again after
+      // closeTimeoutFirstDelayInMs * {number of closed connections in last closeTimeoutWindowInMs} ^ 2
+      closeTimeoutFirstDelayInMs: Long = 1000,
+      closeTimeoutWindowInMs:     Long = 1000 * 60 * 60 * 24 // 1 day
     )
 
     case class KnownPeer(host: String, port: Int)

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
@@ -120,7 +120,8 @@ object BlockChecker {
         bestChain,
         bestKnownRemoteSlotDataHost
       )
-    Actor.make(initialState, getFsm[F])
+    val actorName = "Block checker actor"
+    Actor.make(actorName, initialState, getFsm[F])
   }
 
   private def processSlotData[F[_]: Async: Logger](
@@ -266,7 +267,7 @@ object BlockChecker {
       case Left(HeaderValidationException(id, hostId, error)) =>
         Logger[F].error(show"Failed to apply header $id due validation error: $error from host $hostId")
       case Left(HeaderApplyException.UnknownError(error)) =>
-        Logger[F].error(show"Failed to apply header due next error: ${error.toString}")
+        Logger[F].error(show"Failed to apply header due next error: ${error.getLocalizedMessage}")
     }
 
   private def processHeaderValidationError[F[_]: Async: Logger](

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ColdToWarmSelector.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ColdToWarmSelector.scala
@@ -1,0 +1,26 @@
+package co.topl.networking.fsnetwork
+
+import co.topl.networking.p2p.RemoteAddress
+
+import scala.util.Random
+
+abstract class ColdToWarmSelector[F[_]] {
+  def select(hosts: Set[PeerWithHostAndPort[F]], countToReceive: Int): Set[RemoteAddress]
+}
+
+class RandomColdToWarmSelector[F[_]](closeTimeoutFirstDelayInMs: Long) extends ColdToWarmSelector[F] {
+
+  def select(hosts: Set[PeerWithHostAndPort[F]], countToReceive: Int): Set[RemoteAddress] = {
+    val currentTimestamp = System.currentTimeMillis()
+
+    val eligibleColdPeers = hosts.filter { p =>
+      val timestamps = p.closeTimestamps
+      val lastClose = timestamps.lastOption.getOrElse(0L)
+      val totalCloses = timestamps.size
+      val nonEligibleWindow = totalCloses * totalCloses * closeTimeoutFirstDelayInMs
+      currentTimestamp.toDouble >= (lastClose + nonEligibleWindow)
+    }
+
+    Random.shuffle(eligibleColdPeers).take(countToReceive).map(_.asRemoteAddress)
+  }
+}

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/Notifier.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/Notifier.scala
@@ -44,7 +44,8 @@ object Notifier {
     p2pNetworkConfig:     P2PNetworkConfig
   ): Resource[F, NotifierActor[F]] = {
     val initialState = State(peersManager, reputationAggregator, p2pNetworkConfig)
-    Actor.makeWithFinalize(initialState, getFsm, finalizer[F])
+    val actorName = "Notifier actor"
+    Actor.makeWithFinalize(actorName, initialState, getFsm, finalizer[F])
   }
 
   private def startSendingNotifications[F[_]: Async: Logger](state: State[F]): F[(State[F], Response[F])] =

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockBodyFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockBodyFetcher.scala
@@ -63,7 +63,8 @@ object PeerBlockBodyFetcher {
     headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F]
   ): Resource[F, PeerBlockBodyFetcherActor[F]] = {
     val initialState = State(hostId, client, requestsProxy, transactionStore, headerToBodyValidation)
-    Actor.makeWithFinalize(initialState, getFsm[F], finalizer[F])
+    val actorName = s"Body fetcher actor for peer $hostId"
+    Actor.makeWithFinalize(actorName, initialState, getFsm[F], finalizer[F])
   }
 
   private def downloadBodies[F[_]: Async: Logger](

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -69,7 +69,8 @@ object PeerBlockHeaderFetcher {
   ): Resource[F, Actor[F, Message, Response[F]]] = {
     val initialState =
       State(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, None)
-    Actor.makeWithFinalize(initialState, getFsm[F], finalizer[F])
+    val actorName = s"Header fetcher actor for peer $hostId"
+    Actor.makeWithFinalize(actorName, initialState, getFsm[F], finalizer[F])
   }
 
   private def finalizer[F[_]: Async: Logger](state: State[F]): F[Unit] =

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerNetworkQuality.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerNetworkQuality.scala
@@ -43,7 +43,8 @@ object PeerNetworkQuality {
     reputationAggregator: ReputationAggregatorActor[F]
   ): Resource[F, Actor[F, Message, Response[F]]] = {
     val initialState = State(hostId, client, reputationAggregator)
-    Actor.makeWithFinalize(initialState, getFsm[F], finalizer[F])
+    val actorName = s"Network quality actor for peer $hostId"
+    Actor.makeWithFinalize(actorName, initialState, getFsm[F], finalizer[F])
   }
 
   private def getNetworkQuality[F[_]: Async: Logger](state: State[F]): F[(State[F], Response[F])] =

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerState.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerState.scala
@@ -10,6 +10,12 @@ sealed trait PeerState {
 
 object PeerState {
 
+  // Peer was not known for us, i.e. no record for peer at all
+  case object Unknown extends PeerState {
+    override def networkLevel: Boolean = false
+    override def applicationLevel: Boolean = false
+  }
+
   case object Banned extends PeerState {
     override def networkLevel: Boolean = false
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerState.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerState.scala
@@ -2,10 +2,7 @@ package co.topl.networking.fsnetwork
 
 sealed trait PeerState {
   def networkLevel: Boolean
-
   def applicationLevel: Boolean
-
-  def activeActor: Boolean = networkLevel || applicationLevel
 }
 
 object PeerState {
@@ -18,31 +15,26 @@ object PeerState {
 
   case object Banned extends PeerState {
     override def networkLevel: Boolean = false
-
     override def applicationLevel: Boolean = false
   }
 
   case object Cold extends PeerState {
     override def networkLevel: Boolean = false
-
     override def applicationLevel: Boolean = false
   }
 
   case object PreWarm extends PeerState {
     override def networkLevel: Boolean = false
-
     override def applicationLevel: Boolean = false
   }
 
   case object Warm extends PeerState {
     override def networkLevel: Boolean = true
-
     override def applicationLevel: Boolean = false
   }
 
   case object Hot extends PeerState {
     override def networkLevel: Boolean = true
-
     override def applicationLevel: Boolean = true
   }
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
@@ -1,0 +1,90 @@
+package co.topl.networking.fsnetwork
+
+import co.topl.networking.fsnetwork.PeerActor.PeerActor
+import co.topl.networking.fsnetwork.PeersManager.Peer
+import co.topl.networking.p2p.RemoteAddress
+import org.typelevel.log4cats.Logger
+
+case class PeersHandler[F[_]: Logger](peers: Map[HostId, Peer[F]]) {
+  def hosts: Set[HostId] = peers.keySet
+
+  def get(hostId: HostId): Option[Peer[F]] = peers.get(hostId)
+
+  def apply(hostId: HostId): Peer[F] = peers(hostId)
+
+  def values: Iterable[Peer[F]] = peers.values
+
+  private def getPeers(peerState: PeerState): Map[HostId, Peer[F]] =
+    peers.filter { case (_: String, peer) => peer.state == peerState }
+
+  def getHotPeers: Map[HostId, Peer[F]] = getPeers(PeerState.Hot)
+
+  def getWarmPeers: Map[HostId, Peer[F]] = getPeers(PeerState.Warm)
+
+  def getPreWarmPeers: Map[HostId, Peer[F]] = getPeers(PeerState.PreWarm)
+
+  def getAvailableToConnectAddresses: Set[RemoteAddress] =
+    peers
+      .filterNot(_._2.state == PeerState.Banned)
+      .collect { case (hostId, Peer(_, _, Some(serverPort))) =>
+        RemoteAddress(hostId, serverPort)
+      }
+      .toSet
+
+  def getPeersWithServerPort(state: PeerState): Set[RemoteAddress] =
+    peers.collect { case (host, Peer(`state`, _, Some(address))) =>
+      RemoteAddress(host, address)
+    }.toSet
+
+  def copyWithUpdatedState(toUpdate: Seq[(HostId, PeerState)]): PeersHandler[F] = {
+    val updated =
+      toUpdate.flatMap { case (host, newState) => peers.get(host).map(peer => host -> peer.copy(state = newState)) }
+    PeersHandler(peers ++ updated)
+  }
+
+  def copyWithUpdatedState(hostId: HostId, state: PeerState): PeersHandler[F] =
+    peers
+      .get(hostId)
+      .map(peer => PeersHandler(peers + (hostId -> peer.copy(state = state))))
+      .getOrElse(this)
+
+  def copyWithUpdatedServerPort(hostId: HostId, serverPort: Int): PeersHandler[F] =
+    peers
+      .get(hostId)
+      .map(peer => PeersHandler(peers + (hostId -> peer.copy(serverPort = Option(serverPort)))))
+      .getOrElse(this)
+
+  def copyWithNewPeerActor(hostId: HostId, peerActor: PeerActor[F]): PeersHandler[F] =
+    peers
+      .get(hostId)
+      .map(peer => PeersHandler(peers + (hostId -> peer.copy(actorOpt = Option(peerActor)))))
+      .getOrElse(this)
+
+  def copyWithAddedWarmPeer(host: HostId): PeersHandler[F] = {
+    val toUpdate = peers.get(host) match {
+      case Some(peer) => host -> peer.copy(state = PeerState.Warm)
+      case None       => host -> Peer(state = PeerState.Warm, None, None)
+    }
+    PeersHandler(peers + toUpdate)
+  }
+
+  def copyWithAddedColdPeers(newPeers: Seq[RemoteAddress]): PeersHandler[F] = {
+    val knownPeers: Set[HostId] = peers.keySet
+    val toAdd: Seq[RemoteAddress] = newPeers.filterNot(ra => knownPeers.contains(ra.host))
+    val peersToAdd: Map[HostId, Peer[F]] =
+      toAdd.map(h => h.host -> Peer(PeerState.Cold, None, Option(h.port))).toMap
+    PeersHandler(peers ++ peersToAdd)
+  }
+
+  def copyWithAddedPreWarmPeers(addressesToAdd: Seq[RemoteAddress]): PeersHandler[F] = {
+    val toUpdate = addressesToAdd.map { case RemoteAddress(host, port) =>
+      peers.get(host) match {
+        case Some(peer @ Peer(PeerState.Cold, _, _)) =>
+          host -> peer.copy(state = PeerState.PreWarm, serverPort = Option(port))
+        case Some(peer) => host -> peer
+        case None       => host -> Peer(PeerState.PreWarm, None, Option(port))
+      }
+    }.toMap
+    PeersHandler(peers ++ toUpdate)
+  }
+}

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
@@ -138,8 +138,8 @@ object ReputationAggregator {
       networkConfig,
       None
     )
-
-    Actor.make[F, State[F], Message, Response[F]](initialState, getFsm[F])
+    val actorName = "Reputation aggregator actor"
+    Actor.make[F, State[F], Message, Response[F]](actorName, initialState, getFsm[F])
   }
 
   private def processReputationUpdateTick[F[_]: Async](state: State[F]): F[(State[F], Response[F])] = {

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
@@ -109,7 +109,8 @@ object RequestsProxy {
         bodyRequests,
         blockSource
       )
-    Actor.make(initialState, getFsm[F])
+    val actorName = "Requests proxy actor"
+    Actor.make(actorName, initialState, getFsm[F])
   }
 
   private def setupBlockChecker[F[_]: Async: Logger](

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -10,7 +10,6 @@ import co.topl.consensus.models._
 import co.topl.ledger.models.{BodyAuthorizationError, BodySemanticError, BodySyntaxError, BodyValidationError}
 import co.topl.networking.fsnetwork.NetworkQualityError.{IncorrectPongMessage, NoPongMessage}
 import co.topl.networking.fsnetwork.ReputationAggregator.Message.PingPongMessagePing
-import co.topl.networking.p2p.RemoteAddress
 import co.topl.node.models.BlockBody
 import co.topl.typeclasses.implicits._
 import com.comcast.ip4s.{Dns, Hostname}
@@ -18,7 +17,6 @@ import com.github.benmanes.caffeine.cache.Cache
 import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
-import scala.util.Random
 
 package object fsnetwork {
 
@@ -212,13 +210,6 @@ package object fsnetwork {
     val warmHostsUpdateInterval: FiniteDuration =
       FiniteDuration(Math.round(networkProperties.warmHostsUpdateEveryNBlock * slotDuration.toMillis), MILLISECONDS)
   }
-
-  trait ColdToWarmSelector {
-    def select(coldHosts: Set[RemoteAddress], countToReceive: Int): Set[RemoteAddress]
-  }
-
-  val RandomColdToWarmSelector: ColdToWarmSelector =
-    (coldHosts: Set[RemoteAddress], countToReceive: Int) => Random.shuffle(coldHosts).take(countToReceive)
 
   implicit class LoggerOps[F[_]: Applicative](logger: Logger[F]) {
 


### PR DESCRIPTION
## Purpose
No longer try to connect immediately to recently connected cold peers; no longer try to connect to banned peers

## Approach
Save the last closed connection timestamp, during which the cold peer will be going to a prewarm state considering the last closed timestamp and total count of recent close events

## Testing
Unit tests + integration test + modified integration test

## Tickets
closes #BN-1145