### PR TITLE
BN-1242 Clear cold peers list

### DIFF
--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -60,6 +60,8 @@ object ApplicationConfig {
       minimumBlockProvidingReputationPeers: Int = 2,
       minimumPerformanceReputationPeers:    Int = 2,
       minimumRequiredReputation:            Double = 0.66,
+      minimumEligibleColdConnections:       Int = 50,
+      maximumEligibleColdConnections:       Int = 100,
       minimumHotConnections:                Int = 7,
       maximumWarmConnections:               Int = 12,
       warmHostsUpdateEveryNBlock:           Double = 4.0,

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
@@ -206,6 +206,11 @@ case class PeersHandler[F[_]: Async: Logger](
 
     updatedPeersF.map(peers => this.copy(peers = this.peers ++ peers.toMap))
   }
+
+  def copyWithRemovedPeers(toRemove: Set[HostId]): PeersHandler[F] = {
+    val newPeers = peers -- toRemove
+    this.copy(peers = newPeers)
+  }
 }
 
 case class Peer[F[_]: Logger](


### PR DESCRIPTION
## Purpose
We need to clear the cold peers list from time to time

## Approach
Clear cold peers which are eligible to make a connection if their amount is bigger than `maximumEligibleColdConnections`

## Testing
Unit tests

## Tickets
closes #BN-1242