### PR TITLE
Staking Prevent Slot Re-Use

### DIFF
--- a/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/Staking.scala
@@ -3,6 +3,7 @@ package co.topl.minting.interpreters
 import cats.data.OptionT
 import cats.effect._
 import cats.implicits._
+import cats.effect.implicits._
 import co.topl.brambl.models.LockAddress
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.codecs.bytes.typeclasses.implicits._
@@ -22,7 +23,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object Staking {
 
-  def make[F[_]: Sync](
+  def make[F[_]: Async](
     a:                        StakingAddress,
     rewardAddress:            LockAddress,
     vkVrf:                    ByteString,
@@ -35,93 +36,107 @@ object Staking {
     leaderElectionValidation: LeaderElectionValidationAlgebra[F],
     protocolVersion:          ProtocolVersion
   ): Resource[F, StakingAlgebra[F]] =
-    Resource.pure {
-      val _rewardAddress = rewardAddress
-      new StakingAlgebra[F] {
-        implicit private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass[F](Staking.getClass)
-        val address: F[StakingAddress] = a.pure[F]
-        val rewardAddress: F[LockAddress] = _rewardAddress.pure[F]
+    // Construct a `Ref` which contains the last-eligible slot.
+    // This helps prevent re-using an eligibility for old slots.
+    Ref
+      .of(0L)
+      .toResource
+      .map { lastEligibleSlotRef =>
+        val _rewardAddress = rewardAddress
+        new StakingAlgebra[F] {
+          implicit private val logger: SelfAwareStructuredLogger[F] =
+            Slf4jLogger.getLoggerFromClass[F](Staking.getClass)
+          val address: F[StakingAddress] = a.pure[F]
+          val rewardAddress: F[LockAddress] = _rewardAddress.pure[F]
 
-        def elect(parentSlotId: SlotId, slot: Slot): F[Option[VrfHit]] =
-          (
-            for {
-              eta           <- OptionT.liftF(etaCalculation.etaToBe(parentSlotId, slot))
-              relativeStake <- OptionT(consensusState.operatorRelativeStake(parentSlotId.blockId, slot)(a))
-              threshold <- OptionT.liftF(leaderElectionValidation.getThreshold(relativeStake, slot - parentSlotId.slot))
-              testProof <- OptionT.liftF(vrfCalculator.proofForSlot(slot, eta))
-              rho       <- OptionT.liftF(vrfCalculator.rhoForSlot(slot, eta))
-              isLeader  <- OptionT.liftF(leaderElectionValidation.isSlotLeaderForThreshold(threshold)(rho))
-              vrfHit <- OptionT
-                .whenF[F, VrfHit](isLeader)(
-                  blake2b256Resource
-                    .use(implicit b => Sync[F].delay(thresholdEvidence(threshold)))
-                    .map(evidence =>
-                      VrfHit(
-                        EligibilityCertificate(testProof, vkVrf, evidence, eta.data),
-                        slot,
-                        threshold
+          def elect(parentSlotId: SlotId, slot: Slot): F[Option[VrfHit]] =
+            (
+              for {
+                lastEligibility <- OptionT.liftF(lastEligibleSlotRef.get)
+                // If the input slot is less than or equal to the last used eligibility, return None to avoid eligibility re-use
+                _             <- OptionT.when[F, Unit](slot > lastEligibility)(())
+                eta           <- OptionT.liftF(etaCalculation.etaToBe(parentSlotId, slot))
+                relativeStake <- OptionT(consensusState.operatorRelativeStake(parentSlotId.blockId, slot)(a))
+                threshold <- OptionT.liftF(
+                  leaderElectionValidation.getThreshold(relativeStake, slot - parentSlotId.slot)
+                )
+                testProof <- OptionT.liftF(vrfCalculator.proofForSlot(slot, eta))
+                rho       <- OptionT.liftF(vrfCalculator.rhoForSlot(slot, eta))
+                isLeader  <- OptionT.liftF(leaderElectionValidation.isSlotLeaderForThreshold(threshold)(rho))
+                vrfHit <- OptionT
+                  .whenF[F, VrfHit](isLeader)(
+                    blake2b256Resource
+                      .use(implicit b => Sync[F].delay(thresholdEvidence(threshold)))
+                      .map(evidence =>
+                        VrfHit(
+                          EligibilityCertificate(testProof, vkVrf, evidence, eta.data),
+                          slot,
+                          threshold
+                        )
+                      )
+                  )
+                // Update the last-used slot reference to the new eligibility slot
+                _ <- OptionT.liftF(lastEligibleSlotRef.update(_.max(slot)))
+              } yield vrfHit
+            ).value.flatTap(maybeHit =>
+              Logger[F].debug(
+                show"Eligibility at" +
+                show" slot=$slot" +
+                show" parentId=${parentSlotId.blockId}" +
+                show" parentSlot=${parentSlotId.slot}" +
+                show" eligible=${maybeHit.nonEmpty}"
+              )
+            )
+
+          def certifyBlock(
+            parentSlotId:         SlotId,
+            slot:                 Slot,
+            unsignedBlockBuilder: UnsignedBlockHeader.PartialOperationalCertificate => UnsignedBlockHeader,
+            eta:                  Eta
+          ): F[Option[BlockHeader]] =
+            OptionT(operationalKeyMaker.operationalKeyForSlot(slot, parentSlotId, eta)).semiflatMap {
+              operationalKeyOut =>
+                for {
+                  partialCertificate <- Sync[F].delay(
+                    UnsignedBlockHeader.PartialOperationalCertificate(
+                      operationalKeyOut.parentVK,
+                      operationalKeyOut.parentSignature,
+                      operationalKeyOut.childVK
+                    )
+                  )
+                  unsignedBlock = unsignedBlockBuilder(partialCertificate)
+                  messageToSign = unsignedBlock.signableBytes.toByteArray
+                  signature <- ed25519Resource.use(ed25519 =>
+                    Sync[F].delay(
+                      ed25519.sign(
+                        Ed25519.SecretKey(operationalKeyOut.childSK.toByteArray),
+                        messageToSign
                       )
                     )
-                )
-            } yield vrfHit
-          ).value.flatTap(maybeHit =>
-            Logger[F].debug(
-              show"Eligibility at" +
-              show" slot=$slot" +
-              show" parentId=${parentSlotId.blockId}" +
-              show" parentSlot=${parentSlotId.slot}" +
-              show" eligible=${maybeHit.nonEmpty}"
-            )
-          )
-
-        def certifyBlock(
-          parentSlotId:         SlotId,
-          slot:                 Slot,
-          unsignedBlockBuilder: UnsignedBlockHeader.PartialOperationalCertificate => UnsignedBlockHeader,
-          eta:                  Eta
-        ): F[Option[BlockHeader]] =
-          OptionT(operationalKeyMaker.operationalKeyForSlot(slot, parentSlotId, eta)).semiflatMap { operationalKeyOut =>
-            for {
-              partialCertificate <- Sync[F].delay(
-                UnsignedBlockHeader.PartialOperationalCertificate(
-                  operationalKeyOut.parentVK,
-                  operationalKeyOut.parentSignature,
-                  operationalKeyOut.childVK
-                )
-              )
-              unsignedBlock = unsignedBlockBuilder(partialCertificate)
-              messageToSign = unsignedBlock.signableBytes.toByteArray
-              signature <- ed25519Resource.use(ed25519 =>
-                Sync[F].delay(
-                  ed25519.sign(
-                    Ed25519.SecretKey(operationalKeyOut.childSK.toByteArray),
-                    messageToSign
                   )
-                )
-              )
-              operationalCertificate = OperationalCertificate(
-                operationalKeyOut.parentVK,
-                operationalKeyOut.parentSignature,
-                partialCertificate.childVK,
-                ByteString.copyFrom(signature)
-              )
-              header = BlockHeader(
-                headerId = None,
-                unsignedBlock.parentHeaderId,
-                unsignedBlock.parentSlot,
-                unsignedBlock.txRoot,
-                unsignedBlock.bloomFilter,
-                unsignedBlock.timestamp,
-                unsignedBlock.height,
-                unsignedBlock.slot,
-                unsignedBlock.eligibilityCertificate,
-                operationalCertificate,
-                unsignedBlock.metadata,
-                unsignedBlock.address,
-                protocolVersion
-              )
-            } yield header
-          }.value
+                  operationalCertificate = OperationalCertificate(
+                    operationalKeyOut.parentVK,
+                    operationalKeyOut.parentSignature,
+                    partialCertificate.childVK,
+                    ByteString.copyFrom(signature)
+                  )
+                  header = BlockHeader(
+                    headerId = None,
+                    unsignedBlock.parentHeaderId,
+                    unsignedBlock.parentSlot,
+                    unsignedBlock.txRoot,
+                    unsignedBlock.bloomFilter,
+                    unsignedBlock.timestamp,
+                    unsignedBlock.height,
+                    unsignedBlock.slot,
+                    unsignedBlock.eligibilityCertificate,
+                    operationalCertificate,
+                    unsignedBlock.metadata,
+                    unsignedBlock.address,
+                    protocolVersion
+                  )
+                } yield header
+            }.value
+        }
       }
-    }
 }

--- a/minting/src/test/scala/co/topl/minting/interpreters/StakingSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/StakingSpec.scala
@@ -119,6 +119,101 @@ class StakingSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
     }
   }
 
+  test("elect: with slot-reuse should fail") {
+    PropF.forAllF { (blockId: BlockId) =>
+      withMock {
+        val slot = 10L
+        val parentSlotId = SlotId.of(slot, blockId)
+        val eta = Sized.strictUnsafe(ByteString.copyFrom(Array.fill[Byte](32)(0))): Eta
+        val relativeStake = Ratio.One
+        val address = StakingAddress(ByteString.copyFrom(Array.fill[Byte](32)(0)))
+        val rewardAddress = LockAddress(0, 0, LockId(ByteString.copyFrom(Array.fill[Byte](32)(0))))
+
+        val vkVrf = ByteString.copyFrom(Array.fill[Byte](32)(0))
+        val proof = ByteString.copyFrom(
+          hex"bc31a2fb46995ffbe4b316176407f57378e2f3d7fee57d228a811194361d8e7040c9d15575d7a2e75506ffe1a47d772168b071a99d2e85511730e9c21397a1cea0e7fa4bd161e6d5185a94a665dd190d".toArray
+        )
+        val rho = Rho(
+          Sized.strictUnsafe(
+            data =
+              hex"c30d2304d5d76e7cee8cc0eb66493528cc9e5a9cc03449bc8ed3dab192ba1e8edb3567b4ffc63526c69a6d05a73b57879529ccf8dd22e596080257843748d569"
+          )
+        )
+
+        val etaCalculation = mock[EtaCalculationAlgebra[F]]
+        val consensusState = mock[ConsensusValidationStateAlgebra[F]]
+        val leaderElectionValidation = mock[LeaderElectionValidationAlgebra[F]]
+        val vrfCalculator = mock[VrfCalculatorAlgebra[F]]
+
+        (etaCalculation.etaToBe _)
+          .expects(parentSlotId, slot)
+          .once()
+          .returning(eta.pure[F])
+
+        (consensusState
+          .operatorRelativeStake(_: BlockId, _: Slot)(_: StakingAddress)(_: Monad[F]))
+          .expects(blockId, slot, address, *)
+          .once()
+          .returning(relativeStake.some.pure[F])
+
+        (leaderElectionValidation.getThreshold _)
+          .expects(relativeStake, slot - parentSlotId.slot)
+          .once()
+          .returning(Ratio.One.pure[F])
+
+        (leaderElectionValidation
+          .isSlotLeaderForThreshold(_: Ratio)(_: Rho))
+          .expects(relativeStake, *)
+          .once()
+          .returning(true.pure[F])
+
+        (vrfCalculator.proofForSlot _)
+          .expects(slot, eta)
+          .twice()
+          .returning(proof.pure[F])
+
+        (vrfCalculator.rhoForSlot _)
+          .expects(slot, eta)
+          .once()
+          .returning(rho.pure[F])
+
+        val resource = for {
+          staking <- Staking
+            .make[F](
+              a = address,
+              rewardAddress = rewardAddress,
+              vkVrf,
+              operationalKeyMaker = null,
+              consensusState,
+              etaCalculation,
+              ed25519Resource = null,
+              blake2b256Resource = Resource.pure(new Blake2b256),
+              vrfCalculator,
+              leaderElectionValidation,
+              ProtocolVersion(0, 0, 1)
+            )
+
+          testProof <- vrfCalculator.proofForSlot(slot, eta).toResource
+
+          expectedVrfHit = VrfHit(
+            EligibilityCertificate(
+              testProof,
+              vkVrf,
+              thresholdEvidence(relativeStake)(new Blake2b256),
+              eta.data
+            ),
+            slot,
+            relativeStake
+          )
+          _ <- staking.elect(parentSlotId, slot).assertEquals(expectedVrfHit.some).toResource
+          _ <- staking.elect(parentSlotId, slot - 1).assertEquals(None).toResource
+          _ <- staking.elect(parentSlotId, slot).assertEquals(None).toResource
+        } yield ()
+        resource.use_
+      }
+    }
+  }
+
   test("certifyBlock: with empty operationalKeyForSlot") {
     PropF.forAllF { (parentSlotId: SlotId, slot: Slot) =>
       withMock {


### PR DESCRIPTION
## Purpose
- It is dishonest behavior to re-use a slot/eligibility when producing blocks. (Nothing-at-Stake)
- An honest node can currently produce duplicate eligibilities by accident due to a bug
## Approach
- Staking implementation holds a Ref to the last-eligible slot
- When attempting to elect, it checks the Ref against the proposed slot, and fails immediately if the proposed slot is old
## Testing
- New unit test
## Tickets
- #BN-1308