### PR TITLE
Before release, trying latest versions

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
@@ -15,7 +15,7 @@ import co.topl.crypto.hash.Blake2b256
 import co.topl.crypto.models.SecretKeyKesProduct
 import co.topl.models._
 import co.topl.models.utility._
-import co.topl.numerics.implicits._
+import co.topl.numerics.RatioOps.implicits._
 import com.google.protobuf.ByteString
 import fs2.Chunk
 import fs2.io.file.{Files, Path}

--- a/byzantine-it/src/test/scala/co/topl/byzantine/TransactionTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/TransactionTest.scala
@@ -498,8 +498,8 @@ class TransactionTest extends IntegrationSuite {
         _ = assert(syntacticallyInvalid.contains(iotx_I.id.show))
         _ = assert(syntacticallyInvalid.contains(iotx_J.id.show))
         _ = assert(syntacticallyInvalid.contains(iotx_K.id.show))
+         _ = assert(syntacticallyInvalid.contains(iotx_U_Fail_1.id.show))
         // rule was deactivated on bramblSc. Test them whem implemented
-        // _ = assert(syntacticallyInvalid.contains(iotx_U_Fail_1.id.show))
         // _ = assert(syntacticallyInvalid.contains(iotx_V_Fail_1.id.show))
         // _ = assert(syntacticallyInvalid.contains(iotx_W_Fail_1.id.show))
 

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BodySyntaxValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BodySyntaxValidationSpec.scala
@@ -14,7 +14,6 @@ import co.topl.ledger.algebras.TransactionRewardCalculatorAlgebra
 import co.topl.ledger.models.BodySyntaxErrors
 import co.topl.node.models.BlockBody
 import co.topl.models.ModelGenerators._
-import co.topl.numerics.implicits._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory

--- a/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
@@ -16,7 +16,6 @@ import co.topl.minting.algebras.{BlockPackerAlgebra, BlockProducerAlgebra, Staki
 import co.topl.minting.models.VrfHit
 import co.topl.models._
 import co.topl.node.models.{BlockBody, FullBlock, FullBlockBody}
-import co.topl.numerics.implicits._
 import co.topl.typeclasses.implicits._
 import com.google.protobuf.ByteString
 import fs2._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,8 +12,8 @@ object Dependencies {
   val orientDbVersion = "3.2.22"
   val ioGrpcVersion = "1.58.0"
   val http4sVersion = "0.23.23"
-  val protobufSpecsVersion = "2.0.0-alpha4+8-7b030910-SNAPSHOT" // scala-steward:off // TODO requires protobuf release
-  val bramblScVersion = "2.0.0-alpha4+9-35127e53-SNAPSHOT" // scala-steward:off TODO requires bramblsc release
+  val protobufSpecsVersion = "2.0.0-alpha5" // scala-steward:off
+  val bramblScVersion = "2.0.0-alpha4+15-64d6796c-SNAPSHOT" // scala-steward:off // TODO requires bramblsc release branch: main
 
   val catsSlf4j =
     "org.typelevel" %% "log4cats-slf4j" % "2.6.0"

--- a/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/interpreters/GcpCsvDataPublisher.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/interpreters/GcpCsvDataPublisher.scala
@@ -6,7 +6,6 @@ import co.topl.brambl.models.box.Value
 import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.models.utility._
-import co.topl.numerics.implicits._
 import co.topl.testnetsimulationorchestrator.algebras.DataPublisher
 import co.topl.testnetsimulationorchestrator.models.AdoptionDatum
 import co.topl.testnetsimulationorchestrator.models.BlockDatum


### PR DESCRIPTION
## Purpose
Checks latest dependencies before release.

## Note / Action items.
- BramblSc contains Int128Syntax, which conflicts with NumberOps
- we can not remove NumberOps because BramblSc implementation is a bit different, intAsInt128 is missing
- if we use BramblSc implementation, Numerics models will depend on BramblSC (maybe we don't want this dependency)
- Transaction test updated, 1 test was updated with expected results, 2 tests are still failing. (reason: there are no validation rules defined for **Transfer  Group/Series/Asset**)


## Testing
preparePR, byzantine test
## Tickets
*
