### PR TITLE
Publish Test Result Action: Only Compare Like Event Types

### DIFF
--- a/.github/workflows/_publish_test_results.yml
+++ b/.github/workflows/_publish_test_results.yml
@@ -24,4 +24,5 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           files: "artifacts/**/*.xml"
+          check_name: "Test Results (${{ github.event.workflow_run.event || github.event_name }})"
           check_run_annotations_branch: main, dev


### PR DESCRIPTION
## Purpose
The test results report constantly mentions added or removed test numbers and inconsistent test time deltas and is not very useful because of this.

![image](https://github.com/Topl/Bifrost/assets/17308716/988002cd-aab7-4b37-ba5b-6d140f393e43)

This is because we run the byzantine tests only on `push` events. By default, the check compares runs based on the `check_name`, which defaults to "Test Results". This also causes other weirdness because `push` events will override the `pr` report, which causes the above issue.

From the docs of the action, there is a way to avoid this issue:
https://github.com/EnricoMi/publish-unit-test-result-action#running-with-multiple-event-types-pull_request-push-schedule-

## Approach
* Override the `check_name` parameter to include the `event_type` of the GitHub action to avoid comparing `push` and `pr` events to each other.

## Testing
I tested locally with this PR, but we won't really see the results until this change is merged.

## Tickets
* N/A
