### PR TITLE
Block Producer Allow Blocks at Old Slots

### DIFF
--- a/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
@@ -1,6 +1,5 @@
 package co.topl.minting.interpreters
 
-import cats.Applicative
 import cats.data.OptionT
 import cats.effect._
 import cats.implicits._

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -168,6 +168,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
           .pure[F]
           .rethrow
           .toResource
+      _ <- Logger[F].info(s"Protocol settings=$bigBangProtocol").toResource
       vrfConfig = VrfConfig(
         bigBangProtocol.vrfLddCutoff,
         bigBangProtocol.vrfPrecision,
@@ -445,8 +446,8 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
     for {
       exp   <- ExpInterpreter.make[F](10000, 38)
       log1p <- Log1pInterpreter.make[F](10000, 8).flatMap(Log1pInterpreter.makeCached[F])
-      leaderElectionThreshold = LeaderElectionValidation
-        .make[F](vrfConfig, blake2b512Resource, exp, log1p)
+      base = LeaderElectionValidation.make[F](vrfConfig, blake2b512Resource, exp, log1p)
+      leaderElectionThreshold <- LeaderElectionValidation.makeCached(base)
     } yield leaderElectionThreshold
 
   /**


### PR DESCRIPTION
## Purpose
- Under normal conditions, the global slot and the canonical head slot should be similar, but when a network/node misbehaves, the node may fall into an unrecoverable de-sync
- Insufficient logging for slow operations
- LeaderElectionValidation cached implementation not used
## Approach
- Update BlockProducer to allow blocks to be produced from the parent slot, rather than the global slot
- Add `warnIfSlow` helper
- Use cached LeaderElectionValidation in NodeApp
- Print ProtocolSettings
## Testing
N/A
## Tickets
N/A