### PR TITLE
BodySemanticValidation Check Reward Input Address

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/ToplRpcServer.scala
@@ -39,7 +39,8 @@ object ToplRpcServer {
     case TransactionSyntaxError.InvalidProofType(_, _)       => "InvalidProofType"
     case TransactionSyntaxError.InvalidSchedule(s) =>
       show"InvalidSchedule(creation=${s.timestamp},maximumSlot=${s.max},minimumSlot=${s.min})"
-    case TransactionSyntaxError.InvalidDataLength => "InvalidDataLength"
+    case TransactionSyntaxError.InvalidDataLength        => "InvalidDataLength"
+    case TransactionSyntaxError.InvalidUpdateProposal(_) => "InvalidUpdateProposal"
   }
 
   /**

--- a/blockchain/src/test/scala/co/topl/blockchain/interpreters/EpochDataInterpreterSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/interpreters/EpochDataInterpreterSpec.scala
@@ -106,14 +106,15 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
             .useStateAt(_: BlockId)(_: EpochBoundariesEventSourcedState.EpochBoundaries[F] => F[BlockId]))
             .expects(*, *)
             .twice()
-            .onCall { case (_: BlockId, f: (EpochBoundariesEventSourcedState.EpochBoundaries[F] => F[BlockId])) =>
-              TestStore
-                .make[F, Epoch, BlockId]
-                .flatTap(_.put(0, block2.header.id))
-                .flatTap(_.put(1, block3.header.id))
-                .flatTap(_.put(2, block4.header.id))
-                .flatTap(_.put(3, block5.header.id))
-                .flatMap(f)
+            .onCall {
+              case (_: BlockId, f: (EpochBoundariesEventSourcedState.EpochBoundaries[F] => F[BlockId]) @unchecked) =>
+                TestStore
+                  .make[F, Epoch, BlockId]
+                  .flatTap(_.put(0, block2.header.id))
+                  .flatTap(_.put(1, block3.header.id))
+                  .flatTap(_.put(2, block4.header.id))
+                  .flatTap(_.put(3, block5.header.id))
+                  .flatMap(f)
             }
           consensusDataEss = mock[EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[
             F
@@ -122,37 +123,49 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
             .useStateAt(_: BlockId)(_: ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)]))
             .expects(genesisBlock.header.id, *)
             .repeat(2)
-            .onCall { case (_: BlockId, f: (ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)])) =>
-              (
-                TestStore.make[F, Unit, BigInt].flatTap(_.put((), 40)),
-                TestStore.make[F, Unit, BigInt].flatTap(_.put((), 0))
-              )
-                .mapN(ConsensusDataEventSourcedState.ConsensusData(_, _, null))
-                .flatMap(f)
+            .onCall {
+              case (
+                    _: BlockId,
+                    f: (ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)]) @unchecked
+                  ) =>
+                (
+                  TestStore.make[F, Unit, BigInt].flatTap(_.put((), 40)),
+                  TestStore.make[F, Unit, BigInt].flatTap(_.put((), 0))
+                )
+                  .mapN(ConsensusDataEventSourcedState.ConsensusData(_, _, null))
+                  .flatMap(f)
             }
           _ = (consensusDataEss
             .useStateAt(_: BlockId)(_: ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)]))
             .expects(block2.header.id, *)
             .once()
-            .onCall { case (_: BlockId, f: (ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)])) =>
-              (
-                TestStore.make[F, Unit, BigInt].flatTap(_.put((), 20)),
-                TestStore.make[F, Unit, BigInt].flatTap(_.put((), 20))
-              )
-                .mapN(ConsensusDataEventSourcedState.ConsensusData(_, _, null))
-                .flatMap(f)
+            .onCall {
+              case (
+                    _: BlockId,
+                    f: (ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)]) @unchecked
+                  ) =>
+                (
+                  TestStore.make[F, Unit, BigInt].flatTap(_.put((), 20)),
+                  TestStore.make[F, Unit, BigInt].flatTap(_.put((), 20))
+                )
+                  .mapN(ConsensusDataEventSourcedState.ConsensusData(_, _, null))
+                  .flatMap(f)
             }
           _ = (consensusDataEss
             .useStateAt(_: BlockId)(_: ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)]))
             .expects(block3.header.id, *)
             .once()
-            .onCall { case (_: BlockId, f: (ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)])) =>
-              (
-                TestStore.make[F, Unit, BigInt].flatTap(_.put((), 30)),
-                TestStore.make[F, Unit, BigInt].flatTap(_.put((), 10))
-              )
-                .mapN(ConsensusDataEventSourcedState.ConsensusData(_, _, null))
-                .flatMap(f)
+            .onCall {
+              case (
+                    _: BlockId,
+                    f: (ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)]) @unchecked
+                  ) =>
+                (
+                  TestStore.make[F, Unit, BigInt].flatTap(_.put((), 30)),
+                  TestStore.make[F, Unit, BigInt].flatTap(_.put((), 10))
+                )
+                  .mapN(ConsensusDataEventSourcedState.ConsensusData(_, _, null))
+                  .flatMap(f)
             }
           ess <- EpochDataEventSourcedState.make[F](
             BlockId(zeroBytes(32)).pure[F],

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BodySemanticValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BodySemanticValidation.scala
@@ -1,6 +1,6 @@
 package co.topl.ledger.interpreters
 
-import cats.data.{EitherT, NonEmptyChain, Validated, ValidatedNec}
+import cats.data.{EitherT, NonEmptyChain, OptionT, Validated, ValidatedNec}
 import cats.effect.Sync
 import cats.implicits._
 import co.topl.brambl.models.TransactionId
@@ -24,14 +24,18 @@ object BodySemanticValidation {
          * the outputs of previous transactions in the block, but no two transactions may spend the same input.
          */
         def validate(context: BodyValidationContext)(body: BlockBody): F[ValidatedNec[BodySemanticError, BlockBody]] =
