### PR TITLE
P2P Pre-Genesis Checks

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/LocalChainBroadcaster.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/LocalChainBroadcaster.scala
@@ -43,6 +43,8 @@ object LocalChainBroadcaster {
               .rethrowT
 
           def head: F[SlotData] = localChain.head
+
+          def genesis: F[SlotData] = localChain.genesis
         }
 
         (interpreter, topic)

--- a/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
@@ -92,7 +92,9 @@ object PrivateTestnet {
     initializer: StakerInitializers.Operator,
     stake:       Int128
   ): F[Unit] =
-    Files[F]
+    Files.forAsync[F].createDirectories(stakingDir) >>
+    Files
+      .forAsync[F]
       .list(stakingDir)
       .compile
       .count

--- a/blockchain/src/main/scala/co/topl/blockchain/StakingInit.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/StakingInit.scala
@@ -30,15 +30,20 @@ object StakingInit {
    * Inspects the given stakingDir for the expected keys/files.  If the expected files exist, `true` is returned.
    */
   def stakingIsInitialized[F[_]: Async](stakingDir: Path): F[Boolean] =
-    Files
-      .forAsync[F]
-      .list(stakingDir)
-      .compile
-      .toList
-      .map(files =>
-        files.exists(_.endsWith(KesDirectoryName)) &&
-        files.exists(_.endsWith(VrfKeyName)) &&
-        files.exists(_.endsWith(RegistrationTxName))
+    Files[F]
+      .exists(stakingDir)
+      .ifM(
+        Files
+          .forAsync[F]
+          .list(stakingDir)
+          .compile
+          .toList
+          .map(files =>
+            files.exists(_.endsWith(KesDirectoryName)) &&
+            files.exists(_.endsWith(VrfKeyName)) &&
+            files.exists(_.endsWith(RegistrationTxName))
+          ),
+        false.pure[F]
       )
 
   /**

--- a/consensus/src/main/scala/co/topl/consensus/algebras/LocalChainAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/LocalChainAlgebra.scala
@@ -45,4 +45,9 @@ trait LocalChainAlgebra[F[_]] {
    * The head of the chain that has been adopted locally by this node.
    */
   def head: F[SlotData]
+
+  /**
+   * The first block (SlotData) in the chain
+   */
+  def genesis: F[SlotData]
 }

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/LocalChain.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/LocalChain.scala
@@ -16,15 +16,16 @@ import org.typelevel.log4cats.SelfAwareStructuredLogger
 object LocalChain {
 
   def make[F[_]: Sync](
+    genesis:        SlotData,
     initialHead:    SlotData,
     chainSelection: ChainSelectionAlgebra[F, SlotData],
     onAdopted:      BlockId => F[Unit]
-  ): F[LocalChainAlgebra[F]] =
+  ): F[LocalChainAlgebra[F]] = {
+    val _g = genesis
     Ref
       .of[F, SlotData](initialHead)
       .map(headRef =>
         new LocalChainAlgebra[F] {
-
           implicit private val logger: SelfAwareStructuredLogger[F] =
             Slf4jLogger.getLoggerFromName[F]("Bifrost.LocalChain")
 
@@ -50,6 +51,10 @@ object LocalChain {
 
           val head: F[SlotData] =
             headRef.get
+
+          val genesis: F[SlotData] =
+            _g.pure[F]
         }
       )
+  }
 }

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/LocalChainSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/LocalChainSpec.scala
@@ -44,7 +44,8 @@ class LocalChainSpec
 
       val chainSelection: ChainSelectionAlgebra[F, SlotData] = (a, b) => a.height.compareTo(b.height).pure[F]
 
-      val underTest = LocalChain.make[F](initialHead, chainSelection, _ => Applicative[F].unit).unsafeRunSync()
+      val underTest =
+        LocalChain.make[F](initialHead, initialHead, chainSelection, _ => Applicative[F].unit).unsafeRunSync()
 
       underTest.head.unsafeRunSync() shouldBe initialHead
     }
@@ -63,7 +64,8 @@ class LocalChainSpec
 
       val chainSelection: ChainSelectionAlgebra[F, SlotData] = (a, b) => a.height.compareTo(b.height).pure[F]
 
