### PR TITLE
Epoch=0 Start at Slot=1

### DIFF
--- a/algebras/src/test/scala/co/topl/algebras/ClockAlgebraOpsSpec.scala
+++ b/algebras/src/test/scala/co/topl/algebras/ClockAlgebraOpsSpec.scala
@@ -23,7 +23,12 @@ class ClockAlgebraOpsSpec extends CatsEffectSuite with ScalaCheckEffectSuite wit
       clock.epochOf(1L).assertEquals(0L) >>
       clock.epochOf(500L).assertEquals(0L) >>
       clock.epochOf(499L).assertEquals(0L) >>
-      clock.epochOf(501L).assertEquals(1L)
+      clock.epochOf(501L).assertEquals(1L) >>
+      clock.epochOf(1000L).assertEquals(1L) >>
+      clock.epochOf(1001L).assertEquals(2L) >>
+      clock.epochOf(1500L).assertEquals(2L) >>
+      clock.epochOf(1500L).assertEquals(2L)
+      clock.epochOf(1501L).assertEquals(3L)
     }
   }
 

--- a/blockchain/src/main/scala/co/topl/blockchain/StakingInit.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/StakingInit.scala
@@ -6,7 +6,7 @@ import cats.effect._
 import cats.effect.implicits._
 import cats.implicits._
 import co.topl.algebras.ClockAlgebra
-import co.topl.algebras.ClockAlgebra.implicits.ClockOps
+import co.topl.algebras.ClockAlgebra.implicits._
 import co.topl.blockchain.algebras.NodeMetadataAlgebra
 import co.topl.brambl.models.{LockAddress, TransactionId}
 import co.topl.brambl.models.transaction.IoTransaction

--- a/blockchain/src/main/scala/co/topl/blockchain/StakingInit.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/StakingInit.scala
@@ -174,8 +174,14 @@ object StakingInit {
       _ <- Async[F]
         .whenA(beginSlot > globalSlot)(
           Logger[F].info(s"Delaying staking procedures until slot=$beginSlot") >>
-          clock.delayedUntilSlot(beginSlot) >>
-          Logger[F].info(s"Constructing staker")
+          clock.delayedUntilSlot(beginSlot)
+        )
+        .toResource
+      _ <- Logger[F]
+        .info(
+          show"Constructing staker with" +
+          show" activationSlot=$beginSlot" +
+          show" activationPeriod=$activationPeriod"
         )
         .toResource
       kesPath     <- Sync[F].delay(stakingDir / KesDirectoryName).toResource
@@ -195,7 +201,6 @@ object StakingInit {
           clock = clock,
           vrfCalculator = vrfCalculator,
           leaderElectionThreshold,
-          etaCalculation,
           consensusValidationState,
           cryptoResources.kesProduct,
           cryptoResources.ed25519

--- a/blockchain/src/test/scala/co/topl/blockchain/interpreters/EpochDataInterpreterSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/interpreters/EpochDataInterpreterSpec.scala
@@ -3,18 +3,18 @@ package co.topl.blockchain.interpreters
 import cats.data.OptionT
 import cats.effect.{IO, Sync}
 import cats.implicits._
-import co.topl.algebras.ClockAlgebra
 import co.topl.algebras.testInterpreters.TestStore
 import co.topl.brambl.common.ContainsImmutable
 import co.topl.brambl.models.box.{Attestation, Value}
 import co.topl.brambl.models.{Datum, LockAddress, LockId, TransactionId, TransactionOutputAddress}
 import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.TetraScodecCodecs
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.consensus.interpreters.{ConsensusDataEventSourcedState, EpochBoundariesEventSourcedState}
 import co.topl.consensus.models._
 import co.topl.eventtree.{EventSourcedState, ParentChildTree}
+import co.topl.interpreters.SchedulerClock
 import co.topl.ledger.algebras.TransactionRewardCalculatorAlgebra
 import co.topl.node.models.{BlockBody, FullBlock, FullBlockBody}
 import co.topl.numerics.implicits._
@@ -27,14 +27,16 @@ import quivr.models.Int128
 import co.topl.models._
 import co.topl.models.utility._
 import co.topl.proto.node.EpochData
-import scala.collection.immutable.NumericRange
+
+import java.time.Instant
+import scala.concurrent.duration._
 
 class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
   type F[A] = IO[A]
 
   private val lvlValue: Value =
-    Value().withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(100).toByteArray))))
+    Value.defaultInstance.withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(100).toByteArray))))
 
   private val emptyLockAddress =
     LockAddress(id = LockId(zeroBytes(32)))
