### PR TITLE
Adding ActorPeerHandlerBridgeAlgebra test

### DIFF
--- a/actor/src/main/scala/co/topl/actor/Actor.scala
+++ b/actor/src/main/scala/co/topl/actor/Actor.scala
@@ -8,6 +8,7 @@ import cats.syntax.all._
 import co.topl.actor.Actor.ActorId
 import fs2.Stream
 import fs2.concurrent.SignallingRef
+import org.typelevel.log4cats.Logger
 
 import scala.collection.immutable.ListMap
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -100,16 +101,16 @@ object Actor {
    * @param finalize     the finalizer effect with the last state
    * @return Actor object
    */
-  def makeFull[F[_]: Concurrent, S, I, O](
+  def makeFull[F[_]: Concurrent: Logger, S, I, O](
     actorName:    String,
     initialState: S,
     createFsm:    Actor[F, I, O] => Fsm[F, S, I, O],
     finalize:     S => F[Unit]
   ): Resource[F, Actor[F, I, O]] =
     for {
-      actorRef  <- Deferred[F, Actor[F, I, O]].toResource
-      mailbox   <- Queue.unbounded[F, Option[(I, Deferred[F, O])]].toResource
-      isDeadRef <- Resource.make(Ref.of[F, Boolean](false))(_.set(true))
+      actorRef <- Deferred[F, Actor[F, I, O]].toResource
+      mailbox  <- Queue.unbounded[F, Option[(I, Deferred[F, O])]].toResource
+      isAlive  <- Resource.make(Ref.of[F, Boolean](true))(_.set(false))
       acquiredActors <-
         Resource.make(Ref.of[F, ListMap[ActorId, F[Unit]]](ListMap.empty))(_.get.flatMap(_.values.toList.sequence).void)
       stateRef <- Resource.make(Ref.of[F, S](initialState))(_.get.flatMap(finalize))
@@ -134,7 +135,6 @@ object Actor {
 
       _ <- Resource.onFinalize(mailbox.offer(none) *> processOutcome.flatMap(_.embed(Applicative[F].unit)))
 
-      throwIfDead = isDeadRef.get.flatMap(Concurrent[F].raiseWhen(_)(ActorDeadException(s"Actor: $actorName; is dead")))
       actor = new Actor[F, I, O] {
         override val name: String = actorName
 
@@ -143,10 +143,20 @@ object Actor {
         override def mailboxSize: F[Int] = mailbox.size
 
         override def sendNoWait(input: I): F[Unit] =
-          throwIfDead *> Deferred[F, O].flatMap(promise => mailbox.offer((input, promise).some)).void
+          isAlive.get
+            .ifF(
+              ifTrue = Deferred[F, O].flatMap(promise => mailbox.offer((input, promise).some)).void,
+              ifFalse = Logger[F].error(s"Actor: $actorName; is dead")
+            )
+            .flatten
 
         override def send(msg: I): F[O] =
-          throwIfDead *> Deferred[F, O].flatMap(promise => mailbox.offer((msg, promise).some) *> promise.get)
+          isAlive.get
+            .ifF[F[O]](
+              ifTrue = Deferred[F, O].flatMap(promise => mailbox.offer((msg, promise).some) *> promise.get),
+              ifFalse = throw ActorDeadException(s"Actor: $actorName; is dead")
+            )
+            .flatten
 
         override def acquireActor[I2, O2](actorCreator: () => Resource[F, Actor[F, I2, O2]]): F[Actor[F, I2, O2]] =
           for {
@@ -177,7 +187,7 @@ object Actor {
    * @param finalize     the cleanup effect with the last known state
    * @return Actor object
    */
-  def makeWithFinalize[F[_]: Concurrent, S, I, O](
+  def makeWithFinalize[F[_]: Concurrent: Logger, S, I, O](
     actorName:    String,
     initialState: S,
     fsm:          Fsm[F, S, I, O],
@@ -185,14 +195,14 @@ object Actor {
   ): Resource[F, Actor[F, I, O]] =
     makeFull(actorName, initialState, (_: Actor[F, I, O]) => fsm, finalize)
 
-  def make[F[_]: Concurrent, S, I, O](
+  def make[F[_]: Concurrent: Logger, S, I, O](
     actorName:    String,
     initialState: S,
     fsm:          Fsm[F, S, I, O]
   ): Resource[F, Actor[F, I, O]] =
     makeWithFinalize(actorName, initialState, fsm, (_: S) => Concurrent[F].unit)
 
-  def makeSimple[F[_]: Concurrent, S, I, O](
+  def makeSimple[F[_]: Concurrent: Logger, S, I, O](
     actorName:    String,
     initialState: S,
     fsm:          Fsm[F, S, I, O]

--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -27,7 +27,7 @@ import co.topl.ledger.algebras._
 import co.topl.minting.algebras.StakingAlgebra
 import co.topl.minting.interpreters._
 import co.topl.networking.blockchain._
-import co.topl.networking.fsnetwork.ActorPeerHandlerBridgeAlgebra
+import co.topl.networking.fsnetwork.{ActorPeerHandlerBridgeAlgebra, DnsResolver, DnsResolverInstances}
 import co.topl.networking.p2p._
 import co.topl.node.models.BlockBody
 import co.topl.typeclasses.implicits._
@@ -102,6 +102,8 @@ object Blockchain {
             )
           )
         } else {
+          implicit val dnsResolver: DnsResolver[F] = DnsResolverInstances.defaultResolver[F]
+
           ActorPeerHandlerBridgeAlgebra.make(
             localPeer.localAddress.host,
             localChain,

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -16,13 +16,12 @@ import co.topl.networking.blockchain.{BlockchainPeerClient, BlockchainPeerHandle
 import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.networking.p2p.{ConnectedPeer, DisconnectedPeer, RemoteAddress}
 import co.topl.node.models.{BlockBody, KnownHost}
-import com.comcast.ip4s.Dns
 import fs2.Stream
 import org.typelevel.log4cats.Logger
 
 object ActorPeerHandlerBridgeAlgebra {
 
-  def make[F[_]: Async: Logger: Dns](
+  def make[F[_]: Async: Logger: DnsResolver](
     thisHostId:                  HostId,
     localChain:                  LocalChainAlgebra[F],
     chainSelectionAlgebra:       ChainSelectionAlgebra[F, SlotData],
@@ -44,7 +43,6 @@ object ActorPeerHandlerBridgeAlgebra {
     addRemotePeer:               DisconnectedPeer => F[Unit],
     hotPeersUpdate:              Set[RemoteAddress] => F[Unit]
   ): Resource[F, BlockchainPeerHandlerAlgebra[F]] = {
-    implicit val dnsResolver: DnsResolver[F] = DnsResolverInstances.defaultResolver[F]
 
     val networkAlgebra = new NetworkAlgebraImpl[F](clockAlgebra)
     val networkManager =

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -255,7 +255,7 @@ object PeerActor {
     } yield res
 
   /**
-   * Ensure that the two peers agree on a genesis block.  If not, raise an excecption.
+   * Ensure that the two peers agree on a genesis block.  If not, raise an exception.
    */
   private def verifyGenesisAgreement[F[_]: Async](state: State[F]) =
     state.client

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
@@ -85,11 +85,11 @@ object ReputationAggregator {
     case class BadKLookbackSlotData(hostId: HostId) extends Message
 
     /**
-     * Remote peer provide to us incorrect, by some resons, block.
+     * Remote peer provide to us incorrect, by some reasons, block or other data like genesis block.
      * For example it could be block with incorrect transaction(s)
      * @param hostId remote peer
      */
-    case class HostProvideIncorrectBlock(hostId: HostId) extends Message
+    case class HostProvideIncorrectData(hostId: HostId) extends Message
 
     /**
      * Tick, which do actual update of time based reputation
@@ -114,8 +114,8 @@ object ReputationAggregator {
       case (state, DownloadTimeBody(hostId, delay, txDelays)) => blockDownloadTime(state, hostId, delay, txDelays)
       case (state, BlockProvidingReputationUpdate(data))      => blockProvidingReputationUpdate(state, data)
 
-      case (state, BadKLookbackSlotData(hostId))      => badKLookbackSlotData(state, hostId)
-      case (state, HostProvideIncorrectBlock(hostId)) => incorrectBlockReceived(state, hostId)
+      case (state, BadKLookbackSlotData(hostId))     => badKLookbackSlotData(state, hostId)
+      case (state, HostProvideIncorrectData(hostId)) => incorrectBlockReceived(state, hostId)
 
       case (state, ReputationUpdateTick) => processReputationUpdateTick(state)
       case (state, UpdateWarmHosts)      => processUpdateWarmHosts(state)

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
@@ -258,7 +258,7 @@ object RequestsProxy {
     errorsOpt match {
       case Some(errors) =>
         val reputationMessage: ReputationAggregator.Message =
-          ReputationAggregator.Message.HostProvideIncorrectBlock(source)
+          ReputationAggregator.Message.HostProvideIncorrectData(source)
 
         errors.traverse { case (id, _) =>
           reputationAggregator.sendNoWait(reputationMessage) >>
@@ -388,7 +388,7 @@ object RequestsProxy {
 
     def processError(header: BlockHeader): F[Unit] = {
       val reputationMessage: ReputationAggregator.Message =
-        ReputationAggregator.Message.HostProvideIncorrectBlock(source)
+        ReputationAggregator.Message.HostProvideIncorrectData(source)
 
       {
         for {
@@ -411,7 +411,7 @@ object RequestsProxy {
     @nowarn blockId: BlockId
   ): F[(State[F], Response[F])] =
     // TODO add cache for invalid block thus no longer accept blocks with that particular id
-    state.reputationAggregator.sendNoWait(ReputationAggregator.Message.HostProvideIncorrectBlock(source)) >>
+    state.reputationAggregator.sendNoWait(ReputationAggregator.Message.HostProvideIncorrectData(source)) >>
     (state, state).pure[F]
 
   // Send to block checker first available body for checking,

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
@@ -1,0 +1,254 @@
+package co.topl.networking.fsnetwork
+
+import cats.Applicative
+import cats.data.{Validated, ValidatedNec}
+import cats.effect.kernel.{Async, Sync}
+import cats.effect.{IO, Resource}
+import cats.implicits._
+import co.topl.algebras.ClockAlgebra
+import co.topl.algebras.testInterpreters.TestStore
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.models.{Datum, TransactionId}
+import co.topl.config.ApplicationConfig.Bifrost.NetworkProperties
+import co.topl.consensus.algebras._
+import co.topl.consensus.models.{
+  BlockHeader,
+  BlockHeaderToBodyValidationFailure,
+  BlockHeaderValidationFailure,
+  BlockId,
+  SlotData
+}
+import co.topl.eventtree.ParentChildTree
+import co.topl.ledger.algebras._
+import co.topl.ledger.models.{BodyAuthorizationError, BodySemanticError, BodySyntaxError, BodyValidationContext}
+import co.topl.models.ModelGenerators.GenHelper
+import co.topl.models.generators.consensus.ModelGenerators.arbitrarySlotData
+import co.topl.models.{Epoch, Slot, Timestamp}
+import co.topl.networking.blockchain.BlockchainPeerClient
+import co.topl.networking.fsnetwork.ActorPeerHandlerBridgeAlgebraTest._
+import co.topl.networking.p2p.{ConnectedPeer, DisconnectedPeer, RemoteAddress}
+import co.topl.node.models._
+import co.topl.quivr.runtime.DynamicContext
+import co.topl.typeclasses.implicits._
+import fs2.Stream
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalamock.munit.AsyncMockFactory
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.collection.immutable.NumericRange
+import scala.concurrent.duration.{Duration, DurationLong, FiniteDuration, MILLISECONDS}
+
+object ActorPeerHandlerBridgeAlgebraTest {
+  type F[A] = IO[A]
+
+  val chainSelectionAlgebra: ChainSelectionAlgebra[F, SlotData] =
+    (x: SlotData, y: SlotData) => x.height.compare(y.height).pure[F]
+
+  val networkProperties: NetworkProperties = NetworkProperties()
+
+  val headerValidation: BlockHeaderValidationAlgebra[F] =
+    (header: BlockHeader) => Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F]
+
+  val headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F] =
+    (block: Block) => Either.right[BlockHeaderToBodyValidationFailure, Block](block).pure[F]
+
+  val bodySyntaxValidation: BodySyntaxValidationAlgebra[F] =
+    (blockBody: BlockBody) => Validated.validNec[BodySyntaxError, BlockBody](blockBody).pure[F]
+
+  val bodySemanticValidation: BodySemanticValidationAlgebra[F] = new BodySemanticValidationAlgebra[F] {
+
+    def validate(context: BodyValidationContext)(blockBody: BlockBody): F[ValidatedNec[BodySemanticError, BlockBody]] =
+      Validated.validNec[BodySemanticError, BlockBody](blockBody).pure[F]
+  }
+
+  val bodyAuthorizationValidation: BodyAuthorizationValidationAlgebra[F] = new BodyAuthorizationValidationAlgebra[F] {
+
+    override def validate(context: IoTransaction => DynamicContext[F, HostId, Datum])(
+      blockBody: BlockBody
+    ): F[ValidatedNec[BodyAuthorizationError, BlockBody]] =
+      Validated.validNec[BodyAuthorizationError, BlockBody](blockBody).pure[F]
+  }
+
+  def createSlotDataStore: F[TestStore[F, BlockId, SlotData]] =
+    TestStore.make[F, BlockId, SlotData]
+
+  def createHeaderStore: F[TestStore[F, BlockId, BlockHeader]] =
+    TestStore.make[F, BlockId, BlockHeader]
+
+  def createBodyStore: F[TestStore[F, BlockId, BlockBody]] =
+    TestStore.make[F, BlockId, BlockBody]
+
+  def createTransactionStore: F[TestStore[F, TransactionId, IoTransaction]] =
+    TestStore.make[F, TransactionId, IoTransaction]
+
+  def createKnownHostsStore: F[TestStore[F, Unit, Seq[KnownHost]]] =
+    TestStore.make[F, Unit, Seq[KnownHost]]
+
+  def createBlockIdTree: F[ParentChildTree[F, BlockId]] =
+    ParentChildTree.FromRef.make[F, BlockId]
+
+  def createEmptyLocalChain: LocalChainAlgebra[F] = new LocalChainAlgebra[F] {
+
+    private val genesisSlotData: SlotData = arbitrarySlotData.arbitrary.first.copy(height = 0)
+    private var currentHead: SlotData = genesisSlotData
+
+    override def couldBeWorse(newHead: SlotData): F[Boolean] =
+      (newHead.height > currentHead.height).pure[F]
+
+    override def isWorseThan(newHead: SlotData): F[Boolean] =
+      (newHead.height > currentHead.height).pure[F]
+
+    override def adopt(newHead: Validated.Valid[SlotData]): F[Unit] =
+      (currentHead = newHead.a).pure[F]
+
+    override def head: F[SlotData] =
+      currentHead.copy().pure[F]
+
+    override def genesis: F[SlotData] = genesisSlotData.pure[F]
+  }
+
+  def createClockAlgebra: ClockAlgebra[F] = new ClockAlgebra[F] {
+    private val genesisTime: Instant = Instant.ofEpochMilli(System.currentTimeMillis())
+    private val startTime = genesisTime.toEpochMilli
+
+    private val _slotLength = FiniteDuration(200, MILLISECONDS)
+    override def slotLength: F[FiniteDuration] = _slotLength.pure[F]
+
+    override def slotsPerEpoch: F[Long] = 100L.pure[F]
+
+    override def slotsPerOperationalPeriod: F[Long] = 20L.pure[F]
+
+    override def currentTimestamp: F[Timestamp] = System.currentTimeMillis().pure[F]
+
+    override def timestampToSlot(timestamp: Timestamp): F[Slot] =
+      ((timestamp - startTime) / _slotLength.toMillis).pure[F]
+
+    override def slotToTimestamps(slot: Slot): F[NumericRange.Inclusive[Long]] =
+      Sync[F].delay {
+        val startTimestamp = startTime + (slot * _slotLength.toMillis)
+        val endTimestamp = startTimestamp + (_slotLength.toMillis - 1)
+        NumericRange.inclusive(startTimestamp, endTimestamp, 1L)
+      }
+
+    private val _forwardBiasedSlotWindow = 10L
+    override val forwardBiasedSlotWindow: F[Slot] = _forwardBiasedSlotWindow.pure[F]
+
+    override def globalSlot: F[Slot] = currentTimestamp.flatMap(timestampToSlot)
+
+    override def currentEpoch: F[Epoch] =
+      (globalSlot, slotsPerEpoch).mapN(_ / _)
+
+    override def delayedUntilSlot(slot: Slot): F[Unit] =
+      globalSlot.map(currentSlot => (slot - currentSlot) * _slotLength).flatMap(delayedFor)
+
+    override def delayedUntilTimestamp(timestamp: Timestamp): F[Unit] =
+      currentTimestamp.map(now => (timestamp - now).milli).flatMap(delayedFor)
+
+    private def delayedFor(duration: FiniteDuration): F[Unit] =
+      if (duration < Duration.Zero) Applicative[F].unit
+      else Async[F].sleep(duration)
+  }
+}
+
+class ActorPeerHandlerBridgeAlgebraTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+  implicit val dummyDns: DnsResolver[F] = (host: HostId) => Option(host).pure[F]
+  implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
+  val hostId: HostId = "127.0.0.1"
+
+  test("Start network with add one network peer: adoption shall be started, peers shall be saved in the end") {
+    withMock {
+      val remotePeerPort = 9085
+      val remotePeerAddress = RemoteAddress("2.2.2.2", remotePeerPort)
+      val remotePeer = DisconnectedPeer(remotePeerAddress, (0, 0))
+      val remotePeers: List[DisconnectedPeer] = List(remotePeer)
+      val finishTestFlag: AtomicBoolean = new AtomicBoolean(false)
+
+      val localChainMock = createEmptyLocalChain
+
+      val client =
+        mock[BlockchainPeerClient[F]]
+      (client.getPongMessage _).expects(*).anyNumberOfTimes().onCall { req: PingMessage =>
+        Option(PongMessage(req.ping.reverse)).pure[F]
+      }
+      (client.getRemoteBlockIdAtHeight _)
+        .expects(1, *)
+        .returns(localChainMock.genesis.map(sd => Option(sd.slotId.blockId)))
+      (() => client.remotePeer).expects().once().returns(ConnectedPeer(remotePeerAddress, (0, 0)).pure[F])
+
+      (() => client.remotePeerAdoptions).expects().once().onCall { () =>
+        Stream.fromOption[F](Option.empty[BlockId]).pure[F]
+      }
+      (() => client.remotePeerServerPort).expects().returns(Option(remotePeerPort).pure[F])
+      (client.getRemoteKnownHosts _)
+        .expects(*)
+        .anyNumberOfTimes()
+        .returns(Option(CurrentKnownHostsRes(Seq.empty)).pure[F])
+
+      val closedPeers: Stream[F, ConnectedPeer] = Stream.empty
+
+      val peerOpenRequested: AtomicBoolean = new AtomicBoolean(false)
+      val addRemotePeer: DisconnectedPeer => F[Unit] = mock[DisconnectedPeer => F[Unit]]
+      (addRemotePeer.apply _).expects(remotePeer).once().returns {
+        Sync[F].delay(peerOpenRequested.set(true))
+      }
+
+      var hotPeers: Set[RemoteAddress] = Set.empty
+      val hotPeersUpdate: Set[RemoteAddress] => F[Unit] = mock[Set[RemoteAddress] => F[Unit]]
+      (hotPeersUpdate.apply _).expects(*).anyNumberOfTimes().onCall { peers: Set[RemoteAddress] =>
+        (if (peers.nonEmpty) Sync[F].delay(finishTestFlag.set(true)) else Applicative[F].unit) *>
+        (hotPeers = peers).pure[F]
+      }
+
+      val execResource = for {
+        slotDataStore    <- Resource.liftK(createSlotDataStore)
+        headerStore      <- Resource.liftK(createHeaderStore)
+        bodyStore        <- Resource.liftK(createBodyStore)
+        transactionStore <- Resource.liftK(createTransactionStore)
+        knownHostsStore  <- Resource.liftK(createKnownHostsStore)
+        blockIdTree      <- Resource.liftK(createBlockIdTree)
+        localChain       <- Resource.pure(localChainMock)
+        clockAlgebra     <- Resource.pure(createClockAlgebra)
+
+        algebra <- ActorPeerHandlerBridgeAlgebra
+          .make(
+            hostId,
+            localChain,
+            chainSelectionAlgebra,
+            headerValidation,
+            headerToBodyValidation,
+            bodySyntaxValidation,
+            bodySemanticValidation,
+            bodyAuthorizationValidation,
+            slotDataStore,
+            headerStore,
+            bodyStore,
+            transactionStore,
+            knownHostsStore,
+            blockIdTree,
+            networkProperties,
+            clockAlgebra,
+            remotePeers,
+            closedPeers,
+            addRemotePeer,
+            hotPeersUpdate
+          )
+      } yield (algebra, knownHostsStore)
+
+      for {
+        ((algebra, knownHostsStore), algebraFinalizer) <- execResource.allocated
+        _ <- Sync[F].untilM_(Sync[F].sleep(FiniteDuration(100, MILLISECONDS)))(Sync[F].delay(peerOpenRequested.get()))
+        (_, peerFinalizer) <- algebra.usePeer(client).allocated
+        _ <- Sync[F].untilM_(Sync[F].sleep(FiniteDuration(100, MILLISECONDS)))(Sync[F].delay(finishTestFlag.get()))
+        _ <- peerFinalizer
+        _ <- algebraFinalizer
+        _ = assert(hotPeers.contains(remotePeerAddress))
+        peerSaved <- knownHostsStore.get(()).map(_.get.contains(remotePeerAddress.asKnownHost))
+        _ = assert(peerSaved)
+      } yield ()
+    }
+
+  }
+}

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
@@ -709,7 +709,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       (() => client.remotePeerAdoptions)
         .expects()
         .once()
-        .returning(Stream(slotData.slotId.blockId).pure[F])
+        .returning(Stream(slotData.slotId.blockId).covaryAll[F, BlockId].pure[F])
       (client
         .getSlotDataOrError[Throwable](_: BlockId, _: Throwable)(_: MonadThrow[F]))
         .expects(slotData.slotId.blockId, *, *)
@@ -726,7 +726,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
         .get(_: BlockId))
         .expects(slotData.slotId.blockId)
         .once()
-        .returning(none.pure[F])
+        .returning(none[SlotData].pure[F])
 
       val blockIdTree = mock[ParentChildTree[F, BlockId]]
 
@@ -734,7 +734,8 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       (() => clock.globalSlot)
         .expects()
         .once()
-        .returning((-1L).pure[F])
+        .returning((-10L).pure[F])
+      // magic number -10, can't use -1 because test could failed sometimes otherwise
 
       PeerBlockHeaderFetcher
         .makeActor(hostId, client, requestsProxy, localChain, slotDataStore, blockIdTree, clock)

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
@@ -149,7 +149,7 @@ class ReputationAggregatorTest
         .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
         .use { actor =>
           for {
-            newState <- actor.send(ReputationAggregator.Message.HostProvideIncorrectBlock(host))
+            newState <- actor.send(ReputationAggregator.Message.HostProvideIncorrectData(host))
             _ = assert(newState.performanceReputation == initialPerfMap)
             _ = assert(newState.blockProvidingReputation == initialBlockMap)
             _ = assert(newState.noveltyReputation == initialNewMap)

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
@@ -186,7 +186,7 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
 
           response.collect { case (id, Left(_)) =>
             (reputationAggregator.sendNoWait _)
-              .expects(ReputationAggregator.Message.HostProvideIncorrectBlock(hostId))
+              .expects(ReputationAggregator.Message.HostProvideIncorrectData(hostId))
               .returns(().pure[F])
             (peersManager.sendNoWait _)
               .expects(PeersManager.Message.BlockHeadersRequest(hostId, NonEmptyChain.one(id)))
@@ -355,7 +355,7 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
 
           response.collect { case (header, Left(_)) =>
             (reputationAggregator.sendNoWait _)
-              .expects(ReputationAggregator.Message.HostProvideIncorrectBlock(hostId))
+              .expects(ReputationAggregator.Message.HostProvideIncorrectData(hostId))
               .returns(().pure[F])
             (peersManager.sendNoWait _)
               .expects(PeersManager.Message.BlockBodyRequest(hostId, NonEmptyChain.one(header)))
@@ -414,7 +414,7 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
 
       (reputationAggregator.sendNoWait _)
-        .expects(ReputationAggregator.Message.HostProvideIncorrectBlock(hostId))
+        .expects(ReputationAggregator.Message.HostProvideIncorrectData(hostId))
         .returns(().pure[F])
 
       RequestsProxy


### PR DESCRIPTION
## Purpose
Adding basic integration test of P2P actor system without running the whole node;
Actor no longer throws "Actor dead" exception for "sendNoWait" messages.

## Approach
Created test for `ActorPeerHandlerBridgeAlgebra` 

## Testing
Unit test itself + integration tests

## Tickets
