### PR TITLE
BN-1273 Download slot data by chunks

### DIFF
--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -72,7 +72,8 @@ object ApplicationConfig {
       closeTimeoutFirstDelayInMs: Long = 1000,
       closeTimeoutWindowInMs:     Long = 1000 * 60 * 60 * 24, // 1 day
       aggressiveP2P:              Boolean = true, // always try to found new good remote peers
-      aggressiveP2PCount:         Int = 2 // how many new connection will be opened
+      aggressiveP2PCount:         Int = 2, // how many new connection will be opened
+      slotDataDownloadStep:       Long = 50 // how many slot data is downloaded before building slot data chain
     )
 
     case class KnownPeer(host: String, port: Int)

--- a/models/src/test/scala/co/topl/models/generators/consensus/ModelGenerators.scala
+++ b/models/src/test/scala/co/topl/models/generators/consensus/ModelGenerators.scala
@@ -208,12 +208,17 @@ trait ModelGenerators {
         )
     }
 
-  def arbitraryLinkedSlotDataChainFor(sizeGen: Gen[Long]): Arbitrary[NonEmptyChain[SlotData]] =
+  def arbitraryLinkedSlotDataChainFor(
+    sizeGen:  Gen[Long],
+    parentId: Option[SlotData] = None
+  ): Arbitrary[NonEmptyChain[SlotData]] =
     Arbitrary(
       for {
         size <- sizeGen
         root <- arbitrarySlotData.arbitrary
-      } yield addSlotDataToChain(NonEmptyChain.one(root.copy(height = 0)), arbitrarySlotData.arbitrary, size)
+        updatedRoot =
+          parentId.map(p => root.copy(parentSlotId = p.slotId, height = p.height + 1)).getOrElse(root.copy(height = 0))
+      } yield addSlotDataToChain(NonEmptyChain.one(updatedRoot), arbitrarySlotData.arbitrary, size)
     )
 
   implicit val arbitraryLinkedSlotDataChain: Arbitrary[NonEmptyChain[SlotData]] =

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
@@ -70,9 +70,7 @@ object BlockChecker {
     bodySyntaxValidation:        BodySyntaxValidationAlgebra[F],
     bodySemanticValidation:      BodySemanticValidationAlgebra[F],
     bodyAuthorizationValidation: BodyAuthorizationValidationAlgebra[F],
-    // TODO maybe use some kind of stack to not loose previous best slot data; TODO use more efficient structure
-    bestKnownRemoteSlotDataOpt: Option[BestChain],
-    // TODO will be deleted hostId shall be selected by peers manager
+    bestKnownRemoteSlotDataOpt:  Option[BestChain],
     bestKnownRemoteSlotDataHost: Option[HostId]
   )
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
@@ -672,7 +672,9 @@ object PeersManager {
             state.blockHeights,
             state.headerToBodyValidation,
             state.transactionSyntaxValidation,
-            state.mempool
+            state.mempool,
+            state.p2pNetworkConfig.networkProperties.slotDataDownloadStep,
+            commonAncestor
           )
         )
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
@@ -17,7 +17,7 @@ import co.topl.eventtree.{EventSourcedState, ParentChildTree}
 import co.topl.ledger.algebras.MempoolAlgebra
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.models.generators.consensus.ModelGenerators._
-import co.topl.networking.KnownHostOps
+import co.topl.networking.{fsnetwork, KnownHostOps}
 import co.topl.networking.blockchain.BlockchainPeerClient
 import co.topl.networking.fsnetwork.NetworkQualityError.{IncorrectPongMessage, NoPongMessage}
 import co.topl.networking.fsnetwork.PeerActorTest.F
