### PR TITLE
BN- fix warning introduced on version Replicator

### DIFF
--- a/node/src/main/scala/co/topl/version/VersionReplicator.scala
+++ b/node/src/main/scala/co/topl/version/VersionReplicator.scala
@@ -8,6 +8,7 @@ import co.topl.algebras.SoftwareVersionAlgebra
 import co.topl.blockchain.algebras.NodeMetadataAlgebra
 import org.http4s.ember.client.EmberClientBuilder
 import fs2.Stream
+import fs2.io.net.Network
 import org.typelevel.log4cats.Logger
 import scala.concurrent.duration._
 import io.circe.parser._
@@ -23,7 +24,8 @@ object VersionReplicator {
         override def fetchSoftwareVersion(): F[String] =
           OptionT(nodeMetadataAlgebra.readAppVersion).getOrElse("Undefined")
 
-        override def fetchLatestSoftwareVersion(): F[String] =
+        override def fetchLatestSoftwareVersion(): F[String] = {
+          implicit val networkF: Network[F] = Network.forAsync
           EmberClientBuilder
             .default[F]
             .build
@@ -35,6 +37,7 @@ object VersionReplicator {
                 .map(_.\\("tag_name").headOption.map(_.noSpaces).getOrElse("Undefined"))
                 .merge
             )
+        }
       }
     }
 


### PR DESCRIPTION
## Purpose
fix warning introduced on version Replicator

> method implicitForAsync in trait NetworkLowPriority is deprecated (since 3.7.0): Add Network constraint or use forAsync