### PR TITLE
BN-1323 Move one cold peer to warm state even if there is no eligible cold peers because of recent close events

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
@@ -264,6 +264,8 @@ case class Peer[F[_]: Logger](
   perfRep:            HostReputationValue,
   newRep:             Long
 ) {
+  def couldOpenConnection: Boolean = asServer.isDefined || actorOpt.isDefined
+
   def haveNoConnection: Boolean = actorOpt.isEmpty
 
   def sendNoWait(message: PeerActor.Message): F[Unit] =

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
@@ -934,19 +934,32 @@ object PeersManager {
   ): F[State[F]] = {
     val maximumWarmConnection = state.p2pNetworkConfig.networkProperties.maximumWarmConnections
     val lackWarmPeersCount = maximumWarmConnection - state.peersHandler.getWarmPeersWithActor.size
-    val eligibleColdPeers =
-      getEligibleColdPeers(state).filter { case (_, peer) =>
-        // we shall be able to establish connection or have already established connection
-        peer.asServer.isDefined || peer.actorOpt.isDefined
-      }
-    val coldToWarm: Set[HostId] = state.coldToWarmSelector.select(eligibleColdPeers, lackWarmPeersCount)
 
     for {
+      coldPeers    <- getColdPeersForWarmState(state)
+      coldToWarm   <- state.coldToWarmSelector.select(coldPeers, lackWarmPeersCount).pure[F]
       _            <- Logger[F].infoIf(coldToWarm.nonEmpty, show"Going to warm next cold peers: $coldToWarm")
       peersHandler <- state.peersHandler.moveToState(coldToWarm, PeerState.Warm, peerReleaseAction(thisActor))
       newState     <- state.copy(peersHandler = peersHandler).pure[F]
       _            <- checkConnection(newState, coldToWarm)
     } yield newState
+  }
+
+  private def getColdPeersForWarmState[F[_]: Async: Logger](state: State[F]): F[Map[HostId, Peer[F]]] = {
+    val eligiblePeers = getEligibleColdPeers(state).filter(_._2.couldOpenConnection)
+    if (eligiblePeers.nonEmpty || state.peersHandler.getWarmPeersWithActor.nonEmpty) {
+      eligiblePeers.pure[F]
+    } else {
+      // If no warm peer is present then take cold peer with less closed events, even if they are not eligible right now
+      Logger[F].warn(show"No eligible cold peer had been found, use peer with less count of close events") >>
+      state.peersHandler.getColdPeers
+        .filter(_._2.couldOpenConnection)
+        .toList
+        .sortBy(_._2.closedTimestamps.size)
+        .take(1)
+        .toMap
+        .pure[F]
+    }
   }
 
   private def checkConnection[F[_]: Async: Parallel: Logger: DnsResolver](

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
@@ -871,6 +871,121 @@ class PeersManagerTest
     }
   }
 
