### PR TITLE
BN-1115 Send only part of remote slot data chunk, not whole chain; Cache sent to Block checker slot data.

### DIFF
--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -73,8 +73,7 @@ object ApplicationConfig {
       closeTimeoutFirstDelayInMs: Long = 1000,
       closeTimeoutWindowInMs:     Long = 1000 * 60 * 60 * 24, // 1 day
       aggressiveP2P:              Boolean = true, // always try to found new good remote peers
-      aggressiveP2PCount:         Int = 2, // how many new connection will be opened
-      slotDataDownloadStep:       Long = 50 // how many slot data is downloaded before building slot data chain
+      aggressiveP2PCount:         Int = 2 // how many new connection will be opened
     )
 
     case class KnownPeer(host: String, port: Int)

--- a/consensus/src/main/scala/co/topl/consensus/algebras/ChainSelectionAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/ChainSelectionAlgebra.scala
@@ -7,4 +7,13 @@ trait ChainSelectionAlgebra[F[_], A] {
    * 0 is returned.  If `x` is "worse" than `y`, some value < 0 is returned.
    */
   def compare(x: A, y: A): F[Int]
+
+  /**
+   * Return smallest possible remote height which is enough to make decision which chain is better
+   * @param currentHeight current chain height
+   * @param commonHeight common ancestor height
+   * @param proposedHeight other chain height
+   * @return smallest possible height enough to make decision which chain is better
+   */
+  def enoughHeightToCompare(currentHeight: Long, commonHeight: Long, proposedHeight: Long): F[Long]
 }