@@ -72,7 +72,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
     val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
     (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
     (networkAlgebra.makePeerHeaderFetcher _)
-      .expects(*, *, *, *, *, *, *)
+      .expects(*, *, *, *, *, *, *, *, *, *)
       .returns(
         // simulate real header fetcher behaviour on finalizing
         Resource
@@ -151,7 +151,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           for {
@@ -197,7 +199,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           for {
@@ -244,7 +248,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           for {
@@ -272,7 +278,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val mempool = mock[MempoolAlgebra[F]]
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -320,7 +328,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           for {
@@ -349,7 +359,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val mempool = mock[MempoolAlgebra[F]]
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -414,7 +426,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           actor.send(PeerActor.Message.GetNetworkQuality) >>
@@ -442,7 +456,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val mempool = mock[MempoolAlgebra[F]]
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -480,7 +496,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           actor.send(PeerActor.Message.GetNetworkQuality)
@@ -508,7 +526,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val commonAncestor = commonAncestorSlotData.slotId.blockId
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -552,7 +572,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          fsnetwork.commonAncestor[F]
         )
         .use { actor =>
           actor.send(PeerActor.Message.PrintCommonAncestor)
@@ -580,7 +602,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val commonAncestor = commonAncestorSlotData.slotId.blockId
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -629,7 +653,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          fsnetwork.commonAncestor[F]
         )
         .use { actor =>
           actor.send(PeerActor.Message.PrintCommonAncestor)
@@ -656,7 +682,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val mempool = mock[MempoolAlgebra[F]]
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -684,7 +712,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           for {
@@ -712,7 +742,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val mempool = mock[MempoolAlgebra[F]]
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -749,7 +781,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           for {
@@ -777,7 +811,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val mempool = mock[MempoolAlgebra[F]]
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -805,7 +841,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           for {
@@ -833,7 +871,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val mempool = mock[MempoolAlgebra[F]]
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -865,7 +905,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           for {
@@ -893,7 +935,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val mempool = mock[MempoolAlgebra[F]]
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -928,7 +972,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           for {
@@ -956,7 +1002,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val mempool = mock[MempoolAlgebra[F]]
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -990,7 +1038,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           for {
@@ -1018,7 +1068,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val mempool = mock[MempoolAlgebra[F]]
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (() => blockBodyFetcher.id).expects().anyNumberOfTimes().returns(2)
@@ -1050,7 +1102,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           for {
@@ -1091,7 +1145,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
-      (networkAlgebra.makePeerHeaderFetcher _).expects(*, *, *, *, *, *, *).returns(Resource.pure(blockHeaderFetcher))
+      (networkAlgebra.makePeerHeaderFetcher _)
+        .expects(*, *, *, *, *, *, *, *, *, *)
+        .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
       (networkAlgebra.makePeerBodyFetcher _).expects(*, *, *, *, *, *).returns(Resource.pure(blockBodyFetcher))
@@ -1114,7 +1170,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use(_ => Applicative[F].unit)
     }
@@ -1164,7 +1222,9 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           blockHeights,
           headerToBodyValidation,
           transactionSyntaxValidation,
-          mempool
+          mempool,
+          5,
+          commonAncestor[F]
         )
         .use { actor =>
           for {

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
@@ -1592,7 +1592,7 @@ class PeersManagerTest
       val peer2 = mockPeerActor[F]()
 
       (networkAlgebra.makePeer _)
-        .expects(host1.host, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1.host, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(
           Resource
@@ -1609,7 +1609,7 @@ class PeersManagerTest
       (peer1.sendNoWait _).expects(PeerActor.Message.CloseConnection).returns(Applicative[F].unit)
 
       (networkAlgebra.makePeer _)
-        .expects(host1.host, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1.host, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer2))
       (peer2.sendNoWait _).expects(PeerActor.Message.GetPeerServerAddress).returns(Applicative[F].unit)
@@ -1679,7 +1679,7 @@ class PeersManagerTest
       val peer1 = mockPeerActor[F]()
 
       (networkAlgebra.makePeer _)
-        .expects(host1.host, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1.host, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(
           Resource
@@ -1870,7 +1870,7 @@ class PeersManagerTest
       val host1 = RemoteAddress("1", 1)
       val peer1 = mockPeerActor[F]()
       (networkAlgebra.makePeer _)
-        .expects(host1.host, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1.host, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer1))
       (peer1.sendNoWait _)
@@ -1886,7 +1886,7 @@ class PeersManagerTest
       val host2 = RemoteAddress("2", 2)
       val peer2 = mockPeerActor[F]()
       (networkAlgebra.makePeer _)
-        .expects(host2.host, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host2.host, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer2))
       (peer2.sendNoWait _)
@@ -1902,7 +1902,7 @@ class PeersManagerTest
       val host3 = RemoteAddress("3", 3)
       val peer3 = mockPeerActor[F]()
       (networkAlgebra.makePeer _)
-        .expects(host3.host, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host3.host, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer3))
       (peer3.sendNoWait _)
@@ -1922,7 +1922,7 @@ class PeersManagerTest
       val host5 = RemoteAddress("5", 5)
       val peer5 = mockPeerActor[F]()
       (networkAlgebra.makePeer _)
-        .expects(host5.host, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host5.host, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer5))
       (peer5.sendNoWait _)


### PR DESCRIPTION
## Purpose
Download slot data by chunks in case remote peer is far away by height

## Approach
Split slot data chain to chunks, instead of downloading all slot data at once. Requests blockId for end of the chunk and processes chunk normally

## Testing
unit tests + integration test

## Tickets
closes BN-1273