### PR TITLE
CLI: Init Mainnet Command

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/PublicTestnet.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/PublicTestnet.scala
@@ -9,13 +9,13 @@ object PublicTestnet {
   val DefaultProtocol: ApplicationConfig.Bifrost.Protocol =
     ApplicationConfig.Bifrost.Protocol(
       minAppVersion = "2.0.0",
-      fEffective = co.topl.models.utility.Ratio(15, 100),
-      vrfLddCutoff = 50,
+      fEffective = co.topl.models.utility.Ratio(12997, 100000),
+      vrfLddCutoff = 15,
       vrfPrecision = 40,
-      vrfBaselineDifficulty = co.topl.models.utility.Ratio(1, 20),
-      vrfAmplitude = co.topl.models.utility.Ratio(1, 2),
-      // 10x private testnet default, resulting in ~50 minute epochs
-      chainSelectionKLookback = 500,
+      vrfBaselineDifficulty = co.topl.models.utility.Ratio(5, 100),
+      vrfAmplitude = co.topl.models.utility.Ratio(50, 100),
+      // 20x private testnet default, resulting in ~100 minute epochs
+      chainSelectionKLookback = 1000,
       slotDuration = 1.seconds,
       forwardBiasedSlotWindow = 50,
       operationalPeriodsPerEpoch = 24,

--- a/blockchain/src/main/scala/co/topl/blockchain/PublicTestnet.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/PublicTestnet.scala
@@ -1,0 +1,29 @@
+package co.topl.blockchain
+
+import co.topl.brambl.models.box.Value.UpdateProposal
+import co.topl.config.ApplicationConfig
+import scala.concurrent.duration._
+
+object PublicTestnet {
+
+  val DefaultProtocol: ApplicationConfig.Bifrost.Protocol =
+    ApplicationConfig.Bifrost.Protocol(
+      minAppVersion = "2.0.0",
+      fEffective = co.topl.models.utility.Ratio(15, 100),
+      vrfLddCutoff = 50,
+      vrfPrecision = 40,
+      vrfBaselineDifficulty = co.topl.models.utility.Ratio(1, 20),
+      vrfAmplitude = co.topl.models.utility.Ratio(1, 2),
+      // 10x private testnet default, resulting in ~50 minute epochs
+      chainSelectionKLookback = 500,
+      slotDuration = 1.seconds,
+      forwardBiasedSlotWindow = 50,
+      operationalPeriodsPerEpoch = 24,
+      kesKeyHours = 9,
+      kesKeyMinutes = 9
+    )
+
+  val DefaultUpdateProposal: UpdateProposal =
+    BigBang.protocolToUpdateProposal(DefaultProtocol)
+
+}

--- a/node/src/main/scala/co/topl/node/cli/CliApp.scala
+++ b/node/src/main/scala/co/topl/node/cli/CliApp.scala
@@ -15,7 +15,9 @@ class ConfiguredCliApp(appConfig: ApplicationConfig) {
 
   private val readUserCommand =
     (
-      writeMessage[F]("Please enter a command. [ QUIT | configure | register | proposal | init-testnet]") >>
+      writeMessage[F](
+        "Please enter a command. [ QUIT | configure | register | proposal | init-testnet | init-mainnet]"
+      ) >>
         readLowercasedInput
     ).semiflatMap {
       case "" | "quit" =>
@@ -28,6 +30,8 @@ class ConfiguredCliApp(appConfig: ApplicationConfig) {
         CliApp.Command.Proposal.some.widen[CliApp.Command].pure[F]
       case "init-testnet" =>
         CliApp.Command.InitTestnet.some.widen[CliApp.Command].pure[F]
+      case "init-mainnet" =>
+        CliApp.Command.InitMainnet.some.widen[CliApp.Command].pure[F]
       case v =>
         c.println(s"Invalid command: `$v`").as(none[CliApp.Command])
     }.untilDefinedM
@@ -49,6 +53,7 @@ class ConfiguredCliApp(appConfig: ApplicationConfig) {
       case CliApp.Command.Register    => RegistrationCommand[F](appConfig)
       case CliApp.Command.Proposal    => ProposalCommand[F]
       case CliApp.Command.InitTestnet => InitTestnetCommand[F](appConfig)
+      case CliApp.Command.InitMainnet => InitMainnetCommand[F](appConfig)
     }
 
 }
@@ -62,5 +67,6 @@ object CliApp {
     case object Register extends Command
     case object Proposal extends Command
     case object InitTestnet extends Command
+    case object InitMainnet extends Command
   }
 }

--- a/node/src/main/scala/co/topl/node/cli/InitMainnetCommand.scala
+++ b/node/src/main/scala/co/topl/node/cli/InitMainnetCommand.scala
@@ -1,32 +1,22 @@
 package co.topl.node.cli
 
-import cats.data.{EitherT, OptionT}
+import cats.effect.Async
 import cats.effect.std.Console
-import cats.effect.{Async, Sync}
 import cats.implicits._
-import cats.{MonadThrow, Show}
 import co.topl.blockchain.BigBang
 import co.topl.brambl.constants.NetworkConstants
 import co.topl.brambl.models.box.Value
-import co.topl.brambl.models.box.Value.UpdateProposal
 import co.topl.brambl.models.transaction.{IoTransaction, Schedule, UnspentTransactionOutput}
 import co.topl.brambl.models.{Datum, Event, LockAddress, LockId}
 import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.config.ApplicationConfig
-import co.topl.consensus.models.BlockId
 import co.topl.node.ProtocolVersioner
-import co.topl.node.models.{BlockBody, FullBlock}
+import co.topl.node.models.FullBlock
 import co.topl.typeclasses.implicits._
 import com.google.protobuf.ByteString
-import com.google.protobuf.duration.Duration
 import fs2.io.file.{Files, Path}
-import quivr.models.{Int128, Ratio, SmallData}
-
-import java.nio.charset.StandardCharsets
-import java.time.format.DateTimeFormatter
-import java.time.{Instant, LocalDateTime}
-import scala.util.Try
+import quivr.models.SmallData
 
 object InitMainnetCommand {
 
@@ -41,7 +31,9 @@ object InitMainnetCommand {
 
 }
 
-class InitMainnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit c: Console[F]) {
+class InitMainnetCommandImpl[F[_]: Async: Console](appConfig: ApplicationConfig) {
+
+  import InitNetworkHelpers._
 
   private val intro: StageResultT[F, Unit] =
     writeMessage[F](
@@ -74,7 +66,7 @@ class InitMainnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit
         .value
 
   private val readRegistrationTransactions: StageResultT[F, List[IoTransaction]] =
-    (writeMessage[F]("Enter the directory containing the staker registration transactions.") >>
+    (writeMessage[F]("Enter the directory containing the protobuf-encoded staker registration transactions.") >>
       readInput[F].flatMap {
         case "" => writeMessage[F]("Invalid directory.").as(none[List[IoTransaction]])
         case str =>
@@ -95,205 +87,7 @@ class InitMainnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit
               writeMessage[F]("Not a directory.").as(none[List[IoTransaction]])
             )
       }).untilDefinedM
-
-  /**
-   * Read a lock address (or retry until a valid value is provided)
-   */
-  private val readLockAddress =
-    (writeMessage[F]("Enter a LockAddress.") >>
-      readInput[F].semiflatMap { lockAddressStr =>
-        EitherT
-          .fromEither[F](co.topl.brambl.codecs.AddressCodecs.decodeAddress(lockAddressStr))
-          .ensure("Incorrect network ID")(_.network == NetworkConstants.MAIN_NETWORK_ID)
-          .leftSemiflatTap(error => c.println(s"Invalid Lock Address. reason=$error input=$lockAddressStr"))
-          .toOption
-          .value
-      }).untilDefinedM
-
-  /**
-   * Read an Int128 quantity (or retry until a valid value is provided)
-   */
-  private val readQuantity =
-    readLowercasedInput.semiflatMap { str =>
-      EitherT(MonadThrow[F].catchNonFatal(BigInt(str)).attempt)
-        .leftMap(_ => s"Invalid Quantity. input=$str")
-        .ensure(s"Quantity too large. input=$str")(_.bitLength <= 128)
-        .ensure(s"Quantity must be positive. input=$str")(_ > 0)
-        .map(quantity => Int128(ByteString.copyFrom(quantity.toByteArray)))
-        .leftSemiflatTap(c.println(_))
-        .toOption
-        .value
-    }
-
-  private val readUnstakedTopl: StageResultT[F, UnspentTransactionOutput] =
-    for {
-      quantity    <- (writeMessage[F]("Enter a quantity of TOPLs.") >> readQuantity).untilDefinedM
-      lockAddress <- readLockAddress
-      utxo = UnspentTransactionOutput(
-        lockAddress,
-        Value.defaultInstance.withTopl(Value.TOPL.defaultInstance.withQuantity(quantity))
-      )
-    } yield utxo
-
-  private val readUnstakedTopls: StageResultT[F, List[UnspentTransactionOutput]] =
-    readLowercasedChoice[F]("Do you want to add an unstaked TOPL?")(List("y", "n"), "n".some)
-      .map(_ == "y")
-      .ifM(
-        for {
-          utxo0 <- readUnstakedTopl
-          otherUtxos <- List
-            .empty[UnspentTransactionOutput]
-            .tailRecM(current =>
-              readLowercasedChoice[F]("Add another unstaked Topl?")(List("y", "n"), "n".some)
-                .flatMap {
-                  case "y"      => readUnstakedTopl.map(current.appended).map(_.asLeft[List[UnspentTransactionOutput]])
-                  case "n" | "" => StageResultT.liftF(current.asRight[List[UnspentTransactionOutput]].pure[F])
-                  case _        => writeMessage[F]("Invalid input").as(current.asLeft[List[UnspentTransactionOutput]])
-                }
-            )
-        } yield utxo0 :: otherUtxos,
-        StageResultT.liftF(List.empty[UnspentTransactionOutput].pure[F])
-      )
-
-  private val readLvl: StageResultT[F, UnspentTransactionOutput] =
-    for {
-      quantity    <- (writeMessage[F]("Enter a quantity of LVLs.") >> readQuantity).untilDefinedM
-      lockAddress <- readLockAddress
-      utxo = UnspentTransactionOutput(
-        lockAddress,
-        Value.defaultInstance.withLvl(Value.LVL.defaultInstance.withQuantity(quantity))
-      )
-    } yield utxo
-
-  private val readLvls: StageResultT[F, List[UnspentTransactionOutput]] =
-    readLowercasedChoice[F]("Do you want to add a LVL?")(List("y", "n"), "n".some)
-      .map(_ == "y")
-      .ifM(
-        for {
-          utxo0 <- readLvl
-          otherUtxos <- List
-            .empty[UnspentTransactionOutput]
-            .tailRecM(current =>
-              readLowercasedChoice[F]("Add another LVL?")(List("y", "n"), "n".some)
-                .flatMap {
-                  case "y"      => readLvl.map(current.appended).map(_.asLeft[List[UnspentTransactionOutput]])
-                  case "n" | "" => StageResultT.liftF(current.asRight[List[UnspentTransactionOutput]].pure[F])
-                  case _        => writeMessage[F]("Invalid input").as(current.asLeft[List[UnspentTransactionOutput]])
-                }
-            )
-        } yield utxo0 :: otherUtxos,
-        StageResultT.liftF(List.empty[UnspentTransactionOutput].pure[F])
-      )
-
-  private val readTimestamp = {
-    import scala.concurrent.duration._
-    (writeMessage[F](
-      "Enter a genesis timestamp (milliseconds since UNIX epoch) or a relative duration (i.e. 4 hours).  Leave blank to start in 20 seconds."
-    ) >>
-    readInput[F].flatMap {
-      case "" =>
-        StageResultT.liftF(Async[F].realTime.map(_ + 20.seconds).map(_.some))
-      case str =>
-        OptionT
-          .fromOption[StageResultT[F, *]](Try(scala.concurrent.duration.Duration(str)).toOption)
-          .semiflatMap(duration => StageResultT.liftF(Async[F].realTime.map(_ + duration)))
-          .orElse(
-            OptionT
-              .fromOption[StageResultT[F, *]](str.toLongOption)
-              .flatTapNone(writeMessage[F]("Invalid timestamp"))
-              .map(_.milli)
-          )
-          .collect { case fd: scala.concurrent.duration.FiniteDuration => fd }
-          // Double-check with the user that the genesis date/time is correct
-          .filterF(duration =>
-            StageResultT
-              .liftF(
-                Sync[F].delay(
-                  DateTimeFormatter
-                    .ofPattern("MM/dd/yyy HH:mm:ss")
-                    .format(
-                      LocalDateTime
-                        .ofInstant(Instant.ofEpochMilli(duration.toMillis), java.time.Clock.systemDefaultZone().getZone)
-                    )
-                )
-              )
-              .flatMap(formattedDateTime =>
-                readLowercasedChoice(s"The blockchain will begin on $formattedDateTime. Continue?")(
-                  List("y", "n"),
-                  "y".some
-                )
-                  .map(_ == "y")
-              )
-          )
-          .value
-    }).untilDefinedM
-  }
-
-  private val readProtocolSettings = {
-    implicit val showRatio: Show[co.topl.models.utility.Ratio] = r => s"${r.numerator}/${r.denominator}"
-    readYesNo("Do you want to customize the protocol settings?", No.some)(
-      ifYes = StageResultT.liftF(DefaultUpdateProposal.pure[F]),
-      ifNo =
-        for {
-          fEffective <- readDefaultedOptional[F, Ratio](
-            "f-effective",
-            List("1/5", "15/100", "1"),
-            DefaultProtocol.fEffective.show
-          )
-          vrfLddCutoff <- readDefaultedOptional[F, Int]("vrf-ldd-cutoff", List("50"), DefaultProtocol.vrfLddCutoff.show)
-          vrfPrecision <- readDefaultedOptional[F, Int]("vrf-precision", List("40"), DefaultProtocol.vrfPrecision.show)
-          vrfBaselineDifficulty <- readDefaultedOptional[F, Ratio](
-            "vrf-baseline-difficulty",
-            List("1/20", "1/50"),
-            DefaultProtocol.vrfBaselineDifficulty.show
-          )
-          vrfAmplitude <- readDefaultedOptional[F, Ratio](
-            "vrf-amplitude",
-            List("1/2"),
-            DefaultProtocol.vrfAmplitude.show
-          )
-          chainSelectionKLookback <- readDefaultedOptional[F, Long](
-            "chain-selection-k-lookback",
-            List("500"),
-            DefaultProtocol.chainSelectionKLookback.show
-          )
-          slotDuration <- readDefaultedOptional[F, Duration](
-            "slot-duration",
-            List("1000 milli"),
-            DefaultProtocol.slotDuration.show
-          )
-          forwardBiasedSlotWindow <- readDefaultedOptional[F, Long](
-            "forward-biased-slot-window",
-            List("50"),
-            DefaultProtocol.forwardBiasedSlotWindow.show
-          )
-          operationalPeriodsPerEpoch <- readDefaultedOptional[F, Long](
-            "operational-periods-per-epoch",
-            List("2"),
-            DefaultProtocol.operationalPeriodsPerEpoch.show
-          )
-          kesKeyHours <- readDefaultedOptional[F, Int]("kes-key-hours", List("9"), DefaultProtocol.kesKeyHours.show)
-          kesKeyMinutes <- readDefaultedOptional[F, Int](
-            "kes-key-minutes",
-            List("9"),
-            DefaultProtocol.kesKeyMinutes.show
-          )
-        } yield UpdateProposal(
-          "genesis",
-          fEffective.some,
-          vrfLddCutoff.some,
-          vrfPrecision.some,
-          vrfBaselineDifficulty.some,
-          vrfAmplitude.some,
-          chainSelectionKLookback.some,
-          slotDuration.some,
-          forwardBiasedSlotWindow.some,
-          operationalPeriodsPerEpoch.some,
-          kesKeyHours.some,
-          kesKeyMinutes.some
-        )
-    )
-  }
+      .flatTap(_.traverse(tx => writeMessage[F](show"Loaded transactionId=${tx.id}")))
 
   private def readOutputDirectory(genesisBlock: FullBlock) =
     writeMessage[F]("Enter a save directory.  Leave blank to use a temporary directory.") >>
@@ -303,53 +97,6 @@ class InitMainnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit
       case str =>
         Path(str).pure[F].flatTap(Files.forAsync[F].createDirectories)
     }
-
-  private def saveGenesisBlock(dir: Path)(block: FullBlock) =
-    StageResultT
-      .liftF(Sync[F].delay(block.header.id.show))
-      .flatMap(stringifiedHeaderId =>
-        writeFile[F](dir)(block.header.toByteArray)("Genesis Header", s"$stringifiedHeaderId.header.pbuf") >>
-        writeFile[F](dir)(block.header.toProtoString.getBytes(StandardCharsets.UTF_8))(
-          "Genesis Header (Proto String)",
-          s"$stringifiedHeaderId.header.pstring"
-        ) >>
-        StageResultT
-          .liftF(
-            Sync[F].delay(
-              BlockBody(block.fullBody.transactions.map(_.id), block.fullBody.rewardTransaction.map(_.id))
-            )
-          )
-          .flatMap(body =>
-            writeFile[F](dir)(body.toByteArray)("Genesis Body", s"$stringifiedHeaderId.body.pbuf") >>
-            writeFile[F](dir)(body.toProtoString.getBytes(StandardCharsets.UTF_8))(
-              "Genesis Body (Proto String)",
-              s"$stringifiedHeaderId.body.pstring"
-            )
-          ) >>
-        (block.fullBody.transactions ++ block.fullBody.rewardTransaction).traverse { tx =>
-          val stringifiedTxId = tx.id.show
-          writeFile[F](dir)(tx.toByteArray)(
-            s"Transaction $stringifiedTxId",
-            s"$stringifiedTxId.transaction.pbuf"
-          ) >>
-          writeFile[F](dir)(tx.toProtoString.getBytes(StandardCharsets.UTF_8))(
-            s"Transaction $stringifiedTxId (Proto String)",
-            s"$stringifiedTxId.transaction.pstring"
-          )
-        }
-      )
-
-  private def saveConfig(dir: Path, genesisId: BlockId): StageResultT[F, Unit] =
-    for {
-      configContents <-
-        show"""bifrost:
-          |  big-bang:
-          |    type: public
-          |    genesis-id: $genesisId
-          |    source-path: $dir
-          |""".stripMargin.pure[StageResultT[F, *]]
-      _ <- writeFile(dir)(configContents.getBytes(StandardCharsets.UTF_8))("Config File", "config.yaml")
-    } yield ()
 
   private def outro(dir: Path): StageResultT[F, Unit] =
     writeMessage[F](s"The mainnet genesis block has been initialized.") >>

--- a/node/src/main/scala/co/topl/node/cli/InitMainnetCommand.scala
+++ b/node/src/main/scala/co/topl/node/cli/InitMainnetCommand.scala
@@ -1,20 +1,20 @@
 package co.topl.node.cli
 
-import cats.{MonadThrow, Show}
 import cats.data.{EitherT, OptionT}
-import cats.effect.std.{Console, SecureRandom}
+import cats.effect.std.Console
 import cats.effect.{Async, Sync}
 import cats.implicits._
-import co.topl.blockchain.{BigBang, PrivateTestnet, StakerInitializers, StakingInit}
+import cats.{MonadThrow, Show}
+import co.topl.blockchain.BigBang
+import co.topl.brambl.constants.NetworkConstants
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.box.Value.UpdateProposal
 import co.topl.brambl.models.transaction.{IoTransaction, Schedule, UnspentTransactionOutput}
-import co.topl.brambl.models.{Datum, Event}
+import co.topl.brambl.models.{Datum, Event, LockAddress, LockId}
 import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.config.ApplicationConfig
 import co.topl.consensus.models.BlockId
-import co.topl.crypto.hash.Blake2b256
 import co.topl.node.ProtocolVersioner
 import co.topl.node.models.{BlockBody, FullBlock}
 import co.topl.typeclasses.implicits._
@@ -24,98 +24,106 @@ import fs2.io.file.{Files, Path}
 import quivr.models.{Int128, Ratio, SmallData}
 
 import java.nio.charset.StandardCharsets
-import java.time.{Instant, LocalDateTime}
 import java.time.format.DateTimeFormatter
+import java.time.{Instant, LocalDateTime}
 import scala.util.Try
 
-object InitTestnetCommand {
+object InitMainnetCommand {
 
   def apply[F[_]: Async: Console](appConfig: ApplicationConfig): StageResultT[F, Unit] =
-    new InitTestnetCommandImpl[F](appConfig).command
+    new InitMainnetCommandImpl[F](appConfig).command
+
+  private[cli] val UnspendableLockAddress = LockAddress(
+    network = NetworkConstants.MAIN_NETWORK_ID,
+    ledger = NetworkConstants.MAIN_LEDGER_ID,
+    id = LockId(ByteString.copyFrom(new Array[Byte](32)))
+  )
 
 }
 
-class InitTestnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit c: Console[F]) {
+class InitMainnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit c: Console[F]) {
 
   private val intro: StageResultT[F, Unit] =
     writeMessage[F](
-      "This utility generates a new blockchain.  The output is several files including a genesis block with the initial LVL and TOPL distribution and a staking directory for each genesis staker."
+      "This utility initializes genesis for a public, decentralized network." +
+      "  The output is several files representing the genesis block of the network."
     )
 
-  private val readSeed =
-    writeMessage[F]("Enter a seed for this staker.  Leave blank to use a random seed.") >>
-    readInput[F].semiflatMap {
-      case "" =>
-        SecureRandom.javaSecuritySecureRandom.flatMap(_.nextBytes(32))
-      case lockAddressStr =>
-        Sync[F].delay(new Blake2b256().hash(lockAddressStr.getBytes(StandardCharsets.UTF_8)))
-    }
+  private def validateRegistrationTransactions(
+    transactions: List[IoTransaction]
+  ): StageResultT[F, Option[List[IoTransaction]]] =
+    if (transactions.isEmpty)
+      writeMessage[F]("No transactions found").as(none[List[IoTransaction]])
+    else if (transactions.count(_.outputs.exists(_.value.value.topl.exists(_.registration.nonEmpty))) == 0)
+      writeMessage[F]("No registration transactions found").as(none[List[IoTransaction]])
+    else
+      transactions
+        .traverse(tx =>
+          tx.outputs.traverse(o =>
+            Either.cond(
+              o.address.network == NetworkConstants.MAIN_NETWORK_ID,
+              (),
+              show"Invalid LockAddress network for transactionId=${tx.id}"
+            )
+          )
+        )
+        .toEitherT[StageResultT[F, *]]
+        .leftSemiflatTap(writeMessage[F])
+        .toOption
+        .as(transactions)
+        .value
+
+  private val readRegistrationTransactions: StageResultT[F, List[IoTransaction]] =
+    (writeMessage[F]("Enter the directory containing the staker registration transactions.") >>
+      readInput[F].flatMap {
+        case "" => writeMessage[F]("Invalid directory.").as(none[List[IoTransaction]])
+        case str =>
+          val path = Path(str)
+          StageResultT
+            .liftF(Files.forAsync[F].isDirectory(path))
+            .ifM(
+              StageResultT
+                .liftF(
+                  Files
+                    .forAsync[F]
+                    .list(path)
+                    .evalMap(Files.forAsync[F].readAll(_).compile.to(Array).map(IoTransaction.parseFrom))
+                    .compile
+                    .toList
+                )
+                .flatMap(validateRegistrationTransactions),
+              writeMessage[F]("Not a directory.").as(none[List[IoTransaction]])
+            )
+      }).untilDefinedM
 
   /**
    * Read a lock address (or retry until a valid value is provided)
    */
   private val readLockAddress =
-    (writeMessage[F]("Enter a LockAddress.  Leave blank to use HeightLock=1.") >>
-      readInput[F].semiflatMap {
-        case "" =>
-          PrivateTestnet.HeightLockOneSpendingAddress.some.pure[F]
-        case lockAddressStr =>
-          EitherT
-            .fromEither[F](co.topl.brambl.codecs.AddressCodecs.decodeAddress(lockAddressStr))
-            .leftSemiflatTap(error => c.println(s"Invalid Lock Address. reason=$error input=$lockAddressStr"))
-            .toOption
-            .value
+    (writeMessage[F]("Enter a LockAddress.") >>
+      readInput[F].semiflatMap { lockAddressStr =>
+        EitherT
+          .fromEither[F](co.topl.brambl.codecs.AddressCodecs.decodeAddress(lockAddressStr))
+          .ensure("Incorrect network ID")(_.network == NetworkConstants.MAIN_NETWORK_ID)
+          .leftSemiflatTap(error => c.println(s"Invalid Lock Address. reason=$error input=$lockAddressStr"))
+          .toOption
+          .value
       }).untilDefinedM
 
   /**
    * Read an Int128 quantity (or retry until a valid value is provided)
    */
   private val readQuantity =
-    readLowercasedInput.semiflatMap {
-      case "" => PrivateTestnet.DefaultTotalStake.some.pure[F]
-      case str =>
-        EitherT(MonadThrow[F].catchNonFatal(BigInt(str)).attempt)
-          .leftMap(_ => s"Invalid Quantity. input=$str")
-          .ensure(s"Quantity too large. input=$str")(_.bitLength <= 128)
-          .ensure(s"Quantity must be positive. input=$str")(_ > 0)
-          .map(quantity => Int128(ByteString.copyFrom(quantity.toByteArray)))
-          .leftSemiflatTap(c.println(_))
-          .toOption
-          .value
+    readLowercasedInput.semiflatMap { str =>
+      EitherT(MonadThrow[F].catchNonFatal(BigInt(str)).attempt)
+        .leftMap(_ => s"Invalid Quantity. input=$str")
+        .ensure(s"Quantity too large. input=$str")(_.bitLength <= 128)
+        .ensure(s"Quantity must be positive. input=$str")(_ > 0)
+        .map(quantity => Int128(ByteString.copyFrom(quantity.toByteArray)))
+        .leftSemiflatTap(c.println(_))
+        .toOption
+        .value
     }
-
-  private val readStakerQuantity =
-    (
-      writeMessage[F]("How many TOPLs should this staker possess? default=10,000,000") >>
-        readQuantity
-    ).untilDefinedM
-
-  private val readStaker: StageResultT[F, StakerInitializerWithQuantity] =
-    for {
-      seed        <- readSeed
-      lockAddress <- readLockAddress
-      quantity    <- readStakerQuantity
-      initializer = StakerInitializers.Operator(
-        seed,
-        (appConfig.bifrost.protocols(0).kesKeyHours, appConfig.bifrost.protocols(0).kesKeyMinutes),
-        lockAddress
-      )
-    } yield StakerInitializerWithQuantity(initializer, quantity, initializer.registrationTransaction(quantity))
-
-  private val readStakers: StageResultT[F, List[StakerInitializerWithQuantity]] =
-    for {
-      _       <- writeMessage[F]("Please initialize the first staker.")
-      staker0 <- readStaker
-      otherStakers <- List
-        .empty[StakerInitializerWithQuantity]
-        .tailRecM(current =>
-          readLowercasedChoice("Add another staker?")(List("y", "n"), "n".some).flatMap {
-            case "y"      => readStaker.map(current.appended).map(_.asLeft[List[StakerInitializerWithQuantity]])
-            case "n" | "" => StageResultT.liftF(current.asRight[List[StakerInitializerWithQuantity]].pure[F])
-            case _        => writeMessage[F]("Invalid input").as(current.asLeft[List[StakerInitializerWithQuantity]])
-          }
-        )
-    } yield staker0 :: otherStakers
 
   private val readUnstakedTopl: StageResultT[F, UnspentTransactionOutput] =
     for {
@@ -223,9 +231,9 @@ class InitTestnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit
 
   private val readProtocolSettings = {
     implicit val showRatio: Show[co.topl.models.utility.Ratio] = r => s"${r.numerator}/${r.denominator}"
-    readLowercasedChoice("Do you want to customize the protocol settings?")(List("y", "n"), "n".some).flatMap {
-      case "n" => StageResultT.liftF(DefaultUpdateProposal.pure[F])
-      case "y" =>
+    readYesNo("Do you want to customize the protocol settings?", No.some)(
+      ifYes = StageResultT.liftF(DefaultUpdateProposal.pure[F]),
+      ifNo =
         for {
           fEffective <- readDefaultedOptional[F, Ratio](
             "f-effective",
@@ -284,14 +292,14 @@ class InitTestnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit
           kesKeyHours.some,
           kesKeyMinutes.some
         )
-    }
+    )
   }
 
   private def readOutputDirectory(genesisBlock: FullBlock) =
     writeMessage[F]("Enter a save directory.  Leave blank to use a temporary directory.") >>
     readInput[F].semiflatMap {
       case "" =>
-        Files.forAsync[F].createTempDirectory(None, s"testnet-${genesisBlock.header.id.show}", None)
+        Files.forAsync[F].createTempDirectory(None, s"mainnet-${genesisBlock.header.id.show}", None)
       case str =>
         Path(str).pure[F].flatTap(Files.forAsync[F].createDirectories)
     }
@@ -331,22 +339,6 @@ class InitTestnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit
         }
       )
 
-  private def saveStaker(dir: Path, name: String)(staker: StakerInitializerWithQuantity) =
-    for {
-      _ <- writeFile(dir / name)(staker.initializer.operatorSK.toByteArray)(
-        s"Operator SK ($name)",
-        StakingInit.OperatorKeyName
-      )
-      _ <- writeFile(dir / name)(staker.initializer.vrfSK.toByteArray)(s"VRF SK ($name)", StakingInit.VrfKeyName)
-      _ <- writeFile(dir / name / StakingInit.KesDirectoryName)(
-        persistableKesProductSecretKey.persistedBytes(staker.initializer.kesSK).toByteArray
-      )(s"KES SK ($name)", "0")
-      _ <- writeFile(dir / name)(staker.transaction.toByteArray)(
-        s"Registration Transaction ($name)",
-        StakingInit.RegistrationTxName
-      )
-    } yield ()
-
   private def saveConfig(dir: Path, genesisId: BlockId): StageResultT[F, Unit] =
     for {
       configContents <-
@@ -354,26 +346,26 @@ class InitTestnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit
           |  big-bang:
           |    type: public
           |    genesis-id: $genesisId
-          |    source-path: $dir/genesis
+          |    source-path: $dir
           |""".stripMargin.pure[StageResultT[F, *]]
       _ <- writeFile(dir)(configContents.getBytes(StandardCharsets.UTF_8))("Config File", "config.yaml")
     } yield ()
 
   private def outro(dir: Path): StageResultT[F, Unit] =
-    writeMessage[F](s"The testnet has been initialized.") >>
-    writeMessage[F](s"Each of the stakers in ${dir / "stakers"} should be moved to the corresponding node/machine.") >>
+    writeMessage[F](s"The mainnet genesis block has been initialized.") >>
+    writeMessage[F](s"The contents of $dir should be uploaded to a public location, like GitHub.") >>
     writeMessage[F](s"The node can be launched by passing the following argument at launch: --config $dir/config.yaml")
 
   val command: StageResultT[F, Unit] =
     for {
-      _                <- intro
-      stakers          <- readStakers
-      unstakedTopls    <- readUnstakedTopls
-      lvls             <- readLvls
-      protocolSettings <- readProtocolSettings
-      timestamp        <- readTimestamp.map(_.toMillis)
+      _                        <- intro
+      registrationTransactions <- readRegistrationTransactions
+      unstakedTopls            <- readUnstakedTopls
+      lvls                     <- readLvls
+      protocolSettings         <- readProtocolSettings
+      timestamp                <- readTimestamp.map(_.toMillis)
       protocolUtxo = UnspentTransactionOutput(
-        PrivateTestnet.HeightLockOneSpendingAddress,
+        InitMainnetCommand.UnspendableLockAddress,
         Value.defaultInstance.withUpdateProposal(protocolSettings)
       )
       tokenTransaction =
@@ -385,23 +377,13 @@ class InitTestnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit
         )
       genesisConfig = BigBang.Config(
         timestamp,
-        stakers.map(_.transaction) :+ tokenTransaction,
+        registrationTransactions :+ tokenTransaction,
         protocolVersion = ProtocolVersioner(appConfig.bifrost.protocols).appVersion.asProtocolVersion
       )
       genesisBlock = BigBang.fromConfig(genesisConfig)
       outputDirectory <- readOutputDirectory(genesisBlock)
-      _               <- saveGenesisBlock(outputDirectory / "genesis")(genesisBlock)
-      _ <- stakers.traverse { staker =>
-        val name = staker.initializer.stakingAddress.show
-        saveStaker(outputDirectory / "stakers", name)(staker)
-      }
-      _ <- saveConfig(outputDirectory, genesisBlock.header.id)
-      _ <- outro(outputDirectory)
+      _               <- saveGenesisBlock(outputDirectory)(genesisBlock)
+      _               <- saveConfig(outputDirectory, genesisBlock.header.id)
+      _               <- outro(outputDirectory)
     } yield ()
 }
-
-private[cli] case class StakerInitializerWithQuantity(
-  initializer: StakerInitializers.Operator,
-  quantity:    Int128,
-  transaction: IoTransaction
-)

--- a/node/src/main/scala/co/topl/node/cli/InitNetworkHelpers.scala
+++ b/node/src/main/scala/co/topl/node/cli/InitNetworkHelpers.scala
@@ -1,29 +1,29 @@
 package co.topl.node.cli
 
-import cats.implicits._
-import cats.{MonadThrow, Show}
 import cats.data._
 import cats.effect._
 import cats.effect.std.Console
-import co.topl.blockchain.PrivateTestnet
+import cats.implicits._
+import cats.{MonadThrow, Show}
+import co.topl.blockchain._
 import co.topl.brambl.models.LockAddress
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.box.Value.UpdateProposal
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
+import co.topl.brambl.syntax._
+import co.topl.codecs.bytes.tetra.instances._
+import co.topl.consensus.models.BlockId
 import co.topl.node.models.{BlockBody, FullBlock}
+import co.topl.typeclasses.implicits._
 import com.google.protobuf.ByteString
 import com.google.protobuf.duration.Duration
 import fs2.io.file.Path
 import quivr.models.{Int128, Ratio}
 
 import java.nio.charset.StandardCharsets
-import java.time.{Instant, LocalDateTime}
 import java.time.format.DateTimeFormatter
+import java.time.{Instant, LocalDateTime}
 import scala.util.Try
-import co.topl.brambl.syntax._
-import co.topl.codecs.bytes.tetra.instances._
-import co.topl.consensus.models.BlockId
-import co.topl.typeclasses.implicits._
 
 object InitNetworkHelpers {
 
@@ -164,45 +164,57 @@ object InitNetworkHelpers {
           fEffective <- readDefaultedOptional[F, Ratio](
             "f-effective",
             List("1/5", "15/100", "1"),
-            DefaultProtocol.fEffective.show
+            PublicTestnet.DefaultProtocol.fEffective.show
           )
-          vrfLddCutoff <- readDefaultedOptional[F, Int]("vrf-ldd-cutoff", List("50"), DefaultProtocol.vrfLddCutoff.show)
-          vrfPrecision <- readDefaultedOptional[F, Int]("vrf-precision", List("40"), DefaultProtocol.vrfPrecision.show)
+          vrfLddCutoff <- readDefaultedOptional[F, Int](
+            "vrf-ldd-cutoff",
+            List("50"),
+            PublicTestnet.DefaultProtocol.vrfLddCutoff.show
+          )
+          vrfPrecision <- readDefaultedOptional[F, Int](
+            "vrf-precision",
+            List("40"),
+            PublicTestnet.DefaultProtocol.vrfPrecision.show
+          )
           vrfBaselineDifficulty <- readDefaultedOptional[F, Ratio](
             "vrf-baseline-difficulty",
             List("1/20", "1/50"),
-            DefaultProtocol.vrfBaselineDifficulty.show
+            PublicTestnet.DefaultProtocol.vrfBaselineDifficulty.show
           )
           vrfAmplitude <- readDefaultedOptional[F, Ratio](
             "vrf-amplitude",
             List("1/2"),
-            DefaultProtocol.vrfAmplitude.show
+            PublicTestnet.DefaultProtocol.vrfAmplitude.show
           )
           chainSelectionKLookback <- readDefaultedOptional[F, Long](
             "chain-selection-k-lookback",
             List("500"),
-            DefaultProtocol.chainSelectionKLookback.show
+            PublicTestnet.DefaultProtocol.chainSelectionKLookback.show
           )
           slotDuration <- readDefaultedOptional[F, Duration](
             "slot-duration",
             List("1000 milli"),
-            DefaultProtocol.slotDuration.show
+            PublicTestnet.DefaultProtocol.slotDuration.show
           )
           forwardBiasedSlotWindow <- readDefaultedOptional[F, Long](
             "forward-biased-slot-window",
             List("50"),
-            DefaultProtocol.forwardBiasedSlotWindow.show
+            PublicTestnet.DefaultProtocol.forwardBiasedSlotWindow.show
           )
           operationalPeriodsPerEpoch <- readDefaultedOptional[F, Long](
             "operational-periods-per-epoch",
             List("2"),
-            DefaultProtocol.operationalPeriodsPerEpoch.show
+            PublicTestnet.DefaultProtocol.operationalPeriodsPerEpoch.show
           )
-          kesKeyHours <- readDefaultedOptional[F, Int]("kes-key-hours", List("9"), DefaultProtocol.kesKeyHours.show)
+          kesKeyHours <- readDefaultedOptional[F, Int](
+            "kes-key-hours",
+            List("9"),
+            PublicTestnet.DefaultProtocol.kesKeyHours.show
+          )
           kesKeyMinutes <- readDefaultedOptional[F, Int](
             "kes-key-minutes",
             List("9"),
-            DefaultProtocol.kesKeyMinutes.show
+            PublicTestnet.DefaultProtocol.kesKeyMinutes.show
           )
         } yield UpdateProposal(
           "genesis",
@@ -218,7 +230,7 @@ object InitNetworkHelpers {
           kesKeyHours.some,
           kesKeyMinutes.some
         ),
-      ifNo = StageResultT.liftF(DefaultUpdateProposal.pure[F])
+      ifNo = StageResultT.liftF(PublicTestnet.DefaultUpdateProposal.pure[F])
     )
   }
 

--- a/node/src/main/scala/co/topl/node/cli/InitNetworkHelpers.scala
+++ b/node/src/main/scala/co/topl/node/cli/InitNetworkHelpers.scala
@@ -1,0 +1,272 @@
+package co.topl.node.cli
+
+import cats.implicits._
+import cats.{MonadThrow, Show}
+import cats.data._
+import cats.effect._
+import cats.effect.std.Console
+import co.topl.blockchain.PrivateTestnet
+import co.topl.brambl.models.LockAddress
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.box.Value.UpdateProposal
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
+import co.topl.node.models.{BlockBody, FullBlock}
+import com.google.protobuf.ByteString
+import com.google.protobuf.duration.Duration
+import fs2.io.file.Path
+import quivr.models.{Int128, Ratio}
+
+import java.nio.charset.StandardCharsets
+import java.time.{Instant, LocalDateTime}
+import java.time.format.DateTimeFormatter
+import scala.util.Try
+import co.topl.brambl.syntax._
+import co.topl.codecs.bytes.tetra.instances._
+import co.topl.consensus.models.BlockId
+import co.topl.typeclasses.implicits._
+
+object InitNetworkHelpers {
+
+  /**
+   * Read a lock address (or retry until a valid value is provided)
+   */
+  def readLockAddress[F[_]: Sync: Console]: StageResultT[F, LockAddress] =
+    (writeMessage[F]("Enter a LockAddress.  Leave blank to use HeightLock=1.") >>
+      readInput[F].flatMap {
+        case "" =>
+          StageResultT.liftF(PrivateTestnet.HeightLockOneSpendingAddress.some.pure[F])
+        case lockAddressStr =>
+          EitherT
+            .fromEither[StageResultT[F, *]](co.topl.brambl.codecs.AddressCodecs.decodeAddress(lockAddressStr))
+            .leftSemiflatTap(error => writeMessage(s"Invalid Lock Address. reason=$error input=$lockAddressStr"))
+            .toOption
+            .value
+      }).untilDefinedM
+
+  /**
+   * Read an Int128 quantity (or retry until a valid value is provided)
+   */
+  def readQuantity[F[_]: Sync: Console]: StageResultT[F, Option[Int128]] =
+    readLowercasedInput.flatMap {
+      case "" =>
+        StageResultT.liftF(PrivateTestnet.DefaultTotalStake.some.pure[F])
+      case str =>
+        EitherT(MonadThrow[StageResultT[F, *]].catchNonFatal(BigInt(str)).attempt)
+          .leftMap(_ => s"Invalid Quantity. input=$str")
+          .ensure(s"Quantity too large. input=$str")(_.bitLength <= 128)
+          .ensure(s"Quantity must be positive. input=$str")(_ > 0)
+          .map(quantity => Int128(ByteString.copyFrom(quantity.toByteArray)))
+          .leftSemiflatTap(writeMessage[F])
+          .toOption
+          .value
+    }
+
+  def readUnstakedTopl[F[_]: Sync: Console]: StageResultT[F, UnspentTransactionOutput] =
+    for {
+      quantity    <- (writeMessage[F]("Enter a quantity of TOPLs.") >> readQuantity).untilDefinedM
+      lockAddress <- readLockAddress
+      utxo = UnspentTransactionOutput(
+        lockAddress,
+        Value.defaultInstance.withTopl(Value.TOPL.defaultInstance.withQuantity(quantity))
+      )
+    } yield utxo
+
+  def readUnstakedTopls[F[_]: Sync: Console]: StageResultT[F, List[UnspentTransactionOutput]] =
+    readYesNo[F, List[UnspentTransactionOutput]]("Do you want to add an unstaked TOPL?", No.some)(
+      ifYes = for {
+        utxo0 <- readUnstakedTopl
+        otherUtxos <- List
+          .empty[UnspentTransactionOutput]
+          .tailRecM(current =>
+            readYesNo("Add another unstaked Topl?", No.some)(
+              ifYes = readUnstakedTopl.map(current.appended).map(_.asLeft[List[UnspentTransactionOutput]]),
+              ifNo = StageResultT.liftF(current.asRight[List[UnspentTransactionOutput]].pure[F])
+            )
+          )
+      } yield utxo0 :: otherUtxos,
+      ifNo = StageResultT.liftF(List.empty[UnspentTransactionOutput].pure[F])
+    )
+
+  def readLvl[F[_]: Sync: Console]: StageResultT[F, UnspentTransactionOutput] =
+    for {
+      quantity    <- (writeMessage[F]("Enter a quantity of LVLs.") >> readQuantity).untilDefinedM
+      lockAddress <- readLockAddress
+      utxo = UnspentTransactionOutput(
+        lockAddress,
+        Value.defaultInstance.withLvl(Value.LVL.defaultInstance.withQuantity(quantity))
+      )
+    } yield utxo
+
+  def readLvls[F[_]: Sync: Console]: StageResultT[F, List[UnspentTransactionOutput]] =
+    readYesNo[F, List[UnspentTransactionOutput]]("Do you want to add a LVL?", No.some)(
+      ifYes = for {
+        utxo0 <- readLvl
+        otherUtxos <- List
+          .empty[UnspentTransactionOutput]
+          .tailRecM(current =>
+            readYesNo("Add another LVL?", No.some)(
+              ifYes = readLvl.map(current.appended).map(_.asLeft[List[UnspentTransactionOutput]]),
+              ifNo = StageResultT.liftF(current.asRight[List[UnspentTransactionOutput]].pure[F])
+            )
+          )
+      } yield utxo0 :: otherUtxos,
+      ifNo = StageResultT.liftF(List.empty[UnspentTransactionOutput].pure[F])
+    )
+
+  def readTimestamp[F[_]: Async: Console] = {
+    import scala.concurrent.duration._
+    (writeMessage[F](
+      "Enter a genesis timestamp (milliseconds since UNIX epoch) or a relative duration (i.e. 4 hours).  Leave blank to start in 20 seconds."
+    ) >>
+    readInput[F].flatMap {
+      case "" =>
+        StageResultT.liftF(Async[F].realTime.map(_ + 20.seconds).map(_.some))
+      case str =>
+        OptionT
+          .fromOption[StageResultT[F, *]](Try(scala.concurrent.duration.Duration(str)).toOption)
+          .semiflatMap(duration => StageResultT.liftF(Async[F].realTime.map(_ + duration)))
+          .orElse(
+            OptionT
+              .fromOption[StageResultT[F, *]](str.toLongOption)
+              .flatTapNone(writeMessage[F]("Invalid timestamp"))
+              .map(_.milli)
+          )
+          .collect { case fd: scala.concurrent.duration.FiniteDuration => fd }
+          // Double-check with the user that the genesis date/time is correct
+          .filterF(duration =>
+            StageResultT
+              .liftF(
+                Sync[F].delay(
+                  DateTimeFormatter
+                    .ofPattern("MM/dd/yyy HH:mm:ss")
+                    .format(
+                      LocalDateTime
+                        .ofInstant(Instant.ofEpochMilli(duration.toMillis), java.time.Clock.systemDefaultZone().getZone)
+                    )
+                )
+              )
+              .flatMap(formattedDateTime =>
+                readYesNo(s"The blockchain will begin on $formattedDateTime. Continue?", Yes.some)(
+                  ifYes = StageResultT.liftF(true.pure[F]),
+                  ifNo = StageResultT.liftF(false.pure[F])
+                )
+              )
+          )
+          .value
+    }).untilDefinedM
+  }
+
+  def readProtocolSettings[F[_]: Sync: Console] = {
+    implicit val showRatio: Show[co.topl.models.utility.Ratio] = r => s"${r.numerator}/${r.denominator}"
+    readYesNo("Do you want to customize the protocol settings?", No.some)(
+      ifYes =
+        for {
+          fEffective <- readDefaultedOptional[F, Ratio](
+            "f-effective",
+            List("1/5", "15/100", "1"),
+            DefaultProtocol.fEffective.show
+          )
+          vrfLddCutoff <- readDefaultedOptional[F, Int]("vrf-ldd-cutoff", List("50"), DefaultProtocol.vrfLddCutoff.show)
+          vrfPrecision <- readDefaultedOptional[F, Int]("vrf-precision", List("40"), DefaultProtocol.vrfPrecision.show)
+          vrfBaselineDifficulty <- readDefaultedOptional[F, Ratio](
+            "vrf-baseline-difficulty",
+            List("1/20", "1/50"),
+            DefaultProtocol.vrfBaselineDifficulty.show
+          )
+          vrfAmplitude <- readDefaultedOptional[F, Ratio](
+            "vrf-amplitude",
+            List("1/2"),
+            DefaultProtocol.vrfAmplitude.show
+          )
+          chainSelectionKLookback <- readDefaultedOptional[F, Long](
+            "chain-selection-k-lookback",
+            List("500"),
+            DefaultProtocol.chainSelectionKLookback.show
+          )
+          slotDuration <- readDefaultedOptional[F, Duration](
+            "slot-duration",
+            List("1000 milli"),
+            DefaultProtocol.slotDuration.show
+          )
+          forwardBiasedSlotWindow <- readDefaultedOptional[F, Long](
+            "forward-biased-slot-window",
+            List("50"),
+            DefaultProtocol.forwardBiasedSlotWindow.show
+          )
+          operationalPeriodsPerEpoch <- readDefaultedOptional[F, Long](
+            "operational-periods-per-epoch",
+            List("2"),
+            DefaultProtocol.operationalPeriodsPerEpoch.show
+          )
+          kesKeyHours <- readDefaultedOptional[F, Int]("kes-key-hours", List("9"), DefaultProtocol.kesKeyHours.show)
+          kesKeyMinutes <- readDefaultedOptional[F, Int](
+            "kes-key-minutes",
+            List("9"),
+            DefaultProtocol.kesKeyMinutes.show
+          )
+        } yield UpdateProposal(
+          "genesis",
+          fEffective.some,
+          vrfLddCutoff.some,
+          vrfPrecision.some,
+          vrfBaselineDifficulty.some,
+          vrfAmplitude.some,
+          chainSelectionKLookback.some,
+          slotDuration.some,
+          forwardBiasedSlotWindow.some,
+          operationalPeriodsPerEpoch.some,
+          kesKeyHours.some,
+          kesKeyMinutes.some
+        ),
+      ifNo = StageResultT.liftF(DefaultUpdateProposal.pure[F])
+    )
+  }
+
+  def saveGenesisBlock[F[_]: Async: Console](dir: Path)(block: FullBlock): StageResultT[F, Unit] =
+    StageResultT
+      .liftF(Sync[F].delay(block.header.id.show))
+      .flatMap(stringifiedHeaderId =>
+        writeFile[F](dir)(block.header.toByteArray)("Genesis Header", s"$stringifiedHeaderId.header.pbuf") >>
+        writeFile[F](dir)(block.header.toProtoString.getBytes(StandardCharsets.UTF_8))(
+          "Genesis Header (Proto String)",
+          s"$stringifiedHeaderId.header.pstring"
+        ) >>
+        StageResultT
+          .liftF(
+            Sync[F].delay(
+              BlockBody(block.fullBody.transactions.map(_.id), block.fullBody.rewardTransaction.map(_.id))
+            )
+          )
+          .flatMap(body =>
+            writeFile[F](dir)(body.toByteArray)("Genesis Body", s"$stringifiedHeaderId.body.pbuf") >>
+            writeFile[F](dir)(body.toProtoString.getBytes(StandardCharsets.UTF_8))(
+              "Genesis Body (Proto String)",
+              s"$stringifiedHeaderId.body.pstring"
+            )
+          ) >>
+        (block.fullBody.transactions ++ block.fullBody.rewardTransaction).traverse { tx =>
+          val stringifiedTxId = tx.id.show
+          writeFile[F](dir)(tx.toByteArray)(
+            s"Transaction $stringifiedTxId",
+            s"$stringifiedTxId.transaction.pbuf"
+          ) >>
+          writeFile[F](dir)(tx.toProtoString.getBytes(StandardCharsets.UTF_8))(
+            s"Transaction $stringifiedTxId (Proto String)",
+            s"$stringifiedTxId.transaction.pstring"
+          )
+        }
+      )
+      .void
+
+  def saveConfig[F[_]: Async: Console](dir: Path, genesisId: BlockId): StageResultT[F, Unit] =
+    for {
+      configContents <-
+        show"""bifrost:
+              |  big-bang:
+              |    type: public
+              |    genesis-id: $genesisId
+              |    source-path: $dir
+              |""".stripMargin.pure[StageResultT[F, *]]
+      _ <- writeFile(dir)(configContents.getBytes(StandardCharsets.UTF_8))("Config File", "config.yaml")
+    } yield ()
+}

--- a/node/src/main/scala/co/topl/node/cli/InitTestnetCommand.scala
+++ b/node/src/main/scala/co/topl/node/cli/InitTestnetCommand.scala
@@ -1,32 +1,22 @@
 package co.topl.node.cli
 
-import cats.{MonadThrow, Show}
-import cats.data.{EitherT, OptionT}
 import cats.effect.std.{Console, SecureRandom}
 import cats.effect.{Async, Sync}
 import cats.implicits._
 import co.topl.blockchain.{BigBang, PrivateTestnet, StakerInitializers, StakingInit}
 import co.topl.brambl.models.box.Value
-import co.topl.brambl.models.box.Value.UpdateProposal
 import co.topl.brambl.models.transaction.{IoTransaction, Schedule, UnspentTransactionOutput}
 import co.topl.brambl.models.{Datum, Event}
-import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.config.ApplicationConfig
-import co.topl.consensus.models.BlockId
 import co.topl.crypto.hash.Blake2b256
 import co.topl.node.ProtocolVersioner
-import co.topl.node.models.{BlockBody, FullBlock}
+import co.topl.node.models.FullBlock
 import co.topl.typeclasses.implicits._
-import com.google.protobuf.ByteString
-import com.google.protobuf.duration.Duration
 import fs2.io.file.{Files, Path}
-import quivr.models.{Int128, Ratio, SmallData}
+import quivr.models.{Int128, SmallData}
 
 import java.nio.charset.StandardCharsets
-import java.time.{Instant, LocalDateTime}
-import java.time.format.DateTimeFormatter
-import scala.util.Try
 
 object InitTestnetCommand {
 
@@ -35,7 +25,9 @@ object InitTestnetCommand {
 
 }
 
-class InitTestnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit c: Console[F]) {
+class InitTestnetCommandImpl[F[_]: Async: Console](appConfig: ApplicationConfig) {
+
+  import InitNetworkHelpers._
 
   private val intro: StageResultT[F, Unit] =
     writeMessage[F](
@@ -49,39 +41,6 @@ class InitTestnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit
         SecureRandom.javaSecuritySecureRandom.flatMap(_.nextBytes(32))
       case lockAddressStr =>
         Sync[F].delay(new Blake2b256().hash(lockAddressStr.getBytes(StandardCharsets.UTF_8)))
-    }
-
-  /**
-   * Read a lock address (or retry until a valid value is provided)
-   */
-  private val readLockAddress =
-    (writeMessage[F]("Enter a LockAddress.  Leave blank to use HeightLock=1.") >>
-      readInput[F].semiflatMap {
-        case "" =>
-          PrivateTestnet.HeightLockOneSpendingAddress.some.pure[F]
-        case lockAddressStr =>
-          EitherT
-            .fromEither[F](co.topl.brambl.codecs.AddressCodecs.decodeAddress(lockAddressStr))
-            .leftSemiflatTap(error => c.println(s"Invalid Lock Address. reason=$error input=$lockAddressStr"))
-            .toOption
-            .value
-      }).untilDefinedM
-
-  /**
-   * Read an Int128 quantity (or retry until a valid value is provided)
-   */
-  private val readQuantity =
-    readLowercasedInput.semiflatMap {
-      case "" => PrivateTestnet.DefaultTotalStake.some.pure[F]
-      case str =>
-        EitherT(MonadThrow[F].catchNonFatal(BigInt(str)).attempt)
-          .leftMap(_ => s"Invalid Quantity. input=$str")
-          .ensure(s"Quantity too large. input=$str")(_.bitLength <= 128)
-          .ensure(s"Quantity must be positive. input=$str")(_ > 0)
-          .map(quantity => Int128(ByteString.copyFrom(quantity.toByteArray)))
-          .leftSemiflatTap(c.println(_))
-          .toOption
-          .value
     }
 
   private val readStakerQuantity =
@@ -117,176 +76,6 @@ class InitTestnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit
         )
     } yield staker0 :: otherStakers
 
-  private val readUnstakedTopl: StageResultT[F, UnspentTransactionOutput] =
-    for {
-      quantity    <- (writeMessage[F]("Enter a quantity of TOPLs.") >> readQuantity).untilDefinedM
-      lockAddress <- readLockAddress
-      utxo = UnspentTransactionOutput(
-        lockAddress,
-        Value.defaultInstance.withTopl(Value.TOPL.defaultInstance.withQuantity(quantity))
-      )
-    } yield utxo
-
-  private val readUnstakedTopls: StageResultT[F, List[UnspentTransactionOutput]] =
-    readLowercasedChoice[F]("Do you want to add an unstaked TOPL?")(List("y", "n"), "n".some)
-      .map(_ == "y")
-      .ifM(
-        for {
-          utxo0 <- readUnstakedTopl
-          otherUtxos <- List
-            .empty[UnspentTransactionOutput]
-            .tailRecM(current =>
-              readLowercasedChoice[F]("Add another unstaked Topl?")(List("y", "n"), "n".some)
-                .flatMap {
-                  case "y"      => readUnstakedTopl.map(current.appended).map(_.asLeft[List[UnspentTransactionOutput]])
-                  case "n" | "" => StageResultT.liftF(current.asRight[List[UnspentTransactionOutput]].pure[F])
-                  case _        => writeMessage[F]("Invalid input").as(current.asLeft[List[UnspentTransactionOutput]])
-                }
-            )
-        } yield utxo0 :: otherUtxos,
-        StageResultT.liftF(List.empty[UnspentTransactionOutput].pure[F])
-      )
-
-  private val readLvl: StageResultT[F, UnspentTransactionOutput] =
-    for {
-      quantity    <- (writeMessage[F]("Enter a quantity of LVLs.") >> readQuantity).untilDefinedM
-      lockAddress <- readLockAddress
-      utxo = UnspentTransactionOutput(
-        lockAddress,
-        Value.defaultInstance.withLvl(Value.LVL.defaultInstance.withQuantity(quantity))
-      )
-    } yield utxo
-
-  private val readLvls: StageResultT[F, List[UnspentTransactionOutput]] =
-    readLowercasedChoice[F]("Do you want to add a LVL?")(List("y", "n"), "n".some)
-      .map(_ == "y")
-      .ifM(
-        for {
-          utxo0 <- readLvl
-          otherUtxos <- List
-            .empty[UnspentTransactionOutput]
-            .tailRecM(current =>
-              readLowercasedChoice[F]("Add another LVL?")(List("y", "n"), "n".some)
-                .flatMap {
-                  case "y"      => readLvl.map(current.appended).map(_.asLeft[List[UnspentTransactionOutput]])
-                  case "n" | "" => StageResultT.liftF(current.asRight[List[UnspentTransactionOutput]].pure[F])
-                  case _        => writeMessage[F]("Invalid input").as(current.asLeft[List[UnspentTransactionOutput]])
-                }
-            )
-        } yield utxo0 :: otherUtxos,
-        StageResultT.liftF(List.empty[UnspentTransactionOutput].pure[F])
-      )
-
-  private val readTimestamp = {
-    import scala.concurrent.duration._
-    (writeMessage[F](
-      "Enter a genesis timestamp (milliseconds since UNIX epoch) or a relative duration (i.e. 4 hours).  Leave blank to start in 20 seconds."
-    ) >>
-    readInput[F].flatMap {
-      case "" =>
-        StageResultT.liftF(Async[F].realTime.map(_ + 20.seconds).map(_.some))
-      case str =>
-        OptionT
-          .fromOption[StageResultT[F, *]](Try(scala.concurrent.duration.Duration(str)).toOption)
-          .semiflatMap(duration => StageResultT.liftF(Async[F].realTime.map(_ + duration)))
-          .orElse(
-            OptionT
-              .fromOption[StageResultT[F, *]](str.toLongOption)
-              .flatTapNone(writeMessage[F]("Invalid timestamp"))
-              .map(_.milli)
-          )
-          .collect { case fd: scala.concurrent.duration.FiniteDuration => fd }
-          // Double-check with the user that the genesis date/time is correct
-          .filterF(duration =>
-            StageResultT
-              .liftF(
-                Sync[F].delay(
-                  DateTimeFormatter
-                    .ofPattern("MM/dd/yyy HH:mm:ss")
-                    .format(
-                      LocalDateTime
-                        .ofInstant(Instant.ofEpochMilli(duration.toMillis), java.time.Clock.systemDefaultZone().getZone)
-                    )
-                )
-              )
-              .flatMap(formattedDateTime =>
-                readLowercasedChoice(s"The blockchain will begin on $formattedDateTime. Continue?")(
-                  List("y", "n"),
-                  "y".some
-                )
-                  .map(_ == "y")
-              )
-          )
-          .value
-    }).untilDefinedM
-  }
-
-  private val readProtocolSettings = {
-    implicit val showRatio: Show[co.topl.models.utility.Ratio] = r => s"${r.numerator}/${r.denominator}"
-    readLowercasedChoice("Do you want to customize the protocol settings?")(List("y", "n"), "n".some).flatMap {
-      case "n" => StageResultT.liftF(DefaultUpdateProposal.pure[F])
-      case "y" =>
-        for {
-          fEffective <- readDefaultedOptional[F, Ratio](
-            "f-effective",
-            List("1/5", "15/100", "1"),
-            DefaultProtocol.fEffective.show
-          )
-          vrfLddCutoff <- readDefaultedOptional[F, Int]("vrf-ldd-cutoff", List("50"), DefaultProtocol.vrfLddCutoff.show)
-          vrfPrecision <- readDefaultedOptional[F, Int]("vrf-precision", List("40"), DefaultProtocol.vrfPrecision.show)
-          vrfBaselineDifficulty <- readDefaultedOptional[F, Ratio](
-            "vrf-baseline-difficulty",
-            List("1/20", "1/50"),
-            DefaultProtocol.vrfBaselineDifficulty.show
-          )
-          vrfAmplitude <- readDefaultedOptional[F, Ratio](
-            "vrf-amplitude",
-            List("1/2"),
-            DefaultProtocol.vrfAmplitude.show
-          )
-          chainSelectionKLookback <- readDefaultedOptional[F, Long](
-            "chain-selection-k-lookback",
-            List("500"),
-            DefaultProtocol.chainSelectionKLookback.show
-          )
-          slotDuration <- readDefaultedOptional[F, Duration](
-            "slot-duration",
-            List("1000 milli"),
-            DefaultProtocol.slotDuration.show
-          )
-          forwardBiasedSlotWindow <- readDefaultedOptional[F, Long](
-            "forward-biased-slot-window",
-            List("50"),
-            DefaultProtocol.forwardBiasedSlotWindow.show
-          )
-          operationalPeriodsPerEpoch <- readDefaultedOptional[F, Long](
-            "operational-periods-per-epoch",
-            List("2"),
-            DefaultProtocol.operationalPeriodsPerEpoch.show
-          )
-          kesKeyHours <- readDefaultedOptional[F, Int]("kes-key-hours", List("9"), DefaultProtocol.kesKeyHours.show)
-          kesKeyMinutes <- readDefaultedOptional[F, Int](
-            "kes-key-minutes",
-            List("9"),
-            DefaultProtocol.kesKeyMinutes.show
-          )
-        } yield UpdateProposal(
-          "genesis",
-          fEffective.some,
-          vrfLddCutoff.some,
-          vrfPrecision.some,
-          vrfBaselineDifficulty.some,
-          vrfAmplitude.some,
-          chainSelectionKLookback.some,
-          slotDuration.some,
-          forwardBiasedSlotWindow.some,
-          operationalPeriodsPerEpoch.some,
-          kesKeyHours.some,
-          kesKeyMinutes.some
-        )
-    }
-  }
-
   private def readOutputDirectory(genesisBlock: FullBlock) =
     writeMessage[F]("Enter a save directory.  Leave blank to use a temporary directory.") >>
     readInput[F].semiflatMap {
@@ -295,41 +84,6 @@ class InitTestnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit
       case str =>
         Path(str).pure[F].flatTap(Files.forAsync[F].createDirectories)
     }
-
-  private def saveGenesisBlock(dir: Path)(block: FullBlock) =
-    StageResultT
-      .liftF(Sync[F].delay(block.header.id.show))
-      .flatMap(stringifiedHeaderId =>
-        writeFile[F](dir)(block.header.toByteArray)("Genesis Header", s"$stringifiedHeaderId.header.pbuf") >>
-        writeFile[F](dir)(block.header.toProtoString.getBytes(StandardCharsets.UTF_8))(
-          "Genesis Header (Proto String)",
-          s"$stringifiedHeaderId.header.pstring"
-        ) >>
-        StageResultT
-          .liftF(
-            Sync[F].delay(
-              BlockBody(block.fullBody.transactions.map(_.id), block.fullBody.rewardTransaction.map(_.id))
-            )
-          )
-          .flatMap(body =>
-            writeFile[F](dir)(body.toByteArray)("Genesis Body", s"$stringifiedHeaderId.body.pbuf") >>
-            writeFile[F](dir)(body.toProtoString.getBytes(StandardCharsets.UTF_8))(
-              "Genesis Body (Proto String)",
-              s"$stringifiedHeaderId.body.pstring"
-            )
-          ) >>
-        (block.fullBody.transactions ++ block.fullBody.rewardTransaction).traverse { tx =>
-          val stringifiedTxId = tx.id.show
-          writeFile[F](dir)(tx.toByteArray)(
-            s"Transaction $stringifiedTxId",
-            s"$stringifiedTxId.transaction.pbuf"
-          ) >>
-          writeFile[F](dir)(tx.toProtoString.getBytes(StandardCharsets.UTF_8))(
-            s"Transaction $stringifiedTxId (Proto String)",
-            s"$stringifiedTxId.transaction.pstring"
-          )
-        }
-      )
 
   private def saveStaker(dir: Path, name: String)(staker: StakerInitializerWithQuantity) =
     for {
@@ -345,18 +99,6 @@ class InitTestnetCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implicit
         s"Registration Transaction ($name)",
         StakingInit.RegistrationTxName
       )
-    } yield ()
-
-  private def saveConfig(dir: Path, genesisId: BlockId): StageResultT[F, Unit] =
-    for {
-      configContents <-
-        show"""bifrost:
-          |  big-bang:
-          |    type: public
-          |    genesis-id: $genesisId
-          |    source-path: $dir/genesis
-          |""".stripMargin.pure[StageResultT[F, *]]
-      _ <- writeFile(dir)(configContents.getBytes(StandardCharsets.UTF_8))("Config File", "config.yaml")
     } yield ()
 
   private def outro(dir: Path): StageResultT[F, Unit] =

--- a/node/src/main/scala/co/topl/node/cli/RegistrationCommandImpl.scala
+++ b/node/src/main/scala/co/topl/node/cli/RegistrationCommandImpl.scala
@@ -137,10 +137,9 @@ class RegistrationCommandImpl[F[_]: Async](appConfig: ApplicationConfig)(implici
         )
       )
       .flatTap(key =>
-        writeFile(stakingDirectory)(persistableKesProductSecretKey.persistedBytes(key._1).toByteArray)(
-          "KES SK",
-          s"${StakingInit.KesDirectoryName}/0"
-        )
+        writeFile(stakingDirectory / StakingInit.KesDirectoryName)(
+          persistableKesProductSecretKey.persistedBytes(key._1).toByteArray
+        )("KES SK", "0")
       )
 
   private val askIfExistingNetwork: StageResultT[F, Boolean] =

--- a/node/src/main/scala/co/topl/node/cli/package.scala
+++ b/node/src/main/scala/co/topl/node/cli/package.scala
@@ -4,18 +4,20 @@ import cats.data.EitherT
 import cats.effect.std.Console
 import cats.effect.{Async, Sync}
 import cats.implicits._
+import co.topl.blockchain.BigBang
 import co.topl.brambl.models.LockAddress
 import co.topl.brambl.syntax._
+import co.topl.config.ApplicationConfig
 import co.topl.consensus.models.BlockId
 import co.topl.models.utility._
-import quivr.models.Ratio
+import co.topl.numerics.implicits._
 import com.google.protobuf.ByteString
 import fs2.Chunk
 import fs2.io.file.{Files, Path}
-import quivr.models.Int128
+import quivr.models.{Int128, Ratio}
 import simulacrum.typeclass
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 import scala.util.Try
 
 package object cli {
@@ -196,6 +198,25 @@ package object cli {
         .map(ByteString.copyFrom)
         .map(BlockId(_))
     }
+
+  private[cli] val DefaultProtocol =
+    ApplicationConfig.Bifrost.Protocol(
+      minAppVersion = "2.0.0",
+      fEffective = Ratio(15, 100),
+      vrfLddCutoff = 50,
+      vrfPrecision = 40,
+      vrfBaselineDifficulty = Ratio(1, 20),
+      vrfAmplitude = Ratio(1, 2),
+      // 10x private testnet default, resulting in ~50 minute epochs
+      chainSelectionKLookback = 500,
+      slotDuration = 1.seconds,
+      forwardBiasedSlotWindow = 50,
+      operationalPeriodsPerEpoch = 24,
+      kesKeyHours = 9,
+      kesKeyMinutes = 9
+    )
+
+  private[cli] val DefaultUpdateProposal = BigBang.protocolToUpdateProposal(DefaultProtocol)
 }
 
 @typeclass

--- a/node/src/main/scala/co/topl/node/cli/package.scala
+++ b/node/src/main/scala/co/topl/node/cli/package.scala
@@ -4,13 +4,10 @@ import cats.data.EitherT
 import cats.effect.std.Console
 import cats.effect.{Async, Sync}
 import cats.implicits._
-import co.topl.blockchain.BigBang
 import co.topl.brambl.models.LockAddress
 import co.topl.brambl.syntax._
-import co.topl.config.ApplicationConfig
 import co.topl.consensus.models.BlockId
 import co.topl.models.utility._
-import co.topl.numerics.implicits._
 import com.google.protobuf.ByteString
 import fs2.Chunk
 import fs2.io.file.{Files, Path}
@@ -199,25 +196,6 @@ package object cli {
         .map(ByteString.copyFrom)
         .map(BlockId(_))
     }
-
-  private[cli] val DefaultProtocol =
-    ApplicationConfig.Bifrost.Protocol(
-      minAppVersion = "2.0.0",
-      fEffective = Ratio(15, 100),
-      vrfLddCutoff = 50,
-      vrfPrecision = 40,
-      vrfBaselineDifficulty = Ratio(1, 20),
-      vrfAmplitude = Ratio(1, 2),
-      // 10x private testnet default, resulting in ~50 minute epochs
-      chainSelectionKLookback = 500,
-      slotDuration = 1.seconds,
-      forwardBiasedSlotWindow = 50,
-      operationalPeriodsPerEpoch = 24,
-      kesKeyHours = 9,
-      kesKeyMinutes = 9
-    )
-
-  private[cli] val DefaultUpdateProposal = BigBang.protocolToUpdateProposal(DefaultProtocol)
 }
 
 @typeclass

--- a/node/src/main/scala/co/topl/node/cli/package.scala
+++ b/node/src/main/scala/co/topl/node/cli/package.scala
@@ -51,6 +51,7 @@ package object cli {
     val stringifiedChoices =
       choices.map(c => if (default.contains(c)) c.toUpperCase else c).map(c => s" $c ").mkString("[", "|", "]")
     (writeMessage[F](s"$prompt $stringifiedChoices") >> readLowercasedInput[F])
+      .map(_.trim)
       .flatMap(response =>
         if (response.isEmpty) {
           default.fold(writeMessage[F]("No input provided.").as(none[String]))(d => StageResultT.liftF(d.some.pure[F]))


### PR DESCRIPTION
## Purpose
- Launching a mainnet is decentralized and does not use a common seed like the testnets would
- Instead, the mainnet is initialized using registration transactions constructed using the `register` command
## Approach
- Implement InitMainnetCommand
- Extract common functionality from InitTestnetCommand
## Testing
- Verified using the procedure
  - Run `register` command using a mainnet LockAddress (i.e. `mtetmain1y3LYktMBTcdh6i3aaAKafMiFvFVgKw8Z2SYt3xCZvL9WhkBhpN4`)
  - Use the registration transaction in the `init-mainnet` command
  - Expected files are created
## Tickets
- #BN-1121