### PR TITLE
BN-1157 Assign to this host id all binded interfaces

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -14,9 +14,9 @@ import co.topl.eventtree.ParentChildTree
 import co.topl.ledger.algebras._
 import co.topl.networking.blockchain.{BlockchainPeerClient, BlockchainPeerHandlerAlgebra}
 import co.topl.networking.fsnetwork.PeersManager.PeersManagerActor
-import co.topl.networking.p2p.{ConnectedPeer, DisconnectedPeer, RemoteAddress}
+import co.topl.networking.p2p.{DisconnectedPeer, PeerConnectionChange, RemoteAddress}
 import co.topl.node.models.{BlockBody, KnownHost}
-import fs2.Stream
+import fs2.concurrent.Topic
 import org.typelevel.log4cats.Logger
 
 object ActorPeerHandlerBridgeAlgebra {
@@ -39,7 +39,7 @@ object ActorPeerHandlerBridgeAlgebra {
     networkProperties:           NetworkProperties,
     clockAlgebra:                ClockAlgebra[F],
     remotePeers:                 List[DisconnectedPeer],
-    closedPeers:                 Stream[F, ConnectedPeer],
+    peersStatusChangesTopic:     Topic[F, PeerConnectionChange],
     addRemotePeer:               DisconnectedPeer => F[Unit],
     hotPeersUpdate:              Set[RemoteAddress] => F[Unit]
   ): Resource[F, BlockchainPeerHandlerAlgebra[F]] = {
@@ -66,7 +66,7 @@ object ActorPeerHandlerBridgeAlgebra {
         networkProperties,
         clockAlgebra,
         PeerCreationRequestAlgebra(addRemotePeer),
-        closedPeers,
+        peersStatusChangesTopic,
         hotPeersUpdate
       )
 

--- a/networking/src/main/scala/co/topl/networking/p2p/FS2P2PServer.scala
+++ b/networking/src/main/scala/co/topl/networking/p2p/FS2P2PServer.scala
@@ -1,11 +1,10 @@
 package co.topl.networking.p2p
 
 import cats.data.OptionT
-import cats.effect.Async
-import cats.effect.Resource
+import cats.effect.{Async, Resource}
 import cats.effect.implicits._
-import cats.effect.std.Queue
 import cats.implicits._
+import co.topl.networking.SocketAddressOps
 import com.comcast.ip4s._
 import fs2.Stream
 import fs2.concurrent.Topic
@@ -16,25 +15,24 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 object FS2P2PServer {
 
   def make[F[_]: Async](
-    host:        String,
-    port:        Int,
-    localPeer:   LocalPeer,
-    remotePeers: Stream[F, DisconnectedPeer],
-    peerHandler: (ConnectedPeer, Socket[F]) => Resource[F, Unit],
-    closedPeers: Queue[F, ConnectedPeer]
+    host:                    String,
+    port:                    Int,
+    localPeer:               LocalPeer,
+    remotePeers:             Stream[F, DisconnectedPeer],
+    peerHandler:             (ConnectedPeer, Socket[F]) => Resource[F, Unit],
+    peersStatusChangesTopic: Topic[F, PeerConnectionChange]
   ): Resource[F, P2PServer[F]] =
     for {
       implicit0(logger: Logger[F]) <- Slf4jLogger.fromName("Bifrost.P2P").toResource
-      topic                        <- Resource.make(Topic[F, PeerConnectionChange])(_.close.void)
-      _                            <- eventProcessor(topic, closedPeers)
+      _                            <- eventLogger(peersStatusChangesTopic)
       sockets                      <- socketsStream[F](host, port)
-      _                            <- server(sockets)(topic, peerHandler)
-      _                            <- client(remotePeers, localPeer)(topic, peerHandler)
+      _                            <- server(sockets)(peersStatusChangesTopic, peerHandler)
+      _                            <- client(remotePeers, localPeer)(peersStatusChangesTopic, peerHandler)
       _                            <- Logger[F].info(s"Bound P2P at host=$host port=$port").toResource
     } yield new P2PServer[F] {
 
       def peerChanges: F[Topic[F, PeerConnectionChange]] =
-        topic.pure[F]
+        peersStatusChangesTopic.pure[F]
 
       def localAddress: F[RemoteAddress] =
         localPeer.localAddress.pure[F]
@@ -61,18 +59,22 @@ object FS2P2PServer {
     sockets
       .evalMap(socket =>
         socket.remoteAddress
-          .map(address => ConnectedPeer(RemoteAddress(address.host.toUriString, address.port.value), (0, 0)))
+          .map(address => ConnectedPeer(address.asRemoteAddress, (0, 0)))
           .tupleRight(socket)
       )
-      .evalTap { case (peer, _) =>
-        peerChangesTopic.publish1(
-          PeerConnectionChanges.InboundConnectionInitializing(peer.remoteAddress)
-        )
+      .evalTap { case (peer, socket) =>
+        for {
+          localAddress <- socket.localAddress.map(_.asRemoteAddress)
+          _ <- peerChangesTopic.publish1(
+            PeerConnectionChanges.InboundConnectionInitializing(peer.remoteAddress, localAddress)
+          )
+        } yield ()
       }
       .map { case (peer, socket) =>
         Stream.resource(
           for {
-            _      <- peerChangesTopic.publish1(PeerConnectionChanges.ConnectionEstablished(peer)).toResource
+            localAddress <- socket.localAddress.map(_.asRemoteAddress).toResource
+            _ <- peerChangesTopic.publish1(PeerConnectionChanges.ConnectionEstablished(peer, localAddress)).toResource
             result <- peerHandler(peer, socket).attempt
             _ <- peerChangesTopic
               .publish1(PeerConnectionChanges.ConnectionClosed(peer, result.swap.toOption))
@@ -110,7 +112,10 @@ object FS2P2PServer {
             result <- socketEither match {
               case Left(error) => Resource.pure[F, Either[Throwable, Unit]](Either.left[Throwable, Unit](error))
               case Right(socket) =>
-                peerChangesTopic.publish1(PeerConnectionChanges.ConnectionEstablished(connected)).toResource >>
+                socket.localAddress
+                  .map(_.asRemoteAddress)
+                  .flatMap(a => peerChangesTopic.publish1(PeerConnectionChanges.ConnectionEstablished(connected, a)))
+                  .toResource >>
                 peerHandler(connected, socket).attempt
             }
             _ <- peerChangesTopic
@@ -124,23 +129,18 @@ object FS2P2PServer {
       .drain
       .background
 
-  private def eventProcessor[F[_]: Async: Logger](
-    peerChangesTopic: Topic[F, PeerConnectionChange],
-    closedPeers:      Queue[F, ConnectedPeer]
-  ) =
+  private def eventLogger[F[_]: Async: Logger](peerChangesTopic: Topic[F, PeerConnectionChange]) =
     peerChangesTopic.subscribeUnbounded
       .evalTap {
-        case PeerConnectionChanges.ConnectionEstablished(peer) =>
-          Logger[F].info(s"Connection established with peer=$peer")
+        case PeerConnectionChanges.ConnectionEstablished(peer, localAddress) =>
+          Logger[F].info(s"Connection established local[$localAddress] <=> remote[$peer]")
         case PeerConnectionChanges.ConnectionClosed(peer, reason) =>
-          {
-            reason match {
-              case Some(error) => Logger[F].warn(error)(s"Connection closed with peer=$peer")
-              case _           => Logger[F].info(s"Connection closed with peer=$peer")
-            }
-          } >> closedPeers.offer(peer)
-        case PeerConnectionChanges.InboundConnectionInitializing(peer) =>
-          Logger[F].info(s"Inbound connection initializing with peer=$peer")
+          reason match {
+            case Some(error) => Logger[F].warn(error)(s"Connection closed with peer=$peer")
+            case _           => Logger[F].info(s"Connection closed with peer=$peer")
+          }
+        case PeerConnectionChanges.InboundConnectionInitializing(remotePeer, localAddress) =>
+          Logger[F].info(s"Inbound connection initializing into $localAddress, from remote peer $remotePeer")
         case PeerConnectionChanges.OutboundConnectionInitializing(peer) =>
           Logger[F].info(s"Outbound connection initializing with peer=$peer")
       }

--- a/networking/src/main/scala/co/topl/networking/p2p/P2PServer.scala
+++ b/networking/src/main/scala/co/topl/networking/p2p/P2PServer.scala
@@ -14,10 +14,14 @@ trait P2PServer[F[_]] {
 sealed abstract class PeerConnectionChange
 
 object PeerConnectionChanges {
-  case class InboundConnectionInitializing(remoteAddress: RemoteAddress) extends PeerConnectionChange
+
+  case class InboundConnectionInitializing(remoteAddress: RemoteAddress, localAddress: RemoteAddress)
+      extends PeerConnectionChange
+
   case class OutboundConnectionInitializing(remoteAddress: RemoteAddress) extends PeerConnectionChange
 
-  case class ConnectionEstablished(connectedPeer: ConnectedPeer) extends PeerConnectionChange
+  case class ConnectionEstablished(connectedPeer: ConnectedPeer, localAddress: RemoteAddress)
+      extends PeerConnectionChange
 
   case class ConnectionClosed(connectedPeer: ConnectedPeer, reason: Option[Throwable]) extends PeerConnectionChange
 }

--- a/networking/src/main/scala/co/topl/networking/package.scala
+++ b/networking/src/main/scala/co/topl/networking/package.scala
@@ -2,6 +2,7 @@ package co.topl
 
 import co.topl.networking.p2p.RemoteAddress
 import co.topl.node.models.KnownHost
+import com.comcast.ip4s.{IpAddress, SocketAddress}
 
 import java.nio.ByteBuffer
 
@@ -19,5 +20,9 @@ package object networking {
 
   implicit class RemoteAddressOps(remoteAddress: RemoteAddress) {
     def asKnownHost: KnownHost = KnownHost(remoteAddress.host, remoteAddress.port)
+  }
+
+  implicit class SocketAddressOps(address: SocketAddress[IpAddress]) {
+    def asRemoteAddress: RemoteAddress = RemoteAddress(address.host.toUriString, address.port.value)
   }
 }


### PR DESCRIPTION
## Purpose
Because of the dynamic P2P network, we could receive the local node as a "new remote peer", thus self-connection could be performed. To avoid it we need to have/retreive list of IP addresses that are used by our local node. We can't rely on the IP address used in the configuration file, because `0.0.0.0` could be used (that means we shall use all available interfaces). 

## Approach
Track establishing connection events and save used local addresses. Notify PeerManager about those addresses. Peer manager filters known peers list by removing local IP address.

## Testing
Unit test + integration test

## Tickets
closes #BN-1157