### PR TITLE
Load Protocol Settings from Genesis Block

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/interpreters/EpochDataInterpreter.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/interpreters/EpochDataInterpreter.scala
@@ -10,6 +10,7 @@ import co.topl.blockchain.algebras.EpochDataAlgebra
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.common.ContainsImmutable
+import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.consensus.interpreters.{ConsensusDataEventSourcedState, EpochBoundariesEventSourcedState}
 import co.topl.consensus.models.{BlockHeader, BlockId}

--- a/blockchain/src/test/scala/co/topl/blockchain/StakerInitializersSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/StakerInitializersSpec.scala
@@ -5,6 +5,7 @@ import cats.effect.kernel.Async
 import cats.implicits._
 import co.topl.blockchain.PrivateTestnet.DefaultTotalStake
 import co.topl.brambl.models.box.Value
+import co.topl.brambl.syntax._
 import co.topl.models.utility.Ratio
 import co.topl.numerics.implicits._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}

--- a/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
@@ -12,7 +12,7 @@ import co.topl.brambl.common.ContainsSignable.instances.ioTransactionSignable
 import co.topl.brambl.models.box.{Attestation, Value}
 import co.topl.brambl.models.{Datum, Event, TransactionOutputAddress}
 import co.topl.brambl.models.transaction.{IoTransaction, Schedule, SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.brambl.syntax._
 import co.topl.byzantine.util._
 import co.topl.codecs.bytes.tetra.instances.persistableKesProductSecretKey
 import co.topl.codecs.bytes.typeclasses.Persistable
@@ -26,7 +26,6 @@ import co.topl.interpreters.NodeRpcOps._
 import com.google.protobuf.ByteString
 import fs2.Chunk
 import fs2.io.file.{Files, Path, PosixPermission, PosixPermissions}
-import co.topl.numerics.implicits._
 import co.topl.quivr.api.Prover
 
 import java.security.SecureRandom

--- a/byzantine-it/src/test/scala/co/topl/byzantine/TransactionTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/TransactionTest.scala
@@ -9,11 +9,10 @@ import co.topl.brambl.builders.locks.PropositionTemplate
 import co.topl.brambl.models._
 import co.topl.brambl.models.box._
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.syntax.{ioTransactionAsTransactionSyntaxOps, transactionIdAsIdSyntaxOps}
+import co.topl.brambl.syntax._
 import co.topl.byzantine.transactions.{Locks, TransactionFactory, Wallet}
 import co.topl.byzantine.util._
 import co.topl.interpreters.NodeRpcOps._
-import co.topl.numerics.implicits._
 import co.topl.typeclasses.implicits._
 import com.spotify.docker.client.DockerClient
 import fs2.Stream
@@ -498,7 +497,7 @@ class TransactionTest extends IntegrationSuite {
         _ = assert(syntacticallyInvalid.contains(iotx_I.id.show))
         _ = assert(syntacticallyInvalid.contains(iotx_J.id.show))
         _ = assert(syntacticallyInvalid.contains(iotx_K.id.show))
-         _ = assert(syntacticallyInvalid.contains(iotx_U_Fail_1.id.show))
+        _ = assert(syntacticallyInvalid.contains(iotx_U_Fail_1.id.show))
         // rule was deactivated on bramblSc. Test them whem implemented
         // _ = assert(syntacticallyInvalid.contains(iotx_V_Fail_1.id.show))
         // _ = assert(syntacticallyInvalid.contains(iotx_W_Fail_1.id.show))

--- a/byzantine-it/src/test/scala/co/topl/byzantine/transactions/TransactionFactory.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/transactions/TransactionFactory.scala
@@ -10,10 +10,9 @@ import co.topl.brambl.common.ContainsSignable.instances.ioTransactionSignable
 import co.topl.brambl.models.box.{Attestation, Box, Lock, Value}
 import co.topl.brambl.models.transaction.{IoTransaction, Schedule, SpentTransactionOutput, UnspentTransactionOutput}
 import co.topl.brambl.models._
-import co.topl.brambl.syntax.{groupPolicyAsGroupPolicySyntaxOps, seriesPolicyAsSeriesPolicySyntaxOps}
+import co.topl.brambl.syntax._
 import co.topl.brambl.wallet.WalletApi
 import co.topl.crypto.signing.ExtendedEd25519
-import co.topl.numerics.implicits._
 import co.topl.quivr.api.Prover
 import com.google.protobuf.ByteString
 import quivr.models._

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -4,7 +4,7 @@ import co.topl.brambl.models.LockAddress
 import co.topl.consensus.models.BlockId
 import co.topl.models.Slot
 import co.topl.models.utility.Ratio
-import co.topl.numerics.implicits.Ops
+import co.topl.numerics.implicits._
 import co.topl.proto.node.NodeConfig
 import monocle.macros.Lenses
 

--- a/consensus/src/main/scala/co/topl/consensus/algebras/ConsensusValidationStateAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/ConsensusValidationStateAlgebra.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import co.topl.consensus.models.{ActiveStaker, BlockId, StakingAddress}
 import co.topl.models._
 import co.topl.models.utility.Ratio
-import co.topl.numerics.implicits._
+import co.topl.brambl.syntax._
 
 trait ConsensusValidationStateAlgebra[F[_]] {
 

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/BlockHeaderValidationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/BlockHeaderValidationSpec.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import co.topl.algebras.ClockAlgebra
 import co.topl.algebras.Store
 import co.topl.brambl.utils.CatsUnsafeResource
+import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
 import co.topl.consensus.algebras._

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BodySyntaxValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BodySyntaxValidation.scala
@@ -11,7 +11,7 @@ import co.topl.brambl.validation.algebras.TransactionSyntaxVerifier
 import co.topl.ledger.algebras._
 import co.topl.ledger.models._
 import co.topl.node.models.BlockBody
-import co.topl.numerics.implicits._
+import co.topl.brambl.syntax._
 import com.google.protobuf.ByteString
 
 import scala.collection.immutable.SortedSet

--- a/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
@@ -5,6 +5,7 @@ import cats.effect.std.Queue
 import cats.implicits._
 import co.topl.algebras.ClockAlgebra
 import co.topl.brambl.models.LockAddress
+import co.topl.brambl.syntax._
 import co.topl.catsutils.Iterative
 import co.topl.consensus.models.{BlockHeader, BlockId, SlotData, StakingAddress}
 import co.topl.ledger.algebras.TransactionRewardCalculatorAlgebra
@@ -15,7 +16,6 @@ import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.models.generators.node.ModelGenerators._
 import co.topl.brambl.generators.ModelGenerators._
 import co.topl.node.models.{FullBlock, FullBlockBody}
-import co.topl.numerics.implicits._
 import fs2._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF

--- a/models/src/main/scala/co/topl/models/utility/package.scala
+++ b/models/src/main/scala/co/topl/models/utility/package.scala
@@ -20,6 +20,22 @@ package object utility {
 
   implicit def byteArrayToByteString(byteArray: Array[Byte]): ByteString = ByteString.copyFrom(byteArray)
 
+  implicit def scalaDurationToProtoDuration(
+    duration: scala.concurrent.duration.FiniteDuration
+  ): com.google.protobuf.duration.Duration = {
+    import scala.jdk.DurationConverters._
+    val j = duration.toJava
+    com.google.protobuf.duration.Duration(j.toSeconds, j.toNanosPart)
+  }
+
+  implicit def protoDurationToScalaDuration(
+    duration: com.google.protobuf.duration.Duration
+  ): scala.concurrent.duration.FiniteDuration = {
+    import scala.jdk.DurationConverters._
+    val j = java.time.Duration.ofSeconds(duration.seconds, duration.nanos)
+    j.toScala
+  }
+
   implicit class BlockBodyOps(val body: BlockBody) extends AnyVal {
 
     /**

--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -13,12 +13,11 @@ import co.topl.brambl.models.transaction.{IoTransaction, UnspentTransactionOutpu
 import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.config.ApplicationConfig
-import co.topl.consensus.models.BlockId
+import co.topl.consensus.models.{BlockId, ProtocolVersion}
 import co.topl.grpc.NodeGrpc
 import co.topl.interpreters.NodeRpcOps.clientAsNodeRpcApi
 import co.topl.models.utility._
 import co.topl.node.models.{BlockBody, FullBlock}
-import co.topl.node.ApplicationConfigOps._
 import co.topl.transactiongenerator.interpreters.{Fs2TransactionGenerator, ToplRpcWalletInitializer}
 import co.topl.typeclasses.implicits._
 import com.comcast.ip4s.Port
@@ -31,8 +30,6 @@ import org.http4s.ember.server._
 import org.http4s.server.Router
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-import pureconfig.ConfigSource
-import pureconfig.generic.auto._
 import quivr.models.Int128
 
 import java.nio.charset.StandardCharsets
@@ -69,9 +66,6 @@ class NodeAppTest extends CatsEffectSuite {
          |    type: public
          |    genesis-id: ${genesisBlockId.show}
          |    source-path: $genesisSourcePath
-         |  protocols:
-         |    0:
-         |      slot-duration: 500 milli
          |genus:
          |  enable: true
          |""".stripMargin
@@ -94,9 +88,6 @@ class NodeAppTest extends CatsEffectSuite {
          |    type: public
          |    genesis-id: ${genesisBlockId.show}
          |    source-path: $genesisSourcePath
-         |  protocols:
-         |    0:
-         |      slot-duration: 500 milli
          |genus:
          |  enable: false
          |""".stripMargin
@@ -128,60 +119,76 @@ class NodeAppTest extends CatsEffectSuite {
             configNodeB(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath)
           }
           .flatMap(saveLocalConfig(_, "nodeB"))
-        _          <- launch(configFileA)
-        _          <- launch(configFileB)
-        rpcClientA <- NodeGrpc.Client.make[F]("localhost", 9151, tls = false)
-        rpcClientB <- NodeGrpc.Client.make[F]("localhost", 9153, tls = false)
-        rpcClients = List(rpcClientA, rpcClientB)
-        implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeAppTest").toResource
-        _                            <- rpcClients.parTraverse(_.waitForRpcStartUp).toResource
-        walletInitializer            <- ToplRpcWalletInitializer.make[F](rpcClientA, 1, 1).toResource
-        wallet                       <- walletInitializer.initialize.toResource
-        implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F].toResource
-        // Construct two competing graphs of transactions.
-        // Graph 1 has higher fees and should be included in the chain
-        transactionGenerator1 <- Fs2TransactionGenerator.make[F](wallet, 1, 1, feeF = _ => 1000).toResource
-        transactionGraph1 <- Stream.force(transactionGenerator1.generateTransactions).take(10).compile.toList.toResource
-        // Graph 2 has lower fees, so the Block Packer should never choose them
-        transactionGenerator2 <- Fs2TransactionGenerator.make[F](wallet, 1, 1, feeF = _ => 10).toResource
-        transactionGraph2 <- Stream.force(transactionGenerator2.generateTransactions).take(10).compile.toList.toResource
-        _                 <- rpcClients.parTraverse(fetchUntilHeight(_, 2)).toResource
-        // Broadcast _all_ of the good transactions to the nodes randomly
-        _ <-
-          Stream
-            .repeatEval(random.elementOf(rpcClients))
-            .zip(Stream.evalSeq(random.shuffleList(transactionGraph1)))
-            .evalMap { case (client, tx) => client.broadcastTransaction(tx) }
-            .compile
-            .drain
-            .toResource
-        // Verify that the good transactions were confirmed by both nodes
-        _ <- rpcClients
-          .parTraverse(client =>
-            Async[F].timeout(confirmTransactions(client)(transactionGraph1.map(_.id).toSet), 60.seconds)
+        // Run the nodes in separate fibers, but use the fibers' outcomes as an error signal to
+        // the test by racing the computation
+        _ <- (launch(configFileA), launch(configFileB))
+          .mapN(_.race(_).map(_.merge).flatMap(_.embedNever))
+          .flatMap(nodeCompletion =>
+            nodeCompletion.toResource.race(for {
+              rpcClientA <- NodeGrpc.Client.make[F]("localhost", 9151, tls = false)
+              rpcClientB <- NodeGrpc.Client.make[F]("localhost", 9153, tls = false)
+              rpcClients = List(rpcClientA, rpcClientB)
+              implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeAppTest").toResource
+              _                            <- rpcClients.parTraverse(_.waitForRpcStartUp).toResource
+              walletInitializer            <- ToplRpcWalletInitializer.make[F](rpcClientA, 1, 1).toResource
+              wallet                       <- walletInitializer.initialize.toResource
+              implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F].toResource
+              // Construct two competing graphs of transactions.
+              // Graph 1 has higher fees and should be included in the chain
+              transactionGenerator1 <- Fs2TransactionGenerator.make[F](wallet, 1, 1, feeF = _ => 1000).toResource
+              transactionGraph1 <- Stream
+                .force(transactionGenerator1.generateTransactions)
+                .take(10)
+                .compile
+                .toList
+                .toResource
+              // Graph 2 has lower fees, so the Block Packer should never choose them
+              transactionGenerator2 <- Fs2TransactionGenerator.make[F](wallet, 1, 1, feeF = _ => 10).toResource
+              transactionGraph2 <- Stream
+                .force(transactionGenerator2.generateTransactions)
+                .take(10)
+                .compile
+                .toList
+                .toResource
+              _ <- rpcClients.parTraverse(fetchUntilHeight(_, 2)).toResource
+              // Broadcast _all_ of the good transactions to the nodes randomly
+              _ <-
+                Stream
+                  .repeatEval(random.elementOf(rpcClients))
+                  .zip(Stream.evalSeq(random.shuffleList(transactionGraph1)))
+                  .evalMap { case (client, tx) => client.broadcastTransaction(tx) }
+                  .compile
+                  .drain
+                  .toResource
+              // Verify that the good transactions were confirmed by both nodes
+              _ <- rpcClients
+                .parTraverse(client =>
+                  Async[F].timeout(confirmTransactions(client)(transactionGraph1.map(_.id).toSet), 60.seconds)
+                )
+                .toResource
+              // Submit the bad transactions
+              _ <- Stream
+                .repeatEval(random.elementOf(rpcClients))
+                .zip(Stream.evalSeq(random.shuffleList(transactionGraph2)))
+                .evalMap { case (client, tx) => client.broadcastTransaction(tx) }
+                .compile
+                .drain
+                .toResource
+              // Verify that the nodes are still making blocks properly
+              _ <- rpcClients.parTraverse(fetchUntilHeight(_, targetProductionHeight)).toResource
+              // Verify that the "bad" transactions did not make it onto the chain
+              _ <- rpcClients
+                .parTraverse(verifyNotConfirmed(_)(transactionGraph2.map(_.id).toSet))
+                .toResource
+              // Now check consensus
+              idsAtTargetHeight <- rpcClients
+                .traverse(client =>
+                  OptionT(client.blockIdAtHeight(targetConsensusHeight)).getOrRaise(new IllegalStateException)
+                )
+                .toResource
+              _ <- IO(idsAtTargetHeight.toSet.size == 1).assert.toResource
+            } yield ())
           )
-          .toResource
-        // Submit the bad transactions
-        _ <- Stream
-          .repeatEval(random.elementOf(rpcClients))
-          .zip(Stream.evalSeq(random.shuffleList(transactionGraph2)))
-          .evalMap { case (client, tx) => client.broadcastTransaction(tx) }
-          .compile
-          .drain
-          .toResource
-        // Verify that the nodes are still making blocks properly
-        _ <- rpcClients.parTraverse(fetchUntilHeight(_, targetProductionHeight)).toResource
-        // Verify that the "bad" transactions did not make it onto the chain
-        _ <- rpcClients
-          .parTraverse(verifyNotConfirmed(_)(transactionGraph2.map(_.id).toSet))
-          .toResource
-        // Now check consensus
-        idsAtTargetHeight <- rpcClients
-          .traverse(client =>
-            OptionT(client.blockIdAtHeight(targetConsensusHeight)).getOrRaise(new IllegalStateException)
-          )
-          .toResource
-        _ <- IO(idsAtTargetHeight.toSet.size == 1).assert.toResource
       } yield ()
     resource.use_
   }
@@ -189,9 +196,13 @@ class NodeAppTest extends CatsEffectSuite {
   private def createTestnetConfig: F[TestnetConfig] =
     for {
       random <- SecureRandom.javaSecuritySecureRandom[F]
+      protocol = PrivateTestnet.DefaultProtocol.copy(slotDuration = 500.milli)
       createStaker = random
         .nextBytes(32)
-        .map(seed => StakerInitializers.Operator(seed, (9, 9), PrivateTestnet.HeightLockOneSpendingAddress))
+        .map(seed =>
+          StakerInitializers
+            .Operator(seed, (protocol.kesKeyHours, protocol.kesKeyHours), PrivateTestnet.HeightLockOneSpendingAddress)
+        )
       staker0 <- createStaker
       staker1 <- createStaker
       unstakedTopl = UnspentTransactionOutput(
@@ -203,7 +214,13 @@ class NodeAppTest extends CatsEffectSuite {
         Value.defaultInstance.withLvl(Value.LVL(1_000_000L))
       )
       timestamp <- Async[F].realTime.map(_.plus(20.seconds).toMillis)
-    } yield TestnetConfig(timestamp, List(staker0 -> 500_000L, staker1 -> 500_000L), List(unstakedTopl), List(lvl))
+    } yield TestnetConfig(
+      timestamp,
+      List(staker0 -> 500_000L, staker1 -> 500_000L),
+      List(unstakedTopl),
+      List(lvl),
+      protocol
+    )
 
   /**
    * Launches an HTTP server which mimics the behavior of serving a genesis block from GitHub
@@ -269,13 +286,12 @@ class NodeAppTest extends CatsEffectSuite {
       .compile
       .drain
 
-  private def launch(configFile: Path): Resource[F, Unit] =
+  private def launch(configFile: Path): Resource[F, F[Outcome[F, Throwable, Unit]]] =
     for {
-      app1 <- Sync[F].delay(new AbstractNodeApp {}).toResource
-      _    <- Sync[F].delay(app1.initialize(Array("--config", configFile.toString))).toResource
-      bg   <- app1.run.start.toResource
-      _    <- Resource.onFinalize(bg.cancel)
-    } yield ()
+      app1               <- Sync[F].delay(new AbstractNodeApp {}).toResource
+      _                  <- Sync[F].delay(app1.initialize(Array("--config", configFile.toString))).toResource
+      backgroundOutcomeF <- app1.run.background
+    } yield backgroundOutcomeF
 
   private def confirmTransactions(
     client: RpcClient
@@ -328,26 +344,23 @@ case class TestnetConfig(
   timestamp:     Long,
   stakers:       List[(StakerInitializers.Operator, Int128)],
   unstakedTopls: List[UnspentTransactionOutput],
-  lvls:          List[UnspentTransactionOutput]
+  lvls:          List[UnspentTransactionOutput],
+  protocol:      ApplicationConfig.Bifrost.Protocol
 ) {
 
-  val genesisTransactions =
-    stakers.map { case (init, quantity) => init.registrationTransaction(quantity) } :+ IoTransaction.defaultInstance
-      .withOutputs(unstakedTopls ++ lvls)
+  val protocolUtxo: UnspentTransactionOutput =
+    UnspentTransactionOutput(PrivateTestnet.HeightLockOneSpendingAddress, BigBang.protocolToUpdateProposal(protocol))
 
-  val genesis = BigBang.fromConfig(
-    BigBang.Config(
-      timestamp,
-      genesisTransactions,
-      protocolVersion = ProtocolVersioner(
-        ConfigSource.default
-          .loadOrThrow[ApplicationConfig]
-          .bifrost
-          .protocols
-          .view
-          .mapValues(_.copy(slotDuration = 500.milli))
-          .toMap
-      ).appVersion.asProtocolVersion
+  val genesisTransactions: List[IoTransaction] =
+    stakers.map { case (init, quantity) => init.registrationTransaction(quantity) } :+ IoTransaction.defaultInstance
+      .withOutputs(unstakedTopls ++ lvls :+ protocolUtxo)
+
+  val genesis: FullBlock =
+    BigBang.fromConfig(
+      BigBang.Config(
+        timestamp,
+        genesisTransactions,
+        protocolVersion = ProtocolVersion(2, 0, 0)
+      )
     )
-  )
 }

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -57,6 +57,7 @@ bifrost {
     // The stake quantity to assign to each of the stakers.  If not provided, will default to uniform stake distribution.
     // stakes = ["500", "400", "300"]
   }
+  // DEPRECATED: This section is maintained only for legacy purposes when launching a private testnet.  It is not used for public networks.
   // Settings of the protocol (consensus)
   protocols {
     // The _slot_ at which this protocol begins

--- a/numerics/src/main/scala/co/topl/numerics/NumberOps.scala
+++ b/numerics/src/main/scala/co/topl/numerics/NumberOps.scala
@@ -1,24 +1,19 @@
 package co.topl.numerics
 
-import com.google.protobuf.ByteString
+import co.topl.models.utility.Ratio
 import quivr.models.Int128
 
 import scala.language.implicitConversions
 
 trait NumberOps {
-
-  implicit def int128AsBigInt(int128: Int128): BigInt =
-    BigInt(int128.value.toByteArray)
-
-  implicit def bigIntAsInt128(bigInt: BigInt): Int128 = {
-    val arr = bigInt.toByteArray
-    if (arr.length > 16) throw new IllegalArgumentException("Int128 cannot be larger than 16 bytes")
-    Int128(ByteString.copyFrom(arr))
-  }
+  import co.topl.brambl.syntax._
 
   implicit def intAsInt128(int: Int): Int128 =
     BigInt(int)
 
-  implicit def longAsInt128(long: Long): Int128 =
-    BigInt(long)
+  implicit def protoRatioToRatio(ratio: co.topl.node.models.Ratio): Ratio =
+    Ratio(ratio.numerator: BigInt, ratio.denominator: BigInt)
+
+  implicit def ratioToProtoRatio(ratio: Ratio): co.topl.node.models.Ratio =
+    co.topl.node.models.Ratio(ratio.numerator: Int128, ratio.denominator: Int128)
 }

--- a/numerics/src/main/scala/co/topl/numerics/RatioOps.scala
+++ b/numerics/src/main/scala/co/topl/numerics/RatioOps.scala
@@ -2,111 +2,114 @@ package co.topl.numerics
 
 import co.topl.models.utility.Ratio
 
+import scala.language.implicitConversions
+
 object RatioOps {
 
   trait Implicits {
+    implicit def ratioAsRatioOps(ratio: Ratio): Ops = new Ops(ratio)
+  }
 
-    implicit class Ops(ratio: Ratio) {
+  class Ops(val ratio: Ratio) extends AnyVal {
 
-      def inverse: Ratio =
-        Ratio(ratio.denominator, ratio.numerator)
+    def inverse: Ratio =
+      Ratio(ratio.denominator, ratio.numerator)
 
-      def abs: Ratio =
-        Ratio(
-          ratio.numerator match {
-            case num if num < 0 => -num
-            case num            => num
-          },
-          ratio.denominator match {
-            case den if den < 0 => -den
-            case den            => den
-          }
-        )
-
-      def pow(n: Int) =
-        Ratio(
-          ratio.numerator.pow(n),
-          ratio.denominator.pow(n)
-        )
-
-      def - =
-        Ratio(
-          -ratio.numerator,
-          ratio.denominator
-        )
-
-      def *(that: Int) =
-        Ratio(
-          ratio.numerator * that,
-          ratio.denominator
-        )
-
-      def /(that: Int) =
-        Ratio(
-          ratio.numerator,
-          ratio.denominator * that
-        )
-
-      def *(that: Long) =
-        Ratio(
-          ratio.numerator * that,
-          ratio.denominator
-        )
-
-      def *(that: BigInt) =
-        Ratio(
-          ratio.numerator * that,
-          ratio.denominator
-        )
-
-      def /(that: Long) =
-        Ratio(
-          ratio.numerator,
-          ratio.denominator * that
-        )
-
-      def +(that: Ratio): Ratio =
-        Ratio(
-          ratio.numerator * that.denominator + that.numerator * ratio.denominator,
-          ratio.denominator * that.denominator
-        )
-
-      def -(that: Ratio): Ratio =
-        Ratio(
-          ratio.numerator * that.denominator - that.numerator * ratio.denominator,
-          ratio.denominator * that.denominator
-        )
-
-      def *(that: Ratio): Ratio =
-        Ratio(ratio.numerator * that.numerator, ratio.denominator * that.denominator)
-
-      def /(that: Ratio): Ratio =
-        Ratio(ratio.numerator * that.denominator, ratio.denominator * that.numerator)
-
-      def <(that: Ratio): Boolean =
-        that.denominator * ratio.numerator < that.numerator * ratio.denominator
-
-      def >(that: Ratio): Boolean =
-        that.denominator * ratio.numerator > that.numerator * ratio.denominator
-
-      def <=(that: Ratio): Boolean =
-        that.denominator * ratio.numerator <= that.numerator * ratio.denominator
-
-      def >=(that: Ratio): Boolean =
-        that.denominator * ratio.numerator >= that.numerator * ratio.denominator
-
-      def toBigDecimal: BigDecimal =
-        BigDecimal(ratio.numerator) / BigDecimal(ratio.denominator)
-
-      def toDouble: Double = this.toBigDecimal.toDouble
-
-      def round: BigInt =
-        if (ratio.numerator.abs > ratio.denominator.abs) {
-          ratio.numerator.abs / ratio.denominator.abs
-        } else {
-          BigInt(1)
+    def abs: Ratio =
+      Ratio(
+        ratio.numerator match {
+          case num if num < 0 => -num
+          case num            => num
+        },
+        ratio.denominator match {
+          case den if den < 0 => -den
+          case den            => den
         }
-    }
+      )
+
+    def pow(n: Int) =
+      Ratio(
+        ratio.numerator.pow(n),
+        ratio.denominator.pow(n)
+      )
+
+    def - =
+      Ratio(
+        -ratio.numerator,
+        ratio.denominator
+      )
+
+    def *(that: Int) =
+      Ratio(
+        ratio.numerator * that,
+        ratio.denominator
+      )
+
+    def /(that: Int) =
+      Ratio(
+        ratio.numerator,
+        ratio.denominator * that
+      )
+
+    def *(that: Long) =
+      Ratio(
+        ratio.numerator * that,
+        ratio.denominator
+      )
+
+    def *(that: BigInt) =
+      Ratio(
+        ratio.numerator * that,
+        ratio.denominator
+      )
+
+    def /(that: Long) =
+      Ratio(
+        ratio.numerator,
+        ratio.denominator * that
+      )
+
+    def +(that: Ratio): Ratio =
+      Ratio(
+        ratio.numerator * that.denominator + that.numerator * ratio.denominator,
+        ratio.denominator * that.denominator
+      )
+
+    def -(that: Ratio): Ratio =
+      Ratio(
+        ratio.numerator * that.denominator - that.numerator * ratio.denominator,
+        ratio.denominator * that.denominator
+      )
+
+    def *(that: Ratio): Ratio =
+      Ratio(ratio.numerator * that.numerator, ratio.denominator * that.denominator)
+
+    def /(that: Ratio): Ratio =
+      Ratio(ratio.numerator * that.denominator, ratio.denominator * that.numerator)
+
+    def <(that: Ratio): Boolean =
+      that.denominator * ratio.numerator < that.numerator * ratio.denominator
+
+    def >(that: Ratio): Boolean =
+      that.denominator * ratio.numerator > that.numerator * ratio.denominator
+
+    def <=(that: Ratio): Boolean =
+      that.denominator * ratio.numerator <= that.numerator * ratio.denominator
+
+    def >=(that: Ratio): Boolean =
+      that.denominator * ratio.numerator >= that.numerator * ratio.denominator
+
+    def toBigDecimal: BigDecimal =
+      BigDecimal(ratio.numerator) / BigDecimal(ratio.denominator)
+
+    def toDouble: Double = this.toBigDecimal.toDouble
+
+    def round: BigInt =
+      if (ratio.numerator.abs > ratio.denominator.abs) {
+        ratio.numerator.abs / ratio.denominator.abs
+      } else {
+        BigInt(1)
+      }
   }
 
   object implicits extends Implicits

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val ioGrpcVersion = "1.58.0"
   val http4sVersion = "0.23.23"
   val protobufSpecsVersion = "2.0.0-alpha5" // scala-steward:off
-  val bramblScVersion = "2.0.0-alpha5" // scala-steward:off
+  val bramblScVersion = "2.0.0-alpha5+4-7ed124f8-SNAPSHOT" // scala-steward:off
 
   val catsSlf4j =
     "org.typelevel" %% "log4cats-slf4j" % "2.6.0"

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/Fs2TransactionGenerator.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/Fs2TransactionGenerator.scala
@@ -12,7 +12,7 @@ import co.topl.brambl.models.box._
 import co.topl.brambl.common.ContainsSignable._
 import co.topl.brambl.common.ContainsSignable.instances._
 import co.topl.brambl.models.transaction._
-import co.topl.numerics.implicits._
+import co.topl.brambl.syntax._
 import co.topl.quivr.api.Prover
 import co.topl.transactiongenerator.algebras.TransactionGenerator
 import co.topl.transactiongenerator.models.Wallet


### PR DESCRIPTION
## Purpose
- Protocol settings are currently provided via configuration, but our eventual goal for fork-management is to make those settings controlled by the chain itself
- This PR loads the protocol settings from the genesis block
  - The genesis block must contain exactly one UTxO of type UpdateProposal
  - The UpdateProposal should have all fields provided
  - The UpdateProposal is converted into a Protocol object
- The `init-testnet` command also generates a protocol UTxO, using a set of default settings for now
## Approach
- Add helpers to BigBang for converting to-and-from Protocols and UpdateProposals
- Update init-testnet to output an UpdateProposal in the genesis block
## Testing
- Integration tests and byzantine tests
## Tickets
- #BN-1223