-          // Note: Do not run validation on the reward transaction
-          body.transactionIds
-            .foldLeftM(List.empty[IoTransaction].validNec[BodySemanticError]) {
-              case (Validated.Valid(prefix), transactionId) =>
-                validateTransaction(context, prefix)(transactionId).map(prefix :+ _).value.map(_.toValidated)
-              case (invalid, _) => invalid.pure[F]
-            }
-            .map(_.as(body))
+          EitherT(validateReward(context)(body))
+            .flatMapF(_ =>
+              body.transactionIds
+                .foldLeftM(List.empty[IoTransaction].validNec[BodySemanticError]) {
+                  case (Validated.Valid(prefix), transactionId) =>
+                    validateTransaction(context, prefix)(transactionId).map(prefix :+ _).value.map(_.toValidated)
+                  case (invalid, _) => invalid.pure[F]
+                }
+                .map(_.toEither)
+            )
+            .as(body)
+            .toValidated
 
         /**
          * Fetch the given transaction ID and (semantically) validate it in the context of the given block ID.
@@ -42,7 +46,7 @@ object BodySemanticValidation {
         private def validateTransaction(
           context: BodyValidationContext,
           prefix:  Seq[IoTransaction]
-        )(transactionId: TransactionId) =
+        )(transactionId: TransactionId): EitherT[F, NonEmptyChain[BodySemanticError], IoTransaction] =
           for {
             transaction <- EitherT.liftF(fetchTransaction(transactionId))
             transactionValidationContext = StaticTransactionValidationContext(
@@ -76,6 +80,25 @@ object BodySemanticValidation {
                 )
               )
           } yield transaction
+
+        /**
+         * Verify that the reward transaction (if included) attempts to "spend" the parent header ID.
+         */
+        private def validateReward(context: BodyValidationContext)(body: BlockBody) =
+          OptionT
+            .fromOption[F](body.rewardTransactionId)
+            .semiflatMap(fetchTransaction)
+            .fold(
+              ().asRight[NonEmptyChain[BodySemanticError]]
+            )(reward =>
+              reward.inputs.headOption
+                .toRight(BodySemanticErrors.RewardTransactionError(reward))
+                .ensure(BodySemanticErrors.RewardTransactionError(reward))(
+                  _.address.id.value == context.parentHeaderId.value
+                )
+                .leftMap(NonEmptyChain[BodySemanticError](_))
+                .void
+            )
       }
     }
 

--- a/ledger/src/main/scala/co/topl/ledger/models/BodyValidationError.scala
+++ b/ledger/src/main/scala/co/topl/ledger/models/BodyValidationError.scala
@@ -27,6 +27,8 @@ object BodySemanticErrors {
   ) extends BodySemanticError
 
   case class TransactionRegistrationError(transaction: IoTransaction) extends BodySemanticError
+
+  case class RewardTransactionError(transaction: IoTransaction) extends BodySemanticError
 }
 
 sealed trait BodySyntaxError extends BodyValidationError

--- a/minting/src/test/scala/co/topl/minting/interpreters/OperationalKeyMakerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/OperationalKeyMakerSpec.scala
@@ -103,7 +103,7 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
         .rhoForSlot(_: Slot, _: Eta))
         .expects(*, *)
         .anyNumberOfTimes()
-        .onCall { case (slot: Slot, _: Eta) =>
+        .onCall { case (slot: Slot, _: Eta @unchecked) =>
           // Encode the slot as the first 8 bytes of the Rho so that it can be decoded by another mock later
           Rho(Sized.strictUnsafe(ByteString.copyFrom(Longs.toByteArray(slot)).concat(new Array[Byte](64 - 8)))).pure[F]
         }
@@ -118,7 +118,7 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
         .isSlotLeaderForThreshold(_: Ratio)(_: Rho))
         .expects(*, *)
         .anyNumberOfTimes()
-        .onCall { case (_: Ratio, rho: Rho) =>
+        .onCall { case (_: Ratio, rho: Rho @unchecked) =>
           // Decode the first 8 bytes of the Rho to determine the slot, and return true if the slot is "odd"
           (Longs.fromByteArray(rho.sizedBytes.data.take(8).toArray) % 2 != 0).pure[F]
         }


### PR DESCRIPTION
## Purpose
- Reward Transactions are able to construct tokens without actually spending any input
- To keep Reward Transactions unique, a single input is expected on the Transaction, and that single input is expected to reference the parent block ID as its value
## Approach
- In BodySemanticValidation, enforce that the reward transaction's input address contains the same bytes as the block's parent header ID
## Testing
- New unit tests
## Tickets
- #BN-1256
## Unrelated
- Fixed a few compiler warnings in unit tests by adding `@unchecked` annotations