### PR TITLE
BN-722 Block availability fetch logic implementation

### DIFF
--- a/actor/src/main/scala/co/topl/actor/Actor.scala
+++ b/actor/src/main/scala/co/topl/actor/Actor.scala
@@ -36,7 +36,7 @@ trait Actor[F[_], I, O] {
   /**
    * Get number unprocessed messages for that actor
    */
-  def mailboxSize: F[Int]
+  def mailboxSize(): F[Int]
 
   /**
    * Send the message without waiting for acknowledgement
@@ -140,7 +140,7 @@ object Actor {
 
         override val id: Int = java.util.Objects.hash(mailbox)
 
-        override def mailboxSize: F[Int] = mailbox.size
+        override def mailboxSize(): F[Int] = mailbox.size
 
         override def sendNoWait(input: I): F[Unit] =
           isAlive.get
@@ -221,7 +221,7 @@ object Actor {
       shutdownFunction: F[Unit],
       attemptTimeout:   FiniteDuration = 1 second
     ): F[Fiber[F, Throwable, Unit]] = {
-      def tryToShutdown(stopSignal: SignallingRef[F, Boolean]) = actor.mailboxSize.flatMap {
+      def tryToShutdown(stopSignal: SignallingRef[F, Boolean]) = actor.mailboxSize().flatMap {
         case 0 => shutdownFunction *> stopSignal.set(true)
         case _ => ().pure
       }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -1,8 +1,8 @@
 package co.topl.networking.fsnetwork
 
 import cats.data.{EitherT, NonEmptyChain, OptionT}
-import cats.effect.{Async, Concurrent, Resource}
 import cats.effect.implicits._
+import cats.effect.{Async, Concurrent, Resource}
 import cats.implicits._
 import co.topl.actor.{Actor, Fsm}
 import co.topl.algebras.Store
@@ -116,6 +116,7 @@ object PeerActor {
         hostId,
         client,
         requestsProxy,
+        peersManager,
         localChain,
         slotDataStore,
         blockIdTree

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
@@ -19,6 +19,7 @@ import co.topl.networking.fsnetwork.PeersManager.Message._
 import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
 import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
 import co.topl.networking.p2p.RemoteAddress
+import com.github.benmanes.caffeine.cache.Cache
 import org.typelevel.log4cats.Logger
 
 import scala.annotation.tailrec
@@ -88,17 +89,22 @@ object PeersManager {
     case class AddPreWarmPeers(preWarmPeers: NonEmptyChain[RemoteAddress]) extends Message
 
     /**
-     * @param hostId use hostId as hint for now, later we could have some kind of map of available peer -> headers
+     * @param hostId use hostId as a possible hint
      * @param blockIds list of block's id of headers to be requested from peer
      */
-    case class BlockHeadersRequest(hostId: HostId, blockIds: NonEmptyChain[BlockId]) extends Message
+    case class BlockHeadersRequest(hostId: Option[HostId], blockIds: NonEmptyChain[BlockId]) extends Message
 
     /**
-     * @param hostId use hostId as hint for now, later we could have some kind of map of available peer -> blocks
-     *               and send requests to many peers
+     * @param hostId use hostId as a possible hint
      * @param blockHeaders requested bodies
      */
-    case class BlockBodyRequest(hostId: HostId, blockHeaders: NonEmptyChain[BlockHeader]) extends Message
+    case class BlockBodyRequest(hostId: Option[HostId], blockHeaders: NonEmptyChain[BlockHeader]) extends Message
+
+    /**
+     * Update block availability on remote peer
+     * @param sources block source
+     */
+    case class BlocksSource(sources: NonEmptyChain[(HostId, BlockId)]) extends Message
 
     /**
      * Request current tips from all connected hot peers
@@ -135,7 +141,6 @@ object PeersManager {
     /**
      * Add remote peer server
      */
-
     case class RemotePeerServerPort(hostId: HostId, remotePeerServerPort: Int) extends Message
   }
 
@@ -154,7 +159,8 @@ object PeersManager {
     newPeerCreationAlgebra: PeerCreationRequestAlgebra[F],
     p2pNetworkConfig:       P2PNetworkConfig,
     coldToWarmSelector:     ColdToWarmSelector[F],
-    hotPeersUpdate:         Set[RemoteAddress] => F[Unit]
+    hotPeersUpdate:         Set[RemoteAddress] => F[Unit],
+    blockSource:            Cache[BlockId, Set[HostId]]
   )
 
   type Response[F[_]] = State[F]
