### PR TITLE
BlockProducer Use Real Timestamp

### DIFF
--- a/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
@@ -73,6 +73,10 @@ class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
             .expects(vrfHit.slot)
             .once()
             .returning(NumericRange.inclusive(50L, 99L, 1L).pure[F])
+          (() => clock.currentTimestamp)
+            .expects()
+            .once()
+            .returning(55L.pure[F])
 
           val rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
           (rewardCalculator.rewardOf(_)).expects(*).anyNumberOfTimes().returning(BigInt(10L).pure[F])


### PR DESCRIPTION
## Purpose
- Blocks produced by the block producer currently use the latest possible timestamp of the slot in which it is eligible (i.e. if slotDuration is 1 second, then there are 1000 valid timestamp (millisecond) values, and it'll choose the last possible timestamp in that range)
  - This guarantees valid blocks, but it makes it hard to estimate network delay
## Approach
- Update BlockProducer to use the actual current timestamp if possible
  - If the current timestamp falls outside the slot boundary, just use the slot boundary min or max
## Testing
- `preparePR`
## Tickets
N/A