### PR TITLE
Public Testnet Integration Test

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
@@ -14,7 +14,6 @@ import co.topl.consensus.models.ProtocolVersion
 import co.topl.crypto.hash.Blake2b256
 import co.topl.crypto.models.SecretKeyKesProduct
 import co.topl.models._
-import co.topl.models.utility.HasLength.instances._
 import co.topl.models.utility._
 import co.topl.numerics.implicits._
 import com.google.protobuf.ByteString
@@ -46,7 +45,7 @@ object PrivateTestnet {
           ByteString.copyFrom(BigInt(timestamp).toByteArray).concat(ByteString.copyFrom(BigInt(index).toByteArray))
         )
       )
-      .map(bytes => StakerInitializers.Operator(Sized.strictUnsafe(bytes), (9, 9), HeightLockOneSpendingAddress))
+      .map(bytes => StakerInitializers.Operator(bytes, (9, 9), HeightLockOneSpendingAddress))
   }
 
   def defaultStake(stakerCount: Int): BigInt = Ratio(DefaultTotalStake, stakerCount).round

--- a/blockchain/src/main/scala/co/topl/blockchain/StakerInitializer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/StakerInitializer.scala
@@ -12,8 +12,6 @@ import co.topl.crypto.signing.Ed25519VRF
 import co.topl.crypto.signing.KesProduct
 import co.topl.models._
 import co.topl.models.utility._
-import co.topl.models.utility.Lengths
-import co.topl.models.utility.Sized
 import com.google.protobuf.ByteString
 import quivr.models._
 
@@ -83,7 +81,7 @@ object StakerInitializers {
      * @return an Operator Staker
      */
     def apply(
-      seed:         Sized.Strict[Bytes, Lengths.`32`.type],
+      seed:         Array[Byte],
       kesKeyHeight: (Int, Int),
       lockAddress:  LockAddress
     ): Operator = {
@@ -93,7 +91,7 @@ object StakerInitializers {
 
       val operatorSK = new Ed25519()
         .deriveKeyPairFromSeed(
-          blake2b256.hash(seed.data.toByteArray :+ 1)
+          blake2b256.hash(seed :+ 1)
         )
         .signingKey
         .bytes
@@ -102,10 +100,10 @@ object StakerInitializers {
         Ed25519VRF
           .precomputed()
           .deriveKeyPairFromSeed(
-            blake2b256.hash(seed.data.toByteArray :+ 2)
+            blake2b256.hash(seed :+ 2)
           )
       val (kesSK, _) = new KesProduct().createKeyPair(
-        seed = blake2b256.hash(seed.data.toByteArray :+ 3),
+        seed = blake2b256.hash(seed :+ 3),
         height = kesKeyHeight,
         0
       )

--- a/build.sbt
+++ b/build.sbt
@@ -659,7 +659,8 @@ lazy val nodeIt = project
   .settings(
     name := "node-it",
     commonSettings,
-    crossScalaVersions := Seq(scala213)
+    crossScalaVersions := Seq(scala213),
+    libraryDependencies ++= Dependencies.nodeIt
   )
   .dependsOn(
     node,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -121,6 +121,10 @@ object Dependencies {
     "org.http4s" %% "http4s-dsl"          % http4sVersion
   )
 
+  val http4sServer = http4s ++ Seq(
+    "org.http4s" %% "http4s-ember-server" % http4sVersion
+  )
+
   val bramblScCrypto = "co.topl" %% "crypto"     % bramblScVersion
   val bramblScSdk = "co.topl"    %% "brambl-sdk" % bramblScVersion
   val quivr4s = "co.topl"        %% "quivr4s"    % bramblScVersion
@@ -152,6 +156,9 @@ object Dependencies {
     mUnitTestBase ++
     Seq(grpcServices) ++
     http4s
+
+  val nodeIt =
+    http4sServer.map(_ % Test)
 
   val networkDelayer: Seq[ModuleID] =
     cats ++ catsEffect ++ mainargs ++ logging ++ Seq(


### PR DESCRIPTION
## Purpose
- It would be helpful to ensure public testnets can initialize properly
## Approach
- Modify NodeAppTest to launch in "public" mode
  - Generates a "public" genesis block and stakers
  - Runs an HTTP server which serves a genesis block in the format expected by nodes running in public mode
  - Launches the nodes in "public" configuration, referencing the local HTTP server in the source-path
## Testing
- NodeAppTest passes locally
## Tickets
- #BN-1164