### PR TITLE
Transaction Generator: Random metadata

### DIFF
--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -150,7 +150,7 @@ class NodeAppTest extends CatsEffectSuite {
               // Graph 2 has lower fees, so the Block Packer should never choose them
               transactionGenerator2 <-
                 Fs2TransactionGenerator
-                  .make[F](wallet, _ => 10L.pure[F], Fs2TransactionGenerator.emptyMetadata[F])
+                  .make[F](wallet, _ => 10L.pure[F], Fs2TransactionGenerator.randomMetadata[F])
                   .toResource
               transactionGraph2 <- Stream
                 .force(transactionGenerator2.generateTransactions)

--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -138,7 +138,9 @@ class NodeAppTest extends CatsEffectSuite {
               // Construct two competing graphs of transactions.
               // Graph 1 has higher fees and should be included in the chain
               transactionGenerator1 <-
-                Fs2TransactionGenerator.make[F](wallet, _ => 1000L.pure[F]).toResource
+                Fs2TransactionGenerator
+                  .make[F](wallet, _ => 1000L.pure[F], Fs2TransactionGenerator.emptyMetadata[F])
+                  .toResource
               transactionGraph1 <- Stream
                 .force(transactionGenerator1.generateTransactions)
                 .take(10)
@@ -147,7 +149,9 @@ class NodeAppTest extends CatsEffectSuite {
                 .toResource
               // Graph 2 has lower fees, so the Block Packer should never choose them
               transactionGenerator2 <-
-                Fs2TransactionGenerator.make[F](wallet, _ => 10L.pure[F]).toResource
+                Fs2TransactionGenerator
+                  .make[F](wallet, _ => 10L.pure[F], Fs2TransactionGenerator.emptyMetadata[F])
+                  .toResource
               transactionGraph2 <- Stream
                 .force(transactionGenerator2.generateTransactions)
                 .take(10)

--- a/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/app/Orchestrator.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/app/Orchestrator.scala
@@ -239,7 +239,8 @@ object Orchestrator
       transactionStream <- Fs2TransactionGenerator
         .make[F](
           wallet,
-          TransactionCostCalculatorInterpreter.make(TransactionCostConfig())
+          TransactionCostCalculatorInterpreter.make(TransactionCostConfig()),
+          Fs2TransactionGenerator.randomMetadata[F]
         )
         .flatMap(_.generateTransactions)
       // Build the stream

--- a/transaction-generator/src/main/resources/application.conf
+++ b/transaction-generator/src/main/resources/application.conf
@@ -5,8 +5,9 @@ transaction-generator {
     client = "http://localhost:9084"
   }
   generator {
-    // The number of bytes to generate for each Transaction.data field
-    data-length = 100
+    // If true, adds random metadata of length=64 to each IoTransaction
+    // If false, adds empty metadata instead
+    insert-metadata = true
   }
   broadcaster {
     // The number of transactions to broadcast per second.  Decimals are allowed.

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/ApplicationConfig.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/ApplicationConfig.scala
@@ -29,7 +29,7 @@ object ApplicationConfig {
     case class Rpc(client: String)
 
     @Lenses
-    case class Generator(dataLength: Int)
+    case class Generator(insertMetadata: Boolean)
 
     @Lenses
     case class Broadcaster(tps: Double)

--- a/transaction-generator/src/test/scala/co/topl/transactiongenerator/interpreters/Fs2TransactionGeneratorSpec.scala
+++ b/transaction-generator/src/test/scala/co/topl/transactiongenerator/interpreters/Fs2TransactionGeneratorSpec.scala
@@ -36,7 +36,7 @@ class Fs2TransactionGeneratorSpec extends CatsEffectSuite {
       wallet = applyTransaction(emptyWallet)(seedTransaction)
       implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F]
       costCalculator = TransactionCostCalculatorInterpreter.make[F](TransactionCostConfig())
-      underTest <- Fs2TransactionGenerator.make[F](wallet, costCalculator)
+      underTest <- Fs2TransactionGenerator.make[F](wallet, costCalculator, Fs2TransactionGenerator.randomMetadata[F])
       stream    <- underTest.generateTransactions
       _         <- stream.take(500).compile.count.assertEquals(500L)
     } yield ()


### PR DESCRIPTION
## Purpose
- For testing purposes, it would be helpful to see transactions that contain metadata
## Approach
- Modify TransactionGeneratorApp with new config flag `transaction-generator.generator.insert-metadata` (true by default)
- Modify Fs2TransactionGenerator to include a metadataF helper which generates metadata.  If configured, use random 64-bytes.  If false, use empty metadata.
- Unrelated: Transaction broadcasting will start immediately after launching instead of waiting the delay period
## Testing
- Ran local node and transaction generator with an extra log to print metadata.  Verified randomly generated data.
## Tickets
N/A