### PR TITLE
ProtocolConfiguration Interpreter Make Fix

### DIFF
--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -350,9 +350,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
       healthCheck    <- HealthCheck.make[F]()
       healthServices <- HealthCheckGrpc.Server.services(healthCheck.healthChecker)
 
-      protocolConfig <- ProtocolConfiguration.make[F](
-        appConfig.bifrost.protocols.map { case (slot, protocol) => protocol.nodeConfig(slot) }.toSeq
-      )
+      protocolConfig <- ProtocolConfiguration.make[F](List(bigBangProtocol.nodeConfig(0)))
 
       transactionRewardCalculator <- TransactionRewardCalculator.make[F]
 


### PR DESCRIPTION
## Purpose
- The ProtocolConfiguration interpreter is currently launched using the default private testnet information rather than the current configuration
  - This causes unexpected behavior in Annulus
## Approach
- Update interpreter launch to use the current bigBangProtocol
## Testing
N/A
## Tickets
N/A