### PR TITLE
Fix Slow Genus Shutdown

### DIFF
--- a/node/src/main/scala/co/topl/genus/Replicator.scala
+++ b/node/src/main/scala/co/topl/genus/Replicator.scala
@@ -10,7 +10,6 @@ import co.topl.algebras.SynchronizationTraversalStep
 import co.topl.algebras.SynchronizationTraversalSteps
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.genus.services.BlockData
-import co.topl.genusLibrary.model.GE
 import co.topl.interpreters.NodeRpcOps.clientAsNodeRpcApi
 import co.topl.typeclasses.implicits.showBlockId
 import org.typelevel.log4cats.Logger
@@ -63,7 +62,6 @@ object Replicator {
               .value
         }
         .rethrow
-        .recover(_ => ().asRight[GE])
 
     } yield ()
 }


### PR DESCRIPTION
## Purpose
- Genus takes a long time to shut down (usually exactly 30 seconds)
  - This is caused by the initialization ordering
    - Genus created
    - Replicator launched
    - gRPC services created (but not launched)
    - RPC Server launched
  - The Replicator acts as a gRPC client of its own node
  - Because the gRPC server is shutdown before the Replicator, the Replicator's gRPC client will wait until the stream/connection times out before releasing.
## Approach
- Re-order the Genus initialization such that the Replicator runs in parallel with the rest of Blockchain
- This allows the Replicator to cancel/shut-down immediately
## Testing
- Checked locally:
```
18:53:28.698| INFO  Genus.Replicator - Node RPC is ready. Awaiting Genesis block timestamp=1699469607622
18:53:28.699| INFO  Genus.Replicator - Genesis block timestamp reached.  Node is ready.
18:53:28.722| INFO  Genus.Replicator - Historical data start=1, end=1
18:53:28.783| INFO  Genus.Replicator - Inserting block data b_7R7SCkATv7yLVquVBznbfSExApCuThYMPa9TaEbGmEhz
18:53:28.834| INFO  Genus - No block found.
^CNov 08, 2023 6:53:32 PM com.orientechnologies.common.log.OLogManager log
WARNING: Received signal: SIGINT
Nov 08, 2023 6:53:32 PM com.orientechnologies.common.log.OLogManager log
INFO: Orient Engine is shutting down...
Nov 08, 2023 6:53:32 PM com.orientechnologies.common.log.OLogManager log
INFO: - shutdown storage: orient-db ...
Nov 08, 2023 6:53:33 PM com.orientechnologies.common.log.OLogManager log
INFO: Clearing byte buffer pool
Nov 08, 2023 6:53:33 PM com.orientechnologies.common.log.OLogManager log
INFO: OrientDB Engine shutdown complete
18:53:33.576| INFO  Bifrost.BlockProducer - Abandoned block attempt on parentId=b_7R7SCkATv7yLVquVBznbfSExApCuThYMPa9TaEbGmEhz
18:53:33.601| INFO  Bifrost.P2P - Stopping notification sending from Notifier actor
18:53:33.605| INFO  Bifrost.P2P - Going to save known hosts Set() to local data storage
18:53:33.605| INFO  Bifrost.Blockchain - P2P Actor system had been shutdown
```
(Less than 1 second between ctrl+c and shutdown completion)
## Tickets
N/A