### PR TITLE
EventSourcedStates Force Update

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/EventSourcedStates.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/EventSourcedStates.scala
@@ -1,0 +1,18 @@
+package co.topl.blockchain
+
+import co.topl.blockchain.interpreters.EpochDataEventSourcedState
+import co.topl.consensus.interpreters.{ConsensusDataEventSourcedState, EpochBoundariesEventSourcedState}
+import co.topl.consensus.models.BlockId
+import co.topl.eventtree.EventSourcedState
+import co.topl.interpreters.BlockHeightTree
+import co.topl.ledger.interpreters.{BoxState, Mempool, RegistrationAccumulator}
+
+case class EventSourcedStates[F[_]](
+  epochData:       EventSourcedState[F, EpochDataEventSourcedState.State[F], BlockId],
+  blockHeights:    EventSourcedState[F, BlockHeightTree.State[F], BlockId],
+  consensusData:   EventSourcedState[F, ConsensusDataEventSourcedState.ConsensusData[F], BlockId],
+  epochBoundaries: EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[F], BlockId],
+  boxState:        EventSourcedState[F, BoxState.State[F], BlockId],
+  mempool:         EventSourcedState[F, Mempool.State[F], BlockId],
+  registrations:   EventSourcedState[F, RegistrationAccumulator.State[F], BlockId]
+)

--- a/blockchain/src/main/scala/co/topl/blockchain/Validators.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Validators.scala
@@ -16,16 +16,7 @@ import co.topl.consensus.algebras.LeaderElectionValidationAlgebra
 import co.topl.consensus.interpreters.BlockHeaderToBodyValidation
 import co.topl.consensus.interpreters.BlockHeaderValidation
 import co.topl.consensus.models.BlockId
-import co.topl.eventtree.ParentChildTree
-import co.topl.ledger.algebras.{
-  BodyAuthorizationValidationAlgebra,
-  BodySemanticValidationAlgebra,
-  BodySyntaxValidationAlgebra,
-  BoxStateAlgebra,
-  RegistrationAccumulatorAlgebra,
-  TransactionRewardCalculatorAlgebra,
-  TransactionSemanticValidationAlgebra
-}
+import co.topl.ledger.algebras._
 import co.topl.ledger.interpreters._
 import co.topl.quivr.api.Verifier.instances.verifierInstance
 import co.topl.typeclasses.implicits._
