### PR TITLE
No longer lost remote peer server address if it known from configuration but remote peer do not provide it

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
@@ -169,7 +169,8 @@ case class PeersHandler[F[_]: Async: Logger](
             0
           )
         case Some(peer) =>
-          host -> peer.copy(connectedAddress = address.some, asServer = asServer, actorOpt = peerActor.some)
+          val mergedServerAddress = asServer.orElse(peer.asServer)
+          host -> peer.copy(connectedAddress = address.some, asServer = mergedServerAddress, actorOpt = peerActor.some)
       }
     this.copy(peers = peers + peerToAdd)
   }


### PR DESCRIPTION
## Purpose
Currently we lost remote peer address If remote peer have no public remote ip and port even if we set it in configuration

## Approach
Merge remote peer data instead of just override

## Testing
Unit tests
## Tickets