### PR TITLE
BN-1275 Added cache for block checker to avoid long slot data chain b…

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -33,6 +33,7 @@ package object fsnetwork {
 
   val requestCacheSize = 256
 
+  val bodyStoreContainsCacheSize = 32768
   val blockSourceCacheSize = 1024
 
   type BlockHeights[F[_]] = EventSourcedState[F, Long => F[Option[BlockId]], BlockId]

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
@@ -158,6 +158,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               for {
                 updatedState <- actor.send(BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData))
                 _ = assert(updatedState.bestKnownRemoteSlotDataOpt == Option(BestChain(remoteSlotData)))
+                _ = assert(updatedState.bodyStoreCache.underlying.get(localId).get.value)
               } yield ()
             }
         }

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -86,16 +86,16 @@ bifrost {
       maximum-entries = 512
     }
     slot-data {
-      maximum-entries = 256
+      maximum-entries = 32768
     }
     headers {
-      maximum-entries = 128
+      maximum-entries = 256
     }
     bodies {
-      maximum-entries = 128
+      maximum-entries = 256
     }
     transactions {
-      maximum-entries = 128
+      maximum-entries = 256
     }
     spendable-box-ids {
       maximum-entries = 512


### PR DESCRIPTION
## Purpose
Block checker take a lot of time to build full slot data chain.

## Approach
Added cache to for fixing issue with building too long slot data chain 


## Testing
Unit tests

## Tickets