@@ -48,16 +39,16 @@ case class Validators[F[_]](
 object Validators {
 
   def make[F[_]: Async](
-    cryptoResources:             CryptoResources[F],
-    dataStores:                  DataStores[F],
-    bigBangBlockId:              BlockId,
-    eligibilityCache:            EligibilityCacheAlgebra[F],
-    currentEventIdGetterSetters: CurrentEventIdGetterSetters[F],
-    blockIdTree:                 ParentChildTree[F, BlockId],
-    etaCalculation:              EtaCalculationAlgebra[F],
-    consensusValidationState:    ConsensusValidationStateAlgebra[F],
-    leaderElectionThreshold:     LeaderElectionValidationAlgebra[F],
-    clockAlgebra:                ClockAlgebra[F]
+    cryptoResources:          CryptoResources[F],
+    dataStores:               DataStores[F],
+    bigBangBlockId:           BlockId,
+    eligibilityCache:         EligibilityCacheAlgebra[F],
+    etaCalculation:           EtaCalculationAlgebra[F],
+    consensusValidationState: ConsensusValidationStateAlgebra[F],
+    leaderElectionThreshold:  LeaderElectionValidationAlgebra[F],
+    clockAlgebra:             ClockAlgebra[F],
+    boxState:                 BoxStateAlgebra[F],
+    registrationAccumulator:  RegistrationAccumulatorAlgebra[F]
   ): Resource[F, Validators[F]] =
     for {
       headerValidation <- BlockHeaderValidation
@@ -77,16 +68,6 @@ object Validators {
         .flatMap(BlockHeaderValidation.WithCache.make[F](_))
         .toResource
       headerToBody <- BlockHeaderToBodyValidation.make().toResource
-      boxState <- BoxState
-        .make(
-          currentEventIdGetterSetters.boxState.get(),
-          dataStores.bodies.getOrRaise,
-          dataStores.transactions.getOrRaise,
-          blockIdTree,
-          currentEventIdGetterSetters.boxState.set,
-          dataStores.spendableBoxIds.pure[F]
-        )
-        .toResource
       transactionSyntaxValidation = TransactionSyntaxInterpreter.make[F]()
       transactionSemanticValidation <- TransactionSemanticValidation
         .make[F](dataStores.transactions.getOrRaise, boxState)
@@ -96,14 +77,6 @@ object Validators {
       bodySyntaxValidation <- BodySyntaxValidation
         .make[F](dataStores.transactions.getOrRaise, transactionSyntaxValidation, rewardCalculator)
         .toResource
-      registrationAccumulator <- RegistrationAccumulator.make[F](
-        currentEventIdGetterSetters.registrationAccumulator.get(),
-        dataStores.bodies.getOrRaise,
-        dataStores.transactions.getOrRaise,
-        blockIdTree,
-        currentEventIdGetterSetters.registrationAccumulator.set,
-        dataStores.registrationAccumulator.pure[F]
-      )
       bodySemanticValidation <- BodySemanticValidation
         .make[F](
           dataStores.transactions.getOrRaise,

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/Mempool.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/Mempool.scala
@@ -28,7 +28,7 @@ object Mempool {
     clock:                  ClockAlgebra[F],
     onExpiration:           TransactionId => F[Unit],
     defaultExpirationLimit: Long
-  ): Resource[F, MempoolAlgebra[F]] =
+  ): Resource[F, (MempoolAlgebra[F], EventSourcedState[F, State[F], BlockId])] =
     for {
       graphState <- Ref.of(MempoolGraph(Map.empty, Map.empty, Map.empty)).toResource
       expirationsState <- Resource.make(Ref.of(Map.empty[TransactionId, Fiber[F, Throwable, Unit]]))(
@@ -83,22 +83,23 @@ object Mempool {
           currentEventChanged
         )
         .toResource
-    } yield new MempoolAlgebra[F] {
+      interpreter = new MempoolAlgebra[F] {
 
-      def read(blockId: BlockId): F[MempoolGraph] =
-        eventSourcedState
-          .useStateAt(blockId)(_.get)
+        def read(blockId: BlockId): F[MempoolGraph] =
+          eventSourcedState
+            .useStateAt(blockId)(_.get)
 
-      def add(transactionId: TransactionId): F[Unit] =
-        fetchTransaction(transactionId).flatMap(addWithExpiration)
+        def add(transactionId: TransactionId): F[Unit] =
+          fetchTransaction(transactionId).flatMap(addWithExpiration)
 
-      def remove(transactionId: TransactionId): F[Unit] =
-        fetchTransaction(transactionId).flatMap(removeWithExpiration)
+        def remove(transactionId: TransactionId): F[Unit] =
+          fetchTransaction(transactionId).flatMap(removeWithExpiration)
 
-      def contains(blockId: BlockId, transactionId: TransactionId): F[Boolean] =
-        eventSourcedState
-          .useStateAt(blockId)(_.get)
-          .map(_.transactions.contains(transactionId))
-    }
+        def contains(blockId: BlockId, transactionId: TransactionId): F[Boolean] =
+          eventSourcedState
+            .useStateAt(blockId)(_.get)
+            .map(_.transactions.contains(transactionId))
+      }
+    } yield (interpreter, eventSourcedState)
 
 }

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/AugmentedBoxStateSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/AugmentedBoxStateSpec.scala
@@ -36,7 +36,7 @@ class AugmentedBoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
 
         for {
           parentChildTree <- ParentChildTree.FromRef.make[IO, BlockId]
-          boxState <- BoxState.make[IO](
+          (boxState, _) <- BoxState.make[IO](
             blockId0.pure[IO],
             Map(
               blockId1 ->

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BoxStateSpec.scala
@@ -37,7 +37,7 @@ class BoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
           parentChildTree <- ParentChildTree.FromRef.make[IO, BlockId]
           _               <- parentChildTree.associate(blockId1, blockId0)
           _               <- parentChildTree.associate(blockId2, blockId1)
-          underTest <- BoxState.make[IO](
+          (underTest, _) <- BoxState.make[IO](
             blockId0.pure[IO],
             Map(
               blockId1 -> BlockBody(List(transaction1.id)).pure[IO],

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/MempoolSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/MempoolSpec.scala
@@ -68,6 +68,7 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
               _ => Applicative[F].unit,
               Long.MaxValue
             )
+            .map(_._1)
             .use(underTest =>
               for {
                 _ <- underTest.read(bodies.last._1).map(_.transactions.keySet).assertEquals(Set.empty[TransactionId])
@@ -121,6 +122,7 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
               _ => Applicative[F].unit,
               Long.MaxValue
             )
+            .map(_._1)
             .use(_.add(transaction.id).assert)
         } yield ()
       }
@@ -152,7 +154,7 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
                 .once()
                 .returning(clockDeferred.get)
             expirationDeferred <- Deferred[F, Unit].toResource
-            underTest <-
+            (underTest, _) <-
               Mempool
                 .make[F](
                   currentBlockId.pure[F],
@@ -205,7 +207,7 @@ class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncM
                 .once()
                 .returning(clockDeferred.get)
             expirationDeferred <- Deferred[F, Unit].toResource
-            underTest <-
+            (underTest, _) <-
               Mempool
                 .make[F](
                   currentBlockId.pure[F],

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/RegistrationAccumulatorSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/RegistrationAccumulatorSpec.scala
@@ -86,7 +86,7 @@ class RegistrationAccumulatorSpec extends CatsEffectSuite with ScalaCheckEffectS
         _               <- parentChildTree.associate(blockId0, genesisBlockId).toResource
         _               <- parentChildTree.associate(blockId1, blockId0).toResource
         _               <- parentChildTree.associate(blockId2, blockId1).toResource
-        underTest <- RegistrationAccumulator.make[IO](
+        (underTest, _) <- RegistrationAccumulator.make[IO](
           genesisBlockId.pure[IO],
           Map(
             blockId0 -> BlockBody(List(tx0.id)).pure[IO],


### PR DESCRIPTION
## Purpose
- EventSourcedStates are lazily evaluated
- In some cases, like EpochData, the state may only be evaluated whenever a user requests it.  If there are no requests for several epochs, then the next request will take an extreme length of time
## Approach
- Capture all EventSourcedState implementations into a case class
- In BlockchainImpl, run a background fiber that evaluates all states whenever a block is adopted
## Testing
- Unit test updates
## Tickets
N/A