### PR TITLE
BN-1287 Clear requests proxy invalidating block event had been had been called

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -296,7 +296,7 @@ object PeerActor {
       .flatMap { res =>
         val message =
           PeersManager.Message.PingPongMessagePing(state.hostId, res)
-        Logger[F].info(show"From host ${state.hostId}: $message") >>
+        Logger[F].debug(show"From host ${state.hostId}: $message") >>
         state.peersManager.sendNoWait(message)
       }
       .handleErrorWith { error =>

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -163,15 +163,13 @@ object PeerBlockHeaderFetcher {
   ): F[Unit] = {
     val newSourcesF =
       newSourcesOpt
-        .map(sources => state.peersManager.sendNoWait(PeersManager.Message.BlocksSource(sources)))
-        .getOrElse(().pure[F])
+        .traverse_(sources => state.peersManager.sendNoWait(PeersManager.Message.BlocksSource(sources)))
 
     val newSlotDataF =
       newSlotDataOpt
-        .map(newSlotData =>
+        .traverse_(newSlotData =>
           state.requestsProxy.sendNoWait(RequestsProxy.Message.RemoteSlotData(state.hostId, newSlotData))
         )
-        .getOrElse(().pure[F])
 
     newSourcesF >> newSlotDataF
   }


### PR DESCRIPTION
## Purpose
If we invalidate the block then we need to clear the proxy as well to be able to re-request the block in the future if required

## Approach
In case of an invalid block also clear all proxy cache

## Testing
unit tests

## Tickets
closes #BN-1287