### PR TITLE
Level DB Tuning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -610,7 +610,7 @@ lazy val levelDbStore = project
   )
   .dependsOn(
     byteCodecs,
-    algebras,
+    algebras % "compile->compile;test->test",
     catsUtils
   )
 

--- a/level-db-store/src/main/scala/co/topl/db/leveldb/LevelDbStore.scala
+++ b/level-db-store/src/main/scala/co/topl/db/leveldb/LevelDbStore.scala
@@ -107,7 +107,7 @@ object LevelDbStore {
       .flatMap(factories =>
         List(this.getClass.getClassLoader, ClassLoader.getSystemClassLoader)
           .zip(factories)
-          .traverseFilter { case (loader, factoryName) =>
+          .collectFirstSomeM { case (loader, factoryName) =>
             OptionT(
               Sync[F]
                 .fromTry(
@@ -119,7 +119,7 @@ object LevelDbStore {
                 }
             ).map(factoryName -> _).value
           }
-          .map(_.headOption.toRight(new RuntimeException(s"Could not load any of the factory classes: $factories")))
+          .map(_.toRight(new RuntimeException(s"Could not load any of the factory classes: $factories")))
       )
       .rethrow
       .flatTap {


### PR DESCRIPTION
## Purpose
- I observed that LevelDB is causing a major slowdown after period of block synchronization
## Approach
- Incorporate LevelDBJNI, using the approach from Dion
  - If LevelDBJNI is available, use it.  Otherwise, fallback to Java-LevelDB implementation
## Testing
- Connected to testnet.topl.tech relay node with and without the change; observed faster sync with JNI
## Tickets
N/A