### PR TITLE
Config/Arg to Override LevelDB Implementation

### DIFF
--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -37,7 +37,7 @@ object ApplicationConfig {
   object Bifrost {
 
     @Lenses
-    case class Data(directory: String)
+    case class Data(directory: String, databaseType: String)
 
     @Lenses
     case class Staking(directory: String, rewardAddress: LockAddress)

--- a/level-db-store/src/main/scala/co/topl/db/leveldb/LevelDbStore.scala
+++ b/level-db-store/src/main/scala/co/topl/db/leveldb/LevelDbStore.scala
@@ -129,8 +129,13 @@ object LevelDbStore {
       .rethrow
       .flatTap {
         case (`javaFactory`, _) =>
-          Logger[F].warn("Using the pure java LevelDB implementation which is still experimental")
-        case (name, factory) => Logger[F].info(s"Loaded $name with $factory")
+          Logger[F].warn(
+            "Using the pure java LevelDB implementation which is experimental and slower than the native implementation."
+          )
+        case _ => ().pure[F]
+      }
+      .flatTap { case (name, factory) =>
+        Logger[F].info(s"Loaded $name with $factory")
       }
       .map(_._2)
       .toResource

--- a/level-db-store/src/test/scala/co/topl/db/leveldb/LevelDbStoreSpec.scala
+++ b/level-db-store/src/test/scala/co/topl/db/leveldb/LevelDbStoreSpec.scala
@@ -23,7 +23,7 @@ class LevelDbStoreSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   ResourceFixture[Path](Resource.make(Files[F].createTempDirectory)(Files[F].deleteRecursively))
     .test("Save, Contains, Read, Delete") { testPath =>
-      LevelDbStore.makeFactory[F].flatMap(LevelDbStore.makeDb[F](testPath, _)).use { dbUnderTest =>
+      LevelDbStore.makeFactory[F]().flatMap(LevelDbStore.makeDb[F](testPath, _)).use { dbUnderTest =>
         for {
           underTest <- LevelDbStore.make[F, SpecKey, SpecValue](dbUnderTest)
           key = SpecKey("test1")
@@ -54,7 +54,7 @@ class LevelDbStoreSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   ResourceFixture[Path](Resource.make(Files[F].createTempDirectory)(Files[F].deleteRecursively))
     .test("Malformed data throws exceptions") { testPath =>
-      LevelDbStore.makeFactory[F].flatMap(LevelDbStore.makeDb[F](testPath, _)).use { dbUnderTest =>
+      LevelDbStore.makeFactory[F]().flatMap(LevelDbStore.makeDb[F](testPath, _)).use { dbUnderTest =>
         for {
           underTest <- LevelDbStore.make[F, SpecKey, SpecValue](dbUnderTest)
           key = SpecKey("test1")

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -4,6 +4,11 @@ bifrost {
     // The _base_ directory in which blockchain data is stored.
     // Use {genesisBlockId} to interpolate the Genesis Block ID in the path.
     directory = "/tmp/bifrost/data/{genesisBlockId}"
+    // The data storage engine to use for node operations
+    // Options: `levelDb-jni` and `levelDb-java`
+    // Note: if `levelDb-jni` is selected but can't be loaded, it will fallback to levelDb-java
+    // Note: `levelDb-jni` is much faster but may not work on all systems
+    database-type = "levelDb-jni"
   }
   // Settings for staking
   staking {

--- a/node/src/main/scala/co/topl/node/ApplicationConfigOps.scala
+++ b/node/src/main/scala/co/topl/node/ApplicationConfigOps.scala
@@ -39,6 +39,7 @@ object ApplicationConfigOps {
     val simpleArgApplications =
       List[Option[ApplicationConfig => ApplicationConfig]](
         cmdArgs.runtime.dataDir.map(createF(GenLens[ApplicationConfig](_.bifrost.data.directory))),
+        cmdArgs.runtime.databaseType.map(createF(GenLens[ApplicationConfig](_.bifrost.data.databaseType))),
         cmdArgs.runtime.stakingDir.map(createF(GenLens[ApplicationConfig](_.bifrost.staking.directory))),
         cmdArgs.runtime.rpcBindHost.map(createF(GenLens[ApplicationConfig](_.bifrost.rpc.bindHost))),
         cmdArgs.runtime.rpcBindPort.map(createF(GenLens[ApplicationConfig](_.bifrost.rpc.bindPort))),

--- a/node/src/main/scala/co/topl/node/Args.scala
+++ b/node/src/main/scala/co/topl/node/Args.scala
@@ -48,6 +48,10 @@ object Args {
     )
     dataDir: Option[String],
     @arg(
+      doc = "The type of data storage to use. Valid options: `levelDb-jni` (default), `levelDb-java`"
+    )
+    databaseType: Option[String],
+    @arg(
       doc = "The directory of the block producer's staking keys"
     )
     stakingDir: Option[String],


### PR DESCRIPTION
## Purpose
- New versions are incompatible with old versions for both networking and storage, which means it is impossible to bootstrap/synchronize the two versions
## Approach
- Allow overriding LevelDB storage to support levelDb-java when needed
## Testing
- Launch node without flag and verified JNI was loaded.  Launched node with flag `--databaseType levelDb-java` and verified Java was loaded
## Tickets
N/A