### PR TITLE
BN-1243 Add option to expose server port to P2P network or not

### DIFF
--- a/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
@@ -59,7 +59,8 @@ class MultiNodeTest extends IntegrationSuite {
                 bigBang,
                 totalNodeCount - 1,
                 index,
-                if (index == 0) Nil else List(s"MultiNodeTest-node${index - 1}")
+                if (index == 0) Nil else List(s"MultiNodeTest-node${index - 1}"),
+                exposeServerPort = if (index == 1) false else true
               )
             )
           )

--- a/byzantine-it/src/test/scala/co/topl/byzantine/util/DockerSupport.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/util/DockerSupport.scala
@@ -177,7 +177,8 @@ case class TestNodeConfig(
   p2pPort:              Int = 9085,
   jmxRemotePort:        Int = 9083,
   genusEnabled:         Boolean = false,
-  stakingBindSourceDir: Option[String] = None
+  stakingBindSourceDir: Option[String] = None,
+  exposeServerPort:     Boolean = true
 ) {
 
   def yaml: String = {
@@ -193,6 +194,7 @@ case class TestNodeConfig(
        |    bind-host: 0.0.0.0
        |    port: "$p2pPort"
        |    known-peers: "${knownPeers.map(p => s"$p:9085").mkString(",")}"
+       |    expose-server-port: "$exposeServerPort"
        |  big-bang:
        |    staker-count: $stakerCount
        |    local-staker-index: $localStakerIndex

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -48,6 +48,7 @@ object ApplicationConfig {
       publicHost:        String,
       publicPort:        Int,
       knownPeers:        List[KnownPeer],
+      exposeServerPort:  Boolean,
       networkProperties: NetworkProperties
     )
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -105,6 +105,16 @@ package object fsnetwork {
     case PingPongMessagePing(host, Left(networkError)) => show"$networkError from host $host"
   }
 
+  implicit def showPeer[F[_]]: Show[Peer[F]] = { peer: Peer[F] =>
+    "Peer" +
+    s" ${peer.ip}:[${peer.remoteServerPort.map(_.toString).getOrElse("")}];" +
+    s" State is ${peer.state.toString};" +
+    s" Actor is ${if (peer.actorOpt.isDefined) "present" else "absent"};" +
+    s" Remote peer is ${if (peer.remoteNetworkLevel) "active" else "no active"};" +
+    s" Reputation is: block=${peer.blockRep}, perf=${peer.perfRep}, new=${peer.newRep}, mean=${peer.reputation};" +
+    s" With total ${peer.closedTimestamps.size} closes with timestamps ${peer.closedTimestamps}"
+  }
+
   /**
    * Get some T from chain until reach terminateOn condition, f.e.
    * let assume we have chain:
@@ -179,12 +189,6 @@ package object fsnetwork {
 
   private val remoteAddressCodec: Codec[RemoteAddress] = (cstring :: int32).as[RemoteAddress]
   implicit val peerToAddCodec: Codec[RemotePeer] = (remoteAddressCodec :: double :: double).as[RemotePeer]
-
-  def getTotalReputation(
-    blockProvidingRep: HostReputationValue,
-    performanceRep:    HostReputationValue
-  ): HostReputationValue =
-    (blockProvidingRep + performanceRep) / 2
 
   case class P2PNetworkConfig(networkProperties: NetworkProperties, slotDuration: FiniteDuration) {
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
@@ -938,6 +938,68 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
     }
   }
 
+  test("Request to get server port do nothing if no server port is returned") {
+    withMock {
+      val peersManager = mock[PeersManagerActor[F]]
+      val requestsProxy = mock[RequestsProxyActor[F]]
+      val localChain = mock[LocalChainAlgebra[F]]
+      (() => localChain.genesis).expects().once().returning(genesis.pure[F])
+      val slotDataStore = mock[Store[F, BlockId, SlotData]]
+      val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
+      val blockIdTree = mock[ParentChildTree[F, BlockId]]
+      val blockHeights = mock[EventSourcedState[F, Long => F[Option[BlockId]], BlockId]]
+      val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
+      val client = createDummyClient()
+      val networkAlgebra = mock[NetworkAlgebra[F]]
+      val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
+      val transactionSyntaxValidation = mock[TransactionSyntaxVerifier[F]]
+      val mempool = mock[MempoolAlgebra[F]]
+
+      (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
+      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+
+      val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
+      (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
+      (networkAlgebra.makePeerBodyFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(blockBodyFetcher))
+
+      val mempoolSync = mock[PeerMempoolTransactionSyncActor[F]]
+      (() => mempoolSync.id).expects().anyNumberOfTimes().returns(3)
+      (networkAlgebra.makeMempoolSyncFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(mempoolSync))
+
+      val serverPort = 9085
+      (() => client.remotePeerServerPort)
+        .expects()
+        .returns(None.pure[F])
+
+      (peersManager.sendNoWait _)
+        .expects(PeersManager.Message.RemotePeerServerPort(hostId, serverPort))
+        .never()
+        .returns(Applicative[F].unit)
+
+      PeerActor
+        .makeActor(
+          hostId,
+          networkAlgebra,
+          client,
+          requestsProxy,
+          peersManager,
+          localChain,
+          slotDataStore,
+          transactionStore,
+          blockIdTree,
+          blockHeights,
+          headerToBodyValidation,
+          transactionSyntaxValidation,
+          mempool
+        )
+        .use { actor =>
+          for {
+            _ <- actor.send(PeerActor.Message.GetPeerServerAddress)
+          } yield ()
+        }
+    }
+  }
+
   test("Error during requesting of getting server port shall be processed") {
     withMock {
       val peersManager = mock[PeersManagerActor[F]]

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -26,7 +26,10 @@ bifrost {
     public-port = 9085
     // A comma-delimited list of host:port pairs to connect to initially (i.e. `1.2.3.4:9085,5.6.7.8:9085`)
     known-peers = ""
-    // Use actors system
+    // Expose our server port to P2P network, if set false then that peer will not be discovered by network
+    // no inbound connections will be done
+    expose-server-port = true
+    // Additional network properties
     network-properties {
       ping-pong-interval = 300 seconds
     }

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -366,6 +366,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
           protocolConfig,
           additionalGrpcServices,
           epochData,
+          appConfig.bifrost.p2p.exposeServerPort,
           appConfig.bifrost.p2p.networkProperties
         )
     } yield ()


### PR DESCRIPTION
## Purpose
Some nodes have no accessible  server port, thus incoming connections are not available, added an option to not propagate such inaccessible node addresses to P2P network

## Approach
Clear known server prot after established connection, request port from the remote peer. Remote peer send their own server port only if the appropriate option is set to true

## Testing
Unit test + integration test

## Tickets
closes BN-1243