### PR TITLE
BN-1158 Filter special inet address received from remote peers

### DIFF
--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainSocketHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainSocketHandler.scala
@@ -135,7 +135,7 @@ object BlockchainSocketHandler {
         22: Byte
       )
 
-    val setRemoteAppLevelF =
+    val notifyRemoteAppLevelF =
       TypedProtocolSetFactory.CommonProtocols.requestResponseReciprocated[F, Boolean, Unit](
         BlockchainProtocols.ApplicationLevelNotify,
         protocolServer.notifyApplicationLevel,
@@ -158,7 +158,7 @@ object BlockchainSocketHandler {
         (knownHostsTypedSubHandlers, knownHostsReceivedCallback)   <- knownHostsRecipF.ap(connectionLeader.pure[F])
         (pingPongHandlers, pingMessageReceivedCallback)            <- pingPongF.ap(connectionLeader.pure[F])
         (peerServerHandlers, peerServerCallback)                   <- remotePeerServerF.ap(connectionLeader.pure[F])
-        (appLevelNotifyHandlers, appNotifyCallback)                <- setRemoteAppLevelF.ap(connectionLeader.pure[F])
+        (appLevelNotifyHandlers, appNotifyCallback)                <- notifyRemoteAppLevelF.ap(connectionLeader.pure[F])
         blockchainProtocolClient = new BlockchainPeerClient[F] {
           val remotePeer: F[ConnectedPeer] = connectedPeer.pure[F]
           val remotePeerServerPort: F[Option[Int]] = peerServerCallback(())

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -186,12 +186,12 @@ object PeerActor {
     state.client.closeConnection() >>
     (state, state).pure[F]
 
-  private def startApplicationLevel[F[_]: Concurrent: Logger](state: State[F]): F[Unit] =
+  private def startApplicationLevel[F[_]: Async: Logger](state: State[F]): F[Unit] =
     Logger[F].info(show"Application level is enabled for ${state.hostId}") >>
     state.blockHeaderActor.sendNoWait(PeerBlockHeaderFetcher.Message.StartActor) >>
     state.blockBodyActor.sendNoWait(PeerBlockBodyFetcher.Message.StartActor)
 
-  private def stopApplicationLevel[F[_]: Concurrent: Logger](state: State[F]): F[Unit] =
+  private def stopApplicationLevel[F[_]: Async: Logger](state: State[F]): F[Unit] =
     Logger[F].info(show"Application level is disabled for ${state.hostId}") >>
     state.blockHeaderActor.sendNoWait(PeerBlockHeaderFetcher.Message.StopActor) >>
     state.blockBodyActor.sendNoWait(PeerBlockBodyFetcher.Message.StopActor)

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -239,7 +239,7 @@ package object fsnetwork {
       val res =
         for {
           host     <- OptionT.fromOption[F](Hostname.fromString(unresolvedHost))
-          resolved <- OptionT.liftF(resolver.resolve(host))
+          resolved <- OptionT(resolver.resolveOption(host))
         } yield resolved.toUriString
       res.value
     }

--- a/networking/src/main/scala/co/topl/networking/package.scala
+++ b/networking/src/main/scala/co/topl/networking/package.scala
@@ -4,6 +4,7 @@ import co.topl.networking.p2p.RemoteAddress
 import co.topl.node.models.KnownHost
 import com.comcast.ip4s.{IpAddress, SocketAddress}
 
+import java.net.InetAddress
 import java.nio.ByteBuffer
 
 package object networking {
@@ -20,6 +21,12 @@ package object networking {
 
   implicit class RemoteAddressOps(remoteAddress: RemoteAddress) {
     def asKnownHost: KnownHost = KnownHost(remoteAddress.host, remoteAddress.port)
+
+    def isSpecialHost: Boolean = {
+      val ip = InetAddress.getByName(remoteAddress.host)
+      ip.isLoopbackAddress || ip.isMCGlobal || ip.isMCLinkLocal || ip.isAnyLocalAddress || ip.isMulticastAddress ||
+      ip.getHostName == "255.255.255.255"
+    }
   }
 
   implicit class SocketAddressOps(address: SocketAddress[IpAddress]) {


### PR DESCRIPTION
## Purpose
Filter out special IP addresses from a remote peer like loopback, multicast etc.
## Approach
filter IP addresses received from a remote peer by removing special IP addresses

## Testing
Unit test + integration test

## Tickets
*