### PR TITLE
BlockFinder Parallelism.  Node Metadata.

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/BlockFinder.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BlockFinder.scala
@@ -22,7 +22,7 @@ object BlockFinder {
   )(blockHistory: Stream[F, BlockId], newBlocks: Stream[F, BlockId])(id: TransactionId): F[BlockId] =
     blockHistory
       .merge(newBlocks)
-      .evalFilter(
+      .evalFilterAsync(10)(
         fetchBlockBody(_).map(body => body.transactionIds.contains(id) || body.rewardTransactionId.contains(id))
       )
       .head

--- a/blockchain/src/main/scala/co/topl/blockchain/DataStores.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/DataStores.scala
@@ -30,7 +30,8 @@ case class DataStores[F[_]](
   blockHeightTree:         Store[F, Long, BlockId],
   epochData:               Store[F, Epoch, EpochData],
   registrationAccumulator: Store[F, StakingAddress, Unit],
-  knownHosts:              Store[F, Unit, Seq[RemotePeer]]
+  knownHosts:              Store[F, Unit, Seq[RemotePeer]],
+  metadata:                Store[F, Array[Byte], Array[Byte]]
 )
 
 class CurrentEventIdGetterSetters[F[_]: MonadThrow](store: Store[F, Byte, BlockId]) {

--- a/blockchain/src/main/scala/co/topl/blockchain/algebras/NodeMetadataAlgebra.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/algebras/NodeMetadataAlgebra.scala
@@ -1,0 +1,20 @@
+package co.topl.blockchain.algebras
+
+import co.topl.brambl.models.TransactionId
+import co.topl.consensus.models.BlockId
+
+trait NodeMetadataAlgebra[F[_]] {
+
+  def readAppVersion: F[Option[String]]
+  def setAppVersion(version: String): F[Unit]
+
+  def readInitTime: F[Option[Long]]
+  def setInitTime(timestamp: Long): F[Unit]
+
+  def readStakingRegistrationTransactionId: F[Option[TransactionId]]
+  def setStakingRegistrationTransactionId(id: TransactionId): F[Unit]
+
+  def readStakingRegistrationBlockId: F[Option[BlockId]]
+  def setStakingRegistrationBlockId(id: BlockId): F[Unit]
+
+}

--- a/blockchain/src/main/scala/co/topl/blockchain/interpreters/NodeMetadata.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/interpreters/NodeMetadata.scala
@@ -1,0 +1,64 @@
+package co.topl.blockchain.interpreters
+
+import cats.Monad
+import cats.data.OptionT
+import cats.effect.Resource
+import co.topl.algebras.Store
+import co.topl.blockchain.algebras.NodeMetadataAlgebra
+import co.topl.brambl.models.TransactionId
+import co.topl.consensus.models.BlockId
+import com.google.common.primitives.Longs
+import com.google.protobuf.ByteString
+
+import java.nio.charset.StandardCharsets
+
+object NodeMetadata {
+
+  def make[F[_]: Monad](metadataStore: Store[F, Array[Byte], Array[Byte]]): Resource[F, NodeMetadataAlgebra[F]] =
+    Resource.pure(
+      new NodeMetadataAlgebra[F] {
+
+        def readAppVersion: F[Option[String]] =
+          OptionT(metadataStore.get(Keys.AppVersion))
+            .map(new String(_, StandardCharsets.UTF_8))
+            .value
+
+        def setAppVersion(version: String): F[Unit] =
+          metadataStore.put(Keys.AppVersion, version.getBytes(StandardCharsets.UTF_8))
+
+        def readInitTime: F[Option[Long]] =
+          OptionT(metadataStore.get(Keys.InitTime))
+            .map(Longs.fromByteArray)
+            .value
+
+        def setInitTime(timestamp: Long): F[Unit] =
+          metadataStore.put(Keys.InitTime, Longs.toByteArray(timestamp))
+
+        def readStakingRegistrationTransactionId: F[Option[TransactionId]] =
+          OptionT(metadataStore.get(Keys.StakingRegistrationTransactionId))
+            .map(ByteString.copyFrom)
+            .map(TransactionId(_))
+            .value
+
+        def setStakingRegistrationTransactionId(id: TransactionId): F[Unit] =
+          metadataStore.put(Keys.StakingRegistrationTransactionId, id.value.toByteArray)
+
+        def readStakingRegistrationBlockId: F[Option[BlockId]] =
+          OptionT(metadataStore.get(Keys.StakingRegistrationBlockId))
+            .map(ByteString.copyFrom)
+            .map(BlockId(_))
+            .value
+
+        def setStakingRegistrationBlockId(id: BlockId): F[Unit] =
+          metadataStore.put(Keys.StakingRegistrationBlockId, id.value.toByteArray)
+
+      }
+    )
+
+  object Keys {
+    final val AppVersion = Array[Byte](0)
+    final val InitTime = Array[Byte](1)
+    final val StakingRegistrationTransactionId = Array[Byte](2)
+    final val StakingRegistrationBlockId = Array[Byte](3)
+  }
+}

--- a/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
@@ -85,7 +85,7 @@ class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
               def improvePackedBlock(parentBlockId: BlockId, height: Long, slot: Long): F[Iterative[F, FullBlockBody]] =
                 new Iterative[F, FullBlockBody] {
                   def improve(current: FullBlockBody): F[FullBlockBody] =
-                    blockPackerQueue.take.flatTap(_ => clockDeferment.complete(()))
+                    blockPackerQueue.take.flatTap(_ => (IO.sleep(100.milli) >> clockDeferment.complete(())).start)
                 }.pure[F]
             }
             parents <- Queue.unbounded[F, Option[SlotData]]

--- a/node/src/main/scala/co/topl/node/DataStoresInit.scala
+++ b/node/src/main/scala/co/topl/node/DataStoresInit.scala
@@ -111,8 +111,8 @@ object DataStoresInit {
         appConfig.bifrost.cache.registrationAccumulator,
         identity
       )
-
       knownRemotePeersStore <- makeDb[F, Unit, Seq[RemotePeer]](dataDir)("known-remote-peers")
+      metadataStore         <- makeDb[F, Array[Byte], Array[Byte]](dataDir)("metadata")
 
       dataStores = DataStores(
         dataDir,
@@ -131,7 +131,8 @@ object DataStoresInit {
         blockHeightTreeStore,
         epochDataStore,
         registrationAccumulatorStore,
-        knownRemotePeersStore
+        knownRemotePeersStore,
+        metadataStore
       )
     } yield dataStores
 

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraPersistableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraPersistableCodecs.scala
@@ -53,6 +53,9 @@ trait TetraPersistableCodecs {
   implicit val persistableByte: Persistable[Byte] =
     Persistable.instanceFromCodec
 
+  implicit val persistableByteArray: Persistable[Array[Byte]] =
+    Persistable.instanceFromCodec
+
   implicit val persistableByteString: Persistable[ByteString] =
     Persistable.instanceFromCodec
 


### PR DESCRIPTION
## Purpose
- Staking involves a registration process which involves saving a transaction on chain
- The block containing this transaction ultimately determines when the staker first becomes active
- The process of finding this transaction takes place on every node startup, and in some cases it may be expensive
## Approach
- Add parallelism to the transaction search
- Add caching to basic node metadata, including the staking registration transaction and block IDs
  - Also added node app version and init time
## Testing
- AdHoc Test [Success](https://github.com/Topl/Bifrost/actions/runs/6534074005)
## Tickets
- #BN-1236