### PR TITLE
Bifrost CLI: "Configure"

### DIFF
--- a/node/src/main/resources/logback.xml
+++ b/node/src/main/resources/logback.xml
@@ -1,5 +1,7 @@
 <configuration debug="false">
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS}| %-5level %logger{36} - %msg%n</pattern>

--- a/node/src/main/scala/co/topl/node/cli/CliApp.scala
+++ b/node/src/main/scala/co/topl/node/cli/CliApp.scala
@@ -15,11 +15,13 @@ class ConfiguredCliApp(appConfig: ApplicationConfig) {
 
   private val readUserCommand =
     (
-      writeMessage[F]("Please enter a command. [ QUIT | register | proposal | init-testnet]") >>
+      writeMessage[F]("Please enter a command. [ QUIT | configure | register | proposal | init-testnet]") >>
         readLowercasedInput
     ).semiflatMap {
       case "" | "quit" =>
         CliApp.Command.Quit.some.widen[CliApp.Command].pure[F]
+      case "configure" =>
+        CliApp.Command.Configure.some.widen[CliApp.Command].pure[F]
       case "register" =>
         CliApp.Command.Register.some.widen[CliApp.Command].pure[F]
       case "proposal" =>
@@ -43,6 +45,7 @@ class ConfiguredCliApp(appConfig: ApplicationConfig) {
   private def handleUserCommand(command: CliApp.Command): StageResultT[F, Unit] =
     command match {
       case CliApp.Command.Quit        => QuitCommand[F]
+      case CliApp.Command.Configure   => ConfigureCommand[F](appConfig)
       case CliApp.Command.Register    => RegistrationCommand[F](appConfig)
       case CliApp.Command.Proposal    => ProposalCommand[F]
       case CliApp.Command.InitTestnet => InitTestnetCommand[F](appConfig)
@@ -55,6 +58,7 @@ object CliApp {
 
   object Command {
     case object Quit extends Command
+    case object Configure extends Command
     case object Register extends Command
     case object Proposal extends Command
     case object InitTestnet extends Command

--- a/node/src/main/scala/co/topl/node/cli/ConfigureCommand.scala
+++ b/node/src/main/scala/co/topl/node/cli/ConfigureCommand.scala
@@ -1,0 +1,186 @@
+package co.topl.node.cli
+
+import cats.ApplicativeThrow
+import cats.data.OptionT
+import cats.effect.Async
+import cats.effect.std.{Console, Env}
+import cats.implicits._
+import co.topl.brambl.models.LockAddress
+import co.topl.config.ApplicationConfig
+import co.topl.consensus.models.BlockId
+import co.topl.node.AbstractNodeApp
+import co.topl.typeclasses.implicits._
+import fs2.io.file.{Files, Path}
+import io.circe._
+import io.circe.syntax._
+
+import java.nio.charset.StandardCharsets
+
+object ConfigureCommand {
+
+  def apply[F[_]: Async: Console](appConfig: ApplicationConfig): StageResultT[F, Unit] =
+    new ConfigureCommandImpl[F](appConfig).command
+
+}
+
+class ConfigureCommandImpl[F[_]: Async: Console](appConfig: ApplicationConfig) {
+
+  private val intro: StageResultT[F, Unit] =
+    writeMessage[F]("This utility helps configure your node.")
+
+  private val promptDataDir =
+    writeMessage[F](
+      s"Where should blockchain data be saved? (Leave blank to use default=${appConfig.bifrost.data.directory})"
+    ) >>
+    readInput[F].map(_.some.filterNot(_.isEmpty))
+
+  private val promptStakingSettings: StageResultT[F, (Option[String], Option[LockAddress])] =
+    readYesNo("Enable staking operations?", No.some)(
+      ifYes = for {
+        _ <- writeMessage[F](
+          s"Where should staking data be saved? (Leave blank to use default=${appConfig.bifrost.staking.directory})"
+        )
+        stakingDir <- readInput[F].map(_.some.filterNot(_.isEmpty))
+        rewardAddress <- readOptionalParameter[F, LockAddress](
+          "Reward Address",
+          List("ptetP7jshHTwEg9Fz9Xa1AmmzhYHDHo1zZRde7mnw3fddcXPjV14RPcgVgy7")
+        )
+      } yield (stakingDir, rewardAddress),
+      ifNo = (none[String], none[LockAddress]).pure[StageResultT[F, *]]
+    )
+
+  private val promptGenesis =
+    readYesNo("Configure genesis settings?", Yes.some)(
+      ifYes = for {
+        blockId <- readOptionalParameter[F, BlockId](
+          "Genesis Block ID",
+          List("b_EyNPwteBBfESqrLKPUQ3xRaxaDPESTTENKgMrkTMYGYa")
+        )
+        sourcePath <- readOptionalParameter[F, String](
+          "Genesis Data Source",
+          List("https://raw.githubusercontent.com/Topl/Genesis_Testnets/main/testnet2")
+        )
+      } yield (blockId, sourcePath),
+      ifNo = (none[BlockId], none[String]).pure[StageResultT[F, *]]
+    )
+
+  private val promptSettings =
+    for {
+      dataDir                             <- promptDataDir
+      (stakingDir, stakingRewardAddress)  <- promptStakingSettings
+      (genesisBlockId, genesisSourcePath) <- promptGenesis
+    } yield ConfigureCommandInput(dataDir, stakingDir, stakingRewardAddress, genesisBlockId, genesisSourcePath)
+
+  private def printConfig(configContents: String) =
+    writeMessage[F]("Configuration contents:") >> writeMessage[F](configContents)
+
+  private val promptDestination =
+    StageResultT
+      .liftF(OptionT(Env.make[F].get(AbstractNodeApp.ConfigFileEnvironmentVariable)).fold(Path("./user.yaml"))(Path(_)))
+      .flatMap(default =>
+        readDefaultedOptional[F, String]("Save location", List(default.toString, "/conf/app.yaml"), default.toString)
+      )
+      .map(Path(_))
+
+  private def saveConfig(destination: Path, configContents: String): StageResultT[F, Unit] = {
+    val w = writeFile(destination.parent.getOrElse(Path(".")))(configContents.getBytes(StandardCharsets.UTF_8))(
+      "Config File",
+      destination.fileName.toString
+    )
+    StageResultT
+      .liftF(Files.forAsync[F].exists(destination))
+      .ifM(
+        readYesNo("Destination file exists.  Merge-override contents?", Yes.some)(
+          ifYes = StageResultT
+            .liftF(Files.forAsync[F].readUtf8(destination).compile.foldMonoid)
+            .flatMap(mergeConfigs(_, configContents)),
+          ifNo = configContents.pure[StageResultT[F, *]]
+        ),
+        configContents.pure[StageResultT[F, *]]
+      )
+      .map(_.getBytes(StandardCharsets.UTF_8))
+      .flatMap(
+        writeFile(destination.parent.getOrElse(Path(".")))(_)(
+          "Config File",
+          destination.fileName.toString
+        )
+      )
+
+  }
+
+  private def outro(configFile: Path): StageResultT[F, Unit] =
+    writeMessage[F](s"Configuration complete.") >>
+    writeMessage[F](s"The node can be launched by passing the following argument at launch: --config $configFile")
+
+  private val outroNoConfig =
+    writeMessage[F](s"No configuration required. The node can be launched without arguments.")
+
+  private def mergeConfigs(existingConfigContents: String, newConfigContents: String): StageResultT[F, String] =
+    StageResultT.liftF(
+      ApplicativeThrow[F]
+        .fromEither(
+          (io.circe.yaml.parser.parse(existingConfigContents), io.circe.yaml.parser.parse(newConfigContents))
+            .mapN(_.deepMerge(_))
+        )
+        .map(io.circe.yaml.printer.pretty)
+    )
+
+  val command: StageResultT[F, Unit] =
+    for {
+      _        <- intro
+      settings <- promptSettings
+      _ <- OptionT
+        .fromOption[StageResultT[F, *]](settings.toYaml)
+        .foldF(outroNoConfig)(configYaml =>
+          for {
+            _               <- printConfig(configYaml)
+            saveDestination <- promptDestination
+            _               <- saveConfig(saveDestination, configYaml)
+            _               <- outro(saveDestination)
+          } yield ()
+        )
+    } yield ()
+}
+
+private[cli] case class ConfigureCommandInput(
+  dataDir:              Option[String],
+  stakingDir:           Option[String],
+  stakingRewardAddress: Option[LockAddress],
+  genesisBlockId:       Option[BlockId],
+  genesisSourcePath:    Option[String]
+) {
+
+  def toJson: Option[Json] =
+    Json
+      .obj(
+        "bifrost" -> Json
+          .obj(
+            "data" -> Json
+              .obj(
+                "dir" -> dataDir.asJson
+              )
+              .dropNullValues,
+            "staking" -> Json
+              .obj(
+                "dir"           -> stakingDir.asJson,
+                "rewardAddress" -> stakingRewardAddress.map(co.topl.brambl.codecs.AddressCodecs.encodeAddress).asJson
+              )
+              .dropNullValues,
+            "big-bang" -> Json
+              .obj(
+                "type"        -> genesisBlockId.void.orElse(genesisSourcePath.void).as("public").asJson,
+                "genesis-id"  -> genesisBlockId.map(_.show).asJson,
+                "source-path" -> genesisSourcePath.asJson
+              )
+              .dropNullValues
+          )
+          .dropEmptyValues
+      )
+      .dropEmptyValues
+      .asObject
+      .filter(_.nonEmpty)
+      .map(_.asJson)
+
+  def toYaml: Option[String] =
+    toJson.map(io.circe.yaml.printer.pretty)
+}

--- a/node/src/main/scala/co/topl/node/cli/ConfigureCommand.scala
+++ b/node/src/main/scala/co/topl/node/cli/ConfigureCommand.scala
@@ -229,13 +229,13 @@ private[cli] case class ConfigureCommandInput(
           .obj(
             "data" -> Json
               .obj(
-                "dir" -> dataDir.asJson
+                "directory" -> dataDir.asJson
               )
               .dropNullValues,
             "staking" -> Json
               .obj(
-                "dir"           -> stakingDir.asJson,
-                "rewardAddress" -> stakingRewardAddress.map(co.topl.brambl.codecs.AddressCodecs.encodeAddress).asJson
+                "directory"      -> stakingDir.asJson,
+                "reward-address" -> stakingRewardAddress.map(co.topl.brambl.codecs.AddressCodecs.encodeAddress).asJson
               )
               .dropNullValues,
             "big-bang" -> Json

--- a/node/src/main/scala/co/topl/node/cli/ProposalCommand.scala
+++ b/node/src/main/scala/co/topl/node/cli/ProposalCommand.scala
@@ -38,18 +38,18 @@ private class ProposalCommandImpl[F[_]: Async](implicit c: Console[F]) {
     for {
       _ <- writeMessage[F](Messages.intro)
 
-      label                      <- read[F, String]("label <required>", List("Update Slot duration"))
-      fEffective                 <- readOptional[F, Ratio]("f-effective", List("15/100"))
-      vrfLddCutoff               <- readOptional[F, Int]("vrf-ldd-cutoff", List("50"))
-      vrfPrecision               <- readOptional[F, Int]("vrf-precision", List("40"))
-      vrfBaselineDifficulty      <- readOptional[F, Ratio]("vrf-baseline-difficulty", List("1/20"))
-      vrfAmplitude               <- readOptional[F, Ratio]("vrf-amplitude", List("1/2"))
-      chainSelectionKLookback    <- readOptional[F, Long]("chain-selection-k-lookback", List("50"))
-      slotDuration               <- readOptional[F, Duration]("slot-duration", List("1000 milli"))
-      forwardBiasedSlotWindow    <- readOptional[F, Long]("forward-biased-slot-window", List("50"))
-      operationalPeriodsPerEpoch <- readOptional[F, Long]("operational-periods-per-epoch", List("2"))
-      kesKeyHours                <- readOptional[F, Int]("kes-key-hours", List("2"))
-      kesKeyMinutes              <- readOptional[F, Int]("kes-key-minutes", List("9"))
+      label                      <- readParameter[F, String]("label <required>", List("Update Slot duration"))
+      fEffective                 <- readOptionalParameter[F, Ratio]("f-effective", List("15/100"))
+      vrfLddCutoff               <- readOptionalParameter[F, Int]("vrf-ldd-cutoff", List("50"))
+      vrfPrecision               <- readOptionalParameter[F, Int]("vrf-precision", List("40"))
+      vrfBaselineDifficulty      <- readOptionalParameter[F, Ratio]("vrf-baseline-difficulty", List("1/20"))
+      vrfAmplitude               <- readOptionalParameter[F, Ratio]("vrf-amplitude", List("1/2"))
+      chainSelectionKLookback    <- readOptionalParameter[F, Long]("chain-selection-k-lookback", List("50"))
+      slotDuration               <- readOptionalParameter[F, Duration]("slot-duration", List("1000 milli"))
+      forwardBiasedSlotWindow    <- readOptionalParameter[F, Long]("forward-biased-slot-window", List("50"))
+      operationalPeriodsPerEpoch <- readOptionalParameter[F, Long]("operational-periods-per-epoch", List("2"))
+      kesKeyHours                <- readOptionalParameter[F, Int]("kes-key-hours", List("2"))
+      kesKeyMinutes              <- readOptionalParameter[F, Int]("kes-key-minutes", List("9"))
 
       proposal = UpdateProposal(
         label,
@@ -66,7 +66,7 @@ private class ProposalCommandImpl[F[_]: Async](implicit c: Console[F]) {
         kesKeyMinutes
       )
 
-      lockAddress <- read[F, LockAddress](
+      lockAddress <- readParameter[F, LockAddress](
         "Address",
         List("ptetP7jshHVrEKqDRdKAZtuybPZoMWTKKM2ngaJ7L5iZnxP5BprDB3hGJEFr")
       )

--- a/node/src/main/scala/co/topl/node/cli/package.scala
+++ b/node/src/main/scala/co/topl/node/cli/package.scala
@@ -106,7 +106,10 @@ package object cli {
         .drain
     }
 
-  def readParameter[F[_]: Sync: Console, T: UserInputParser](param: String, examples: List[String]): StageResultT[F, T] =
+  def readParameter[F[_]: Sync: Console, T: UserInputParser](
+    param:    String,
+    examples: List[String]
+  ): StageResultT[F, T] =
     readOptionalParameter[F, T](param, examples).untilDefinedM
 
   def readOptionalParameter[F[_]: Sync: Console, T: UserInputParser](
@@ -154,6 +157,13 @@ package object cli {
 
   implicit private[cli] val parseInt128: UserInputParser[Int128] = (s: String) =>
     parseBigInt.parse(s).map(bigInt => bigInt: Int128)
+
+  implicit private[cli] val parseBoolean: UserInputParser[Boolean] = (s: String) =>
+    s.toLowerCase match {
+      case "true" | "t" | "yes" | "y" => true.asRight[String]
+      case "false" | "f" | "no" | "n" => false.asRight[String]
+      case _                          => "Not a boolean".asLeft[Boolean]
+    }
 
   implicit private[cli] val parseString: UserInputParser[String] = (s: String) =>
     Either.cond(s.nonEmpty, s, "Empty Input")


### PR DESCRIPTION
## Purpose
- To assist with user on-boarding, a utility can guide users through the configuration process
## Approach
- New "configure" CLI command
  - Prompt user for common settings, default to None for all
  - Save settings as YAML to disk.  Default location is the value of the `BIFROST_CONFIG_FILE` environment variable.  If file exists, merge-and-overwrite.
## Testing
- User workflow
  - `mkdir .bifrost`
  - `sudo chown 1001 .bifrost`
  - `docker run --rm -it -v $(pwd)/.bifrost:/bifrost toplprotocol/bifrost-node cli`
  - `docker run --rm -it -v $(pwd)/.bifrost:/bifrost toplprotocol/bifrost-node`
## Tickets
- #BN-1295