### PR TITLE
Fix: Run Genus Replicator

### DIFF
--- a/node/src/main/scala/co/topl/genus/Replicator.scala
+++ b/node/src/main/scala/co/topl/genus/Replicator.scala
@@ -11,11 +11,10 @@ import co.topl.algebras.SynchronizationTraversalSteps
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.genus.services.BlockData
 import co.topl.genusLibrary.model.GE
+import co.topl.interpreters.NodeRpcOps.clientAsNodeRpcApi
 import co.topl.typeclasses.implicits.showBlockId
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-
-import scala.concurrent.duration._
 
 object Replicator {
 
@@ -25,7 +24,7 @@ object Replicator {
   def stream[F[_]: Async](genus: Genus[F, fs2.Stream[F, *]]): fs2.Stream[F, Unit] =
     for {
       implicit0(logger: Logger[F]) <- fs2.Stream.eval(Slf4jLogger.fromName("Genus.Replicator"))
-      _                            <- fs2.Stream.sleep[F](20.seconds)
+      _                            <- fs2.Stream.eval(genus.nodeRpcClient.waitForRpcStartUp)
       nodeLatestHeight <- fs2.Stream.eval(
         OptionT(genus.nodeBlockFetcher.fetchHeight()).getOrRaise(new IllegalStateException("Unknown node height"))
       )

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -264,6 +264,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
                         .getOrElse(dataStores.baseDirectory./("orient-db").toString),
                       appConfig.genus.orientDbPassword
                     )
+                  _ <- Replicator.background(genus)
                   definitions <-
                     GenusGrpc.Server.services(
                       genus.blockFetcher,


### PR DESCRIPTION
## Purpose
- A previous PR accidentally removed the line to run the Genus Replicator which causes tests to fail
## Approach
- Re-enable Genus Replicator
- Update Genus Replicator initialization to poll Node RPC instead of sleeping
## Testing
- Re-ran failed tests locally
## Tickets
N/A