-      val underTest = LocalChain.make[F](initialHead, chainSelection, _ => Applicative[F].unit).unsafeRunSync()
+      val underTest =
+        LocalChain.make[F](initialHead, initialHead, chainSelection, _ => Applicative[F].unit).unsafeRunSync()
 
       val newHead =
         SlotData(
@@ -91,7 +93,8 @@ class LocalChainSpec
 
       val chainSelection: ChainSelectionAlgebra[F, SlotData] = (a, b) => a.height.compareTo(b.height).pure[F]
 
-      val underTest = LocalChain.make[F](initialHead, chainSelection, _ => Applicative[F].unit).unsafeRunSync()
+      val underTest =
+        LocalChain.make[F](initialHead, initialHead, chainSelection, _ => Applicative[F].unit).unsafeRunSync()
 
       val newHead =
         SlotData(

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -46,7 +46,7 @@ object ActorPeerHandlerBridgeAlgebra {
   ): Resource[F, BlockchainPeerHandlerAlgebra[F]] = {
     implicit val dnsResolver: DnsResolver[F] = DnsResolverInstances.defaultResolver[F]
 
-    val networkAlgebra = new NetworkAlgebraImpl[F]()
+    val networkAlgebra = new NetworkAlgebraImpl[F](clockAlgebra)
     val networkManager =
       NetworkManager.startNetwork[F](
         thisHostId,

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
@@ -1,7 +1,7 @@
 package co.topl.networking.fsnetwork
 
 import cats.effect.{Async, Resource}
-import co.topl.algebras.Store
+import co.topl.algebras.{ClockAlgebra, Store}
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.algebras._
@@ -101,7 +101,7 @@ trait NetworkAlgebra[F[_]] {
   ): Resource[F, PeerBlockBodyFetcherActor[F]]
 }
 
-class NetworkAlgebraImpl[F[_]: Async: Logger: DnsResolver] extends NetworkAlgebra[F] {
+class NetworkAlgebraImpl[F[_]: Async: Logger: DnsResolver](clock: ClockAlgebra[F]) extends NetworkAlgebra[F] {
 
   override def makePeerManger(
     thisHostId:             HostId,
@@ -218,7 +218,7 @@ class NetworkAlgebraImpl[F[_]: Async: Logger: DnsResolver] extends NetworkAlgebr
     slotDataStore: Store[F, BlockId, SlotData],
     blockIdTree:   ParentChildTree[F, BlockId]
   ): Resource[F, PeerBlockHeaderFetcherActor[F]] =
-    PeerBlockHeaderFetcher.makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+    PeerBlockHeaderFetcher.makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)
 
   def makePeerBodyFetcher(
     hostId:                 HostId,

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
@@ -30,6 +30,7 @@ import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import co.topl.models.generators.consensus.ModelGenerators._
 
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
 
@@ -44,14 +45,21 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
   test("Setting application level to true shall send start fetching stream message") {
     withMock {
+      val genesis = arbitrarySlotData.arbitrary.first
       val peersManager = mock[PeersManagerActor[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
+      (() => localChain.genesis).expects().once().returning(genesis.pure[F])
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val client = mock[BlockchainPeerClient[F]]
+      (client
+        .getRemoteBlockIdAtHeight(_: Long, _: Option[BlockId]))
+        .expects(1L, genesis.slotId.blockId.some)
+        .once()
+        .returning(genesis.slotId.blockId.some.pure[F])
       val reputationAggregation = mock[ReputationAggregatorActor[F]]
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
@@ -92,14 +100,21 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
   test("Block header download shall be forwarded to header fetcher") {
     withMock {
+      val genesis = arbitrarySlotData.arbitrary.first
       val peersManager = mock[PeersManagerActor[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
+      (() => localChain.genesis).expects().once().returning(genesis.pure[F])
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val client = mock[BlockchainPeerClient[F]]
+      (client
+        .getRemoteBlockIdAtHeight(_: Long, _: Option[BlockId]))
+        .expects(1L, genesis.slotId.blockId.some)
+        .once()
+        .returning(genesis.slotId.blockId.some.pure[F])
       val reputationAggregation = mock[ReputationAggregatorActor[F]]
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
@@ -146,14 +161,21 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
   test("Block body download shall be forwarded to body fetcher") {
     withMock {
+      val genesis = arbitrarySlotData.arbitrary.first
       val peersManager = mock[PeersManagerActor[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
+      (() => localChain.genesis).expects().once().returning(genesis.pure[F])
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val client = mock[BlockchainPeerClient[F]]
+      (client
+        .getRemoteBlockIdAtHeight(_: Long, _: Option[BlockId]))
+        .expects(1L, genesis.slotId.blockId.some)
+        .once()
+        .returning(genesis.slotId.blockId.some.pure[F])
       val reputationAggregation = mock[ReputationAggregatorActor[F]]
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
@@ -200,9 +222,11 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
   test("Ping shall be started and result is sent to reputation aggregator") {
     withMock {
+      val genesis = arbitrarySlotData.arbitrary.first
       val peersManager = mock[PeersManagerActor[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
+      (() => localChain.genesis).expects().once().returning(genesis.pure[F])
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
@@ -226,6 +250,12 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       (client.getPongMessage _).expects(*).atLeastOnce().onCall { ping: PingMessage =>
         Async[F].delayBy(Option(PongMessage(ping.ping.reverse)).pure[F], pingDelay)
       }
+
+      (client
+        .getRemoteBlockIdAtHeight(_: Long, _: Option[BlockId]))
+        .expects(1L, genesis.slotId.blockId.some)
+        .once()
+        .returning(genesis.slotId.blockId.some.pure[F])
 
       val reputationAggregation = mock[ReputationAggregatorActor[F]]
       (reputationAggregation.sendNoWait _).expects(*).atLeastOnce().onCall { message: ReputationAggregator.Message =>
@@ -263,9 +293,11 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
   test("Ping shall be started: one success and two errors") {
     withMock {
+      val genesis = arbitrarySlotData.arbitrary.first
       val peersManager = mock[PeersManagerActor[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
+      (() => localChain.genesis).expects().once().returning(genesis.pure[F])
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
@@ -295,6 +327,11 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       (client.getPongMessage _).expects(*).atLeastOnce().onCall { ping: PingMessage =>
         Option(PongMessage(ping.ping)).pure[F]
       }
+      (client
+        .getRemoteBlockIdAtHeight(_: Long, _: Option[BlockId]))
+        .expects(1L, genesis.slotId.blockId.some)
+        .once()
+        .returning(genesis.slotId.blockId.some.pure[F])
 
       val reputationAggregation = mock[ReputationAggregatorActor[F]]
       (reputationAggregation.sendNoWait _).expects(*).once().onCall { message: ReputationAggregator.Message =>
@@ -343,14 +380,21 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
   test("Request to get current tip shall be forwarded to block header fetcher") {
     withMock {
+      val genesis = arbitrarySlotData.arbitrary.first
       val peersManager = mock[PeersManagerActor[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
+      (() => localChain.genesis).expects().once().returning(genesis.pure[F])
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val client = mock[BlockchainPeerClient[F]]
+      (client
+        .getRemoteBlockIdAtHeight(_: Long, _: Option[BlockId]))
+        .expects(1L, genesis.slotId.blockId.some)
+        .once()
+        .returning(genesis.slotId.blockId.some.pure[F])
       val reputationAggregation = mock[ReputationAggregatorActor[F]]
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
@@ -392,14 +436,21 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
   test("Request to get peer neighbours shall be processed if none empty known hosts received") {
     withMock {
+      val genesis = arbitrarySlotData.arbitrary.first
       val peersManager = mock[PeersManagerActor[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
+      (() => localChain.genesis).expects().once().returning(genesis.pure[F])
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val client = mock[BlockchainPeerClient[F]]
+      (client
+        .getRemoteBlockIdAtHeight(_: Long, _: Option[BlockId]))
+        .expects(1L, genesis.slotId.blockId.some)
+        .once()
+        .returning(genesis.slotId.blockId.some.pure[F])
       val reputationAggregation = mock[ReputationAggregatorActor[F]]
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
@@ -450,14 +501,21 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
   test("Request to get peer neighbours shall not be processed if empty known hosts received") {
     withMock {
+      val genesis = arbitrarySlotData.arbitrary.first
       val peersManager = mock[PeersManagerActor[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
+      (() => localChain.genesis).expects().once().returning(genesis.pure[F])
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val client = mock[BlockchainPeerClient[F]]
+      (client
+        .getRemoteBlockIdAtHeight(_: Long, _: Option[BlockId]))
+        .expects(1L, genesis.slotId.blockId.some)
+        .once()
+        .returning(genesis.slotId.blockId.some.pure[F])
       val reputationAggregation = mock[ReputationAggregatorActor[F]]
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
@@ -499,14 +557,21 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
   test("Request to get server port shall be processed") {
     withMock {
+      val genesis = arbitrarySlotData.arbitrary.first
       val peersManager = mock[PeersManagerActor[F]]
       val requestsProxy = mock[RequestsProxyActor[F]]
       val localChain = mock[LocalChainAlgebra[F]]
+      (() => localChain.genesis).expects().once().returning(genesis.pure[F])
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val client = mock[BlockchainPeerClient[F]]
+      (client
+        .getRemoteBlockIdAtHeight(_: Long, _: Option[BlockId]))
+        .expects(1L, genesis.slotId.blockId.some)
+        .once()
+        .returning(genesis.slotId.blockId.some.pure[F])
       val reputationAggregation = mock[ReputationAggregatorActor[F]]
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
@@ -521,7 +586,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       (blockBodyFetcher.sendNoWait _).expects(PeerBlockBodyFetcher.Message.StopActor).returns(Applicative[F].unit)
 
       val serverPort = 9085
-      (client.remotePeerServerPort _)
+      (() => client.remotePeerServerPort)
         .expects()
         .returns(Option(serverPort).pure[F])
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
@@ -4,7 +4,7 @@ import cats.MonadThrow
 import cats.data.{NonEmptyChain, OptionT}
 import cats.effect.{Async, IO}
 import cats.implicits._
-import co.topl.algebras.Store
+import co.topl.algebras.{ClockAlgebra, Store}
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.consensus.algebras.LocalChainAlgebra
 import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
@@ -74,8 +74,10 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
 
+      val clock = mock[ClockAlgebra[F]]
+
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)
         .use { actor =>
           for {
             _ <- actor.sendNoWait(PeerBlockHeaderFetcher.Message.DownloadBlockHeaders(idAndHeader.map(_._1)))
@@ -118,8 +120,10 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
 
+      val clock = mock[ClockAlgebra[F]]
+
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)
         .use { actor =>
           for {
             _ <- actor.sendNoWait(PeerBlockHeaderFetcher.Message.DownloadBlockHeaders(NonEmptyChain.one(header.id)))
@@ -170,8 +174,10 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
 
+      val clock = mock[ClockAlgebra[F]]
+
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)
         .use { actor =>
           for {
             _ <- actor.sendNoWait(PeerBlockHeaderFetcher.Message.DownloadBlockHeaders(idAndHeader.map(_._1)))
@@ -228,8 +234,10 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
 
+      val clock = mock[ClockAlgebra[F]]
+
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)
         .use { actor =>
           for {
             _ <- actor.sendNoWait(PeerBlockHeaderFetcher.Message.DownloadBlockHeaders(idAndHeader.map(_._1)))
@@ -289,8 +297,11 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
       (blockIdTree.associate _).expects(*, *).rep(remoteSlotDataCount).returning(().pure[F])
 
+      val clock = mock[ClockAlgebra[F]]
+      (() => clock.globalSlot).expects().once().returning(2L.pure[F])
+
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)
         .use { actor =>
           for {
             state <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)
@@ -344,8 +355,10 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
 
+      val clock = mock[ClockAlgebra[F]]
+
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)
         .use { actor =>
           for {
             state <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)
@@ -400,8 +413,10 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
 
+      val clock = mock[ClockAlgebra[F]]
+
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)
         .use { actor =>
           for {
             state <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)
@@ -467,8 +482,11 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
       (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
 
+      val clock = mock[ClockAlgebra[F]]
+      (() => clock.globalSlot).expects().once().returning(2L.pure[F])
+
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)
         .use { actor =>
           for {
             _     <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)
@@ -533,8 +551,10 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
       (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
 
+      val clock = mock[ClockAlgebra[F]]
+
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)
         .use { actor =>
           for {
             _     <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)
@@ -599,8 +619,10 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
       (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
 
+      val clock = mock[ClockAlgebra[F]]
+
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)
         .use { actor =>
           for {
             _     <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)
@@ -659,8 +681,10 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
 
+      val clock = mock[ClockAlgebra[F]]
+
       PeerBlockHeaderFetcher
-        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree)
+        .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)
         .use { actor =>
           for {
             _     <- actor.send(PeerBlockHeaderFetcher.Message.StartActor)


### PR DESCRIPTION
## Purpose
- A node can be launched before the genesis block elapses.  This is called "pre-genesis".
- Pre-genesis is helpful for forming the P2P graph to achieve stable launch of the blockchain
- During pre-genesis, it would be invalid to create and transmit any "new" blocks (i.e. any blocks past genesis)
## Approach
- When constructing a PeerActor, verify that the remote peer uses the same genesis block
- When fetching block headers from the remote peer, if there is a header past genesis, verify that the local global slot is non-negative
## Testing
- Updated unit tests
## Tickets
- #BN-1120