### PR TITLE
Genus Remove deprecated DB Util Fixture V1

### DIFF
--- a/genus-library/src/test/scala/co/topl/genusLibrary/DbFixtureUtil.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/DbFixtureUtil.scala
@@ -10,50 +10,12 @@ import munit.{CatsEffectSuite, FunSuite, TestOptions}
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-/**
- * @deprecated use DbFixtureUtilV2, and then remove this util
- */
 trait DbFixtureUtil { self: FunSuite with CatsEffectSuite =>
 
   type F[A] = IO[A]
   implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
 
-  val orientDbFixture: SyncIO[FunFixture[(OrientDB, OrientThread[F])]] = {
-    val dbName = "testDb"
-    val dbConfig = new OrientDBConfigBuilder().addGlobalUser("testUser", "testPass", "*").build()
-
-    val factoryR =
-      OrientThread
-        .create[F]
-        .flatMap(orientThread =>
-          Resource
-            .make[F, OrientDB](orientThread.delay(new OrientDB("memory", "root", "root", dbConfig)))(oDb =>
-              orientThread.delay(oDb.close())
-            )
-            .tupleRight(orientThread)
-        )
-
-    def setup(t: TestOptions, odb: (OrientDB, OrientThread[F])): F[Unit] =
-      odb._2
-        .delay(odb._1.createIfNotExists(dbName, ODatabaseType.MEMORY))
-        .flatMap(res => logger.info(s"Db Created $res"))
-
-    def teardown(odb: (OrientDB, OrientThread[F])): IO[Unit] =
-      odb._2
-        .delay(odb._1.drop(dbName))
-        .flatTap(_ => logger.info("Teardown, db dropped"))
-
-    ResourceFixture(factoryR, setup _, teardown _)
-  }
-
-}
-
-trait DbFixtureUtilV2 { self: FunSuite with CatsEffectSuite =>
-
-  type F[A] = IO[A]
-  implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
-
-  val orientDbFixtureV2: SyncIO[FunFixture[(OrientGraphFactoryV2, OrientThread[F])]] = {
+  val orientDbFixture: SyncIO[FunFixture[(OrientGraphFactoryV2, OrientThread[F])]] = {
     val dbName = "testDb"
     val dbConfig = new OrientDBConfigBuilder()
       .addGlobalUser("testUser", "testPass", "*")

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphBlockFetcherTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphBlockFetcherTest.scala
@@ -13,7 +13,7 @@ import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 
-class GraphBlockFetcherSuite extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+class GraphBlockFetcherTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
   type F[A] = IO[A]
 

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcherTest.scala
@@ -10,7 +10,7 @@ import co.topl.brambl.syntax.{
   seriesPolicyAsSeriesPolicySyntaxOps
 }
 import co.topl.genus.services.{BlockStats, BlockchainSizeStats, Txo, TxoState, TxoStats}
-import co.topl.genusLibrary.DbFixtureUtilV2
+import co.topl.genusLibrary.DbFixtureUtil
 import co.topl.genusLibrary.model.GE
 import co.topl.genusLibrary.orientDb.OrientThread
 import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.{blockBodySchema, Ops}
@@ -29,9 +29,9 @@ class GraphVertexFetcherTest
     extends CatsEffectSuite
     with ScalaCheckEffectSuite
     with AsyncMockFactory
-    with DbFixtureUtilV2 {
+    with DbFixtureUtil {
 
-  orientDbFixtureV2.test("On fetchBlockHeader, None should be returned") {
+  orientDbFixture.test("On fetchBlockHeader, None should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         blockHeader        <- ModelGenerators.arbitraryHeader.arbitrary.first.pure[F].toResource
@@ -46,7 +46,7 @@ class GraphVertexFetcherTest
       res.use_
   }
 
-  orientDbFixtureV2.test("On fetchBlockHeader, a blockHeader should be returned") {
+  orientDbFixture.test("On fetchBlockHeader, a blockHeader should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         blockHeader        <- ModelGenerators.arbitraryHeader.arbitrary.first.pure[F].toResource
@@ -67,7 +67,7 @@ class GraphVertexFetcherTest
       res.use_
   }
 
-  orientDbFixtureV2.test("On fetchHeaderByHeight, a blockHeader should be returned") {
+  orientDbFixture.test("On fetchHeaderByHeight, a blockHeader should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         blockHeader        <- ModelGenerators.arbitraryHeader.arbitrary.first.copy(height = 1).pure[F].toResource
@@ -88,7 +88,7 @@ class GraphVertexFetcherTest
       res.use_
   }
 
-  orientDbFixtureV2.test("On fetchHeaderByDepth, a blockHeader should be returned") {
+  orientDbFixture.test("On fetchHeaderByDepth, a blockHeader should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         blockHeader        <- ModelGenerators.arbitraryHeader.arbitrary.first.copy(height = 1).pure[F].toResource
@@ -110,7 +110,7 @@ class GraphVertexFetcherTest
       res.use_
   }
 
-  orientDbFixtureV2.test("On fetchBody, None should be returned") {
+  orientDbFixture.test("On fetchBody, None should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         notx <- oThread.delay(odbFactory.getNoTx).toResource
@@ -125,7 +125,7 @@ class GraphVertexFetcherTest
 
   }
 
-  orientDbFixtureV2.test("On fetchBody, Body should be returned") {
+  orientDbFixture.test("On fetchBody, Body should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         tx   <- oThread.delay(odbFactory.getTx).toResource
@@ -153,7 +153,7 @@ class GraphVertexFetcherTest
 
   }
 
-  orientDbFixtureV2.test("On fetchTransactions, None should be returned") {
+  orientDbFixture.test("On fetchTransactions, None should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         notx <- oThread.delay(odbFactory.getNoTx).toResource
@@ -171,7 +171,7 @@ class GraphVertexFetcherTest
 
   }
 
-  orientDbFixtureV2.test("On fetchLockAddress, None should be returned") {
+  orientDbFixture.test("On fetchLockAddress, None should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         lockAddress        <- BramblGenerator.arbitraryLockAddress.arbitrary.first.pure[F].toResource
@@ -187,7 +187,7 @@ class GraphVertexFetcherTest
       res.use_
   }
 
-  orientDbFixtureV2.test("On fetchLockAddress, a LockAddress should be returned") {
+  orientDbFixture.test("On fetchLockAddress, a LockAddress should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         lockAddress        <- BramblGenerator.arbitraryLockAddress.arbitrary.first.pure[F].toResource
@@ -209,7 +209,7 @@ class GraphVertexFetcherTest
 
   }
 
-  orientDbFixtureV2.test("On fetchTxo, None should be returned") {
+  orientDbFixture.test("On fetchTxo, None should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         transactionOutputAddress <- BramblGenerator.arbitraryTransactionOutputAddress.arbitrary.first.pure[F].toResource
@@ -226,7 +226,7 @@ class GraphVertexFetcherTest
 
   }
 
-  orientDbFixtureV2.test("On fetchTxo, Txo should be returned") {
+  orientDbFixture.test("On fetchTxo, Txo should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         transactionOutputAddress <- BramblGenerator.arbitraryTransactionOutputAddress.arbitrary.first.pure[F].toResource
@@ -250,7 +250,7 @@ class GraphVertexFetcherTest
 
   }
 
-  orientDbFixtureV2.test(
+  orientDbFixture.test(
     "On fetchTxoStats, a default instance of TxoStats should be returned"
   ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
@@ -261,7 +261,7 @@ class GraphVertexFetcherTest
     res.use_
   }
 
-  orientDbFixtureV2.test(
+  orientDbFixture.test(
     "On fetchTxoStats, TxoStats SPENT should be returned"
   ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
@@ -289,7 +289,7 @@ class GraphVertexFetcherTest
     res.use_
   }
 
-  orientDbFixtureV2.test(
+  orientDbFixture.test(
     "On fetchTxoStats, TxoStats UNSPENT should be returned"
   ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
@@ -317,7 +317,7 @@ class GraphVertexFetcherTest
     res.use_
   }
 
-  orientDbFixtureV2.test(
+  orientDbFixture.test(
     "On fetchBlockchainSizeStats, a default instance of BlockchainSizeStats should be returned"
   ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
@@ -334,7 +334,7 @@ class GraphVertexFetcherTest
     res.use_
   }
 
-  orientDbFixtureV2.test(
+  orientDbFixture.test(
     "On fetchBlockchainSizeStats, after saving a blockheader and an IoTransaction, BlockchainSizeStats should be returned with sizes"
   ) { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
@@ -371,7 +371,7 @@ class GraphVertexFetcherTest
     res.use_
   }
 
-  orientDbFixtureV2.test("On fetchBlockStats, BodyStats with 1 empty result should be returned") {
+  orientDbFixture.test("On fetchBlockStats, BodyStats with 1 empty result should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         tx   <- oThread.delay(odbFactory.getTx).toResource
@@ -396,7 +396,7 @@ class GraphVertexFetcherTest
 
   }
 
-  orientDbFixtureV2.test("On fetchBlockStats, BodyStats with 1 non empty result should be returned") {
+  orientDbFixture.test("On fetchBlockStats, BodyStats with 1 non empty result should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         tx   <- oThread.delay(odbFactory.getTx).toResource
@@ -422,7 +422,7 @@ class GraphVertexFetcherTest
 
   }
 
-  orientDbFixtureV2.test("On fetchGroupPolicy, None should be returned") {
+  orientDbFixture.test("On fetchGroupPolicy, None should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         registrationUtxo <- BramblGenerator.arbitraryTransactionOutputAddress.arbitrary.first.pure[F].toResource
@@ -439,7 +439,7 @@ class GraphVertexFetcherTest
       res.use_
   }
 
-  orientDbFixtureV2.test("On fetchGroupPolicy, a policy should be returned") {
+  orientDbFixture.test("On fetchGroupPolicy, a policy should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         registrationUtxo <- BramblGenerator.arbitraryTransactionOutputAddress.arbitrary.first.pure[F].toResource
@@ -462,7 +462,7 @@ class GraphVertexFetcherTest
       res.use_
   }
 
-  orientDbFixtureV2.test("On fetchSeriesPolicy, None should be returned") {
+  orientDbFixture.test("On fetchSeriesPolicy, None should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         registrationUtxo <- BramblGenerator.arbitraryTransactionOutputAddress.arbitrary.first.pure[F].toResource
@@ -483,7 +483,7 @@ class GraphVertexFetcherTest
       res.use_
   }
 
-  orientDbFixtureV2.test("On fetchSeriesPolicy, a policy should be returned") {
+  orientDbFixture.test("On fetchSeriesPolicy, a policy should be returned") {
     case (odbFactory, implicit0(oThread: OrientThread[F])) =>
       val res = for {
         registrationUtxo <- BramblGenerator.arbitraryTransactionOutputAddress.arbitrary.first.pure[F].toResource

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcherTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/NodeBlockFetcherTest.scala
@@ -23,7 +23,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.collection.immutable.ListSet
 
-class NodeBlockFetcherSuite extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
+class NodeBlockFetcherTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
   type F[A] = IO[A]
   implicit private val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)

--- a/genus-library/src/test/scala/co/topl/genusLibrary/model/GETest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/model/GETest.scala
@@ -6,7 +6,7 @@ import com.google.protobuf.ByteString
 
 import scala.collection.immutable.ListSet
 
-class GESuite extends munit.FunSuite {
+class GETest extends munit.FunSuite {
 
   test("Genus Exception Message") {
     val msg = "boom!"

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockBodyTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockBodyTest.scala
@@ -1,7 +1,7 @@
 package co.topl.genusLibrary.orientDb.instances
 
 import cats.implicits._
-import co.topl.genusLibrary.DbFixtureUtilV2
+import co.topl.genusLibrary.DbFixtureUtil
 import co.topl.genusLibrary.orientDb.OrientThread
 import co.topl.genusLibrary.orientDb.instances.SchemaBlockBody.Field
 import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.blockBodySchema
@@ -16,9 +16,9 @@ class SchemaBlockBodyTest
     with ScalaCheckEffectSuite
     with AsyncMockFactory
     with CatsEffectFunFixtures
-    with DbFixtureUtilV2 {
+    with DbFixtureUtil {
 
-  orientDbFixtureV2.test("Block body Schema Metadata") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+  orientDbFixture.test("Block body Schema Metadata") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
       dbNoTx <- oThread.delay(odbFactory.getNoTx).toResource
 
@@ -43,16 +43,13 @@ class SchemaBlockBodyTest
 
   }
 
-  orientDbFixtureV2.test("Block Body Schema Add vertex") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+  orientDbFixture.test("Block Body Schema Add vertex") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
 
       dbTx <- oThread.delay(odbFactory.getTx).toResource
 
       vertex <- oThread
-        .delay(
-          dbTx
-            .addVertex(s"class:${blockBodySchema.name}", blockBodySchema.encode(BlockBody(Seq.empty)).asJava)
-        )
+        .delay(dbTx.addVertex(s"class:${blockBodySchema.name}", blockBodySchema.encode(BlockBody(Seq.empty)).asJava))
         .toResource
 
       _ <- assertIO(

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaGroupPolicyTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaGroupPolicyTest.scala
@@ -5,7 +5,7 @@ import co.topl.brambl.models.Event.{GroupPolicy, SeriesPolicy}
 import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.generators.{ModelGenerators => BramblGenerator}
 import co.topl.brambl.syntax.seriesPolicyAsSeriesPolicySyntaxOps
-import co.topl.genusLibrary.DbFixtureUtilV2
+import co.topl.genusLibrary.DbFixtureUtil
 import co.topl.genusLibrary.orientDb.OrientThread
 import com.orientechnologies.orient.core.metadata.schema.OType
 import co.topl.genusLibrary.orientDb.instances.SchemaGroupPolicy.Field
@@ -21,9 +21,9 @@ class SchemaGroupPolicyTest
     with ScalaCheckEffectSuite
     with AsyncMockFactory
     with CatsEffectFunFixtures
-    with DbFixtureUtilV2 {
+    with DbFixtureUtil {
 
-  orientDbFixtureV2.test("GroupPolicy Schema Metadata") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+  orientDbFixture.test("GroupPolicy Schema Metadata") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
       dbNoTx             <- oThread.delay(odbFactory.getNoTx).toResource
       databaseDocumentTx <- oThread.delay(dbNoTx.getRawGraph).toResource
@@ -64,7 +64,7 @@ class SchemaGroupPolicyTest
 
   }
 
-  orientDbFixtureV2.test("GroupPolicy Schema Add vertex") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+  orientDbFixture.test("GroupPolicy Schema Add vertex") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
 
       dbTx          <- oThread.delay(odbFactory.getTx).toResource

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaSeriesPolicyTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaSeriesPolicyTest.scala
@@ -5,7 +5,7 @@ import co.topl.brambl.generators.{ModelGenerators => BramblGenerator}
 import co.topl.brambl.models.Event.SeriesPolicy
 import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.syntax.seriesPolicyAsSeriesPolicySyntaxOps
-import co.topl.genusLibrary.DbFixtureUtilV2
+import co.topl.genusLibrary.DbFixtureUtil
 import co.topl.genusLibrary.orientDb.OrientThread
 import co.topl.genusLibrary.orientDb.instances.SchemaSeriesPolicy.Field
 import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances.seriesPolicySchema
@@ -20,9 +20,9 @@ class SchemaSeriesPolicyTest
     with ScalaCheckEffectSuite
     with AsyncMockFactory
     with CatsEffectFunFixtures
-    with DbFixtureUtilV2 {
+    with DbFixtureUtil {
 
-  orientDbFixtureV2.test("SeriesPolicy Schema Metadata") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+  orientDbFixture.test("SeriesPolicy Schema Metadata") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
       dbNoTx             <- oThread.delay(odbFactory.getNoTx).toResource
       databaseDocumentTx <- oThread.delay(dbNoTx.getRawGraph).toResource
@@ -90,7 +90,7 @@ class SchemaSeriesPolicyTest
 
   }
 
-  orientDbFixtureV2.test("Series Policy Schema Add vertex") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
+  orientDbFixture.test("Series Policy Schema Add vertex") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
 
       dbTx          <- oThread.delay(odbFactory.getTx).toResource

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/schema/VertexSchemaTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/schema/VertexSchemaTest.scala
@@ -2,9 +2,8 @@ package co.topl.genusLibrary.orientDb.schema
 
 import cats.implicits._
 import co.topl.genusLibrary.DbFixtureUtil
-import co.topl.genusLibrary.orientDb.OrientDBMetadataFactory
+import co.topl.genusLibrary.orientDb.{OrientDBMetadataFactory, OrientThread}
 import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
-import com.tinkerpop.blueprints.impls.orient.OrientGraphFactoryV2
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalamock.munit.AsyncMockFactory
 import scala.jdk.CollectionConverters._
@@ -24,9 +23,8 @@ class VertexSchemaTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
     v => TestClass(v(StringParamName): String)
   )
 
-  orientDbFixture.test("Test Schema Metadata") { case (odb, oThread) =>
+  orientDbFixture.test("Test Schema Metadata") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
-      odbFactory         <- oThread.delay(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
       databaseDocumentTx <- oThread.delay(odbFactory.getNoTx.getRawGraph).toResource
       _                  <- OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, testSchema).toResource
 
@@ -44,9 +42,8 @@ class VertexSchemaTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
 
   }
 
-  orientDbFixture.test("Test Schema Add Vertex") { case (odb, oThread) =>
+  orientDbFixture.test("Test Schema Add Vertex") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>
     val res = for {
-      odbFactory         <- oThread.delay(new OrientGraphFactoryV2(odb, "testDb", "testUser", "testPass")).toResource
       databaseDocumentTx <- oThread.delay(odbFactory.getNoTx.getRawGraph).toResource
       _                  <- OrientDBMetadataFactory.createVertex[F](databaseDocumentTx, testSchema).toResource
 


### PR DESCRIPTION
## Purpose
- Genus db util Fixture v2, is the new fixture to test Genus schema, it contains the benefits of creating all the dependencies between schemas and reducing boilerplate code.
## Note
- This PR, only updates test files in genus-library module

## Approach
- all files ending with Suite, renamed to Test
- remove db fixture V1
- update unit test

## Testing
preparePR, 
