### PR TITLE
Disable Ancestor Trace Recovery

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,7 @@ jobs:
     needs: [sbt-build]
   publish-docker-images-unofficial:
     uses: ./.github/workflows/_docker_publish_private.yml
-    needs: [sbt-build, sbt-integration-tests, sbt-byzantine-tests, build-jar]
+    needs: [sbt-build, build-jar]
     with:
       remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
     secrets: inherit

--- a/blockchain/src/main/scala/co/topl/blockchain/BlockchainPeerHandler.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BlockchainPeerHandler.scala
@@ -477,9 +477,9 @@ object BlockchainPeerHandler {
             )
         )
         .void
-        .handleErrorWith(
-          Logger[F].error(_)("Common ancestor trace failed")
-        )
+        .onError { case e =>
+          Logger[F].error(e)("Common ancestor trace failed")
+        }
   }
 
   implicit class OptionTOps[F[_], T](val optionT: OptionT[F, T]) extends AnyVal {

--- a/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
+++ b/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
@@ -335,7 +335,7 @@ object TypedProtocolSetFactory {
               Async[F].race(
                 Async[F].delayBy(
                   Async[F].delay(new TimeoutException(s"RequestResponse failed for query=$query")),
-                  10.seconds
+                  3.seconds
                 ),
                 response
               )


### PR DESCRIPTION
## Purpose
- When the common ancestor trace fails, errors are currently caught and recovered
- This results in the stream running without termination, even after the connection is closed
- Unrelated: The RequestResponse timeout is 10 seconds, which exceeds normal behavior
- Unrelated: Push a (private) docker image on every push to dev/main, even if integration/byzantine tests fail
## Approach
- Remove recovery from common ancestor trace failures
- Update RequestResponse timeout to 3 seconds
## Testing
N/A
## Tickets
N/A