### PR TITLE
BN-1199 Ban strategy tuning

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockDownloadError.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockDownloadError.scala
@@ -6,7 +6,9 @@ import co.topl.consensus.models.BlockId
 import co.topl.models.TxRoot
 import co.topl.typeclasses.implicits._
 
-sealed abstract class BlockDownloadError extends Exception
+sealed abstract class BlockDownloadError extends Exception {
+  def notCritical: Boolean
+}
 
 object BlockDownloadError {
   sealed trait BlockHeaderDownloadError extends BlockDownloadError
@@ -15,10 +17,12 @@ object BlockDownloadError {
 
     case object HeaderNotFoundInPeer extends BlockHeaderDownloadError {
       override def toString: String = "Block body has not found in peer"
+      override val notCritical: Boolean = false
     }
 
     case class HeaderHaveIncorrectId(expected: BlockId, actual: BlockId) extends BlockHeaderDownloadError {
       override def toString: String = show"Peer returns header with bad id: expected $expected, actual $actual"
+      override val notCritical: Boolean = false
     }
 
     case class UnknownError(ex: Throwable) extends BlockHeaderDownloadError {
@@ -29,6 +33,7 @@ object BlockDownloadError {
         val message = Option(ex.getLocalizedMessage).getOrElse("")
         show"Unknown error during getting header from peer due next throwable $name : $message"
       }
+      override val notCritical: Boolean = true
     }
   }
 
@@ -38,19 +43,23 @@ object BlockDownloadError {
 
     case object BodyNotFoundInPeer extends BlockBodyDownloadError {
       override def toString: String = "Block body has not found in peer"
+      override val notCritical: Boolean = false
     }
 
     case class BodyHaveIncorrectTxRoot(headerTxRoot: TxRoot, bodyTxRoot: TxRoot) extends BlockBodyDownloadError {
       override def toString: String = show"Peer returns body with bad txRoot: expected $headerTxRoot, got $bodyTxRoot"
+      override val notCritical: Boolean = false
     }
 
     case class TransactionNotFoundInPeer(transactionId: TransactionId) extends BlockBodyDownloadError {
       override def toString: String = show"Peer have no transaction $transactionId despite having appropriate block"
+      override val notCritical: Boolean = false
     }
 
     case class TransactionHaveIncorrectId(expected: TransactionId, actual: TransactionId)
         extends BlockBodyDownloadError {
       override def toString: String = show"Peer returns transaction with bad id: expected $expected, actual $actual"
+      override val notCritical: Boolean = false
     }
 
     case class UnknownError(ex: Throwable) extends BlockBodyDownloadError {
@@ -61,6 +70,8 @@ object BlockDownloadError {
         val message = Option(ex.getLocalizedMessage).getOrElse("")
         show"Unknown error during getting block from peer due next throwable $name : $message"
       }
+
+      override val notCritical: Boolean = true
     }
   }
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -288,6 +288,6 @@ object PeerActor {
       )
       .recoverWith { case exception =>
         Logger[F].error(s"Remote peer provide incorrect genesis information: ${exception.getLocalizedMessage}") >>
-        state.reputationAggregator.sendNoWait(ReputationAggregator.Message.HostProvideIncorrectData(state.hostId))
+        state.reputationAggregator.sendNoWait(ReputationAggregator.Message.CriticalErrorForHost(state.hostId))
       }
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
@@ -83,7 +83,7 @@ object PeersManager {
      * Move peer to cold status, close connection ONLY if remote peer is not used it as well
      * @param hostIds peer for moving to cold state
      */
-    case class MoveToCold(hostIds: Set[HostId]) extends Message
+    case class MoveToCold(hostIds: NonEmptyChain[HostId]) extends Message
 
     /**
      * Add known peers to peers list
@@ -385,9 +385,9 @@ object PeersManager {
 
   private def coldPeer[F[_]: Async: Logger](
     state:   State[F],
-    hostIds: Set[HostId]
+    hostIds: NonEmptyChain[HostId]
   ): F[(State[F], Response[F])] =
-    moveToColdStatus(state, hostIds).map { case (_, newState) => (newState, newState) }
+    moveToColdStatus(state, hostIds.toList.toSet).map { case (_, newState) => (newState, newState) }
 
   // Disable application level AND close connection as well for peer
   private def closePeer[F[_]: Async: Logger](

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ReputationAggregator.scala
@@ -232,8 +232,8 @@ object ReputationAggregator {
 
   private def badKLookbackSlotData[F[_]: Async: Logger](state: State[F], hostId: HostId): F[(State[F], Response[F])] =
     Logger[F].error(show"Got got bad k lookback slot data from host $hostId") >>
-      state.peerManager.sendNoWait(PeersManager.Message.MoveToCold(NonEmptyChain.one(hostId))) >>
-      (state, state).pure[F]
+    state.peerManager.sendNoWait(PeersManager.Message.MoveToCold(NonEmptyChain.one(hostId))) >>
+    (state, state).pure[F]
 
   private def incorrectBlockReceived[F[_]: Async: Logger](
     state:  State[F],

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
@@ -622,7 +622,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       (client.closeConnection _).stubs().returns(Applicative[F].unit)
       val reputationAggregation = mock[ReputationAggregatorActor[F]]
       (reputationAggregation.sendNoWait _)
-        .expects(ReputationAggregator.Message.HostProvideIncorrectData(hostId))
+        .expects(ReputationAggregator.Message.CriticalErrorForHost(hostId))
         .once()
         .returns(Applicative[F].unit)
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
@@ -435,7 +435,7 @@ class PeersManagerTest
           for {
             _            <- actor.send(PeersManager.Message.SetupReputationAggregator(reputationAggregator))
             preTimestamp <- System.currentTimeMillis().pure[F]
-            endState     <- actor.send(PeersManager.Message.MoveToCold(Set(host1, host2)))
+            endState     <- actor.send(PeersManager.Message.MoveToCold(NonEmptyChain(host1, host2)))
             endTimestamp = System.currentTimeMillis()
             _ = assert(endState.peers(host1).actorOpt.isDefined) // actor will be released on close connection message
             _ = assert(endState.peers(host1).state == PeerState.Cold)
@@ -507,7 +507,7 @@ class PeersManagerTest
           for {
             _            <- actor.send(PeersManager.Message.SetupReputationAggregator(reputationAggregator))
             preTimestamp <- System.currentTimeMillis().pure[F]
-            endState     <- actor.send(PeersManager.Message.MoveToCold(Set(hostId)))
+            endState     <- actor.send(PeersManager.Message.MoveToCold(NonEmptyChain(hostId)))
             _ = assert(endState.peers(hostId).state == PeerState.Cold)
             _ = assert(endState.peers(hostId).closedTimestamps.size == 2)
             timestamp = endState.peers(hostId).closedTimestamps.last

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
@@ -149,7 +149,7 @@ class ReputationAggregatorTest
         .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
         .use { actor =>
           for {
-            newState <- actor.send(ReputationAggregator.Message.HostProvideIncorrectData(host))
+            newState <- actor.send(ReputationAggregator.Message.CriticalErrorForHost(host))
             _ = assert(newState.performanceReputation == initialPerfMap)
             _ = assert(newState.blockProvidingReputation == initialBlockMap)
             _ = assert(newState.noveltyReputation == initialNewMap)
@@ -294,26 +294,27 @@ class ReputationAggregatorTest
     }
   }
 
-  test("Reputation shall be set to zero if remote host provide bad k lookback slot data") {
+  test("Move remote peer to cold if remote host provide bad k lookback slot data") {
     withMock {
       val peersManager = mock[PeersManagerActor[F]]
       val host = arbitraryHost.arbitrary.first
 
-      val initialReputation = 0.5
-      val initialPerfMap =
-        Map(arbitraryHost.arbitrary.first -> initialReputation, arbitraryHost.arbitrary.first -> 0.1)
-      val initialBlockMap =
-        Map(arbitraryHost.arbitrary.first -> 0.1, arbitraryHost.arbitrary.first -> 0.7)
-      val initialNewMap =
-        Map(arbitraryHost.arbitrary.first -> 1L)
+      val initialPerfMap: Map[HostId, HostReputationValue] = Map.empty
+      val initialBlockMap: Map[HostId, HostReputationValue] = Map.empty
+      val initialNewMap: Map[HostId, Long] = Map.empty
+
+      (peersManager.sendNoWait _)
+        .expects(PeersManager.Message.MoveToCold(NonEmptyChain.one(host)))
+        .once()
+        .returns(().pure[F])
 
       ReputationAggregator
-        .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap + (host -> 1.0), initialNewMap)
+        .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
         .use { actor =>
           for {
             newState <- actor.send(ReputationAggregator.Message.BadKLookbackSlotData(host))
             _ = assert(newState.performanceReputation == initialPerfMap)
-            _ = assert(newState.blockProvidingReputation == initialBlockMap + (host -> 0.0))
+            _ = assert(newState.blockProvidingReputation == initialBlockMap)
             _ = assert(newState.noveltyReputation == initialNewMap)
           } yield ()
         }


### PR DESCRIPTION
## Purpose
No longer Ban remote peer if a network error has occurred, just move that peer to a cold state.
In case of a bad k lookback message move the remote peer to a cold state

## Approach
Add `isCritical` description for the download header/body and send different messages to the reputation aggregator.

## Testing
Unit tests + integration tests

## Tickets
#BN-1199