### PR TITLE
Mempool Default Expiration

### DIFF
--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -42,7 +42,7 @@ bifrost {
   // Settings for the mempool
   mempool {
     // The maximum number of slots to retain a Transaction that fails to find its way into a block
-    default-expiration-slots = 1000
+    default-expiration-slots = 60
   }
   // Settings for the big bang initialization
   big-bang {


### PR DESCRIPTION
## Purpose
- The mempool's default expiration is too generous (1000 slots = 1000 seconds)
## Approach
- Set default mempool expiration to 60 slots (60 seconds)
## Testing
- N/A
## Tickets
- #BN-1123