### PR TITLE
Update config for Toplnet docs to reduce confusion

### DIFF
--- a/documentation/docs/reference/Networks/connect-to-toplnet.md
+++ b/documentation/docs/reference/Networks/connect-to-toplnet.md
@@ -21,7 +21,7 @@ In this example, we will be using Docker to run the node.
 
 The way to connect to `toplnet` is by adding it as a known peer. To do this via CLI, you can use `--knownPeers testnet.topl.co:9085`. You will also need to pass the `--config` which contains the genesis block information and other configuration requirements for the given testnet.
 
-The testnet configs are hosted on GitHub https://github.com/Topl/Genesis which can be automatically downloaded by Bifrost using the `--config https://raw.githubusercontent.com/Topl/Genesis_Testnets/main/testnet2/config.yaml` parameter.
+The testnet configs are hosted on GitHub https://github.com/Topl/Genesis which can be automatically downloaded by Bifrost using the `--config https://raw.githubusercontent.com/Topl/Genesis/main/toplnet/config.yaml` parameter.
 
 A full example of connecting to the node:
 


### PR DESCRIPTION
## Purpose
The docs for connecting to Toplnet reference a different config file in the example. Going to remove this to avoid confusion.

## Approach
* Update reference to config file in docs to use the production link.

## Testing
N/A

## Tickets
*
