### PR TITLE
beta1 to main

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/BigBang.scala
@@ -196,7 +196,8 @@ object BigBang {
       forwardBiasedSlotWindow,
       operationalPeriodsPerEpoch,
       kesKeyHours,
-      kesKeyMinutes
+      kesKeyMinutes,
+      None
     )
 
   def protocolToValue(protocol: ApplicationConfig.Bifrost.Protocol): Value =

--- a/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
@@ -157,19 +157,18 @@ object PrivateTestnet {
   val DefaultProtocol: ApplicationConfig.Bifrost.Protocol =
     ApplicationConfig.Bifrost.Protocol(
       minAppVersion = "2.0.0",
-      fEffective = Ratio(12997, 100000),
+      fEffective = Ratio(12, 100),
       vrfLddCutoff = 15,
       vrfPrecision = 40,
       vrfBaselineDifficulty = Ratio(5, 100),
       vrfAmplitude = Ratio(50, 100),
-      // Note: Testnet/Mainnet default=1000
-      chainSelectionKLookback = 50,
+      chainSelectionKLookback = 5184,
       slotDuration = 1.seconds,
       forwardBiasedSlotWindow = 50,
-      // Note: Testnet/Mainnet default=24
-      operationalPeriodsPerEpoch = 2,
+      operationalPeriodsPerEpoch = 25,
       kesKeyHours = 9,
-      kesKeyMinutes = 9
+      kesKeyMinutes = 9,
+      epochLengthOverride = None
     )
 
 }

