### PR TITLE
DataReaders.fromUrl Follow Redirects

### DIFF
--- a/node/src/main/scala/co/topl/node/DataReaders.scala
+++ b/node/src/main/scala/co/topl/node/DataReaders.scala
@@ -4,6 +4,7 @@ import cats.data.{Kleisli, ReaderT}
 import cats.effect.{Async, Resource}
 import fs2.io.file.{Files, Path}
 import fs2.io.net.Network
+import org.http4s.client.middleware.FollowRedirect
 import org.http4s.ember.client.EmberClientBuilder
 
 object DataReaders {
@@ -32,6 +33,7 @@ object DataReaders {
     EmberClientBuilder
       .default[F]
       .build
+      .map(FollowRedirect(10))
       .map(client => Kleisli(fileName => client.expect[Array[Byte]](s"$baseUrl/$fileName")))
   }
 


### PR DESCRIPTION
## Purpose
- The `DataReader.fromUrl` allows a user to specify a remote location for genesis data files.  Users may add an erroneous `/` character to this URL, which in the case of fetching from GitHub, requires a redirect
## Approach
- Add the `FollowRedirect` middleware from http4s
## Testing
- Verified locally using this configuration:
```
bifrost:
  big-bang:
    type: public
    genesis-id: b_6D8mXdqjsGrJbnXf6PqfWQrdTfKr3U5nbLGJGyYVgjqs
    source-path: https://raw.githubusercontent.com/Topl/Genesis_Testnets/main/testnet0/
```
## Tickets
N/A