### PR TITLE
BN-1322-genus-block-header-new-index

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/OrientDBMetadataFactory.scala
@@ -3,6 +3,8 @@ package co.topl.genusLibrary.orientDb
 import cats.effect.Async
 import cats.effect.{Resource, Sync, SyncIO}
 import cats.implicits._
+import co.topl.consensus.models.BlockHeader
+import co.topl.genusLibrary.orientDb.instances.SchemaBlockHeader
 import co.topl.genusLibrary.orientDb.schema.{EdgeSchema, VertexSchema}
 import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances._
 import co.topl.genusLibrary.orientDb.schema.EdgeSchemaInstances._
@@ -11,7 +13,7 @@ import com.orientechnologies.orient.core.metadata.schema.OClass
 import com.orientechnologies.orient.core.metadata.schema.OType
 import com.tinkerpop.blueprints.impls.orient.OrientGraphFactory
 import org.typelevel.log4cats.Logger
-
+import scala.jdk.CollectionConverters.SetHasAsScala
 import scala.util.Try
 
 /**
@@ -69,6 +71,8 @@ object OrientDBMetadataFactory {
           } yield ()
         )
       )
+
+      _ <- Resource.eval(OrientThread[F].defer(updateBlockHeaderHeightIndex(db, blockHeaderSchema)))
     } yield ()
 
   private[genusLibrary] def createVertex[F[_]: Sync: Logger](db: ODatabaseDocumentInternal, schema: VertexSchema[_]) =
@@ -147,4 +151,50 @@ object OrientDBMetadataFactory {
         case _ =>
           Sync[F].delay(db.createClass(edge.label, "E")).void
       }
+
+  /**
+   * This method updates an existing BlockHeader schema, createVertex skip vertex creating if they already exist.
+   * This new index was proposed after some DBs was on test/production mode, for this reason was isolated from the schema definition.
+   * If there is no database, createVertex method will create 2 indices and this method will be not used.
+   * This method could be safely removed if it was executed on a previous Database at least once,
+   * or the db schemas was created from scratch
+   * @param db
+   * @param schema
+   * @tparam F
+   * @return
+   */
+  private[orientDb] def updateBlockHeaderHeightIndex[F[_]: Sync: Logger](
+    db:     ODatabaseDocumentInternal,
+    schema: VertexSchema[BlockHeader]
+  ): F[Unit] =
+    Sync[F].delay(db.activateOnCurrentThread()) >>
+    Sync[F]
+      .delay(Option(db.getClass(schema.name)))
+      .flatMap {
+        case Some(oClass) =>
+          oClass.getIndexes.asScala
+            .map(_.getName)
+            .contains(SchemaBlockHeader.Field.BlockHeaderHeightIndex)
+            .pure[F]
+            .ifM(
+              Sync[F].unit,
+              SyncIO
+                .fromTry(
+                  Try(
+                    schema.indices
+                      .filter(_.name == SchemaBlockHeader.Field.BlockHeaderHeightIndex)
+                      .foreach(i => oClass.createIndex(i.name, i.indexType, i.propertyNames: _*))
+                  )
+                )
+                .to[F]
+                .onError { case e => Logger[F].error(e)(s"Failed to update Schema BlockHeader") }
+                .void
+            )
+
+        case _ =>
+          Logger[F]
+            .info(s"Class ${schema.name} not found, index height was not created")
+
+      }
+
 }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeader.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaBlockHeader.scala
@@ -2,11 +2,10 @@ package co.topl.genusLibrary.orientDb.instances
 
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.consensus.models._
-import co.topl.genusLibrary.orientDb.schema.OIndexable.Instances._
 import co.topl.codecs.bytes.tetra.TetraScodecCodecs._
 import co.topl.codecs.bytes.typeclasses.ImmutableCodec
 import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