@@ -77,13 +79,8 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
           _               <- parentChildTree.associate(block4.header.id, block3.header.id).toResource
           _               <- parentChildTree.associate(block5.header.id, block4.header.id).toResource
           state           <- TestStore.make[F, Epoch, EpochData].toResource
-          clock = mock[ClockAlgebra[F]]
-          _ = (() => clock.slotsPerEpoch).expects().anyNumberOfTimes().returning(10L.pure[F])
-          _ = (clock
-            .slotToTimestamps(_: Slot))
-            .expects(*)
-            .anyNumberOfTimes()
-            .onCall((slot: Slot) => NumericRange.inclusive[Long](slot * 1000, (slot + 1) * 1000 - 1, 1).pure[F])
+          clock <- SchedulerClock
+            .make[F](1000.milli, 10L, 1L, Instant.ofEpochMilli(genesisBlock.header.timestamp), 0L, () => 0L.pure[F])
           headerStore      <- TestStore.make[F, BlockId, BlockHeader].toResource
           bodyStore        <- TestStore.make[F, BlockId, BlockBody].toResource
           transactionStore <- TestStore.make[F, TransactionId, IoTransaction].toResource
@@ -105,11 +102,12 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
           _ = (epochBoundaryEss
             .useStateAt(_: BlockId)(_: EpochBoundariesEventSourcedState.EpochBoundaries[F] => F[BlockId]))
             .expects(*, *)
