### PR TITLE
Tx Generator Allow UTxO Consolidation

### DIFF
--- a/transaction-generator/src/main/resources/application.conf
+++ b/transaction-generator/src/main/resources/application.conf
@@ -10,7 +10,7 @@ transaction-generator {
   }
   broadcaster {
     // The number of transactions to broadcast per second.  Decimals are allowed.
-    tps = 0.1
+    tps = 0.5
   }
   mempool {
     // How frequently should the mempool be polled and printed?

--- a/transaction-generator/src/main/resources/application.conf
+++ b/transaction-generator/src/main/resources/application.conf
@@ -10,7 +10,7 @@ transaction-generator {
   }
   broadcaster {
     // The number of transactions to broadcast per second.  Decimals are allowed.
-    tps = 0.5
+    tps = 0.1
   }
   mempool {
     // How frequently should the mempool be polled and printed?

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/Fs2TransactionGenerator.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/Fs2TransactionGenerator.scala
@@ -46,8 +46,8 @@ object Fs2TransactionGenerator {
     )
 
   /**
-   * Given a _current_ wallet, produce a new Transaction and new Wallet.  The generated transaction
-   * will spend a random input from the wallet and produce two new outputs
+   * Given a _current_ wallet, produce a new Transaction and new Wallet.  If the wallet is small, create extra UTxOs.
+   * If the wallet is large, consolidate UTxOs.
    */
   private def nextTransactionOf[F[_]: Async: Logger](
     wallet:         Wallet,
@@ -57,20 +57,26 @@ object Fs2TransactionGenerator {
      else generateConsolidatingTransaction(wallet, costCalculator))
       .map(transaction => transaction -> applyTransaction(wallet)(transaction))
 
+  /**
+   * Constructs a Transaction which attempts to split a UTxO into two
+   */
   private def generateExpandingTransaction[F[_]: Async: Logger](
     wallet:         Wallet,
     costCalculator: TransactionCostCalculator[F]
   ): OptionT[F, IoTransaction] =
-    pickInput[F](wallet).semiflatMap { case (inputBoxId, inputBox) =>
+    pickSingleInput[F](wallet).semiflatMap { case (inputBoxId, inputBox) =>
       for {
         predicate <- Attestation.Predicate(inputBox.lock.getPredicate, Nil).pure[F]
         unprovenAttestation = Attestation(Attestation.Value.Predicate(predicate))
         inputs = List(SpentTransactionOutput(inputBoxId, unprovenAttestation, inputBox.value))
-        outputs           <- createOutputs[F](inputBox)
+        outputs           <- createManyOutputs[F](inputBox)
         provenTransaction <- formTransaction(costCalculator)(inputs, outputs)
       } yield provenTransaction
     }
 
+  /**
+   * Constructs a Transaction which attempts to consolidate several UTxOs into one
+   */
   private def generateConsolidatingTransaction[F[_]: Async: Logger](
     wallet:         Wallet,
     costCalculator: TransactionCostCalculator[F]
@@ -103,6 +109,9 @@ object Fs2TransactionGenerator {
         )
       )
 
+  /**
+   * Constructs a proven Transaction from the given inputs and outputs
+   */
   private def formTransaction[F[_]: Async: Logger](
     costCalculator: TransactionCostCalculator[F]
   )(inputs: Seq[SpentTransactionOutput], outputs: Seq[UnspentTransactionOutput]) =
@@ -131,9 +140,9 @@ object Fs2TransactionGenerator {
     } yield provenTransaction
 
   /**
-   * Selects a spendable box from the wallet
+   * Selects a single spendable box from the wallet
    */
-  private def pickInput[F[_]: Applicative](wallet: Wallet): OptionT[F, (TransactionOutputAddress, Box)] =
+  private def pickSingleInput[F[_]: Applicative](wallet: Wallet): OptionT[F, (TransactionOutputAddress, Box)] =
     OptionT.fromOption[F](
       wallet.spendableBoxes.filter(_._2.value.value.isLvl).toList.maximumByOption(_._2.value.getLvl.quantity: BigInt)
     )
@@ -141,7 +150,7 @@ object Fs2TransactionGenerator {
   /**
    * Constructs two outputs from the given input box.  The two outputs will split the input box in half.
    */
-  private def createOutputs[F[_]: Applicative](
+  private def createManyOutputs[F[_]: Applicative](
     inputBox: Box
   ): F[List[UnspentTransactionOutput]] = {
     val lvlBoxValue = inputBox.value.getLvl

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/Fs2TransactionGenerator.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/interpreters/Fs2TransactionGenerator.scala
@@ -77,7 +77,7 @@ object Fs2TransactionGenerator {
   ): OptionT[F, IoTransaction] =
     OptionT
       .pure[F](
-        wallet.spendableBoxes.filter(_._2.value.value.isLvl).toList.sortBy(_._2.value.getLvl.quantity: BigInt).take(4)
+        wallet.spendableBoxes.filter(_._2.value.value.isLvl).toList.sortBy(_._2.value.getLvl.quantity: BigInt).take(15)
       )
       .filter(_.nonEmpty)
       .map(_.map { case (inputBoxId, inputBox) =>


### PR DESCRIPTION
## Purpose
- The default Brambl CLI behavior is to consolidate UTxOs in a wallet
- If the available UTxO set is too large, the resulting Transaction is too large and fails validation
- This PR modifies the tx generator to attempt to consolidate UTxOs when possible
## Approach
- Modify Fs2TransactionGenerator
  - If wallet's size is > 5, generate a "consolidating" transaction
  - Otherwise, generate an "expanding" transaction
## Testing
- Ran against seannet
## Tickets
N/A