### PR TITLE
Added option to use hostnames instead of ip addresses

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -23,13 +23,8 @@ import co.topl.ledger.algebras._
 import co.topl.minting.algebras.StakingAlgebra
 import co.topl.minting.interpreters._
 import co.topl.networking.blockchain._
-import co.topl.networking.fsnetwork.{
-  ActorPeerHandlerBridgeAlgebra,
-  DnsResolver,
-  DnsResolverInstances,
-  ReverseDnsResolver,
-  ReverseDnsResolverInstances
-}
+import co.topl.networking.fsnetwork.ReverseDnsResolverInstances.{NoOpReverseResolver, ReverseResolver}
+import co.topl.networking.fsnetwork._
 import co.topl.networking.p2p._
 import co.topl.node.models.BlockBody
 import co.topl.typeclasses.implicits._
@@ -70,7 +65,8 @@ object Blockchain {
   ): Resource[F, Unit] = {
     implicit val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("Bifrost.Blockchain")
     implicit val dnsResolver: DnsResolver[F] = DnsResolverInstances.defaultResolver[F]
-    implicit val reverseDnsResolver: ReverseDnsResolver[F] = ReverseDnsResolverInstances.defaultResolver[F]
+    implicit val reverseDnsResolver: ReverseDnsResolver[F] =
+      if (networkProperties.useHostNames) new ReverseResolver[F]() else new NoOpReverseResolver[F]
 
     for {
       remotePeers             <- Queue.unbounded[F, DisconnectedPeer].toResource

--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -23,7 +23,8 @@ import co.topl.ledger.algebras._
 import co.topl.minting.algebras.StakingAlgebra
 import co.topl.minting.interpreters._
 import co.topl.networking.blockchain._
-import co.topl.networking.fsnetwork.ReverseDnsResolverInstances.{NoOpReverseResolver, ReverseResolver}
+import co.topl.networking.fsnetwork.DnsResolverInstances.DefaultDnsResolver
+import co.topl.networking.fsnetwork.ReverseDnsResolverInstances.{DefaultReverseDnsResolver, NoOpReverseResolver}
 import co.topl.networking.fsnetwork._
 import co.topl.networking.p2p._
 import co.topl.node.models.BlockBody
@@ -64,9 +65,9 @@ object Blockchain {
     networkProperties:         NetworkProperties
   ): Resource[F, Unit] = {
     implicit val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("Bifrost.Blockchain")
-    implicit val dnsResolver: DnsResolver[F] = DnsResolverInstances.defaultResolver[F]
+    implicit val dnsResolver: DnsResolver[F] = new DefaultDnsResolver[F]()
     implicit val reverseDnsResolver: ReverseDnsResolver[F] =
-      if (networkProperties.useHostNames) new ReverseResolver[F]() else new NoOpReverseResolver[F]
+      if (networkProperties.useHostNames) new DefaultReverseDnsResolver[F]() else new NoOpReverseResolver[F]
 
     for {
       remotePeers             <- Queue.unbounded[F, DisconnectedPeer].toResource

--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -23,7 +23,13 @@ import co.topl.ledger.algebras._
 import co.topl.minting.algebras.StakingAlgebra
 import co.topl.minting.interpreters._
 import co.topl.networking.blockchain._
-import co.topl.networking.fsnetwork.{ActorPeerHandlerBridgeAlgebra, DnsResolver, DnsResolverInstances}
+import co.topl.networking.fsnetwork.{
+  ActorPeerHandlerBridgeAlgebra,
+  DnsResolver,
+  DnsResolverInstances,
+  ReverseDnsResolver,
+  ReverseDnsResolverInstances
+}
 import co.topl.networking.p2p._
 import co.topl.node.models.BlockBody
 import co.topl.typeclasses.implicits._
@@ -64,6 +70,7 @@ object Blockchain {
   ): Resource[F, Unit] = {
     implicit val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("Bifrost.Blockchain")
     implicit val dnsResolver: DnsResolver[F] = DnsResolverInstances.defaultResolver[F]
+    implicit val reverseDnsResolver: ReverseDnsResolver[F] = ReverseDnsResolverInstances.defaultResolver[F]
 
     for {
       remotePeers             <- Queue.unbounded[F, DisconnectedPeer].toResource

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -53,6 +53,7 @@ object ApplicationConfig {
     )
 
     case class NetworkProperties(
+      useHostNames:                         Boolean = false,
       pingPongInterval:                     FiniteDuration = FiniteDuration(90, SECONDS),
       expectedSlotsPerBlock:                Double = 5.0, // TODO shall be calculated?
       maxPerformanceDelayInSlots:           Double = 2.0,

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -23,7 +23,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object ActorPeerHandlerBridgeAlgebra {
 
-  def make[F[_]: Async: DnsResolver](
+  def make[F[_]: Async: DnsResolver: ReverseDnsResolver](
     thisHostId:                  HostId,
     localChain:                  LocalChainAlgebra[F],
     chainSelectionAlgebra:       ChainSelectionAlgebra[F, SlotData],

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
@@ -111,7 +111,8 @@ trait NetworkAlgebra[F[_]] {
   ): Resource[F, PeerMempoolTransactionSyncActor[F]]
 }
 
-class NetworkAlgebraImpl[F[_]: Async: Logger: DnsResolver](clock: ClockAlgebra[F]) extends NetworkAlgebra[F] {
+class NetworkAlgebraImpl[F[_]: Async: Logger: DnsResolver: ReverseDnsResolver](clock: ClockAlgebra[F])
+    extends NetworkAlgebra[F] {
 
   override def makePeerManger(
     thisHostId:                  HostId,

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
@@ -1,5 +1,6 @@
 package co.topl.networking.fsnetwork
 
+import cats.Parallel
 import cats.effect.{Async, Resource}
 import co.topl.algebras.{ClockAlgebra, Store}
 import co.topl.brambl.models.TransactionId
@@ -111,7 +112,7 @@ trait NetworkAlgebra[F[_]] {
   ): Resource[F, PeerMempoolTransactionSyncActor[F]]
 }
 
-class NetworkAlgebraImpl[F[_]: Async: Logger: DnsResolver: ReverseDnsResolver](clock: ClockAlgebra[F])
+class NetworkAlgebraImpl[F[_]: Async: Parallel: Logger: DnsResolver: ReverseDnsResolver](clock: ClockAlgebra[F])
     extends NetworkAlgebra[F] {
 
   override def makePeerManger(

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -264,7 +264,7 @@ object PeerActor {
       hotPeers <- OptionT
         .fromOption[F](NonEmptyChain.fromSeq(response.hotHosts.map(_.asRemoteAddress)))
         .flatTapNone(Logger[F].info(s"Got no hot peers from ${state.hostId}"))
-      _ <- OptionT.liftF(Logger[F].debug(s"Got hot peers $hotPeers from ${state.hostId}"))
+      _ <- OptionT.liftF(Logger[F].info(s"Got hot peers $hotPeers from ${state.hostId}"))
       _ <- OptionT.liftF(state.peersManager.sendNoWait(PeersManager.Message.AddKnownNeighbors(state.hostId, hotPeers)))
     } yield (state, state)
   }.getOrElse((state, state))

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -264,7 +264,7 @@ object PeerActor {
       hotPeers <- OptionT
         .fromOption[F](NonEmptyChain.fromSeq(response.hotHosts.map(_.asRemoteAddress)))
         .flatTapNone(Logger[F].info(s"Got no hot peers from ${state.hostId}"))
-      _ <- OptionT.liftF(Logger[F].info(s"Got hot peers $hotPeers from ${state.hostId}"))
+      _ <- OptionT.liftF(Logger[F].debug(s"Got hot peers $hotPeers from ${state.hostId}"))
       _ <- OptionT.liftF(state.peersManager.sendNoWait(PeersManager.Message.AddKnownNeighbors(state.hostId, hotPeers)))
     } yield (state, state)
   }.getOrElse((state, state))

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
@@ -131,6 +131,7 @@ object ActorPeerHandlerBridgeAlgebraTest {
 
 class ActorPeerHandlerBridgeAlgebraTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   implicit val dummyDns: DnsResolver[F] = (host: HostId) => Option(host).pure[F]
+  implicit val dummyReverseDns: ReverseDnsResolver[F] = (h: HostId) => h.pure[F]
   implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
   val hostId: HostId = "127.0.0.1"
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
@@ -3,7 +3,7 @@ package co.topl.networking.fsnetwork
 import cats.Applicative
 import cats.data.NonEmptyChain
 import cats.effect.kernel.Sync
-import cats.effect.{IO, Resource}
+import cats.effect.{Async, IO, Resource}
 import cats.implicits._
 import co.topl.algebras.Store
 import co.topl.brambl.generators.TransactionGenerator
@@ -50,7 +50,7 @@ class PeersManagerTest
   implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
   val maxChainSize = 99
 
-  val thisHostId: HostId = "0.0.0.0"
+  val thisHostId: HostId = "43.0.0.0"
   val hostId: HostId = "127.0.0.1"
 
   val defaultColdToWarmSelector: SelectorColdToWarm[F] =
@@ -76,6 +76,7 @@ class PeersManagerTest
     Caffeine.newBuilder.maximumSize(blockSourceCacheSize).build[BlockId, Set[HostId]]()
 
   implicit val dummyDns: DnsResolver[F] = (host: HostId) => Option(host).pure[F]
+  implicit val dummyReverseDns: ReverseDnsResolver[F] = (h: HostId) => h.pure[F]
 
   def mockPeerActor[F[_]: Applicative](): PeerActor[F] = {
     val mocked = mock[PeerActor[F]]
@@ -2163,8 +2164,17 @@ class PeersManagerTest
         )
 
       val hotUpdater = mock[Set[RemoteAddress] => F[Unit]]
-      (hotUpdater.apply _).expects(Set(host1serverAddress, host4serverAddress)).twice().returns(().pure[F])
+      (hotUpdater.apply _)
+        .expects(
+          Set(
+            host1serverAddress.copy(host = host1serverAddress.host.reverse),
+            host4serverAddress.copy(host = host4serverAddress.host.reverse)
+          )
+        )
+        .twice()
+        .returns(().pure[F])
 
+      implicit val dummyReverseReverseDns: ReverseDnsResolver[F] = (h: HostId) => h.reverse.pure[F]
       PeersManager
         .makeActor(
           thisHostId,
@@ -2185,7 +2195,7 @@ class PeersManagerTest
           defaultWarmToHotSelector,
           initialPeersMap,
           defaultCache()
-        )
+        )(implicitly[Async[IO]], logger, dummyDns, dummyReverseReverseDns)
         .use { actor =>
           for {
             _         <- actor.send(PeersManager.Message.SetupBlockChecker(blockChecker))
@@ -2201,7 +2211,7 @@ class PeersManagerTest
     }
   }
 
-  test("Finalized actor shall write non-banned hosts") {
+  test("Finalized actor shall write non-banned hosts by using their hostnames") {
     withMock {
       val networkAlgebra: NetworkAlgebra[F] = mock[NetworkAlgebra[F]]
       val localChain: LocalChainAlgebra[F] = mock[LocalChainAlgebra[F]]
@@ -2215,22 +2225,22 @@ class PeersManagerTest
       val requestProxy = mock[RequestsProxyActor[F]]
       val mempool = mock[MempoolAlgebra[F]]
 
-      val host1 = "1"
+      val host1 = "host1"
       val hostServer1Port = 1
 
-      val host2 = "2"
+      val host2 = "host2"
       val hostServer2Port = 2
 
-      val host3 = "3"
+      val host3 = "host3"
       val hostServer3Port = 3
 
-      val host4 = "4"
+      val host4 = "host4"
       val hostServer4Port = 4
 
-      val host5 = "5"
+      val host5 = "host5"
       val hostServer5Port = 5
 
-      val host6 = "6"
+      val host6 = "host6"
 
       val initialPeersMap: Map[HostId, Peer[F]] =
         Map(
@@ -2294,13 +2304,14 @@ class PeersManagerTest
 
       val writingHosts = mock[Set[RemotePeer] => F[Unit]]
       val expectedHosts = Set(
-        RemotePeer(RemoteAddress(host2, hostServer2Port), 0, 0),
-        RemotePeer(RemoteAddress(host3, hostServer3Port), 0, 0),
-        RemotePeer(RemoteAddress(host4, hostServer4Port), 0, 0),
-        RemotePeer(RemoteAddress(host5, hostServer5Port), 0, 0)
+        RemotePeer(RemoteAddress(host2.reverse, hostServer2Port), 0, 0),
+        RemotePeer(RemoteAddress(host3.reverse, hostServer3Port), 0, 0),
+        RemotePeer(RemoteAddress(host4.reverse, hostServer4Port), 0, 0),
+        RemotePeer(RemoteAddress(host5.reverse, hostServer5Port), 0, 0)
       )
       (writingHosts.apply _).expects(expectedHosts).once().returns(().pure[F])
 
+      implicit val dummyReverseReverseDns: ReverseDnsResolver[F] = (h: HostId) => h.reverse.pure[F]
       PeersManager
         .makeActor(
           thisHostId,
@@ -2321,7 +2332,7 @@ class PeersManagerTest
           defaultWarmToHotSelector,
           initialPeersMap,
           defaultCache()
-        )
+        )(implicitly[Async[IO]], logger, dummyDns, dummyReverseReverseDns)
         .use { actor =>
           for {
             _ <- actor.send(PeersManager.Message.SetupBlockChecker(blockChecker))
@@ -2331,7 +2342,7 @@ class PeersManagerTest
     }
   }
 
-  test("Add known neighbours shall correctly filter out special IP addresses") {
+  test("Add known neighbours shall correctly filter out special IP addresses and local address") {
     withMock {
       val networkAlgebra: NetworkAlgebra[F] = mock[NetworkAlgebra[F]]
       val localChain: LocalChainAlgebra[F] = mock[LocalChainAlgebra[F]]
@@ -2350,10 +2361,20 @@ class PeersManagerTest
 
       val externalIPs = Set("126.0.0.0", "8.8.8.8")
       val specialIPs =
-        Set("0.0.0.0", "127.127.127.127", "238.255.255.255", "224.0.0.0", "0.0.0.0", "255.255.255.255", "wrong ip")
+        Set(
+          "0.0.0.0",
+          "127.127.127.127",
+          "238.255.255.255",
+          "224.0.0.0",
+          "0.0.0.0",
+          "255.255.255.255",
+          "wrong ip"
+        )
+
+      val loopBack = Set(thisHostId)
 
       val remoteAddresses =
-        NonEmptyChain.fromSeq((externalIPs ++ specialIPs).map(ip => RemoteAddress(ip, 0)).toSeq).get
+        NonEmptyChain.fromSeq((externalIPs ++ specialIPs ++ loopBack).map(ip => RemoteAddress(ip, 0)).toSeq).get
       val peersToAdd = remoteAddresses.map(ra => RemotePeer(ra, 0, 0))
 
       PeersManager


### PR DESCRIPTION
## Purpose
Use hostnames instead of ip addresses for saving known peers / propagate known P2P hosts

## Approach
do reverse resolving of ip addresses before saving peers / propagate them to the network

## Testing
Unit tests + integration test

## Tickets
closes #BN-1294