### PR TITLE
BN-1285 Fixing possible lost request for data downloading; Fixing issue trying verify header too early

### DIFF
--- a/consensus/src/main/scala/co/topl/consensus/algebras/BlockHeaderValidationAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/BlockHeaderValidationAlgebra.scala
@@ -1,7 +1,6 @@
 package co.topl.consensus.algebras
 
-import co.topl.consensus.models.BlockHeaderValidationFailure
-import co.topl.consensus.models.BlockHeader
+import co.topl.consensus.models.{BlockHeader, BlockHeaderValidationFailure, SlotData}
 
 trait BlockHeaderValidationAlgebra[F[_]] {
 
@@ -9,4 +8,6 @@ trait BlockHeaderValidationAlgebra[F[_]] {
    * Indicates if the claimed child is a valid descendent of the parent
    */
   def validate(header: BlockHeader): F[Either[BlockHeaderValidationFailure, BlockHeader]]
+
+  def couldBeValidated(header: BlockHeader, currentHead: SlotData): F[Boolean]
 }

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
@@ -74,11 +74,11 @@ object BlockHeaderValidation {
     blake2b256Resource:       Resource[F, Blake2b256]
   ) extends BlockHeaderValidationAlgebra[F] {
 
-    def couldBeValidated(header: BlockHeader, currentLocalBestBlock: SlotData): F[Boolean] =
+    def couldBeValidated(header: BlockHeader, lastProcessedBodyInChain: SlotData): F[Boolean] =
       for {
-        headerEpoch    <- clockAlgebra.epochOf(header.slot)
-        bestBlockEpoch <- clockAlgebra.epochOf(currentLocalBestBlock.slotId.slot)
-      } yield (bestBlockEpoch - headerEpoch) < 2
+        checkedHeaderEpoch <- clockAlgebra.epochOf(header.slot)
+        bestBlockEpoch     <- clockAlgebra.epochOf(lastProcessedBodyInChain.slotId.slot)
+      } yield (checkedHeaderEpoch - bestBlockEpoch) < 2
 
     def validate(header: BlockHeader): F[Either[BlockHeaderValidationFailure, BlockHeader]] = {
       if (header.id === bigBangBlockId) EitherT.rightT[F, BlockHeaderValidationFailure](header)

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/BlockHeaderValidation.scala
@@ -4,6 +4,7 @@ import cats.data._
 import cats.effect.Resource
 import cats.effect.kernel.Sync
 import cats.implicits._
+import co.topl.algebras.ClockAlgebra.implicits.clockAsClockOps
 import co.topl.algebras.{ClockAlgebra, Store}
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
@@ -72,6 +73,12 @@ object BlockHeaderValidation {
     ed25519Resource:          Resource[F, Ed25519],
     blake2b256Resource:       Resource[F, Blake2b256]
   ) extends BlockHeaderValidationAlgebra[F] {
+
+    def couldBeValidated(header: BlockHeader, currentLocalBestBlock: SlotData): F[Boolean] =
+      for {
+        headerEpoch    <- clockAlgebra.epochOf(header.slot)
+        bestBlockEpoch <- clockAlgebra.epochOf(currentLocalBestBlock.slotId.slot)
+      } yield (bestBlockEpoch - headerEpoch) < 2
 
     def validate(header: BlockHeader): F[Either[BlockHeaderValidationFailure, BlockHeader]] = {
       if (header.id === bigBangBlockId) EitherT.rightT[F, BlockHeaderValidationFailure](header)
@@ -359,6 +366,9 @@ object BlockHeaderValidation {
         .map(implicit cache =>
           new BlockHeaderValidationAlgebra[F] {
 
+            def couldBeValidated(header: BlockHeader, currentHead: SlotData): F[Boolean] =
+              underlying.couldBeValidated(header, currentHead)
+
             def validate(header: BlockHeader): F[Either[BlockHeaderValidationFailure, BlockHeader]] =
               cache
                 .cachingF(header.id)(ttl = None)(
@@ -368,6 +378,7 @@ object BlockHeaderValidation {
                 )
                 .as(header.asRight[BlockHeaderValidationFailure])
                 .recover { case w: WrappedFailure => w.failure.asLeft[BlockHeader] }
+
           }
         )
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
@@ -49,8 +49,13 @@ object ActorPeerHandlerBridgeAlgebraTest {
 
   val networkProperties: NetworkProperties = NetworkProperties()
 
-  val headerValidation: BlockHeaderValidationAlgebra[F] =
-    (header: BlockHeader) => Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F]
+  val headerValidation: BlockHeaderValidationAlgebra[F] = new BlockHeaderValidationAlgebra[F] {
+
+    override def validate(header: BlockHeader): F[Either[BlockHeaderValidationFailure, BlockHeader]] =
+      Either.right[BlockHeaderValidationFailure, BlockHeader](header).pure[F]
+
+    override def couldBeValidated(header: BlockHeader, currentHead: SlotData): F[Boolean] = true.pure[F]
+  }
 
   val headerToBodyValidation: BlockHeaderToBodyValidationAlgebra[F] =
     (block: Block) => Either.right[BlockHeaderToBodyValidationFailure, Block](block).pure[F]

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
@@ -483,7 +483,7 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
         RequestsProxy.Message.RemoteSlotData(hostId, lastBatch.map(_._2))
       (requestsProxy.sendNoWait _).expects(expectedSlotDataMessage).once().returning(().pure[F])
 
-      val slotDataStoreMap = mutable.Map.empty[BlockId, SlotData] + (knownId -> knownSlotData)
+      val slotDataStoreMap = mutable.Map(knownId -> knownSlotData)
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
         slotDataStoreMap.get(id).pure[F]
@@ -561,8 +561,8 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           Stream.eval[F, BlockId](remoteIdAndSlotData.last._1.pure[F]).pure[F]
         }
 
-        val slotDataStoreMap = mutable.Map[BlockId, SlotData](localIdAndSlotData.toList: _*) +
-          (commonAncestor.slotId.blockId -> commonAncestor)
+        val slotDataStoreMap = mutable.Map[BlockId, SlotData](localIdAndSlotData.toList: _*)
+        slotDataStoreMap.addOne(commonAncestor.slotId.blockId -> commonAncestor)
         val slotDataStore = mock[Store[F, BlockId, SlotData]]
         (slotDataStore.get _).expects(*).anyNumberOfTimes().onCall { id: BlockId =>
           slotDataStoreMap.get(id).pure[F]


### PR DESCRIPTION
## Purpose
In some rare cases, we could lose the request to download remote data, in that case, the sync is stopped. Added request timeout, thus we will be able to recover.
Block checker could try to apply header which cannot be verified (because bodies for N-2 epoch are missed). Fix it by checking could header be verified first.

## Approach
Added timeout for data download request, thus we could recover if we receive no response. Block checker will pause header applying if we can't verify the header. Header will be requested again as soon as body validation reach the header which can't be verified in past.

## Testing
Unit test + integration test

## Tickets
closes BN-1285