@@ -168,6 +174,7 @@ object PeersManager {
         case (state, agr: SetupReputationAggregator[F] @unchecked) => setupRepAggregator(state, agr.aggregator)
         case (state, BlockHeadersRequest(hostId, blocks))          => blockHeadersRequest(state, hostId, blocks)
         case (state, BlockBodyRequest(hostId, blockHeaders))       => blockDownloadRequest(state, hostId, blockHeaders)
+        case (state, BlocksSource(sources))                        => blocksSourceProcessing(state, sources)
         case (state, GetNetworkQualityForWarmHosts)                => doNetworkQualityMeasure(state)
         case (state, GetCurrentTips)                               => getCurrentTips(state)
         case (state, GetCurrentTip(hostId))                        => getCurrentTip(state, hostId)
@@ -194,7 +201,8 @@ object PeersManager {
     hotPeersUpdate:         Set[RemoteAddress] => F[Unit],
     savePeersFunction:      Set[RemoteAddress] => F[Unit],
     coldToWarmSelector:     ColdToWarmSelector[F],
-    initialPeers:           Map[HostId, Peer[F]] = Map.empty[HostId, Peer[F]]
+    initialPeers:           Map[HostId, Peer[F]],
+    blockSource:            Cache[BlockId, Set[HostId]]
   ): Resource[F, PeersManagerActor[F]] =
     for {
       resolvedHost <- Resource.liftK(thisHostId.resolveHost.map(_.get)) // TODO error processing
@@ -214,7 +222,8 @@ object PeersManager {
           newPeerCreationAlgebra,
           p2pConfig,
           coldToWarmSelector,
-          hotPeersUpdate
+          hotPeersUpdate,
+          blockSource
         )
       actorName = s"Peers manager actor"
       _     <- Resource.liftK(Logger[F].info(s"Start PeerManager for host ${initialState.thisHostId}"))
@@ -254,39 +263,72 @@ object PeersManager {
   }
 
   private def blockHeadersRequest[F[_]: Async](
-    state:           State[F],
-    requestedHostId: HostId,
-    blockIds:        NonEmptyChain[BlockId]
+    state:    State[F],
+    hostId:   Option[HostId],
+    blockIds: NonEmptyChain[BlockId]
   ): F[(State[F], Response[F])] =
-    state.peers.get(requestedHostId) match {
+    // request is done for linked blocks, i.e. last block is child for any other block in request,
+    // thus we could use it for detect block source. TODO make request parallel
+    getHotPeerByBlockId(state, blockIds.last, hostId) match {
       case Some(peer) =>
         peer.sendNoWait(PeerActor.Message.DownloadBlockHeaders(blockIds)) >>
         (state, state).pure[F]
-      // TODO temporary solution, we shall check is block is available on other hosts first
       case None =>
         state.blocksChecker
-          .map(_.sendNoWait(BlockChecker.Message.InvalidateBlockIds(blockIds)))
+          .map(_.sendNoWait(BlockChecker.Message.InvalidateBlockIds(NonEmptyChain.one(blockIds.last))))
           .getOrElse(().pure[F]) >>
         (state, state).pure[F]
     }
 
   private def blockDownloadRequest[F[_]: Async](
-    state:           State[F],
-    requestedHostId: HostId,
-    blocks:          NonEmptyChain[BlockHeader]
+    state:  State[F],
+    hostId: Option[HostId],
+    blocks: NonEmptyChain[BlockHeader]
   ): F[(State[F], Response[F])] =
-    state.peers.get(requestedHostId) match {
+    // request is done for linked blocks, i.e. last block is child for any other block in request,
+    // thus we could use it for detect block source. TODO make request parallel
+    getHotPeerByBlockId(state, blocks.last.id, hostId) match {
       case Some(peer) =>
-        // TODO add logic if no peer actor is present
         peer.sendNoWait(PeerActor.Message.DownloadBlockBodies(blocks)) >>
         (state, state).pure[F]
-      // TODO temporary solution, we shall check is block is available on other hosts first
       case None =>
         state.blocksChecker
-          .map(_.sendNoWait(BlockChecker.Message.InvalidateBlockIds(blocks.map(_.id))))
+          .map(_.sendNoWait(BlockChecker.Message.InvalidateBlockIds(NonEmptyChain.one(blocks.last.id))))
           .getOrElse(().pure[F]) >>
         (state, state).pure[F]
     }
+
+  private def getHotPeerByBlockId[F[_]](state: State[F], blockId: BlockId, hostId: Option[HostId]): Option[Peer[F]] =
+    for {
+      sources <- Option(state.blockSource.getOrElse(blockId, Set.empty) ++ hostId.toSet)
+      source  <- state.peers.getHotPeers.keySet.find(sources.contains)
+      peer    <- state.peers.get(source)
+    } yield peer
+
+  private def blocksSourceProcessing[F[_]: Async](
+    state:   State[F],
+    sources: NonEmptyChain[(HostId, BlockId)]
+  ): F[(State[F], Response[F])] = {
+    val toSend: Seq[(HostId, Long)] =
+      sources.toList.flatMap { case (host, blockId) =>
+        val previousSource: Set[HostId] = state.blockSource.get(blockId).getOrElse(Set.empty[HostId])
+        if (previousSource.contains(host)) {
+          Option.empty[(HostId, Long)]
+        } else {
+          val newSource: Set[HostId] = previousSource + host
+          state.blockSource.put(blockId, newSource)
+          Option((host, newSource.size))
+        }
+      }
+
+    val sendMessage: NonEmptyChain[(HostId, Long)] => F[Unit] =
+      d =>
+        state.reputationAggregator
+          .map(_.sendNoWait(ReputationAggregator.Message.BlockProvidingReputationUpdate(d)))
+          .getOrElse(Applicative[F].unit)
+
+    NonEmptyChain.fromSeq(toSend).map(sendMessage).getOrElse(().pure[F]) >> (state, state).pure[F]
+  }
 
   private def doNetworkQualityMeasure[F[_]: Async](state: State[F]): F[(State[F], Response[F])] =
     state.peers.getWarmPeers.values.toSeq.traverse(_.sendNoWait(PeerActor.Message.GetNetworkQuality)) >>
@@ -395,17 +437,17 @@ object PeersManager {
     } else {
       for {
         _                     <- Logger[F].info(show"New connection to remote peer $hostId had been established")
-        (warmPeers, newPeers) <- state.peers.copyWithAddedHost(hostId).moveToState(hostId, PeerState.Warm).pure[F]
-        newPeers <- warmPeers
+        (warmPeers, withWarm) <- state.peers.copyWithAddedHost(hostId).moveToState(hostId, PeerState.Warm).pure[F]
+        withActor <- warmPeers
           .contains(hostId)
           .pure[F]
           .ifM(
             ifTrue = Logger[F].info(s"Accept remote peer $hostId as new warm connection") >>
-              setupPeerActor.map(peerActor => newPeers.copyWithNewPeerActor(hostId, peerActor)),
+              setupPeerActor.map(peerActor => withWarm.copyWithNewPeerActor(hostId, peerActor)),
             ifFalse = Logger[F].info(s"Decline remote peer $hostId as new warm connection") >>
-              newPeers.pure[F]
+              withWarm.pure[F]
           )
-        newState = state.copy(peers = newPeers)
+        newState = state.copy(peers = withActor)
       } yield (newState, newState)
     }
   }
@@ -426,10 +468,12 @@ object PeersManager {
     knownPeers: NonEmptyChain[RemoteAddress]
   ): F[(State[F], Response[F])] =
     for {
-      _             <- Logger[F].info(show"Going to add know peers: $knownPeers")
-      resolvedPeers <- resolveHosts(knownPeers)
-      newPeers      <- state.peers.copyWithAddedRemoteAddresses(resolvedPeers.toSet).pure[F]
-      newState      <- state.copy(peers = newPeers).pure[F]
+      resolvedPeers       <- resolveHosts(knownPeers)
+      oldPeers            <- state.peers.pure[F]
+      newPeers            <- oldPeers.copyWithAddedRemoteAddresses(resolvedPeers.toSet).pure[F]
+      peersHadBeenChanged <- (newPeers.peers.size != oldPeers.peers.size).pure[F]
+      _                   <- Logger[F].infoIf(peersHadBeenChanged, s"Add some peers from: $knownPeers")
+      newState            <- state.copy(peers = newPeers).pure[F]
     } yield (newState, newState)
 
   private def addPreWarmPeers[F[_]: Async: Logger: DnsResolver](
@@ -525,7 +569,7 @@ object PeersManager {
 
     Logger[F].infoIf(
       hotToCold.nonEmpty,
-      s"Going to close $hotToCold due of bad reputation. Reputations: $perfRep; $blockRep; $noveltyRep"
+      s"Going to close $hotToCold due of bad reputation. Reputations:\n$perfRep;\n$blockRep;\n$noveltyRep"
     ) >>
     peersToCold(thisActor, state, hotToCold)
   }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/RequestsProxy.scala
@@ -12,10 +12,11 @@ import co.topl.networking.fsnetwork.BlockDownloadError.{BlockBodyDownloadError, 
 import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
 import co.topl.networking.fsnetwork.RequestsProxy.Message._
-import co.topl.node.models.BlockBody
-import org.typelevel.log4cats.Logger
 import co.topl.typeclasses.implicits._
+import co.topl.node.models.BlockBody
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
+import org.typelevel.log4cats.Logger
+
 import scala.annotation.nowarn
 
 object RequestsProxy {
@@ -27,8 +28,6 @@ object RequestsProxy {
     case object GetCurrentTips extends Message
 
     case class RemoteSlotData(hostId: HostId, slotData: NonEmptyChain[SlotData]) extends Message
-
-    case class BlocksSource(sources: NonEmptyChain[(HostId, BlockId)]) extends Message
 
     case class BadKLookbackSlotData(hostId: HostId) extends Message
 
@@ -65,8 +64,7 @@ object RequestsProxy {
     headerStore:          Store[F, BlockId, BlockHeader],
     bodyStore:            Store[F, BlockId, BlockBody],
     headerRequests:       Cache[BlockId, Option[UnverifiedBlockHeader]],
-    bodyRequests:         Cache[BlockId, Option[UnverifiedBlockBody]],
-    blockSource:          Cache[BlockId, Set[HostId]]
+    bodyRequests:         Cache[BlockId, Option[UnverifiedBlockBody]]
   )
 
   type Response[F[_]] = State[F]
@@ -78,7 +76,6 @@ object RequestsProxy {
       case (state, GetCurrentTips)                              => getCurrentTips(state)
       case (state, RemoteSlotData(hostId, slotData))            => processRemoteSlotData(state, hostId, slotData)
       case (state, BadKLookbackSlotData(hostId))                => resendBadKLookbackSlotData(state, hostId)
-      case (state, BlocksSource(sources))                       => blocksSourceProcessing(state, sources)
       case (state, DownloadHeadersRequest(hostId, blockIds))    => downloadHeadersRequest(state, hostId, blockIds)
       case (state, DownloadHeadersResponse(source, response))   => downloadHeadersResponse(state, source, response)
       case (state, DownloadBodiesRequest(hostId, blockHeaders)) => downloadBodiesRequest(state, hostId, blockHeaders)
@@ -94,9 +91,7 @@ object RequestsProxy {
     headerRequests: Cache[BlockId, Option[UnverifiedBlockHeader]] =
       Caffeine.newBuilder.maximumSize(requestCacheSize).build[BlockId, Option[UnverifiedBlockHeader]](),
     bodyRequests: Cache[BlockId, Option[UnverifiedBlockBody]] =
-      Caffeine.newBuilder.maximumSize(requestCacheSize).build[BlockId, Option[UnverifiedBlockBody]](),
-    blockSource: Cache[BlockId, Set[HostId]] =
-      Caffeine.newBuilder.maximumSize(blockSourceCacheSize).build[BlockId, Set[HostId]]()
+      Caffeine.newBuilder.maximumSize(requestCacheSize).build[BlockId, Option[UnverifiedBlockBody]]()
   ): Resource[F, RequestsProxyActor[F]] = {
     val initialState =
       State(
@@ -106,8 +101,7 @@ object RequestsProxy {
         headerStore,
         bodyStore,
         headerRequests,
-        bodyRequests,
-        blockSource
+        bodyRequests
       )
     val actorName = "Requests proxy actor"
     Actor.make(actorName, initialState, getFsm[F])
@@ -144,38 +138,16 @@ object RequestsProxy {
     state.reputationAggregator.sendNoWait(ReputationAggregator.Message.BadKLookbackSlotData(source)) >>
     (state, state).pure[F]
 
-  private def blocksSourceProcessing[F[_]: Async](
-    state:   State[F],
-    sources: NonEmptyChain[(HostId, BlockId)]
-  ): F[(State[F], Response[F])] = {
-    val toSend: Seq[(HostId, Long)] =
-      sources.toList.flatMap { case (host, blockId) =>
-        val previousSource: Set[HostId] = state.blockSource.get(blockId).getOrElse(Set.empty[HostId])
-        if (previousSource.contains(host)) {
-          Option.empty[(HostId, Long)]
-        } else {
-          val newSource: Set[HostId] = previousSource + host
-          state.blockSource.put(blockId, newSource)
-          Option((host, newSource.size))
-        }
-      }
-
-    val sendMessage: NonEmptyChain[(HostId, Long)] => F[Unit] =
-      d => state.reputationAggregator.sendNoWait(ReputationAggregator.Message.BlockProvidingReputationUpdate(d))
-
-    NonEmptyChain.fromSeq(toSend).map(sendMessage).getOrElse(().pure[F]) >> (state, state).pure[F]
-  }
-
   private def downloadHeadersRequest[F[_]: Async: Logger](
     state:    State[F],
-    hostId:   HostId,
+    source:   HostId,
     blockIds: NonEmptyChain[BlockId]
   ): F[(State[F], Response[F])] =
     for {
       _              <- Logger[F].info(show"Get request for headers downloads $blockIds")
       idsDownloaded  <- sendAlreadyDownloadedHeadersToBlockChecker(state, blockIds)
       _              <- Logger[F].info(show"Send already downloaded header to block checker $idsDownloaded")
-      idsForDownload <- sendDownloadRequestForNewHeaders(state, hostId, blockIds)
+      idsForDownload <- sendDownloadRequestForNewHeaders(state, source, blockIds)
       _              <- Logger[F].info(show"Send request for additional block header download $idsForDownload")
       _ = saveDownloadRequestToCache(state.headerRequests, idsForDownload)
     } yield (state, state)
@@ -201,14 +173,14 @@ object RequestsProxy {
   // send block download request only for new headers
   private def sendDownloadRequestForNewHeaders[F[_]: Async](
     state:    State[F],
-    hostId:   HostId,
+    source:   HostId,
     blockIds: NonEmptyChain[BlockId]
   ): F[List[BlockId]] = {
     val newBlockIds = blockIds.filterNot(state.headerRequests.contains)
     NonEmptyChain
       .fromChain(newBlockIds)
       .map { blockIds =>
-        state.peersManager.sendNoWait(PeersManager.Message.BlockHeadersRequest(hostId, blockIds)) >>
+        state.peersManager.sendNoWait(PeersManager.Message.BlockHeadersRequest(source.some, blockIds)) >>
         blockIds.toList.pure[F]
       }
       .getOrElse(List.empty[BlockId].pure[F])
@@ -263,7 +235,7 @@ object RequestsProxy {
         errors.traverse { case (id, _) =>
           reputationAggregator.sendNoWait(reputationMessage) >>
           // TODO we shall not try to download header from the same host, peer manager shall decide it
-          peersManager.sendNoWait(PeersManager.Message.BlockHeadersRequest(source, NonEmptyChain.one(id)))
+          peersManager.sendNoWait(PeersManager.Message.BlockHeadersRequest(None, NonEmptyChain.one(id)))
         }.void
 
       case None => ().pure[F]
@@ -335,7 +307,7 @@ object RequestsProxy {
     NonEmptyChain
       .fromChain(newBlockData)
       .map { blockData =>
-        state.peersManager.sendNoWait(PeersManager.Message.BlockBodyRequest(hostId, blockData)) >>
+        state.peersManager.sendNoWait(PeersManager.Message.BlockBodyRequest(hostId.some, blockData)) >>
         blockData.map(_.id).toList.pure[F]
       }
       .getOrElse(List.empty[BlockId].pure[F])
@@ -393,7 +365,7 @@ object RequestsProxy {
       {
         for {
           _ <- OptionT.liftF(reputationAggregator.sendNoWait(reputationMessage))
-          message = PeersManager.Message.BlockBodyRequest(source, NonEmptyChain.one(header))
+          message = PeersManager.Message.BlockBodyRequest(None, NonEmptyChain.one(header))
           _ <- OptionT.liftF(peersManager.sendNoWait(message))
         } yield ()
       }.getOrElse(())

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -37,6 +37,9 @@ package object fsnetwork {
     def contains(key: K): Boolean = cache.getIfPresent(key) != null
 
     def get(key: K): Option[V] = Option(cache.getIfPresent(key))
+
+    def getOrElse[B >: V](key: K, default: => V): V =
+      get(key).getOrElse(default)
   }
 
   implicit class StreamOps[T, F[_]: Async](stream: fs2.Stream[F, T]) {

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
@@ -10,13 +10,7 @@ import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.models.{Datum, TransactionId}
 import co.topl.config.ApplicationConfig.Bifrost.NetworkProperties
 import co.topl.consensus.algebras._
-import co.topl.consensus.models.{
-  BlockHeader,
-  BlockHeaderToBodyValidationFailure,
-  BlockHeaderValidationFailure,
-  BlockId,
-  SlotData
-}
+import co.topl.consensus.models._
 import co.topl.eventtree.ParentChildTree
 import co.topl.interpreters.SchedulerClock
 import co.topl.ledger.algebras._

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
@@ -14,7 +14,7 @@ import co.topl.consensus.algebras.{BlockHeaderToBodyValidationAlgebra, LocalChai
 import co.topl.consensus.models.{BlockId, SlotData}
 import co.topl.eventtree.ParentChildTree
 import co.topl.models.ModelGenerators.GenHelper
-import co.topl.models.generators.consensus.ModelGenerators.arbitraryHeader
+import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.networking.KnownHostOps
 import co.topl.networking.blockchain.BlockchainPeerClient
 import co.topl.networking.fsnetwork.NetworkQualityError.{IncorrectPongMessage, NoPongMessage}
@@ -25,12 +25,11 @@ import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
 import co.topl.networking.fsnetwork.ReputationAggregator.Message.PingPongMessagePing
 import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorActor
 import co.topl.networking.fsnetwork.RequestsProxy.RequestsProxyActor
-import co.topl.node.models.{CurrentKnownHostsReq, CurrentKnownHostsRes, KnownHost, PingMessage, PongMessage}
+import co.topl.node.models._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-import co.topl.models.generators.consensus.ModelGenerators._
 
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
 
@@ -64,7 +63,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -119,7 +118,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -180,7 +179,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -234,7 +233,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -305,7 +304,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -399,7 +398,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -455,7 +454,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -520,7 +519,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -576,7 +575,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -644,7 +643,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
       (blockHeaderFetcher.sendNoWait _)
         .expects(PeerBlockHeaderFetcher.Message.StopActor)
         .once()

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/RequestsProxyTest.scala
@@ -18,7 +18,6 @@ import co.topl.networking.fsnetwork.ReputationAggregator.ReputationAggregatorAct
 import co.topl.networking.fsnetwork.RequestsProxyTest.RequestStatus.{InProgress, NewRequest, ReceivedOk}
 import co.topl.networking.fsnetwork.RequestsProxyTest.ResponseStatus.{DownloadError, DownloadedOk}
 import co.topl.networking.fsnetwork.RequestsProxyTest.{F, RequestStatus, ResponseStatus}
-import co.topl.networking.fsnetwork.TestHelper.arbitraryHostBlockId
 import co.topl.node.models.{Block, BlockBody}
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -29,7 +28,6 @@ import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.collection.immutable.ListMap
-import scala.jdk.CollectionConverters._
 
 object RequestsProxyTest {
   type F[A] = IO[A]
@@ -93,7 +91,7 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
 
           NonEmptyChain.fromChain(headerWithStatus.collect { case (h, NewRequest) => h.id }).map { req =>
             (peersManager.sendNoWait _)
-              .expects(PeersManager.Message.BlockHeadersRequest(hostId, req))
+              .expects(PeersManager.Message.BlockHeadersRequest(hostId.some, req))
               .returns(().pure[F])
           }
 
@@ -189,7 +187,7 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
               .expects(ReputationAggregator.Message.HostProvideIncorrectData(hostId))
               .returns(().pure[F])
             (peersManager.sendNoWait _)
-              .expects(PeersManager.Message.BlockHeadersRequest(hostId, NonEmptyChain.one(id)))
+              .expects(PeersManager.Message.BlockHeadersRequest(None, NonEmptyChain.one(id)))
               .returns(().pure[F])
           }
 
@@ -237,7 +235,7 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
 
           NonEmptyChain.fromSeq(idsWithStatus.collect { case (id, NewRequest) => id }).map { blockIds =>
             (peersManager.sendNoWait _)
-              .expects(PeersManager.Message.BlockBodyRequest(hostId, blockIds.map(id => dataMap(id)._1)))
+              .expects(PeersManager.Message.BlockBodyRequest(hostId.some, blockIds.map(id => dataMap(id)._1)))
               .returns(().pure[F])
           }
 
@@ -358,7 +356,7 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
               .expects(ReputationAggregator.Message.HostProvideIncorrectData(hostId))
               .returns(().pure[F])
             (peersManager.sendNoWait _)
-              .expects(PeersManager.Message.BlockBodyRequest(hostId, NonEmptyChain.one(header)))
+              .expects(PeersManager.Message.BlockBodyRequest(None, NonEmptyChain.one(header)))
               .returns(().pure[F])
           }
 
@@ -447,52 +445,6 @@ class RequestsProxyTest extends CatsEffectSuite with ScalaCheckEffectSuite with 
           } yield ()
         }
 
-    }
-  }
-
-  test("Block source shall be sent to reputation aggregator with correct count") {
-    PropF.forAllF(nonEmptyChainArbOfLen(arbitraryHostBlockId, maxChainSize).arbitrary) {
-      inputData: NonEmptyChain[(HostId, BlockId)] =>
-        withMock {
-          val reputationAggregator = mock[ReputationAggregatorActor[F]]
-          val peersManager = mock[PeersManagerActor[F]]
-          val headerStore = mock[Store[F, BlockId, BlockHeader]]
-          val bodyStore = mock[Store[F, BlockId, BlockBody]]
-
-          val blockWithSource: Map[BlockId, Set[HostId]] =
-            inputData.toList
-              .take(10)
-              .map(d => d._2)
-              .zipWithIndex
-              .map { case (block, index) =>
-                val sourcesForBlock = (1 to index).map(i => i.toString).toSet
-                (block, sourcesForBlock)
-              }
-              .toMap
-
-          val initialCash =
-            Caffeine.newBuilder.maximumSize(blockSourceCacheSize).build[BlockId, Set[HostId]]()
-          initialCash.putAll(blockWithSource.asJava)
-
-          val expectedData = inputData.map { case (host, blockId) =>
-            (host, blockWithSource.getOrElse(blockId, Set.empty).size.toLong + 1)
-          }
-
-          (reputationAggregator.sendNoWait _)
-            .expects(ReputationAggregator.Message.BlockProvidingReputationUpdate(expectedData))
-            .once()
-            .returns(().pure[F])
-
-          RequestsProxy
-            .makeActor(reputationAggregator, peersManager, headerStore, bodyStore, blockSource = initialCash)
-            .use { actor =>
-              for {
-                _ <- actor.send(RequestsProxy.Message.BlocksSource(inputData))
-                // if we send the same data no message is sent
-                _ <- actor.send(RequestsProxy.Message.BlocksSource(inputData))
-              } yield ()
-            }
-        }
     }
   }
 }

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/TestHelper.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/TestHelper.scala
@@ -45,7 +45,7 @@ object TestHelper extends TransactionGenerator {
         addHeaderToChain(headers.append(gen.sample.get.copy(parentHeaderId = parentId)), gen, count - 1)
     }
 
-  val arbitraryHost: Arbitrary[HostId] = Arbitrary(Arbitrary.arbitrary[String])
+  val arbitraryHost: Arbitrary[HostId] = Arbitrary(Gen.identifier)
 
   val arbitraryHostBlockId: Arbitrary[(HostId, BlockId)] = Arbitrary(
     for {


### PR DESCRIPTION
## Purpose
We shall correctly get block data from other peer, if the initial block data peer goes offline

## Approach
Move block source to Peersmanager, used that source for selecting peer to download

## Testing
Unit test + integration test

## Tickets
closes #2657 