### PR TITLE
[BN-1274]: Publish bifrost to dockerhub for dev images

### DIFF
--- a/.github/workflows/_docker_publish_dev.yml
+++ b/.github/workflows/_docker_publish_dev.yml
@@ -43,7 +43,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images to registries
-        run: DOCKER_PUBLISH_DEV_TAG=true sbt node/Docker/publish
+        run: DOCKER_PUBLISH_DEV_TAG=false sbt node/Docker/publish
 
       # Then publish other iamges to GCP Artifact Registry
       - id: "auth"

--- a/.github/workflows/_docker_publish_dev.yml
+++ b/.github/workflows/_docker_publish_dev.yml
@@ -1,15 +1,15 @@
-name: Publish Docker Images (Private)
+name: Publish Docker Images (Dev)
 
 on:
   workflow_call:
     inputs:
       remote-repository:
-        description: 'Name of the GCP managed Artifact Registry.'
+        description: "Name of the GCP managed Artifact Registry."
         default: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev/"
         required: false
         type: string
       registry-auth-location:
-        description: 'Name of the GCP managed Artifact Registry.'
+        description: "Name of the GCP managed Artifact Registry."
         default: "us-central1-docker.pkg.dev"
         required: false
         type: string
@@ -28,7 +28,25 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - id: 'auth'
+      # First publish bifrost-node to Dockerhub and GHCR (dev image).
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to the Github Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push images to registries
+        run: DOCKER_PUBLISH_DEV_TAG=true sbt node/Docker/publish
+
+      # Then publish other iamges to GCP Artifact Registry
+      - id: "auth"
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0
         with:
@@ -36,7 +54,7 @@ jobs:
           service_account: ${{ secrets.GCP_OIDC_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Set up gcloud
-        uses: 'google-github-actions/setup-gcloud@v0'
+        uses: "google-github-actions/setup-gcloud@v0"
 
       - name: Auth Artifact Registry
         run: gcloud auth configure-docker ${{ inputs.registry-auth-location }}
@@ -46,9 +64,7 @@ jobs:
 
       - name: Tag and push image to remote registry
         run: |
-          docker tag $(docker images toplprotocol/bifrost-node --format "{{.ID}}" | head -n 1) ${{ inputs.remote-repository }}/bifrost-node:$(docker images toplprotocol/bifrost-node --format "{{.Tag}}" | head -n 1)
           docker tag $(docker images toplprotocol/testnet-simulation-orchestrator --format "{{.ID}}" | head -n 1) ${{ inputs.remote-repository }}/testnet-simulation-orchestrator:$(docker images toplprotocol/testnet-simulation-orchestrator --format "{{.Tag}}" | head -n 1)
           docker tag $(docker images toplprotocol/network-delayer --format "{{.ID}}" | head -n 1) ${{ inputs.remote-repository }}/network-delayer:$(docker images toplprotocol/network-delayer --format "{{.Tag}}" | head -n 1)
-          docker push --all-tags ${{ inputs.remote-repository }}/bifrost-node
           docker push --all-tags ${{ inputs.remote-repository }}/testnet-simulation-orchestrator
           docker push --all-tags ${{ inputs.remote-repository }}/network-delayer

--- a/.github/workflows/_docker_publish_dev.yml
+++ b/.github/workflows/_docker_publish_dev.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v3

--- a/.github/workflows/_docker_publish_dev.yml
+++ b/.github/workflows/_docker_publish_dev.yml
@@ -44,7 +44,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images to registries
-        run: DOCKER_PUBLISH_DEV_TAG=false sbt node/Docker/publish
+        run: DOCKER_PUBLISH_DEV_TAG=true sbt node/Docker/publish
 
       # Then publish other iamges to GCP Artifact Registry
       - id: "auth"

--- a/.github/workflows/_docker_publish_release.yml
+++ b/.github/workflows/_docker_publish_release.yml
@@ -1,4 +1,4 @@
-name: Publish Docker Image (Public)
+name: Publish Docker Image (Release)
 
 on:
   workflow_call:
@@ -30,4 +30,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images to registries
-        run: DOCKER_PUBLISH_LATEST_TAG=false sbt node/Docker/publish
+        run: DOCKER_PUBLISH_LATEST_TAG=true sbt node/Docker/publish

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,31 +8,30 @@ on:
       - "release-**"
 
 jobs:
-  sbt-build:
-    uses: ./.github/workflows/_sbt_build.yml
-    with:
-      preserve-cache-between-runs: true
+  # sbt-build:
+  #   uses: ./.github/workflows/_sbt_build.yml
+  #   with:
+  #     preserve-cache-between-runs: true
 
-  sbt-integration-tests:
-    uses: ./.github/workflows/_sbt_integration_tests.yml
-    needs: [sbt-build]
-    with:
-      preserve-cache-between-runs: true
+  # sbt-integration-tests:
+  #   uses: ./.github/workflows/_sbt_integration_tests.yml
+  #   needs: [sbt-build]
+  #   with:
+  #     preserve-cache-between-runs: true
 
-  sbt-jar:
-    uses: ./.github/workflows/_sbt_jar.yml
-    needs: [sbt-build]
-    with:
-      preserve-cache-between-runs: true
+  # sbt-jar:
+  #   uses: ./.github/workflows/_sbt_jar.yml
+  #   needs: [sbt-build]
+  #   with:
+  #     preserve-cache-between-runs: true
 
   publish-docker-images-unofficial:
     uses: ./.github/workflows/_docker_publish_dev.yml
-    needs: [sbt-build, sbt-jar]
     with:
       remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
     secrets: inherit
 
-  publish-test-results:
-    uses: ./.github/workflows/_publish_test_results.yml
-    needs: [sbt-build, sbt-integration-tests]
-    if: always()
+  # publish-test-results:
+  #   uses: ./.github/workflows/_publish_test_results.yml
+  #   needs: [sbt-build, sbt-integration-tests]
+  #   if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,13 @@ jobs:
     with:
       preserve-cache-between-runs: true
 
+  publish-docker-images-unofficial:
+    uses: ./.github/workflows/_docker_publish_dev.yml
+    needs: [sbt-build, sbt-jar]
+    with:
+      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
+    secrets: inherit
+
   publish-test-results:
     uses: ./.github/workflows/_publish_test_results.yml
     needs: [sbt-build, sbt-integration-tests]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,30 +8,24 @@ on:
       - "release-**"
 
 jobs:
-  # sbt-build:
-  #   uses: ./.github/workflows/_sbt_build.yml
-  #   with:
-  #     preserve-cache-between-runs: true
-
-  # sbt-integration-tests:
-  #   uses: ./.github/workflows/_sbt_integration_tests.yml
-  #   needs: [sbt-build]
-  #   with:
-  #     preserve-cache-between-runs: true
-
-  # sbt-jar:
-  #   uses: ./.github/workflows/_sbt_jar.yml
-  #   needs: [sbt-build]
-  #   with:
-  #     preserve-cache-between-runs: true
-
-  publish-docker-images-unofficial:
-    uses: ./.github/workflows/_docker_publish_dev.yml
+  sbt-build:
+    uses: ./.github/workflows/_sbt_build.yml
     with:
-      remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"
-    secrets: inherit
+      preserve-cache-between-runs: true
 
-  # publish-test-results:
-  #   uses: ./.github/workflows/_publish_test_results.yml
-  #   needs: [sbt-build, sbt-integration-tests]
-  #   if: always()
+  sbt-integration-tests:
+    uses: ./.github/workflows/_sbt_integration_tests.yml
+    needs: [sbt-build]
+    with:
+      preserve-cache-between-runs: true
+
+  sbt-jar:
+    uses: ./.github/workflows/_sbt_jar.yml
+    needs: [sbt-build]
+    with:
+      preserve-cache-between-runs: true
+
+  publish-test-results:
+    uses: ./.github/workflows/_publish_test_results.yml
+    needs: [sbt-build, sbt-integration-tests]
+    if: always()

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/_sbt_jar.yml
     needs: [sbt-build]
   publish-docker-images-unofficial:
-    uses: ./.github/workflows/_docker_publish_private.yml
+    uses: ./.github/workflows/_docker_publish_dev.yml
     needs: [sbt-build, build-jar]
     with:
       remote-repository: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,6 @@ jobs:
             ${{ env.MD5_LOCATION }}
             ${{ env.SHA256_LOCATION }}
   publish-docker-images-official:
-    uses: ./.github/workflows/_docker_publish_public.yml
+    uses: ./.github/workflows/_docker_publish_release.yml
     needs: [create-release]
     secrets: inherit

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,13 @@ lazy val dockerSettings = Seq(
       alias.withRegistryHost(Some("docker.io/toplprotocol")),
       alias.withRegistryHost(Some("ghcr.io/topl"))
     )
-  }
+  },
+  dockerAliases ++= (
+    if (sys.env.get("DOCKER_PUBLISH_DEV_TAG").fold(false)(_.toBoolean)) Seq(
+      DockerAlias(Some("docker.io"), Some("toplprotocol"), "bifrost-node", Some("dev")),
+      DockerAlias(Some("ghcr.io"), Some("topl"), "bifrost-node", Some("dev"))
+    ) else Seq()
+  )
 )
 
 lazy val nodeDockerSettings =

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val dockerSettings = Seq(
   dockerAliases := dockerAliases.value.flatMap { alias =>
     Seq(
       alias.withTag(if (sys.env.get("DOCKER_PUBLISH_DEV_TAG").fold(false)(_.toBoolean)) Option("dev") else None),
-      alias.withRegistryHost(Some("docker.io/toplprotocol:blahblah")),
+      alias.withRegistryHost(Some("docker.io/toplprotocol")),
       alias.withRegistryHost(Some("ghcr.io/topl"))
     )
   }

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,6 @@ lazy val dockerSettings = Seq(
   ),
   dockerAliases := dockerAliases.value.flatMap { alias =>
     Seq(
-      alias.withTag(if (sys.env.get("DOCKER_PUBLISH_DEV_TAG").fold(false)(_.toBoolean)) Option("dev") else None),
       alias.withRegistryHost(Some("docker.io/toplprotocol")),
       alias.withRegistryHost(Some("ghcr.io/topl"))
     )

--- a/build.sbt
+++ b/build.sbt
@@ -53,13 +53,14 @@ lazy val commonSettings = Seq(
 
 lazy val dockerSettings = Seq(
   dockerBaseImage := "eclipse-temurin:11-jre",
-  dockerUpdateLatest := sys.env.get("DOCKER_PUBLISH_LATEST_TAG").fold(true)(_.toBoolean),
+  dockerUpdateLatest := sys.env.get("DOCKER_PUBLISH_LATEST_TAG").fold(false)(_.toBoolean),
   dockerLabels ++= Map(
     "bifrost.version" -> version.value
   ),
   dockerAliases := dockerAliases.value.flatMap { alias =>
     Seq(
-      alias.withRegistryHost(Some("docker.io/toplprotocol")),
+      alias.withTag(if (sys.env.get("DOCKER_PUBLISH_DEV_TAG").fold(false)(_.toBoolean)) Option("dev") else None),
+      alias.withRegistryHost(Some("docker.io/toplprotocol:blahblah")),
       alias.withRegistryHost(Some("ghcr.io/topl"))
     )
   }


### PR DESCRIPTION
## Purpose
Start publishing `bifrost-node` Docker image from dev branch to Dockerhub and GHCR.

## Approach
* Rename `_docker_publish_private.yml` and `_docker_pubilsh_public.yml` to  `_docker_publish_dev.yml` and `_docker_publish_releases.yml` to reflect new functionality.
* Update `_docker_publish_dev.yml` to publish to Dockerhub and GHCR. These will github sha tagged images.
* Invert `DOCKER_PUBLISH_LATEST_TAG` logic to be `false` by default so we have to explicitly opt in to publish the latest tag.
* `DOCKER_PUBLISH_DEV_TAG` can now be used to add the dev tag. This does not happen on releases.

## Testing
* https://github.com/Topl/Bifrost/pkgs/container/bifrost-node/146099641?tag=2.0.0-alpha10-26-d0ca7252
* https://hub.docker.com/layers/toplprotocol/bifrost-node/2.0.0-alpha10-26-d0ca7252/images/sha256-24f2f8fc16e8559c20b605c1ce3484d73b39e389b9397225e121aad83f477302?context=explore

## Tickets
* Bn-1274