-            .twice()
+            .anyNumberOfTimes()
             .onCall {
               case (_: BlockId, f: (EpochBoundariesEventSourcedState.EpochBoundaries[F] => F[BlockId]) @unchecked) =>
                 TestStore
                   .make[F, Epoch, BlockId]
+                  .flatTap(_.put(-1, genesisBlock.header.id))
                   .flatTap(_.put(0, block2.header.id))
                   .flatTap(_.put(1, block3.header.id))
                   .flatTap(_.put(2, block4.header.id))
@@ -122,7 +120,7 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
           _ = (consensusDataEss
             .useStateAt(_: BlockId)(_: ConsensusDataEventSourcedState.ConsensusData[F] => F[(BigInt, BigInt)]))
             .expects(genesisBlock.header.id, *)
-            .repeat(2)
+            .repeat(3)
             .onCall {
               case (
                     _: BlockId,
@@ -168,7 +166,7 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
                   .flatMap(f)
             }
           ess <- EpochDataEventSourcedState.make[F](
-            BlockId(zeroBytes(32)).pure[F],
+            genesisBlock.header.parentHeaderId.pure[F],
             genesisBlock.header.id,
             parentChildTree,
             _ => IO.unit,
@@ -183,23 +181,41 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
           )
           canonicalHeadRef <- IO.ref(block5.header.id).toResource
           underTest        <- EpochDataInterpreter.make[F](Sync[F].defer(canonicalHeadRef.get), ess)
+          expectedDataMinus1 =
+            EpochData(
+              epoch = -1,
+              eon = 1,
+              era = 0,
+              isComplete = true,
+              startHeight = 1,
+              endHeight = 1,
+              startSlot = 0,
+              endSlot = 0,
+              startTimestamp = 0,
+              endTimestamp = 0,
+              transactionCount = 1,
+              totalTransactionReward = 50,
+              activeStake = 40,
+              inactiveStake = 0,
+              dataBytes = blockSize(genesisBlock)
+            )
           expectedData0 =
             EpochData(
               epoch = 0,
               eon = 1,
               era = 0,
               isComplete = true,
-              startHeight = 1,
+              startHeight = 2,
               endHeight = 2,
-              startSlot = 0,
-              endSlot = 9,
-              startTimestamp = 0,
-              endTimestamp = 9999,
-              transactionCount = 3,
-              totalTransactionReward = 150,
+              startSlot = 1,
+              endSlot = 10,
+              startTimestamp = 1000,
+              endTimestamp = 10999,
+              transactionCount = 2,
+              totalTransactionReward = 100,
               activeStake = 40,
               inactiveStake = 0,
-              dataBytes = blockSize(genesisBlock) + blockSize(block2)
+              dataBytes = blockSize(block2)
             )
           expectedData1 = EpochData(
             epoch = 1,
@@ -208,10 +224,10 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
             isComplete = true,
             startHeight = 3,
             endHeight = 3,
-            startSlot = 10,
-            endSlot = 19,
-            startTimestamp = 10000,
-            endTimestamp = 19999,
+            startSlot = 11,
+            endSlot = 20,
+            startTimestamp = 11000,
+            endTimestamp = 20999,
             transactionCount = 1,
             totalTransactionReward = 50,
             activeStake = 40,
@@ -225,10 +241,10 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
             isComplete = true,
             startHeight = 4,
             endHeight = 4,
-            startSlot = 20,
-            endSlot = 29,
-            startTimestamp = 20000,
-            endTimestamp = 29999,
+            startSlot = 21,
+            endSlot = 30,
+            startTimestamp = 21000,
+            endTimestamp = 30999,
             transactionCount = 2,
             totalTransactionReward = 100,
             activeStake = 20,
@@ -242,10 +258,10 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
             isComplete = false,
             startHeight = 5,
             endHeight = 5,
-            startSlot = 30,
-            endSlot = 39,
-            startTimestamp = 30000,
-            endTimestamp = 39999,
+            startSlot = 31,
+            endSlot = 40,
+            startTimestamp = 31000,
+            endTimestamp = 40999,
             transactionCount = 1,
             totalTransactionReward = 50,
             activeStake = 30,
@@ -253,42 +269,25 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
             dataBytes = blockSize(block5)
           )
           _ <- List(
-            0 -> expectedData0,
-            1 -> expectedData1,
-            2 -> expectedData2,
-            3 -> expectedData3,
-            2 -> expectedData2,
-            1 -> expectedData1,
-            0 -> expectedData0
+            -1 -> expectedDataMinus1,
+            0  -> expectedData0,
+            1  -> expectedData1,
+            2  -> expectedData2,
+            3  -> expectedData3,
+            2  -> expectedData2,
+            1  -> expectedData1,
+            0  -> expectedData0
           ).traverse { case (i, expectedData) =>
             OptionT(underTest.dataOf(i)).getOrRaise(new NoSuchElementException).assertEquals(expectedData).toResource
           }
 
           // Verify the "unapply" functionality works
           _ <- canonicalHeadRef.set(genesisBlock.header.id).toResource
-          altExpectedData0 =
-            EpochData(
-              epoch = 0,
-              eon = 1,
-              era = 0,
-              isComplete = false,
-              startHeight = 1,
-              endHeight = 1,
-              startSlot = 0,
-              endSlot = 9,
-              startTimestamp = 0,
-              endTimestamp = 9999,
-              transactionCount = 1,
-              totalTransactionReward = 50,
-              activeStake = 40,
-              inactiveStake = 0,
-              dataBytes = blockSize(genesisBlock)
-            )
-          _ <- OptionT(underTest.dataOf(0))
+          _ <- OptionT(underTest.dataOf(-1))
             .getOrRaise(new NoSuchElementException)
-            .assertEquals(altExpectedData0)
+            .assertEquals(expectedDataMinus1)
             .toResource
-          _ <- underTest.dataOf(1).assertEquals(None).toResource
+          _ <- underTest.dataOf(0).assertEquals(None).toResource
         } yield ()
       testResource.use_
     }
@@ -300,7 +299,7 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
       parentSlot = -1,
       txRoot = zeroBytes(32),
       bloomFilter = zeroBytes(256),
-      timestamp = System.currentTimeMillis(),
+      timestamp = 0L,
       height = 1,
       slot = 0,
       eligibilityCertificate = eligibilityCertificate,

