### PR TITLE
Bifrost CLI, init-testnet: Allow protocol configuration

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
@@ -199,21 +199,22 @@ object BigBang {
       kesKeyMinutes
     )
 
-  def protocolToUpdateProposal(protocol: ApplicationConfig.Bifrost.Protocol): Value =
-    Value.defaultInstance.withUpdateProposal(
-      Value.UpdateProposal(
-        label = "genesis",
-        fEffective = (protocol.fEffective: co.topl.node.models.Ratio).some,
-        vrfLddCutoff = protocol.vrfLddCutoff.some,
-        vrfPrecision = protocol.vrfPrecision.some,
-        vrfBaselineDifficulty = (protocol.vrfBaselineDifficulty: co.topl.node.models.Ratio).some,
-        vrfAmplitude = (protocol.vrfAmplitude: co.topl.node.models.Ratio).some,
-        chainSelectionKLookback = protocol.chainSelectionKLookback.some,
-        slotDuration = (protocol.slotDuration: com.google.protobuf.duration.Duration).some,
-        forwardBiasedSlotWindow = protocol.forwardBiasedSlotWindow.some,
-        operationalPeriodsPerEpoch = protocol.operationalPeriodsPerEpoch.some,
-        kesKeyHours = protocol.kesKeyHours.some,
-        kesKeyMinutes = protocol.kesKeyMinutes.some
-      )
+  def protocolToValue(protocol: ApplicationConfig.Bifrost.Protocol): Value =
+    Value.defaultInstance.withUpdateProposal(protocolToUpdateProposal(protocol))
+
+  def protocolToUpdateProposal(protocol: ApplicationConfig.Bifrost.Protocol): Value.UpdateProposal =
+    Value.UpdateProposal(
+      label = "genesis",
+      fEffective = (protocol.fEffective: co.topl.node.models.Ratio).some,
+      vrfLddCutoff = protocol.vrfLddCutoff.some,
+      vrfPrecision = protocol.vrfPrecision.some,
+      vrfBaselineDifficulty = (protocol.vrfBaselineDifficulty: co.topl.node.models.Ratio).some,
+      vrfAmplitude = (protocol.vrfAmplitude: co.topl.node.models.Ratio).some,
+      chainSelectionKLookback = protocol.chainSelectionKLookback.some,
+      slotDuration = (protocol.slotDuration: com.google.protobuf.duration.Duration).some,
+      forwardBiasedSlotWindow = protocol.forwardBiasedSlotWindow.some,
+      operationalPeriodsPerEpoch = protocol.operationalPeriodsPerEpoch.some,
+      kesKeyHours = protocol.kesKeyHours.some,
+      kesKeyMinutes = protocol.kesKeyMinutes.some
     )
 }

--- a/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
@@ -77,7 +77,10 @@ object PrivateTestnet {
                 HeightLockOneSpendingAddress,
                 Value.defaultInstance.withLvl(Value.LVL(DefaultTotalLvls))
               ),
-              UnspentTransactionOutput(HeightLockOneSpendingAddress, BigBang.protocolToUpdateProposal(protocol))
+              UnspentTransactionOutput(
+                HeightLockOneSpendingAddress,
+                Value.defaultInstance.withUpdateProposal(BigBang.protocolToUpdateProposal(protocol))
+              )
             ),
             datum = Datum.IoTransaction.defaultInstance
           )

--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -364,7 +364,7 @@ case class TestnetConfig(
 ) {
 
   val protocolUtxo: UnspentTransactionOutput =
-    UnspentTransactionOutput(PrivateTestnet.HeightLockOneSpendingAddress, BigBang.protocolToUpdateProposal(protocol))
+    UnspentTransactionOutput(PrivateTestnet.HeightLockOneSpendingAddress, BigBang.protocolToValue(protocol))
 
   val genesisTransactions: List[IoTransaction] =
     stakers.map { case (init, quantity) => init.registrationTransaction(quantity) } :+ IoTransaction.defaultInstance

--- a/node/src/main/scala/co/topl/node/cli/CliApp.scala
+++ b/node/src/main/scala/co/topl/node/cli/CliApp.scala
@@ -33,7 +33,8 @@ class ConfiguredCliApp(appConfig: ApplicationConfig) {
   private val applicationResource: Resource[F, Unit] =
     Sync[F]
       .defer(
-        (writeMessage[F]("Welcome to the Bifrost CLI") >> readUserCommand >>= handleUserCommand).value
+        writeMessage[F]("Welcome to the Bifrost CLI").value >>
+        (readUserCommand >>= handleUserCommand).value
           .iterateWhile(_ != StageResult.Exit)
           .void
       )


### PR DESCRIPTION
## Purpose
- It may be necessary to experiment with different protocol settings on different testnets
- This change adds some optional steps to the `init-testnet` command of the Bifrost CLI to allow a user to configure the protocol settings
## Approach
- Leverage helpers from the `proposal` command to configure the various settings of a protocol
- Insert user-constructed protocol into genesis UTxO
## Testing
- Manual testing
## Tickets
- #BN-1235