--- a/blockchain/src/main/scala/co/topl/blockchain/PublicTestnet.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/PublicTestnet.scala
@@ -9,18 +9,18 @@ object PublicTestnet {
   val DefaultProtocol: ApplicationConfig.Bifrost.Protocol =
     ApplicationConfig.Bifrost.Protocol(
       minAppVersion = "2.0.0",
-      fEffective = co.topl.models.utility.Ratio(12997, 100000),
+      fEffective = co.topl.models.utility.Ratio(12, 100),
       vrfLddCutoff = 15,
       vrfPrecision = 40,
       vrfBaselineDifficulty = co.topl.models.utility.Ratio(5, 100),
       vrfAmplitude = co.topl.models.utility.Ratio(50, 100),
-      // 20x private testnet default, resulting in ~100 minute epochs
-      chainSelectionKLookback = 1000,
+      chainSelectionKLookback = 5184,
       slotDuration = 1.seconds,
       forwardBiasedSlotWindow = 50,
-      operationalPeriodsPerEpoch = 24,
+      operationalPeriodsPerEpoch = 25,
       kesKeyHours = 9,
-      kesKeyMinutes = 9
+      kesKeyMinutes = 9,
+      epochLengthOverride = None
     )
 
   val DefaultUpdateProposal: UpdateProposal =

--- a/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
@@ -44,7 +44,6 @@ class MultiNodeTest extends IntegrationSuite {
   require(totalNodeCount >= 3)
 
   test("Multiple nodes launch and maintain consensus for three epochs") {
-    val epochSlotLength: Long = 6 * 50 // See co.topl.node.ApplicationConfig.Bifrost.Protocol
     val bigBang = Instant.now().plusSeconds(30)
     val resource =
       for {
@@ -113,7 +112,7 @@ class MultiNodeTest extends IntegrationSuite {
               .rpcClient[F](node.config.rpcPort)
               .use(
                 _.adoptedHeaders
-                  .takeWhile(_.slot < (epochSlotLength * 2))
+                  .takeWhile(_.slot < (TestNodeConfig.epochSlotLength * 2))
                   // Verify that the delayed node doesn't produce any blocks in the first 2 epochs
                   .evalTap(h => IO(h.address != delayedNodeStakingAddress).assert)
                   .timeout(9.minutes)

--- a/byzantine-it/src/test/scala/co/topl/byzantine/util/DockerSupport.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/util/DockerSupport.scala
@@ -178,8 +178,8 @@ case class TestNodeConfig(
   jmxRemotePort:        Int = 9083,
   genusEnabled:         Boolean = false,
   stakingBindSourceDir: Option[String] = None,
-  serverHost: Option[String] = None,
-  serverPort: Option[Int] = None
+  serverHost:           Option[String] = None,
+  serverPort:           Option[Int] = None
 ) {
 
   def yaml: String = {
@@ -205,9 +205,15 @@ case class TestNodeConfig(
        |  protocols:
        |    0:
        |      slot-duration: 500 milli
+       |      chain-selection-k-lookback: 6
+       |      operational-periods-per-epoch: 2
        |genus:
        |  enable: "$genusEnabled"
        |""".stripMargin
   }
 
+}
+
+object TestNodeConfig {
+  val epochSlotLength: Long = 150 // See co.topl.node.ApplicationConfig.Bifrost.Protocol
 }

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -67,17 +67,15 @@ bifrost {
     // The _slot_ at which this protocol begins
     0 {
       min-app-version = "2.0.0"
-      f-effective = "12997/100000"
+      f-effective = "12/100"
       vrf-ldd-cutoff = 15
       vrf-precision = 40
       vrf-baseline-difficulty = "5/100"
       vrf-amplitude = "50/100"
-      // Note: Testnet/Mainnet default=1000
-      chain-selection-k-lookback = 50
+      chain-selection-k-lookback = 5184
       slot-duration = 1000 milli
       forward-biased-slot-window = 50
-      // Note: Testnet/Mainnet default=24
-      operational-periods-per-epoch = 2
+      operational-periods-per-epoch = 25
       kes-key-hours = 9
       kes-key-minutes = 9
     }

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -172,8 +172,30 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
           )
           .pure[F]
           .rethrow
+          .flatMap(protocol =>
+            appConfig.bifrost
+              .protocols(0)
+              .epochLengthOverride
+              .foldLeftM(
+                protocol
+              )((protocol, lengthOverride) =>
+                Logger[F].warn(s"Overriding epoch length to $lengthOverride slots") >>
+                protocol
+                  .copy(epochLengthOverride = appConfig.bifrost.protocols(0).epochLengthOverride)
+                  .pure[F]
+              )
+          )
+          .flatTap(p => p.validation.leftMap(new IllegalArgumentException(_)).pure[F].rethrow)
           .toResource
-      _ <- Logger[F].info(s"Protocol settings=$bigBangProtocol").toResource
+      _ <- Logger[F]
+        .info(
+          s"Protocol" +
+          s" epochLength=${bigBangProtocol.epochLength}" +
+          s" operationalPeriodLength=${bigBangProtocol.operationalPeriodLength}" +
+          s" chainSelectionSWindow=${bigBangProtocol.chainSelectionSWindow}" +
+          s" settings=$bigBangProtocol"
+        )
+        .toResource
       vrfConfig = VrfConfig(
         bigBangProtocol.vrfLddCutoff,
         bigBangProtocol.vrfPrecision,

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -307,7 +307,8 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
                     bigBangBlock.header.version,
                     blockFinder,
                     metadata,
-                    dataStores.headers.get
+                    dataStores.headers.get,
+                    bigBangBlock
                   )
               )
           }

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -267,21 +267,26 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
                   fs2.Stream.force(localChain.adoptions)
                 )(transactionId)
                 .flatMap(dataStores.headers.getOrRaise)
-            StakingInit
-              .makeStakingFromDisk(
-                stakingDir,
-                appConfig.bifrost.staking.rewardAddress,
-                clock,
-                etaCalculation,
-                consensusValidationState,
-                leaderElectionThreshold,
-                cryptoResources,
-                bigBangProtocol,
-                vrfConfig,
-                bigBangBlock.header.version,
-                blockFinder,
-                metadata,
-                dataStores.headers.get
+            // Construct a separate threshold calcualtor instance with a separate cache to avoid
+            // polluting the staker's cache with remote block eligibilities
+            makeLeaderElectionThreshold(cryptoResources.blake2b512, vrfConfig).toResource
+              .flatMap(leaderElectionThreshold =>
+                StakingInit
+                  .makeStakingFromDisk(
+                    stakingDir,
+                    appConfig.bifrost.staking.rewardAddress,
+                    clock,
+                    etaCalculation,
+                    consensusValidationState,
+                    leaderElectionThreshold,
+                    cryptoResources,
+                    bigBangProtocol,
+                    vrfConfig,
+                    bigBangBlock.header.version,
+                    blockFinder,
+                    metadata,
+                    dataStores.headers.get
+                  )
               )
           }
           .value
@@ -467,7 +472,11 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
       exp   <- ExpInterpreter.make[F](10000, 38)
       log1p <- Log1pInterpreter.make[F](10000, 8).flatMap(Log1pInterpreter.makeCached[F])
       base = LeaderElectionValidation.make[F](vrfConfig, blake2b512Resource, exp, log1p)
-      leaderElectionThreshold <- LeaderElectionValidation.makeCached(base)
+      leaderElectionThresholdCached <- LeaderElectionValidation.makeCached(base)
+      leaderElectionThreshold = LeaderElectionValidation.makeWithCappedSlotDiff(
+        leaderElectionThresholdCached,
+        vrfConfig.lddCutoff
+      )
     } yield leaderElectionThreshold
 
   /**


### PR DESCRIPTION
# Changes
## Protocol
- Update `epochLength` calculation to `((Ratio(chainSelectionKLookback) * fEffective.inverse) * 3).round.toLong`
- Update VRF fEffective to 12/100
- Update Chain Selection KLookback to 5184
- Update OperationalPeriodsPerEpoch to 25

## Block Production
- Additional logging around eligibility slots

## Leader Election
- Cap search for "Threshold" values to lddCutoff + 1
- Use separate caches for Block Production vs Header Validation