### PR TITLE
Load Config from Environment

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
@@ -83,9 +83,9 @@ object BigBang {
   }
 
   val ParentId: BlockId = BlockId(ByteString.copyFrom(Array.fill[Byte](32)(0)))
-  val ParentSlot: Slot = -1
-  val Slot = 0
-  val Height = 1
+  val ParentSlot: Slot = -1L
+  val Slot: Slot = 0L
+  val Height: Long = 1L
 
   def vrfCertificate(eta: Eta): EligibilityCertificate = EligibilityCertificate(
     ByteString.copyFrom(Array.fill[Byte](80)(0)),

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
+import com.typesafe.sbt.packager.docker.DockerChmodType
 import sbt.Keys.{organization, test}
 import sbtassembly.MergeStrategy
+import NativePackagerHelper._
 
 val scala213 = "2.13.12"
 
@@ -66,8 +68,11 @@ lazy val dockerSettings = Seq(
 lazy val nodeDockerSettings =
   dockerSettings ++ Seq(
     dockerExposedPorts := Seq(9084, 9085),
-    dockerExposedVolumes ++= Seq("/bifrost-data", "/bifrost-staking", "/bifrost-config"),
-    Docker / packageName := "bifrost-node"
+    dockerExposedVolumes ++= Seq("/opt/docker/.bifrost/data", "/opt/docker/.bifrost/staking", "/opt/docker/conf"),
+    Docker / packageName := "bifrost-node",
+    Docker / mappings += (file("node/docker/conf/docker.yaml"), "/opt/docker/conf/docker.yaml"),
+    dockerEnvVars ++= Map("BIFROST_CONFIG_FILE" -> "conf/docker.yaml"),
+    dockerChmodType := DockerChmodType.UserGroupWriteExecute
   )
 
 lazy val networkDelayerDockerSettings =

--- a/build.sbt
+++ b/build.sbt
@@ -70,9 +70,10 @@ lazy val nodeDockerSettings =
     dockerExposedPorts := Seq(9084, 9085),
     Docker / packageName := "bifrost-node",
     dockerExposedVolumes += "/bifrost",
+    dockerExposedVolumes += "/bifrost-staking",
     dockerEnvVars ++= Map(
       "BIFROST_APPLICATION_DATA_DIR" -> "/bifrost/data/{genesisBlockId}",
-      "BIFROST_APPLICATION_STAKING_DIR" -> "/bifrost/staking/{genesisBlockId}",
+      "BIFROST_APPLICATION_STAKING_DIR" -> "/bifrost-staking/{genesisBlockId}",
       "BIFROST_CONFIG_FILE" -> "/bifrost/config/user.yaml"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
-import com.typesafe.sbt.packager.docker.DockerChmodType
+import com.typesafe.sbt.packager.docker.{DockerChmodType, ExecCmd}
 import sbt.Keys.{organization, test}
 import sbtassembly.MergeStrategy
-import NativePackagerHelper._
+import NativePackagerHelper.*
 
 val scala213 = "2.13.12"
 
@@ -68,11 +68,13 @@ lazy val dockerSettings = Seq(
 lazy val nodeDockerSettings =
   dockerSettings ++ Seq(
     dockerExposedPorts := Seq(9084, 9085),
-    dockerExposedVolumes ++= Seq("/opt/docker/.bifrost/data", "/opt/docker/.bifrost/staking", "/opt/docker/conf"),
     Docker / packageName := "bifrost-node",
-    Docker / mappings += (file("node/docker/conf/docker.yaml"), "/opt/docker/conf/docker.yaml"),
-    dockerEnvVars ++= Map("BIFROST_CONFIG_FILE" -> "conf/docker.yaml"),
-    dockerChmodType := DockerChmodType.UserGroupWriteExecute
+    dockerExposedVolumes += "/bifrost",
+    dockerEnvVars ++= Map(
+      "BIFROST_APPLICATION_DATA_DIR" -> "/bifrost/data/{genesisBlockId}",
+      "BIFROST_APPLICATION_STAKING_DIR" -> "/bifrost/staking/{genesisBlockId}",
+      "BIFROST_CONFIG_FILE" -> "/bifrost/config/user.yaml"
+    )
   )
 
 lazy val networkDelayerDockerSettings =

--- a/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
@@ -6,7 +6,7 @@ import cats.effect.implicits._
 import cats.effect.kernel.Sync
 import cats.implicits._
 import co.topl.algebras.NodeRpc
-import co.topl.blockchain.{PrivateTestnet, StakerInitializers, StakingInit}
+import co.topl.blockchain.{BigBang, PrivateTestnet, StakerInitializers, StakingInit}
 import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
 import co.topl.brambl.common.ContainsSignable.instances.ioTransactionSignable
 import co.topl.brambl.models.box.{Attestation, Value}
@@ -70,8 +70,10 @@ class MultiNodeTest extends IntegrationSuite {
         _ <- initialNodes
           .parTraverse(node => node.rpcClient[F](node.config.rpcPort).use(_.waitForRpcStartUp))
           .toResource
-        client         <- node0.rpcClient[F](node0.config.rpcPort)
-        genesisBlockId <- OptionT(client.blockIdAtHeight(1)).getOrRaise(new IllegalStateException).toResource
+        client <- node0.rpcClient[F](node0.config.rpcPort)
+        genesisBlockId <- OptionT(client.blockIdAtHeight(BigBang.Height))
+          .getOrRaise(new IllegalStateException)
+          .toResource
         genesisTransaction <-
           OptionT(client.fetchBlockBody(genesisBlockId))
             .map(_.transactionIds.head)

--- a/byzantine-it/src/test/scala/co/topl/byzantine/SanityCheckNodeTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/SanityCheckNodeTest.scala
@@ -4,6 +4,7 @@ import co.topl.byzantine.util._
 import com.spotify.docker.client.DockerClient
 import org.typelevel.log4cats.Logger
 import co.topl.interpreters.NodeRpcOps._
+import scala.concurrent.duration._
 
 class SanityCheckNodeTest extends IntegrationSuite {
 
@@ -25,7 +26,14 @@ class SanityCheckNodeTest extends IntegrationSuite {
         // Restart the container to verify that it is able to reload from disk
         _ <- node1.restartContainer[F].toResource
         _ <- node1Client.waitForRpcStartUp.toResource
-        _ <- fs2.Stream.force(node1Client.synchronizationTraversal()).drop(1).head.compile.lastOrError.toResource
+        _ <- fs2.Stream
+          .force(node1Client.synchronizationTraversal())
+          .drop(1)
+          .head
+          .compile
+          .lastOrError
+          .timeout(1.minute)
+          .toResource
         _ <- Logger[F].info("Success").toResource
       } yield ()
 

--- a/byzantine-it/src/test/scala/co/topl/byzantine/util/DockerSupport.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/util/DockerSupport.scala
@@ -147,7 +147,7 @@ object DockerSupport {
               HostConfig.Bind
                 .builder()
                 .from(sourceDir)
-                .to("/bifrost/staking")
+                .to("/bifrost-staking")
                 .selinuxLabeling(true)
                 .build()
             )

--- a/documentation/docs/reference/Installing Your Node/docker.md
+++ b/documentation/docs/reference/Installing Your Node/docker.md
@@ -11,10 +11,11 @@ tags:
 ## Quickstart
 
 ```sh
-mkdir ./bifrost-data
-sudo chown  1001 ./bifrost-data
-docker run -d --name bifrost-tetra $(pwd)/bifrost-data:/tmp/bifrost -p 9084:9084 -p 9085:9085 toplprotocol/bifrost-node:2.0.0-alpha10
+mkdir .bifrost
+sudo chown  1001 .bifrost
+docker run -d --name bifrost-tetra -v $(pwd)/.bifrost:/bifrost -p 9084:9084 -p 9085:9085 toplprotocol/bifrost-node:2.0.0-alpha10
 docker ps
+docker logs -f bifrost-tetra
 ```
 
 ## Ubuntu
@@ -51,9 +52,9 @@ docker run -d --name bifrost-tetra -p 9084:9084 -p 9085:9085 toplprotocol/bifros
 Run with volume to persist data
 
 ```sh
-mkdir ./bifrost-data
-sudo chown  1001 ./bifrost-data
-docker run -d --name bifrost-tetra $(pwd)/bifrost-data:/tmp/bifrost -p 9084:9084 -p 9085:9085 toplprotocol/bifrost-node:2.0.0-alpha10
+mkdir .bifrost
+sudo chown  1001 .bifrost
+docker run -d --name bifrost-tetra -v $(pwd)/.bifrost:/bifrost -p 9084:9084 -p 9085:9085 toplprotocol/bifrost-node:2.0.0-alpha10
 ```
 
 Interact with the node

--- a/network-delayer/src/main/scala/co/topl/networkdelayer/NetworkDelayer.scala
+++ b/network-delayer/src/main/scala/co/topl/networkdelayer/NetworkDelayer.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
 object NetworkDelayer
     extends IOBaseApp[Args, ApplicationConfig](
       createArgs = args => IO.delay(Args.parserArgs.constructOrThrow(args)),
-      createConfig = IOBaseApp.createTypesafeConfig,
+      createConfig = IOBaseApp.createTypesafeConfig(_),
       parseConfig = (_: Args, conf) => IO.delay(ApplicationConfig.unsafe(conf))
     ) {
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -19,10 +19,11 @@ import co.topl.networking.p2p.{DisconnectedPeer, PeerConnectionChange, RemoteAdd
 import co.topl.node.models.BlockBody
 import fs2.concurrent.Topic
 import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object ActorPeerHandlerBridgeAlgebra {
 
-  def make[F[_]: Async: Logger: DnsResolver](
+  def make[F[_]: Async: DnsResolver](
     thisHostId:                  HostId,
     localChain:                  LocalChainAlgebra[F],
     chainSelectionAlgebra:       ChainSelectionAlgebra[F, SlotData],
@@ -47,6 +48,7 @@ object ActorPeerHandlerBridgeAlgebra {
     addRemotePeer:               DisconnectedPeer => F[Unit],
     hotPeersUpdate:              Set[RemoteAddress] => F[Unit]
   ): Resource[F, BlockchainPeerHandlerAlgebra[F]] = {
+    implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName("Bifrost.P2P")
 
     val networkAlgebra = new NetworkAlgebraImpl[F](clockAlgebra)
     val networkManager =

--- a/node/docker/conf/docker.yaml
+++ b/node/docker/conf/docker.yaml
@@ -1,5 +1,0 @@
-bifrost:
-  data:
-    directory: /opt/docker/.bifrost/data/{genesisBlockId}
-  staking:
-    directory: /opt/docker/.bifrost/staking/{genesisBlockId}

--- a/node/docker/conf/docker.yaml
+++ b/node/docker/conf/docker.yaml
@@ -1,0 +1,5 @@
+bifrost:
+  data:
+    directory: /opt/docker/.bifrost/data/{genesisBlockId}
+  staking:
+    directory: /opt/docker/.bifrost/staking/{genesisBlockId}

--- a/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/app/Orchestrator.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/app/Orchestrator.scala
@@ -30,7 +30,7 @@ import scala.concurrent.duration._
 object Orchestrator
     extends IOBaseApp[Args, ApplicationConfig](
       createArgs = args => IO.delay(Args.parserArgs.constructOrThrow(args)),
-      createConfig = IOBaseApp.createTypesafeConfig,
+      createConfig = IOBaseApp.createTypesafeConfig(_),
       parseConfig = (_, conf) => IO.delay(ApplicationConfig.unsafe(conf))
     ) {
 

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/TransactionGeneratorApp.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/TransactionGeneratorApp.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration._
 object TransactionGeneratorApp
     extends IOBaseApp[Args, ApplicationConfig](
       createArgs = args => IO.delay(Args.parserArgs.constructOrThrow(args)),
-      createConfig = IOBaseApp.createTypesafeConfig,
+      createConfig = IOBaseApp.createTypesafeConfig(_),
       parseConfig = (_, conf) => IO.delay(ApplicationConfig.unsafe(conf))
     ) {
 


### PR DESCRIPTION
## Purpose
- To support upcoming work to allow the Bifrost CLI to generate a config file, the node needs a way to load a config file from a predictable location
## Approach
- Use an environment variable to reference a file location of a Bifrost configuration file
  - When empty, no-op
  - When provided, load and parse the file as a config
  - When provided but non-existent on disk, log and continue
- Also, updated the Docker settings
  - Volumes collapsed into `/bifrost`
  - Environment variables will save data to `/bifrost/data` and `/bifrost/staking` instead of the default `/tmp`
  - Configuration file will be loaded from `/bifrost/config/user.yaml` if it exists
    - In the future, this is where the CLI will save a user's configuration file
## Testing
- Manual testing with successive launches of the node
## Tickets
- #BN-1258