-import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, VertexSchema}
+import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, OIndexable, VertexSchema}
 import com.google.protobuf.ByteString
 
 object SchemaBlockHeader {
@@ -34,6 +33,7 @@ object SchemaBlockHeader {
     val Size = "size"
     val Version = "version"
     val BlockHeaderIndex = "blockHeaderIndex"
+    val BlockHeaderHeightIndex = "blockHeaderHeightIndex"
   }
 
   private[genusLibrary] def size(blockHeader: BlockHeader): Long =
@@ -57,7 +57,8 @@ object SchemaBlockHeader {
       .withProperty(Field.Address,_.address.toByteArray,mandatory = true, readOnly = true, notNull = true)
       .withProperty(Field.Size, blockHeader => java.lang.Long.valueOf(size(blockHeader)) ,mandatory = true, readOnly = true, notNull = true)
       .withProperty(Field.Version, blockHeader => blockHeader.version.toByteArray ,mandatory = true, readOnly = true, notNull = true)
-      .withIndex[BlockHeader](Field.BlockHeaderIndex, Field.BlockId),
+      .withIndex[BlockHeader](Field.BlockHeaderIndex, Field.BlockId)(OIndexable.Instances.blockHeader)
+      .withIndex[BlockHeader](Field.BlockHeaderHeightIndex, Field.Height)(OIndexable.Instances.blockHeightHeader),
       // @formatter:on
     v =>
       BlockHeader(

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/OIndexable.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/OIndexable.scala
@@ -21,6 +21,10 @@ object OIndexable {
       override def indexType: OClass.INDEX_TYPE = INDEX_TYPE.UNIQUE
     }
 
+    implicit val blockHeightHeader: OIndexable[BlockHeader] = new OIndexable[BlockHeader] {
+      override def indexType: OClass.INDEX_TYPE = INDEX_TYPE.NOTUNIQUE
+    }
+
     implicit val ioTransaction: OIndexable[IoTransaction] = new OIndexable[IoTransaction] {
       override def indexType: OClass.INDEX_TYPE = INDEX_TYPE.UNIQUE
     }


### PR DESCRIPTION
## Purpose
- Add a new index on block header class

## Approach
- if the database exists, skip the vertex creation and add new index
- if the database is new, create index on vertex creation, and not add the index


#Note 
Unit test were not created because I do know how it will perform underload.

If we don't see benefits we should see which library we should use:
- getVertexByKey is deprecated, and the suggestion is to use getVertices,
- getVertices does not provide information about which indices we could use.

`/**
   * Lookup for a vertex by id using an index.<br>
   * This API relies on Unique index (SBTREE/HASH) but is deprecated.<br>
   * Example:<code> Vertex v = getVertexByKey("V.name", "name", "Jay");
   * </code>
   *
   * @param iKey Name of the indexed property
   * @param iValue Field value
   * @return Vertex instance if found, otherwise null
   * @see #getVertices(String, Object)
   */
  @Deprecated
  public Vertex getVertexByKey(final String iKey, Object iValue) {
    makeActive();

    String indexName;
    if (iKey.indexOf('.') > -1) indexName = iKey;
    else indexName = OrientVertexType.CLASS_NAME + "." + iKey;

    final ODatabaseDocumentInternal database = getDatabase();
    final OIndex idx =
        database.getMetadata().getIndexManagerInternal().getIndex(database, indexName);
    if (idx != null) {
      iValue = convertKey(idx, iValue);

      try (Stream<ORID> rids = idx.getInternal().getRids(iValue)) {
        return rids.findFirst().map(this::getVertex).orElse(null);
      }
    } else throw new IllegalArgumentException("Index '" + indexName + "' not found");
  }`



## Testing

- from a db with an old schema, 
- from scratch 
- the the


```OrientDB console v.3.2.24 (build ${buildNumber}, branch UNKNOWN) https://www.orientdb.com
Type 'help' to display all the supported commands.
orientdb> connect plocal:/tmp/bifrost/data/b_2am1BwpvLWtYHFcjFPc9eDeRKHcF3LjpdXwXDv8suGss/orient-db/ admin topl

Connecting to database [plocal:/tmp/bifrost/data/b_2am1BwpvLWtYHFcjFPc9eDeRKHcF3LjpdXwXDv8suGss/orient-db/] with user 'admin'...WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by jnr.posix.JavaLibCHelper$ReflectiveAccess (file:/home/fernando/topl/orientdb-community-3.2.24/lib/jnr-posix-3.1.15.jar) to method sun.nio.ch.SelChImpl.getFD()
WARNING: Please consider reporting this to the maintainers of jnr.posix.JavaLibCHelper$ReflectiveAccess
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
OK
orientdb {db=orient-db}> info class Blockheader                                                                               

CLASS 'BlockHeader'

Records..............: 864
Super classes........: [V]
Default cluster......: blockheader (id=26)
Supported clusters...: blockheader(26), blockheader_1(27), blockheader_2(28), blockheader_3(29), blockheader_4(30), blockheader_5(31), blockheader_6(32), blockheader_7(33)
Cluster selection....: round-robin
Oversize.............: 0.0


INDEXES (1 altogether)
+----+----------------+----------+
|#   |NAME            |PROPERTIES|
+----+----------------+----------+
|0   |blockHeaderIndex|[blockId] |
+----+----------------+----------+
orientdb {db=orient-db}> exit


#################### stop node, enable the schema upgrade, run node


➜  bin ./console.sh

OrientDB console v.3.2.24 (build ${buildNumber}, branch UNKNOWN) https://www.orientdb.com
Type 'help' to display all the supported commands.
orientdb> connect plocal:/tmp/bifrost/data/b_2am1BwpvLWtYHFcjFPc9eDeRKHcF3LjpdXwXDv8suGss/orient-db/ admin topl

Connecting to database [plocal:/tmp/bifrost/data/b_2am1BwpvLWtYHFcjFPc9eDeRKHcF3LjpdXwXDv8suGss/orient-db/] with user 'admin'...WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by jnr.posix.JavaLibCHelper$ReflectiveAccess (file:/home/fernando/topl/orientdb-community-3.2.24/lib/jnr-posix-3.1.15.jar) to method sun.nio.ch.SelChImpl.getFD()
WARNING: Please consider reporting this to the maintainers of jnr.posix.JavaLibCHelper$ReflectiveAccess
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
OK
orientdb {db=orient-db}> info class Blockheader                                                                               

CLASS 'BlockHeader'

Records..............: 872
Super classes........: [V]
Default cluster......: blockheader (id=26)
Supported clusters...: blockheader(26), blockheader_1(27), blockheader_2(28), blockheader_3(29), blockheader_4(30), blockheader_5(31), blockheader_6(32), blockheader_7(33)
Cluster selection....: round-robin
Oversize.............: 0.0


INDEXES (2 altogether)
+----+----------------------+----------+
|#   |NAME                  |PROPERTIES|
+----+----------------------+----------+
|0   |blockHeaderHeightIndex|[height]  |
|1   |blockHeaderIndex      |[blockId] |
+----+----------------------+----------+
orientdb {db=orient-db}> exit
````

## Tickets
BN-1322