### PR TITLE
Fixed possible spamming by BlockChecker

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
@@ -236,7 +236,7 @@ object BlockChecker {
       (appliedHeaders, error) <- processedHeadersAndErrors
       newState                <- processHeaderValidationError(state, error)
       _                       <- requestMissedBodies(newState, hostId, appliedHeaders.lastOption.map(_.id))
-      _                       <- requestNextHeaders(newState)
+      _                       <- if (appliedHeaders.nonEmpty) requestNextHeaders(newState) else ().pure[F]
     } yield (newState, newState)
   }
 
@@ -346,8 +346,8 @@ object BlockChecker {
     for {
       (appliedBlockIds, error) <- processedBlocksAndError
       stateAfterError          <- processBodyValidationError(state, error)
-      _                        <- requestNextBodies(stateAfterError, hostId)
-      newState                 <- updateState(stateAfterError, appliedBlockIds.lastOption).pure[F]
+      _        <- if (appliedBlockIds.nonEmpty) requestNextBodies(stateAfterError, hostId) else ().pure[F]
+      newState <- updateState(stateAfterError, appliedBlockIds.lastOption).pure[F]
     } yield (newState, newState)
   }
 


### PR DESCRIPTION
## Purpose
In some rare cases BlockChecker could send unnecessary messages to download block data, it shall be addressed 

## Approach
Request download block data if previous data wasn't empty / already known

## Testing
Unit tests

## Tickets
*