--- a/consensus/src/main/scala/co/topl/consensus/algebras/LocalChainAlgebra.scala
+++ b/consensus/src/main/scala/co/topl/consensus/algebras/LocalChainAlgebra.scala
@@ -41,4 +41,6 @@ trait LocalChainAlgebra[F[_]] {
    * The first block (SlotData) in the chain
    */
   def genesis: F[SlotData]
+
+  def chainSelectionAlgebra: F[ChainSelectionAlgebra[F, SlotData]]
 }

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/ChainSelection.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/ChainSelection.scala
@@ -67,6 +67,15 @@ object ChainSelection {
     implicit private val logger: Logger[F] =
       Slf4jLogger.getLoggerFromName("Bifrost.ChainSelection")
 
+    override def enoughHeightToCompare(currentHeight: Long, commonHeight: Long, proposedHeight: Long): F[Long] = {
+      val densitySelection = (currentHeight - commonHeight) > kLookback
+      if (densitySelection) {
+        (commonHeight + sWindow).pure[F]
+      } else {
+        Math.min(currentHeight + kLookback, proposedHeight).pure[F]
+      }
+    }
+
     override def compare(x: SlotData, y: SlotData): F[Int] =
       if (x === y) 0.pure[F]
       else

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/LocalChain.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/LocalChain.scala
@@ -29,6 +29,8 @@ object LocalChain {
         implicit private val logger: SelfAwareStructuredLogger[F] =
           Slf4jLogger.getLoggerFromName[F]("Bifrost.LocalChain")
 
+        override val chainSelectionAlgebra: F[ChainSelectionAlgebra[F, SlotData]] = chainSelection.pure[F]
+
         def isWorseThan(newHead: SlotData): F[Boolean] =
           head.flatMap(chainSelection.compare(_, newHead).map(_ < 0))
 

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/LocalChainSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/LocalChainSpec.scala
@@ -25,6 +25,11 @@ class LocalChainSpec extends CatsEffectSuite with ScalaCheckEffectSuite with Asy
   private val blockId1 = BlockId(ByteString.copyFrom(Array.fill[Byte](32)(1)))
   private val blockId2 = BlockId(ByteString.copyFrom(Array.fill[Byte](32)(2)))
 
+  val chainSelection: ChainSelectionAlgebra[F, SlotData] = new ChainSelectionAlgebra[F, SlotData] {
+    override def compare(x: SlotData, y: SlotData): F[Int] = x.height.compareTo(y.height).pure[F]
+    override def enoughHeightToCompare(currentHeight: Long, commonHeight: Long, proposedHeight: Long): F[Long] = ???
+  }
+
   test("store the head of the local canonical tine") {
     PropF.forAllF(genSizedStrictByteString[Lengths.`64`.type](), etaGen) { (rho, eta) =>
       val initialHead =
@@ -35,8 +40,6 @@ class LocalChainSpec extends CatsEffectSuite with ScalaCheckEffectSuite with Asy
           eta.data,
           0
         )
-
-      val chainSelection: ChainSelectionAlgebra[F, SlotData] = (a, b) => a.height.compareTo(b.height).pure[F]
 
       LocalChain
         .make[F](initialHead, initialHead, chainSelection, _ => Applicative[F].unit)
@@ -54,8 +57,6 @@ class LocalChainSpec extends CatsEffectSuite with ScalaCheckEffectSuite with Asy
           eta.data,
           0
         )
-
-      val chainSelection: ChainSelectionAlgebra[F, SlotData] = (a, b) => a.height.compareTo(b.height).pure[F]
 
       val newHead =
         SlotData(
@@ -82,8 +83,6 @@ class LocalChainSpec extends CatsEffectSuite with ScalaCheckEffectSuite with Asy
           eta.data,
           0
         )
-
-      val chainSelection: ChainSelectionAlgebra[F, SlotData] = (a, b) => a.height.compareTo(b.height).pure[F]
 
       val newHead =
         SlotData(
@@ -123,8 +122,6 @@ class LocalChainSpec extends CatsEffectSuite with ScalaCheckEffectSuite with Asy
         etaGen.first.data,
         1
       )
-
-    val chainSelection: ChainSelectionAlgebra[F, SlotData] = (a, b) => a.height.compareTo(b.height).pure[F]
 
     LocalChain
       .make[F](initialHead, initialHead, chainSelection, _ => Applicative[F].unit)

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
@@ -80,21 +80,19 @@ trait NetworkAlgebra[F[_]] {
     headerToBodyValidation:      BlockHeaderToBodyValidationAlgebra[F],
     transactionSyntaxValidation: TransactionSyntaxVerifier[F],
     mempool:                     MempoolAlgebra[F],
-    slotDataDownloadStep:        Long,
     commonAncestorF:             (BlockchainPeerClient[F], BlockHeights[F], LocalChainAlgebra[F]) => F[BlockId]
   ): Resource[F, PeerActor[F]]
 
   def makePeerHeaderFetcher(
-    hostId:               HostId,
-    client:               BlockchainPeerClient[F],
-    requestsProxy:        RequestsProxyActor[F],
-    peersManager:         PeersManagerActor[F],
-    localChain:           LocalChainAlgebra[F],
-    slotDataStore:        Store[F, BlockId, SlotData],
-    blockIdTree:          ParentChildTree[F, BlockId],
-    blockHeights:         BlockHeights[F],
-    slotDataDownloadStep: Long,
-    commonAncestorF:      (BlockchainPeerClient[F], BlockHeights[F], LocalChainAlgebra[F]) => F[BlockId]
+    hostId:          HostId,
+    client:          BlockchainPeerClient[F],
+    requestsProxy:   RequestsProxyActor[F],
+    peersManager:    PeersManagerActor[F],
+    localChain:      LocalChainAlgebra[F],
+    slotDataStore:   Store[F, BlockId, SlotData],
+    blockIdTree:     ParentChildTree[F, BlockId],
+    blockHeights:    BlockHeights[F],
+    commonAncestorF: (BlockchainPeerClient[F], BlockHeights[F], LocalChainAlgebra[F]) => F[BlockId]
   ): Resource[F, PeerBlockHeaderFetcherActor[F]]
 
   def makePeerBodyFetcher(
@@ -212,7 +210,6 @@ class NetworkAlgebraImpl[F[_]: Async: Parallel: Logger: DnsResolver: ReverseDnsR
     headerToBodyValidation:      BlockHeaderToBodyValidationAlgebra[F],
     transactionSyntaxValidation: TransactionSyntaxVerifier[F],
     mempool:                     MempoolAlgebra[F],
-    slotDataDownloadStep:        Long,
     commonAncestorF:             (BlockchainPeerClient[F], BlockHeights[F], LocalChainAlgebra[F]) => F[BlockId]
   ): Resource[F, PeerActor[F]] =
     PeerActor.makeActor(
@@ -229,21 +226,19 @@ class NetworkAlgebraImpl[F[_]: Async: Parallel: Logger: DnsResolver: ReverseDnsR
       headerToBodyValidation,
       transactionSyntaxValidation,
       mempool,
-      slotDataDownloadStep,
       commonAncestorF
     )
 
   override def makePeerHeaderFetcher(
-    hostId:               HostId,
-    client:               BlockchainPeerClient[F],
-    requestsProxy:        RequestsProxyActor[F],
-    peersManager:         PeersManagerActor[F],
-    localChain:           LocalChainAlgebra[F],
-    slotDataStore:        Store[F, BlockId, SlotData],
-    blockIdTree:          ParentChildTree[F, BlockId],
-    blockHeights:         BlockHeights[F],
-    slotDataDownloadStep: Long,
-    commonAncestorF:      (BlockchainPeerClient[F], BlockHeights[F], LocalChainAlgebra[F]) => F[BlockId]
+    hostId:          HostId,
+    client:          BlockchainPeerClient[F],
+    requestsProxy:   RequestsProxyActor[F],
+    peersManager:    PeersManagerActor[F],
+    localChain:      LocalChainAlgebra[F],
+    slotDataStore:   Store[F, BlockId, SlotData],
+    blockIdTree:     ParentChildTree[F, BlockId],
+    blockHeights:    BlockHeights[F],
+    commonAncestorF: (BlockchainPeerClient[F], BlockHeights[F], LocalChainAlgebra[F]) => F[BlockId]
   ): Resource[F, PeerBlockHeaderFetcherActor[F]] =
     PeerBlockHeaderFetcher.makeActor(
       hostId,
@@ -255,7 +250,6 @@ class NetworkAlgebraImpl[F[_]: Async: Parallel: Logger: DnsResolver: ReverseDnsR
       blockIdTree,
       clock,
       blockHeights,
-      slotDataDownloadStep,
       commonAncestorF
     )
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -122,7 +122,6 @@ object PeerActor {
     headerToBodyValidation:      BlockHeaderToBodyValidationAlgebra[F],
     transactionSyntaxValidation: TransactionSyntaxVerifier[F],
     mempool:                     MempoolAlgebra[F],
-    slotDataDownloadStep:        Long,
     commonAncestorF:             (BlockchainPeerClient[F], BlockHeights[F], LocalChainAlgebra[F]) => F[BlockId]
   ): Resource[F, PeerActor[F]] = {
     val initNetworkLevel = false
@@ -141,7 +140,6 @@ object PeerActor {
         slotDataStore,
         blockIdTree,
         blockHeights,
-        slotDataDownloadStep,
         commonAncestorF
       )
       body <- networkAlgebra.makePeerBodyFetcher(

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
@@ -532,7 +532,7 @@ object PeersManager {
     val warmPeers = state.peersHandler.getWarmPeers
     val coldPeers = state.peersHandler.getColdPeers
 
-    Logger[F].info(show"PeerId: ${state.thisHostId}") >>
+    Logger[F].info(show"This peer id: ${state.thisHostId}") >>
     state.localChain.head.map(head => Logger[F].info(show"Current head: ${head.slotId}")) >>
     Logger[F].info(show"Known local addresses: ${state.thisHostIps}") >>
     Logger[F].info(show"Current (${hotPeers.size}) hot peer(s) state: $hotPeers") >>
@@ -719,7 +719,6 @@ object PeersManager {
             state.headerToBodyValidation,
             state.transactionSyntaxValidation,
             state.mempool,
-            state.p2pNetworkConfig.networkProperties.slotDataDownloadStep,
             commonAncestor
           )
         )

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -32,6 +32,7 @@ package object fsnetwork {
   val chunkSize = 1
 
   val requestCacheSize = 256
+  val slotIdResponseCacheSize = 2048
 
   val bodyStoreContainsCacheSize = 32768
   val blockSourceCacheSize = 1024

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
@@ -73,7 +73,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
     val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
     (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
     (networkAlgebra.makePeerHeaderFetcher _)
-      .expects(*, *, *, *, *, *, *, *, *, *)
+      .expects(*, *, *, *, *, *, *, *, *)
       .returns(
         // simulate real header fetcher behaviour on finalizing
         Resource
@@ -153,7 +153,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           commonAncestor[F]
         )
         .use { actor =>
@@ -201,7 +200,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           commonAncestor[F]
         )
         .use { actor =>
@@ -250,7 +248,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           commonAncestor[F]
         )
         .use { actor =>
@@ -280,7 +277,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
       (networkAlgebra.makePeerHeaderFetcher _)
-        .expects(*, *, *, *, *, *, *, *, *, *)
+        .expects(*, *, *, *, *, *, *, *, *)
         .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
@@ -330,7 +327,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           commonAncestor[F]
         )
         .use { actor =>
@@ -361,7 +357,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
       (networkAlgebra.makePeerHeaderFetcher _)
-        .expects(*, *, *, *, *, *, *, *, *, *)
+        .expects(*, *, *, *, *, *, *, *, *)
         .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
@@ -428,7 +424,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           commonAncestor[F]
         )
         .use { actor =>
@@ -458,7 +453,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
       (networkAlgebra.makePeerHeaderFetcher _)
-        .expects(*, *, *, *, *, *, *, *, *, *)
+        .expects(*, *, *, *, *, *, *, *, *)
         .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
@@ -498,7 +493,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           commonAncestor[F]
         )
         .use { actor =>
@@ -528,7 +522,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
       (networkAlgebra.makePeerHeaderFetcher _)
-        .expects(*, *, *, *, *, *, *, *, *, *)
+        .expects(*, *, *, *, *, *, *, *, *)
         .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
@@ -574,7 +568,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           fsnetwork.commonAncestor[F]
         )
         .use { actor =>
@@ -604,7 +597,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
       (networkAlgebra.makePeerHeaderFetcher _)
-        .expects(*, *, *, *, *, *, *, *, *, *)
+        .expects(*, *, *, *, *, *, *, *, *)
         .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
@@ -655,7 +648,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           fsnetwork.commonAncestor[F]
         )
         .use { actor =>
@@ -684,7 +676,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
       (networkAlgebra.makePeerHeaderFetcher _)
-        .expects(*, *, *, *, *, *, *, *, *, *)
+        .expects(*, *, *, *, *, *, *, *, *)
         .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
@@ -714,7 +706,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           commonAncestor[F]
         )
         .use { actor =>
@@ -744,7 +735,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
       (networkAlgebra.makePeerHeaderFetcher _)
-        .expects(*, *, *, *, *, *, *, *, *, *)
+        .expects(*, *, *, *, *, *, *, *, *)
         .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
@@ -783,7 +774,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           commonAncestor[F]
         )
         .use { actor =>
@@ -813,7 +803,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
       (networkAlgebra.makePeerHeaderFetcher _)
-        .expects(*, *, *, *, *, *, *, *, *, *)
+        .expects(*, *, *, *, *, *, *, *, *)
         .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
@@ -843,7 +833,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           commonAncestor[F]
         )
         .use { actor =>
@@ -873,7 +862,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
 
       (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
       (networkAlgebra.makePeerHeaderFetcher _)
-        .expects(*, *, *, *, *, *, *, *, *, *)
+        .expects(*, *, *, *, *, *, *, *, *)
         .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
@@ -907,7 +896,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           commonAncestor[F]
         )
         .use { actor =>
@@ -950,7 +938,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
       (networkAlgebra.makePeerHeaderFetcher _)
-        .expects(*, *, *, *, *, *, *, *, *, *)
+        .expects(*, *, *, *, *, *, *, *, *)
         .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
@@ -975,7 +963,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           commonAncestor[F]
         )
         .use(_ => Applicative[F].unit)
@@ -1027,7 +1014,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
-          5,
           commonAncestor[F]
         )
         .use { actor =>

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
@@ -1676,7 +1676,7 @@ class PeersManagerTest
       val peer2 = mockPeerActor[F]()
 
       (networkAlgebra.makePeer _)
-        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(
           Resource
@@ -1694,7 +1694,7 @@ class PeersManagerTest
       (peer1.sendNoWait _).expects(PeerActor.Message.CloseConnection).returns(Applicative[F].unit)
 
       (networkAlgebra.makePeer _)
-        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer2))
       (peer2.sendNoWait _)
@@ -1772,7 +1772,7 @@ class PeersManagerTest
       val peer1 = mockPeerActor[F]()
 
       (networkAlgebra.makePeer _)
-        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(
           Resource
@@ -1975,7 +1975,7 @@ class PeersManagerTest
       val host1Ra = RemoteAddress("1", 1)
       val peer1 = mockPeerActor[F]()
       (networkAlgebra.makePeer _)
-        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer1))
       (peer1.sendNoWait _)
@@ -1992,7 +1992,7 @@ class PeersManagerTest
       val host2Ra = RemoteAddress("2", 2)
       val peer2 = mockPeerActor[F]()
       (networkAlgebra.makePeer _)
-        .expects(host2Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host2Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer2))
       (peer2.sendNoWait _)
@@ -2009,7 +2009,7 @@ class PeersManagerTest
       val host3Ra = RemoteAddress("3", 3)
       val peer3 = mockPeerActor[F]()
       (networkAlgebra.makePeer _)
-        .expects(host3Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host3Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer3))
       (peer3.sendNoWait _)
@@ -2031,7 +2031,7 @@ class PeersManagerTest
       val host5Ra = RemoteAddress("5", 5)
       val peer5 = mockPeerActor[F]()
       (networkAlgebra.makePeer _)
-        .expects(host5Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host5Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer5))
       (peer5.sendNoWait _)


### PR DESCRIPTION
## Purpose
If we sync with the remote peer far-far ahead of us we will suffer of long slot data chain. Fix it by working with small chunk of slot data at all

## Approach
Send only part of remote slot data chunk, not whole chain; Cache sent to Block checker slot data.

## Testing
Unit test + Integration test

## Tickets