--- a/byzantine-it/src/test/resources/logback-test.xml
+++ b/byzantine-it/src/test/resources/logback-test.xml
@@ -1,5 +1,7 @@
 <configuration debug="true">
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoders are by default assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder -->

--- a/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
@@ -124,12 +124,15 @@ class MultiNodeTest extends IntegrationSuite {
         _ <- Logger[F].info("Nodes have reached target epoch").toResource
         // The delayed node's blocks should be valid on other nodes (like node0), so search node0 for adoptions of a block produced
         // by the delayed node's staking address
+        _ <- Logger[F].info("Searching for block from new staker").toResource
         _ <- client.adoptedHeaders
           .find(_.address == delayedNodeStakingAddress)
           .timeout(2.minutes)
           .compile
           .lastOrError
           .toResource
+        _ <- Logger[F].info("Found block from new staker").toResource
+        _ <- Logger[F].info("Verifying consensus of nodes").toResource
         heights = thirdEpochHeads.map(_.height)
         // All nodes should be at _roughly_ equal height
         _ <- IO(heights.max - heights.min <= 5).assert.toResource
@@ -143,6 +146,7 @@ class MultiNodeTest extends IntegrationSuite {
           .map(_.toSet.size)
           .assertEquals(1)
           .toResource
+        _ <- Logger[F].info("Nodes are in consensus").toResource
       } yield ()
 
     resource.use_

--- a/common-interpreters/src/main/scala/co/topl/interpreters/SchedulerClock.scala
+++ b/common-interpreters/src/main/scala/co/topl/interpreters/SchedulerClock.scala
@@ -50,9 +50,12 @@ object SchedulerClock {
 
         override def slotToTimestamps(slot: Slot): F[NumericRange.Inclusive[Long]] =
           Sync[F].delay {
-            val startTimestamp = startTime + (slot * _slotLength.toMillis)
-            val endTimestamp = startTimestamp + (_slotLength.toMillis - 1)
-            NumericRange.inclusive(startTimestamp, endTimestamp, 1L)
+            if (slot == 0L) (0L to startTime)
+            else {
+              val startTimestamp = startTime + (slot * _slotLength.toMillis)
+              val endTimestamp = startTimestamp + (_slotLength.toMillis - 1)
+              NumericRange.inclusive(startTimestamp, endTimestamp, 1L)
+            }
           }
 
         override val forwardBiasedSlotWindow: F[Slot] = _forwardBiasedSlotWindow.pure[F]

--- a/common-interpreters/src/test/resources/logback-test.xml
+++ b/common-interpreters/src/test/resources/logback-test.xml
@@ -1,5 +1,7 @@
 <configuration debug="false">
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS}| %-5level %logger{36} - %msg%n</pattern>

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusValidationState.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusValidationState.scala
@@ -46,11 +46,10 @@ object ConsensusValidationState {
         )(f: ConsensusDataEventSourcedState.ConsensusData[F] => F[Res]): F[Res] =
           for {
             epoch <- clock.epochOf(slot)
-            targetEpoch = epoch - 2
             // Note: Blocks created within the first two epochs should use the state from the genesis block
             boundaryBlockId <-
-              if (targetEpoch > 0)
-                epochBoundaryEventSourcedState.useStateAt(currentBlockId)(_.getOrRaise(targetEpoch))
+              if (epoch > 1)
+                epochBoundaryEventSourcedState.useStateAt(currentBlockId)(_.getOrRaise(epoch - 2))
               else
                 genesisBlockId.pure[F]
             res <- consensusDataEventSourcedState.useStateAt(boundaryBlockId)(f)

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusValidationState.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/ConsensusValidationState.scala
@@ -49,7 +49,7 @@ object ConsensusValidationState {
             targetEpoch = epoch - 2
             // Note: Blocks created within the first two epochs should use the state from the genesis block
             boundaryBlockId <-
-              if (targetEpoch >= 0)
+              if (targetEpoch > 0)
                 epochBoundaryEventSourcedState.useStateAt(currentBlockId)(_.getOrRaise(targetEpoch))
               else
                 genesisBlockId.pure[F]

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/EtaCalculation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/EtaCalculation.scala
@@ -165,7 +165,5 @@ object EtaCalculation {
         .map(v => v: ByteString)
         .map(Sized.strictUnsafe(_): Eta)
 
-    private def emptyEpochDetected(epoch: Epoch) =
-      MonadThrow[F].raiseError(new IllegalStateException(s"Eta calculation encountered empty epoch=$epoch"))
   }
 }

--- a/consensus/src/test/resources/logback-test.xml
+++ b/consensus/src/test/resources/logback-test.xml
@@ -1,5 +1,7 @@
 <configuration debug="false">
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoders are by default assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder -->

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusValidationStateSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/ConsensusValidationStateSpec.scala
@@ -36,7 +36,7 @@ class ConsensusValidationStateSpec extends CatsEffectSuite with ScalaCheckEffect
               TestStore.make[F, Unit, BigInt],
               TestStore.make[F, StakingAddress, ActiveStaker]
             ).mapN(ConsensusDataEventSourcedState.ConsensusData[F])
-            _ <- boundaryStore.put(3L, n2Id)
+            _ <- boundaryStore.put(2L, n2Id)
             _ <- consensusData.stakers.put(staker.registration.address, staker)
             epochBoundaryEventSourcedState = new EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
               F

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/EpochBoundariesEventSourcedStateSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/EpochBoundariesEventSourcedStateSpec.scala
@@ -64,11 +64,11 @@ class EpochBoundariesEventSourcedStateSpec extends CatsEffectSuite with ScalaChe
           )
 
         _ <- underTest.useStateAt(slotData.last.slotId.blockId)(state =>
-          state.getOrRaise(0).assertEquals(slotData(1).slotId.blockId) >>
-          state.getOrRaise(1).assertEquals(slotData(3).slotId.blockId) >>
-          state.getOrRaise(2).assertEquals(slotData(5).slotId.blockId) >>
-          state.getOrRaise(3).assertEquals(slotData(7).slotId.blockId) >>
-          state.getOrRaise(4).assertEquals(slotData(9).slotId.blockId)
+          state.getOrRaise(-1).assertEquals(slotData(0).slotId.blockId) >>
+          state.getOrRaise(0).assertEquals(slotData(2).slotId.blockId) >>
+          state.getOrRaise(1).assertEquals(slotData(4).slotId.blockId) >>
+          state.getOrRaise(2).assertEquals(slotData(6).slotId.blockId) >>
+          state.getOrRaise(3).assertEquals(slotData(8).slotId.blockId)
         )
 
       } yield ()