+  test("Reputation update: move only one non-eligible by timeout and to warm because no warm peers with actor") {
+    withMock {
+      val newPeerCreationAlgebra: PeerCreationRequestAlgebra[F] = mock[PeerCreationRequestAlgebra[F]]
+
+      val host1Id = arbitraryHost.arbitrary.first
+      val host1Ra = RemoteAddress("1", 1)
+      val host2Id = arbitraryHost.arbitrary.first
+      val host2Ra = RemoteAddress("2", 2)
+      val host3Id = arbitraryHost.arbitrary.first
+      val host3Ra = RemoteAddress("3", 3)
+      val host4Id = arbitraryHost.arbitrary.first
+      val host4Ra = RemoteAddress("4", 4)
+
+      (newPeerCreationAlgebra.requestNewPeerCreation _)
+        .expects(DisconnectedPeer(host1Ra, host1Id.id.some))
+        .returns(().pure[F])
+
+      val initialPeersMap: Map[HostId, Peer[F]] =
+        Map(
+          buildSimplePeerEntry(PeerState.Cold, None, host1Id, host1Ra),
+          buildSimplePeerEntry(
+            PeerState.Cold,
+            None,
+            host1Id,
+            host1Ra,
+            closedTimestamps = Seq(System.currentTimeMillis())
+          ),
+          buildSimplePeerEntry(
+            PeerState.Cold,
+            None,
+            host2Id,
+            host2Ra,
+            closedTimestamps = Seq(System.currentTimeMillis(), System.currentTimeMillis())
+          ),
+          buildSimplePeerEntry(
+            PeerState.Cold,
+            None,
+            host3Id,
+            host3Ra,
+            closedTimestamps = Seq(System.currentTimeMillis(), System.currentTimeMillis(), System.currentTimeMillis())
+          ),
+          buildSimplePeerEntry(PeerState.Warm, None, host4Id, host4Ra) // doesn't count because have no actor
+        )
+
+      val mockData = buildDefaultMockData(
+        newPeerCreationAlgebra = newPeerCreationAlgebra,
+        initialPeers = initialPeersMap
+      )
+      buildActorFromMockData(mockData)
+        .use { actor =>
+          for {
+            withUpdate <- actor.send(PeersManager.Message.UpdatedReputationTick)
+            _ = assert(withUpdate.peersHandler(host1Id).state == PeerState.Warm)
+            _ = assert(withUpdate.peersHandler(host2Id).state == PeerState.Cold)
+            _ = assert(withUpdate.peersHandler(host3Id).state == PeerState.Cold)
+          } yield ()
+        }
+    }
+  }
+
+  test("Reputation update: Do not move non-eligible by timeout and to warm because at least one warm peer") {
+    withMock {
+      val host1Id = arbitraryHost.arbitrary.first
+      val host1Ra = RemoteAddress("1", 1)
+      val host2Id = arbitraryHost.arbitrary.first
+      val host2Ra = RemoteAddress("2", 2)
+      val host3Id = arbitraryHost.arbitrary.first
+      val host3Ra = RemoteAddress("3", 3)
+      val host4Id = arbitraryHost.arbitrary.first
+      val host4Ra = RemoteAddress("4", 4)
+      val host4Actor = mock[PeerActor[F]]
+      (host4Actor.sendNoWait _)
+        .expects(PeerActor.Message.UpdateState(networkLevel = true, applicationLevel = true))
+        .returning(Applicative[F].unit)
+
+      val initialPeersMap: Map[HostId, Peer[F]] =
+        Map(
+          buildSimplePeerEntry(
+            PeerState.Cold,
+            None,
+            host1Id,
+            host1Ra,
+            closedTimestamps = Seq(System.currentTimeMillis())
+          ),
+          buildSimplePeerEntry(
+            PeerState.Cold,
+            None,
+            host2Id,
+            host2Ra,
+            closedTimestamps = Seq(System.currentTimeMillis(), System.currentTimeMillis())
+          ),
+          buildSimplePeerEntry(
+            PeerState.Cold,
+            None,
+            host3Id,
+            host3Ra,
+            closedTimestamps = Seq(System.currentTimeMillis(), System.currentTimeMillis(), System.currentTimeMillis())
+          ),
+          buildSimplePeerEntry(PeerState.Warm, host4Actor.some, host4Id, host4Ra)
+        )
+
+      val mockData = buildDefaultMockData(initialPeers = initialPeersMap)
+      buildActorFromMockData(mockData)
+        .use { actor =>
+          for {
+            withUpdate <- actor.send(PeersManager.Message.UpdatedReputationTick)
+            _ = assert(withUpdate.peersHandler(host1Id).state == PeerState.Cold)
+            _ = assert(withUpdate.peersHandler(host2Id).state == PeerState.Cold)
+            _ = assert(withUpdate.peersHandler(host3Id).state == PeerState.Cold)
+            _ = assert(withUpdate.peersHandler(host4Id).state == PeerState.Hot)
+          } yield ()
+        }
+    }
+  }
+
   test("Adding cold peer: ignore banned peers") {
     withMock {
       val p2pConfig: P2PNetworkConfig =


### PR DESCRIPTION
## Purpose
Fix situation where we have very few hot connections because of failures on networks

## Approach
Move one cold peer to warm state even if there is no eligible cold peers because of recent close events

## Testing
Unit tests + integration test

## Tickets
BN-1323