### PR TITLE
BN-1302 Stop self connections

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -163,7 +163,7 @@ object PeerBlockHeaderFetcher {
     blockId: BlockId
   ): F[Unit] =
     for {
-      _                 <- Logger[F].info(show"Got blockId: $blockId from remote peer ${state.hostId}")
+      _                 <- Logger[F].info(show"Sync $blockId from remote peer ${state.hostId}")
       blockSlotData     <- getSlotDataFromStorageOrRemote(state)(blockId)
       newSlotDataOpt    <- getRemoteBetterSlotDataChain(state, blockSlotData).value
       _                 <- Logger[F].info(show"Build slot data chain from tip $blockId is ${newSlotDataOpt.isDefined}")
@@ -361,7 +361,7 @@ object PeerBlockHeaderFetcher {
         _                              <- Logger[F].info(show"Fetching remote header id=$blockId from peer $hostId")
         (downloadTime, headerWithNoId) <- Async[F].timed(client.getHeaderOrError(blockId, HeaderNotFoundInPeer))
         header                         <- headerWithNoId.embedId.pure[F]
-        _                              <- Logger[F].info(show"Fetched remote header id=$blockId  from peer $hostId")
+        _                              <- Logger[F].info(show"Fetched header $blockId: $header from peer $hostId")
         _ <- MonadThrow[F].raiseWhen(header.id =!= blockId)(HeaderHaveIncorrectId(blockId, header.id))
       } yield UnverifiedBlockHeader(hostId, header, downloadTime.toMillis)
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
@@ -82,7 +82,7 @@ case class PeersHandler[F[_]: Async: Logger](
             peerWithRep             <- updateReputation(oldPeer, peerWithClosedTimestamp).pure[F]
             actorOpt                <- closePeerIfNecessary(peerWithClosedTimestamp, peerActorCloseAndRelease)
             newPeer                 <- peerWithRep.copy(actorOpt = actorOpt).pure[F]
-            _                       <- Logger[F].info(show"Move host $host with peer $oldPeer to new state $newPeer")
+            _                       <- Logger[F].info(show"Move $host from ${oldPeer.state} to ${newPeer.state}")
           } yield host -> newPeer
         }
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -134,6 +134,14 @@ package object fsnetwork {
     case PingPongMessagePing(host, Left(networkError)) => show"$networkError from host $host"
   }
 
+  implicit val showPeerState: Show[PeerState] = {
+    case PeerState.Banned  => "BANNED"
+    case PeerState.Cold    => "COLD"
+    case PeerState.Warm    => "WARM"
+    case PeerState.Hot     => "HOT"
+    case PeerState.Unknown => "UNKNOWN"
+  }
+
   implicit def showPeer[F[_]]: Show[Peer[F]] = { peer: Peer[F] =>
     "Peer" +
     s" ${peer.ip}:[${peer.remoteServerPort.map(_.toString).getOrElse("")}];" +

--- a/networking/src/main/scala/co/topl/networking/package.scala
+++ b/networking/src/main/scala/co/topl/networking/package.scala
@@ -1,5 +1,6 @@
 package co.topl
 
+import co.topl.networking.fsnetwork.HostId
 import co.topl.networking.p2p.RemoteAddress
 import co.topl.node.models.KnownHost
 import com.comcast.ip4s.{IpAddress, SocketAddress}
@@ -21,6 +22,7 @@ package object networking {
   }
 
   implicit class RemoteAddressOps(remoteAddress: RemoteAddress) {
+    def asHostId: HostId = remoteAddress.host
 
     def isSpecialHost: Boolean =
       Try {

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
@@ -414,6 +414,8 @@ class PeersManagerTest
             _ = assert(updatedState1.thisHostIds.contains(addedAddress1.host))
             updatedState2 <- actor.send(PeersManager.Message.UpdateThisPeerAddress(addedAddress2))
             _ = assert(updatedState2.thisHostIds.contains(addedAddress2.host))
+            _ = assert(updatedState2.peersHandler.peers(addedAddress1.asHostId).state == PeerState.Banned)
+            _ = assert(updatedState2.peersHandler.peers(addedAddress2.asHostId).state == PeerState.Banned)
           } yield ()
         }
     }

--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -59,8 +59,6 @@ class NodeAppTest extends CatsEffectSuite {
          |  p2p:
          |    bind-port: 9150
          |    public-port: 9150
-         |    network-properties:
-         |      legacy-network: false
          |  rpc:
          |    bind-port: 9151
          |  big-bang:
@@ -80,9 +78,7 @@ class NodeAppTest extends CatsEffectSuite {
          |  p2p:
          |    bind-port: 9152
          |    public-port: 9152
-         |    known-peers: localhost:9150
-         |    network-properties:
-         |      legacy-network: false
+         |    known-peers: 127.0.0.2:9150
          |  rpc:
          |    bind-port: 9153
          |  big-bang:
@@ -127,7 +123,7 @@ class NodeAppTest extends CatsEffectSuite {
           .mapN(_.race(_).map(_.merge).flatMap(_.embedNever))
           .flatMap(nodeCompletion =>
             nodeCompletion.toResource.race(for {
-              rpcClientA <- NodeGrpc.Client.make[F]("localhost", 9151, tls = false)
+              rpcClientA <- NodeGrpc.Client.make[F]("127.0.0.2", 9151, tls = false)
               rpcClientB <- NodeGrpc.Client.make[F]("localhost", 9153, tls = false)
               rpcClients = List(rpcClientA, rpcClientB)
               implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeAppTest").toResource


### PR DESCRIPTION
## Purpose
Self connection is not managed properly: they shall be closed and no new self connection shall be allowed
 
## Approach
Ban remote peers which have the same IP as the local node, i.e. ban self-connection

## Testing
Unit test + integration test

## Tickets
closes BN-1302