@@ -104,7 +104,7 @@ class EpochBoundariesEventSourcedStateSpec extends CatsEffectSuite with ScalaChe
           )
 
         _ <- underTest.useStateAt(slotData.last.slotId.blockId)(state =>
-          state.get(-1).assertEquals(None) >>
+          state.get(-1).assertEquals(slotData.head.slotId.blockId.some) >>
           state.get(2).assertEquals(None)
         )
 

--- a/genus-library/src/test/resources/logback-test.xml
+++ b/genus-library/src/test/resources/logback-test.xml
@@ -1,5 +1,7 @@
 <configuration debug="false">
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS}| %-5level %logger{36} - %msg%n</pattern>

--- a/ledger/src/test/resources/logback-test.xml
+++ b/ledger/src/test/resources/logback-test.xml
@@ -1,5 +1,7 @@
 <configuration debug="false">
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS}| %-5level %logger{36} - %msg%n</pattern>

--- a/minting/src/main/scala/co/topl/minting/algebras/OperationalKeyMakerAlgebra.scala
+++ b/minting/src/main/scala/co/topl/minting/algebras/OperationalKeyMakerAlgebra.scala
@@ -1,7 +1,7 @@
 package co.topl.minting.algebras
 
 import co.topl.minting.models.OperationalKeyOut
-import co.topl.models.Slot
+import co.topl.models.{Eta, Slot}
 import co.topl.consensus.models.SlotId
 
 /**
@@ -9,5 +9,5 @@ import co.topl.consensus.models.SlotId
  * it for some particular slot on demand
  */
 trait OperationalKeyMakerAlgebra[F[_]] {
-  def operationalKeyForSlot(slot: Slot, parentSlotId: SlotId): F[Option[OperationalKeyOut]]
+  def operationalKeyForSlot(slot: Slot, parentSlotId: SlotId, eta: Eta): F[Option[OperationalKeyOut]]
 }

