### PR TITLE
BN-1205 Incoming connection is considered as Cold instead of Warm, PeerActor error handling added

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -102,28 +102,30 @@ object Blockchain {
         } else {
           implicit val dnsResolver: DnsResolver[F] = DnsResolverInstances.defaultResolver[F]
 
-          ActorPeerHandlerBridgeAlgebra.make(
-            localPeer.localAddress.host,
-            localChain,
-            chainSelectionAlgebra,
-            validators.header,
-            validators.headerToBody,
-            validators.bodySyntax,
-            validators.bodySemantics,
-            validators.bodyAuthorization,
-            dataStores.slotData,
-            dataStores.headers,
-            dataStores.bodies,
-            dataStores.transactions,
-            dataStores.knownHosts,
-            blockIdTree,
-            networkProperties,
-            clock,
-            initialPeers,
-            peersStatusChangesTopic,
-            remotePeers.offer,
-            currentPeers.set
-          )
+          ActorPeerHandlerBridgeAlgebra
+            .make(
+              localPeer.localAddress.host,
+              localChain,
+              chainSelectionAlgebra,
+              validators.header,
+              validators.headerToBody,
+              validators.bodySyntax,
+              validators.bodySemantics,
+              validators.bodyAuthorization,
+              dataStores.slotData,
+              dataStores.headers,
+              dataStores.bodies,
+              dataStores.transactions,
+              dataStores.knownHosts,
+              blockIdTree,
+              networkProperties,
+              clock,
+              initialPeers,
+              peersStatusChangesTopic,
+              remotePeers.offer,
+              currentPeers.set
+            )
+            .onFinalize(Logger[F].info("P2P Actor system had been shutdown"))
         }
       clientHandler <- Resource.pure[F, BlockchainPeerHandlerAlgebra[F]](
         List(

--- a/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
+++ b/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
@@ -322,22 +322,25 @@ object TypedProtocolSetFactory {
         queue <- Queue.bounded[F, OutboundMessage](1)
         stream = Stream.fromQueueUnterminated(queue)
         clientCallback = (query: Query) =>
-          requestPermit.use(_ =>
-            for {
-              deferred <- Deferred[F, Option[T]]
-              _        <- responsePromisesQueue.offer(deferred)
-              _        <- queue.offer(OutboundMessage(TypedProtocol.CommonMessages.Get(query)))
-              result <- EitherT(
-                Async[F].race(
-                  Async[F].delayBy(
-                    Async[F].delay(new TimeoutException(s"RequestResponse failed for query=$query")),
-                    5.seconds
-                  ),
-                  deferred.get
-                )
-              ).rethrowT
-            } yield result
-          )
+          requestPermit.use { _ =>
+            val response =
+              for {
+                deferred <- Deferred[F, Option[T]]
+                _        <- responsePromisesQueue.offer(deferred)
+                _        <- queue.offer(OutboundMessage(TypedProtocol.CommonMessages.Get(query)))
+                result   <- deferred.get
+              } yield result
+
+            EitherT(
+              Async[F].race(
+                Async[F].delayBy(
+                  Async[F].delay(new TimeoutException(s"RequestResponse failed 2 for query=$query")),
+                  10.seconds
+                ),
+                response
+              )
+            ).rethrowT
+          }
         multiplexerCodec = MultiplexerCodecBuilder()
           .withCodec[TypedProtocol.CommonMessages.Start.type](1: Byte)
           .withCodec[TypedProtocol.CommonMessages.Done.type](2: Byte)

--- a/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
+++ b/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
@@ -334,7 +334,7 @@ object TypedProtocolSetFactory {
             EitherT(
               Async[F].race(
                 Async[F].delayBy(
-                  Async[F].delay(new TimeoutException(s"RequestResponse failed 2 for query=$query")),
+                  Async[F].delay(new TimeoutException(s"RequestResponse failed for query=$query")),
                   10.seconds
                 ),
                 response

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerState.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerState.scala
@@ -3,6 +3,8 @@ package co.topl.networking.fsnetwork
 sealed trait PeerState {
   def networkLevel: Boolean
   def applicationLevel: Boolean
+
+  def isActive: Boolean = networkLevel || applicationLevel
 }
 
 object PeerState {

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
@@ -34,6 +34,12 @@ case class PeersHandler[F[_]: Async: Logger](peers: Map[HostId, Peer[F]], timeSt
 
   def apply(hostId: HostId): Peer[F] = peers(hostId)
 
+  def haveNoActorForHost(hostId: HostId): Boolean = peers.get(hostId).flatMap(_.actorOpt).isEmpty
+
+  def hostIsBanned(hostId: HostId): Boolean = peers.get(hostId).exists(_.state == PeerState.Banned)
+
+  def hostIsNotBanned(hostId: HostId): Boolean = !hostIsBanned(hostId)
+
   private def getPeers(peerState: PeerState): Map[HostId, Peer[F]] =
     peers.filter { case (_: String, peer) => peer.state == peerState }
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ReputationAggregatorTest.scala
@@ -45,11 +45,11 @@ class ReputationAggregatorTest
         .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
         .use { actor =>
           for {
-            newState <- actor.send(ReputationAggregator.Message.StopReputationTracking(Set(hostToRemove)))
+            newState <- actor.send(ReputationAggregator.Message.StopReputationTracking(hostToRemove))
             _ = assert(!newState.performanceReputation.contains(hostToRemove))
             _ = assert(!newState.blockProvidingReputation.contains(hostToRemove))
             _ = assert(!newState.noveltyReputation.contains(hostToRemove))
-            newState2 <- actor.send(ReputationAggregator.Message.StopReputationTracking(Set(hostToRemove)))
+            newState2 <- actor.send(ReputationAggregator.Message.StopReputationTracking(hostToRemove))
             _ = assert(!newState2.performanceReputation.contains(hostToRemove))
             _ = assert(!newState2.blockProvidingReputation.contains(hostToRemove))
             _ = assert(!newState2.noveltyReputation.contains(hostToRemove))
@@ -232,7 +232,7 @@ class ReputationAggregatorTest
         .makeActor(peersManager, defaultP2PConfig, initialPerfMap, initialBlockMap, initialNewMap)
         .use { actor =>
           for {
-            newState <- actor.send(ReputationAggregator.Message.NewHotPeer(NonEmptyChain.one(host)))
+            newState <- actor.send(ReputationAggregator.Message.NewHotPeer(host))
             _ = assert(newState.performanceReputation == (initialPerfMap + (host -> 0.0)))
             _ = assert(newState.blockProvidingReputation == (initialBlockMap + (host -> 0.0)))
             _ = assert(newState.noveltyReputation == (initialNewMap + (host -> reputation)))

--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -44,7 +44,7 @@ class NodeAppTest extends CatsEffectSuite {
 
   type RpcClient = NodeRpc[F, Stream[F, *]]
 
-  override val munitTimeout: Duration = 3.minutes
+  override val munitTimeout: Duration = 5.minutes
 
   test("Two block-producing nodes that maintain consensus") {
     // Allow the nodes to produce/adopt blocks until reaching this height

--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -44,7 +44,7 @@ class NodeAppTest extends CatsEffectSuite {
 
   type RpcClient = NodeRpc[F, Stream[F, *]]
 
-  override val munitTimeout: Duration = 5.minutes
+  override val munitTimeout: Duration = 3.minutes
 
   test("Two block-producing nodes that maintain consensus") {
     // Allow the nodes to produce/adopt blocks until reaching this height


### PR DESCRIPTION
## Purpose
1. Incoming connections from remote peers shall be treated as COLD initially, otherwise, remote peer could try to manipulate our node connections because HOT connection is selected from the pool of WARM connections
2. Added Peer actor error handling, incorrect genesis leads to COLD state, not BAN
3. Do not request a new connection while going to WARM state from COLD if the connection already existed

## Approach
Do not set WARM state for peer during new incoming connection; Add error handling for PeerActor

## Testing
Unit tests + Integration tests

## Tickets
#BN-1205
