### PR TITLE
BN-1310-node-g-rpc-service-admin (do NOT merge)

### DIFF
--- a/algebras/src/main/scala/co/topl/algebras/AdminRpc.scala
+++ b/algebras/src/main/scala/co/topl/algebras/AdminRpc.scala
@@ -1,0 +1,14 @@
+package co.topl.algebras
+
+/**
+ * AdminRpc
+ * An interaction layer intended to convey the admin endpoints of a blockchain node and its services.
+ *
+ * @tparam F Effect type
+ * @tparam S Response container, Ex: Stream, Seq, etc.
+ */
+trait AdminRpc[F[_], S[_]] {
+
+  def fetchSoftwareVersion(): F[String]
+
+}

--- a/blockchain/src/main/scala/co/topl/blockchain/ToplAdminRpcServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/ToplAdminRpcServer.scala
@@ -1,0 +1,19 @@
+package co.topl.blockchain
+
+import cats.data.OptionT
+import cats.effect.{Async, Resource}
+import co.topl.algebras.AdminRpc
+import co.topl.blockchain.algebras.NodeMetadataAlgebra
+import fs2.Stream
+
+object ToplAdminRpcServer {
+
+  def make[F[_]: Async](nodeMetadataAlgebra: NodeMetadataAlgebra[F]): Resource[F, AdminRpc[F, Stream[F, *]]] =
+    Resource.pure {
+      new AdminRpc[F, Stream[F, *]] {
+        override def fetchSoftwareVersion(): F[String] =
+          OptionT(nodeMetadataAlgebra.readAppVersion).getOrElse("Undefined")
+      }
+    }
+
+}

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -26,6 +26,7 @@ object ApplicationConfig {
     staking:   Bifrost.Staking,
     p2p:       Bifrost.P2P,
     rpc:       Bifrost.RPC,
+    rpcAdmin:  Bifrost.RPC,
     mempool:   Bifrost.Mempool,
     bigBang:   Bifrost.BigBang,
     protocols: Map[Slot, Bifrost.Protocol],

--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -61,6 +61,8 @@ class NodeAppTest extends CatsEffectSuite {
          |    public-port: 9150
          |  rpc:
          |    bind-port: 9151
+         |  rpc-admin:
+         |    bind-port: 9154
          |  big-bang:
          |    type: public
          |    genesis-id: ${genesisBlockId.show}
@@ -81,6 +83,8 @@ class NodeAppTest extends CatsEffectSuite {
          |    known-peers: 127.0.0.2:9150
          |  rpc:
          |    bind-port: 9153
+         |  rpc-admin:
+         |    bind-port: 9155
          |  big-bang:
          |    type: public
          |    genesis-id: ${genesisBlockId.show}

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -41,6 +41,13 @@ bifrost {
     // The local port for binding at the OS-level to allow outside gRPC connections
     bind-port = 9084
   }
+  // Settings for admin RPC/gRPC
+  rpc-admin {
+    // The local host/IP for binding at the OS-level to allow outside gRPC connections
+    bind-host = "0.0.0.0"
+    // The local port for binding at the OS-level to allow outside gRPC connections
+    bind-port = 9086
+  }
   // Settings for the mempool
   mempool {
     // The maximum number of slots to retain a Transaction that fails to find its way into a block

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -345,11 +345,14 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
           appConfig.bifrost.p2p.knownPeers,
           appConfig.bifrost.rpc.bindHost,
           appConfig.bifrost.rpc.bindPort,
+          appConfig.bifrost.rpcAdmin.bindHost,
+          appConfig.bifrost.rpcAdmin.bindPort,
           protocolConfig,
           genusServices ::: healthServices,
           epochData,
           appConfig.bifrost.p2p.exposeServerPort,
-          appConfig.bifrost.p2p.networkProperties
+          appConfig.bifrost.p2p.networkProperties,
+          metadata
         )
         .parProduct(genusOpt.traverse(Replicator.background[F]).void)
     } yield ()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val orientDbVersion = "3.2.24"
   val ioGrpcVersion = "1.59.0"
   val http4sVersion = "0.23.23"
-  val protobufSpecsVersion = "2.0.0-beta0" // scala-steward:off
+  val protobufSpecsVersion = "2.0.0-beta0+1-498c6043-SNAPSHOT" // scala-steward:off
   val bramblScVersion = "2.0.0-alpha7+10-9ae3b5ba-SNAPSHOT" // scala-steward:off
 
   val catsSlf4j =

--- a/topl-grpc/src/main/scala/co/topl/grpc/AdminGrpc.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/AdminGrpc.scala
@@ -1,0 +1,34 @@
+package co.topl.grpc
+
+import cats.effect.kernel.{Async, Resource}
+import cats.implicits._
+import co.topl.algebras.AdminRpc
+import co.topl.grpc.services.AdminService
+import co.topl.node.services.NodeAdminRpcFs2Grpc
+import fs2.Stream
+import fs2.grpc.syntax.all.fs2GrpcSyntaxServerBuilder
+import io.grpc.{Server, ServerServiceDefinition}
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
+import io.grpc.protobuf.services.ProtoReflectionService
+import java.net.InetSocketAddress
+
+object AdminGrpc {
+
+  object Server {
+
+    def serve[F[_]: Async](host: String, port: Int)(services: List[ServerServiceDefinition]): Resource[F, Server] =
+      services
+        .foldLeft(
+          NettyServerBuilder
+            .forAddress(new InetSocketAddress(host, port))
+        )(_.addService(_))
+        .addService(ProtoReflectionService.newInstance())
+        .resource[F]
+        .evalMap(server => Async[F].delay(server.start()))
+
+    def services[F[_]: Async](
+      interpreter: AdminRpc[F, Stream[F, *]]
+    ): Resource[F, List[ServerServiceDefinition]] =
+      List(NodeAdminRpcFs2Grpc.bindServiceResource(new AdminService(interpreter))).sequence
+  }
+}

--- a/topl-grpc/src/main/scala/co/topl/grpc/services/AdminService.scala
+++ b/topl-grpc/src/main/scala/co/topl/grpc/services/AdminService.scala
@@ -1,0 +1,15 @@
+package co.topl.grpc.services
+
+import cats.implicits._
+import cats.effect.Async
+import co.topl.algebras.AdminRpc
+import co.topl.node.services.{FetchSoftwareVersionReq, FetchSoftwareVersionRes, NodeAdminRpcFs2Grpc}
+import fs2.Stream
+import io.grpc.Metadata
+
+class AdminService[F[_]: Async](interpreter: AdminRpc[F, Stream[F, *]]) extends NodeAdminRpcFs2Grpc[F, Metadata] {
+
+  override def fetchSoftwareVersion(request: FetchSoftwareVersionReq, ctx: Metadata): F[FetchSoftwareVersionRes] =
+    interpreter.fetchSoftwareVersion().map(FetchSoftwareVersionRes(_))
+
+}


### PR DESCRIPTION
## Purpose

Node gRPC service "Admin"

it will be used to :
- fetch software version (implemented)
- updating staking reward address (TBD)
- restarting block producing (TBD)
- clear banned peers (TBD)

------

## Approach
- implement a new blockchain server for admin rpc calls, a new Rpc was defined, which will be  executed on port `9086`
- requires protobuf specs pr: https://github.com/Topl/protobuf-specs/pull/95
### Questions TODO:
- should this service always enabled, or drive by enabled flag config
- talk with Sean, Rick, if this is right approach, and check if host/port configuration should be exposed and included on other places of the code, for docker/kubernetes..


## Testing

```
fernando@fernando-um700:~/topl/Bifrost$ gwhisper localhost:9086 co.topl.node.services.NodeAdminRpc FetchSoftwareVersion
2023-11-27 11:42:38: Received message:
| version = "2.0.0-alpha10-46-00a3273d-20231127-1141"
RPC succeeded :D
fernando@fernando-um700:~/topl/Bifrost$ 
```

## Tickets  
BN- 1310