--- a/minting/src/main/scala/co/topl/minting/algebras/StakingAlgebra.scala
+++ b/minting/src/main/scala/co/topl/minting/algebras/StakingAlgebra.scala
@@ -44,6 +44,7 @@ trait StakingAlgebra[F[_]] {
   def certifyBlock(
     parentSlotId:         SlotId,
     slot:                 Slot,
-    unsignedBlockBuilder: UnsignedBlockHeader.PartialOperationalCertificate => UnsignedBlockHeader
+    unsignedBlockBuilder: UnsignedBlockHeader.PartialOperationalCertificate => UnsignedBlockHeader,
+    eta:                  Eta
   ): F[Option[BlockHeader]]
 }

--- a/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
@@ -78,7 +78,7 @@ object Staking {
           parentSlotId:         SlotId,
           slot:                 Slot,
           unsignedBlockBuilder: UnsignedBlockHeader.PartialOperationalCertificate => UnsignedBlockHeader,
-          eta: Eta
+          eta:                  Eta
         ): F[Option[BlockHeader]] =
           OptionT(operationalKeyMaker.operationalKeyForSlot(slot, parentSlotId, eta)).semiflatMap { operationalKeyOut =>
             for {

--- a/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
@@ -77,9 +77,10 @@ object Staking {
         def certifyBlock(
           parentSlotId:         SlotId,
           slot:                 Slot,
-          unsignedBlockBuilder: UnsignedBlockHeader.PartialOperationalCertificate => UnsignedBlockHeader
+          unsignedBlockBuilder: UnsignedBlockHeader.PartialOperationalCertificate => UnsignedBlockHeader,
+          eta: Eta
         ): F[Option[BlockHeader]] =
-          OptionT(operationalKeyMaker.operationalKeyForSlot(slot, parentSlotId)).semiflatMap { operationalKeyOut =>
+          OptionT(operationalKeyMaker.operationalKeyForSlot(slot, parentSlotId, eta)).semiflatMap { operationalKeyOut =>
             for {
               partialCertificate <- Sync[F].delay(
                 UnsignedBlockHeader.PartialOperationalCertificate(

--- a/minting/src/test/resources/logback-test.xml
+++ b/minting/src/test/resources/logback-test.xml
@@ -1,5 +1,7 @@
 <configuration debug="false">
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoders are by default assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder -->

--- a/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
@@ -54,8 +54,8 @@ class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
             .once()
             .returning(vrfHit.some.pure[F])
           (staker
-            .certifyBlock(_, _, _))
-            .expects(parentSlotData.slotId, vrfHit.slot, *)
+            .certifyBlock(_, _, _, _))
+            .expects(parentSlotData.slotId, vrfHit.slot, *, *)
             .once()
             .returning(outputHeader.some.pure[F])
 
@@ -66,8 +66,8 @@ class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
               .returning(rewardAddress.pure[F])
 
           val clock = mock[ClockAlgebra[F]]
-          (() => clock.slotsPerEpoch).expects().once().returning(300L.pure[F])
-          (() => clock.globalSlot).expects().twice().returning((parentSlotData.slotId.slot + 1).pure[F])
+          (() => clock.slotsPerEpoch).expects().anyNumberOfTimes().returning(300L.pure[F])
+          (() => clock.globalSlot).expects().anyNumberOfTimes().returning((parentSlotData.slotId.slot + 1).pure[F])
           (clock
             .slotToTimestamps(_))
             .expects(vrfHit.slot)

--- a/minting/src/test/scala/co/topl/minting/interpreters/OperationalKeyMakerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/OperationalKeyMakerSpec.scala
@@ -239,7 +239,7 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
       (consensusState
         .operatorRelativeStake(_: BlockId, _: Slot)(_: StakingAddress)(_: Monad[F]))
         .expects(*, *, *, *)
-        .once()
+        .anyNumberOfTimes()
         .returning(Ratio.One.some.pure[F])
 
       val res = for {
@@ -261,9 +261,9 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
           )
         // The keys are created in a background fiber, so we need to wait for that fiber to complete before
         // verifying mocks
-        _ <- underTest.operationalKeyForSlot(operationalPeriodLength * 2 - 1, parentSlotId).toResource
+        _ <- underTest.operationalKeyForSlot(operationalPeriodLength * 2, parentSlotId).toResource
         _ <- Range
-          .Long(operationalPeriodLength, operationalPeriodLength * 2, 1)
+          .Long(operationalPeriodLength + 1, operationalPeriodLength * 2, 1)
           .toVector
           .traverse(slot =>
             verifyOut(underTest)(vk.copy(step = 1), slot, parentSlotId)(kesProductResource, ed25519Resource)

--- a/minting/src/test/scala/co/topl/minting/interpreters/OperationalKeyMakerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/OperationalKeyMakerSpec.scala
@@ -24,12 +24,9 @@ import com.google.protobuf.ByteString
 import munit.CatsEffectSuite
 import munit.ScalaCheckEffectSuite
 import org.scalamock.munit.AsyncMockFactory
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 import scala.util.Random
 
 class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
@@ -37,8 +34,6 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
   override def munitTimeout: Duration = new FiniteDuration(2, TimeUnit.MINUTES)
 
   type F[A] = cats.effect.IO[A]
-
-  implicit private val logger: Logger[F] = Slf4jLogger.getLoggerFromName("OperationalKeyMakerSpec")
 
   implicit private val kesProduct: KesProduct = new KesProduct
 
@@ -52,7 +47,6 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
       val clock = mock[ClockAlgebra[F]]
       val vrfCalculator = mock[VrfCalculatorAlgebra[F]]
       val leaderElection = mock[LeaderElectionValidationAlgebra[F]]
-      val etaCalculation = mock[EtaCalculationAlgebra[F]]
       val consensusState = mock[ConsensusValidationStateAlgebra[F]]
       val parentSlotId = SlotId(0L, BlockId.of(ByteString.copyFrom(Array.fill(32)(0: Byte))))
       val operationalPeriodLength = 30L
@@ -92,12 +86,6 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
         .expects(*, *, *)
         .once()
         .returning(Applicative[F].unit)
-
-      (etaCalculation
-        .etaToBe(_: SlotId, _: Slot))
-        .expects(*, *)
-        .once()
-        .returning(eta.pure[F])
 
       (vrfCalculator
         .rhoForSlot(_: Slot, _: Eta))
@@ -141,23 +129,22 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
             clock,
             vrfCalculator,
             leaderElection,
-            etaCalculation,
             consensusState,
             kesProductResource,
             ed25519Resource
           )
           // The keys are created in a background fiber, so we need to wait for that fiber to complete before
           // verifying mocks
-          _ <- underTest.operationalKeyForSlot(operationalPeriodLength - 1, parentSlotId).toResource
+          _ <- underTest.operationalKeyForSlot(operationalPeriodLength - 1, parentSlotId, eta).toResource
 
           _ <- Range
             .Long(1, operationalPeriodLength, 1)
             .toVector
             .traverse(slot =>
               if (ineligibilities.contains(slot))
-                underTest.operationalKeyForSlot(slot, parentSlotId).assertEquals(None)
+                underTest.operationalKeyForSlot(slot, parentSlotId, eta).assertEquals(None)
               else
-                verifyOut(underTest)(vk, slot, parentSlotId)(kesProductResource, ed25519Resource)
+                verifyOut(underTest)(vk, slot, parentSlotId, eta)(kesProductResource, ed25519Resource)
             )
             .toResource
         } yield ()
@@ -172,7 +159,6 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
       val secureStore = mock[SecureStore[F]]
       val clock = mock[ClockAlgebra[F]]
       val vrfCalculator = mock[VrfCalculatorAlgebra[F]]
-      val etaCalculation = mock[EtaCalculationAlgebra[F]]
       val leaderElection = mock[LeaderElectionValidationAlgebra[F]]
       val consensusState = mock[ConsensusValidationStateAlgebra[F]]
       val parentSlotId = SlotId(10L, BlockId.of(ByteString.copyFrom(Array.fill(32)(0: Byte))))
@@ -230,12 +216,6 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
         .anyNumberOfTimes()
         .returning(true.pure[F])
 
-      (etaCalculation
-        .etaToBe(_: SlotId, _: Slot))
-        .expects(*, *)
-        .once()
-        .returning(eta.pure[F])
-
       (consensusState
         .operatorRelativeStake(_: BlockId, _: Slot)(_: StakingAddress)(_: Monad[F]))
         .expects(*, *, *, *)
@@ -254,19 +234,18 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
             clock,
             vrfCalculator,
             leaderElection,
-            etaCalculation,
             consensusState,
             kesProductResource,
             ed25519Resource
           )
         // The keys are created in a background fiber, so we need to wait for that fiber to complete before
         // verifying mocks
-        _ <- underTest.operationalKeyForSlot(operationalPeriodLength * 2, parentSlotId).toResource
+        _ <- underTest.operationalKeyForSlot(operationalPeriodLength * 2, parentSlotId, eta).toResource
         _ <- Range
           .Long(operationalPeriodLength + 1, operationalPeriodLength * 2, 1)
           .toVector
           .traverse(slot =>
-            verifyOut(underTest)(vk.copy(step = 1), slot, parentSlotId)(kesProductResource, ed25519Resource)
+            verifyOut(underTest)(vk.copy(step = 1), slot, parentSlotId, eta)(kesProductResource, ed25519Resource)
           )
           .toResource
       } yield ()
@@ -277,10 +256,11 @@ class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite
   private def verifyOut(underTest: OperationalKeyMakerAlgebra[F])(
     parentVK:     VerificationKeyKesProduct,
     slot:         Slot,
-    parentSlotId: SlotId
+    parentSlotId: SlotId,
+    eta:          Eta
   )(kesProductResource: Resource[F, KesProduct], ed25519Resource: Resource[F, Ed25519]) =
     for {
-      out <- underTest.operationalKeyForSlot(slot, parentSlotId).map(_.get)
+      out <- underTest.operationalKeyForSlot(slot, parentSlotId, eta).map(_.get)
       _ = assert(out.slot == slot)
       _ = assert(out.parentVK == parentVK)
       childVK <- ed25519Resource.use(ed => IO.delay(ed.getVerificationKey(Ed25519.SecretKey(out.childSK.toByteArray))))

--- a/minting/src/test/scala/co/topl/minting/interpreters/StakingSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/StakingSpec.scala
@@ -21,6 +21,7 @@ import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 import scodec.bits._
+import co.topl.models.ModelGenerators.GenHelper
 
 class StakingSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   type F[A] = IO[A]
@@ -122,8 +123,9 @@ class StakingSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
     PropF.forAllF { (parentSlotId: SlotId, slot: Slot) =>
       withMock {
         val operationalKeyMaker = mock[OperationalKeyMakerAlgebra[F]]
+        val eta = etaGen.first
         (operationalKeyMaker.operationalKeyForSlot _)
-          .expects(slot, parentSlotId)
+          .expects(slot, parentSlotId, eta)
           .once()
           .returning(Option.empty[OperationalKeyOut].pure[F])
 
@@ -144,7 +146,7 @@ class StakingSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
             )
 
           _ <- staking
-            .certifyBlock(parentSlotId, slot, _ => throw new NotImplementedError("unsignedBlockBuilder"))
+            .certifyBlock(parentSlotId, slot, _ => throw new NotImplementedError("unsignedBlockBuilder"), eta)
             .assertEquals(None)
             .toResource
         } yield ()

--- a/networking/src/test/resources/logback-test.xml
+++ b/networking/src/test/resources/logback-test.xml
@@ -1,5 +1,7 @@
 <configuration debug="false">
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoders are by default assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder -->


### PR DESCRIPTION
## Purpose
- The Ouroboros Genesis paper specifies that epoch=0 starts at slot=1
  - The genesis block has slot=0, thus genesis takes place in epoch=-1
## Approach
- Update Clock implementation to shift slot offsets for epochs and operational periods
## Testing
- Updated unit tests
## Tickets
- #BN-1264