### PR TITLE
Block Producer Logging and Retry

### DIFF
--- a/cats-utils/src/main/scala/co/topl/catsutils/Iterative.scala
+++ b/cats-utils/src/main/scala/co/topl/catsutils/Iterative.scala
@@ -1,6 +1,5 @@
 package co.topl.catsutils
 
-import cats.data.EitherT
 import cats.effect.implicits._
 import cats.effect.kernel.Async
 import cats.effect.{Deferred, Ref, Resource}

--- a/cats-utils/src/main/scala/co/topl/catsutils/Iterative.scala
+++ b/cats-utils/src/main/scala/co/topl/catsutils/Iterative.scala
@@ -41,6 +41,7 @@ object Iterative {
                 .improve(_)
                 .flatTap(result.set)
             )
+            .race(stopDeferred.get)
             .guarantee(Async[F].cede)
         )
         .interruptWhen(stopDeferred)

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
@@ -23,6 +23,8 @@ import com.google.protobuf.ByteString
 import fs2.concurrent.Topic
 import org.typelevel.log4cats.Logger
 
+import scala.util.Random
+
 object NetworkManager {
 
   def startNetwork[F[_]: Async: Logger](
@@ -153,7 +155,7 @@ object NetworkManager {
   ): Seq[KnownRemotePeer] = {
     val remoteAddressMap = remoteAddress.map { ra =>
       val id =
-        ra.p2pVK.map(HostId).getOrElse(HostId(ByteString.copyFrom(ra.remoteAddress.host.getBytes.take(hostIdBytesLen))))
+        ra.p2pVK.map(HostId).getOrElse(HostId(ByteString.copyFrom(Random.nextBytes(hostIdBytesLen))))
       ra.remoteAddress -> KnownRemotePeer(id, ra.remoteAddress, 0, 0)
     }.toMap
     val remotePeersMap = remotePeers.map(p => p.address -> p).toMap


### PR DESCRIPTION
## Purpose
- Additional logging, especially in error cases
- Retry failed block production
- Fix P2P host IDs for unknown hosts
## Approach
- Add error logging statements to background streams and iterative
- Add extra logging statements around local block validation
- When a known peer is provided, its peer ID is not known, so previously it was derived from first 32 bytes of hostname.  For long hosts like `bifrost-node-0.bifrost-node-p2p.bifrost-testnet-dev-s-1.svc.cluster.local`, this causes conflicts between nodes in the cluster. Now, it'll be generated randomly
## Testing
N/A
## Tickets
N/A