### PR TITLE
No lost server address 2

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
@@ -149,15 +149,15 @@ case class PeersHandler[F[_]: Async: Logger](
     }
 
   def copyWithUpdatedPeer(
-    host:      HostId,
+    hostId:    HostId,
     address:   RemoteAddress,
     asServer:  Option[RemotePeer],
     peerActor: PeerActor[F]
   ): PeersHandler[F] = {
     val peerToAdd =
-      peers.get(host) match {
+      peers.get(hostId) match {
         case None =>
-          host -> Peer(
+          hostId -> Peer(
             PeerState.Cold,
             peerActor.some,
             address.some,
@@ -169,8 +169,12 @@ case class PeersHandler[F[_]: Async: Logger](
             0
           )
         case Some(peer) =>
-          val mergedServerAddress = asServer.orElse(peer.asServer)
-          host -> peer.copy(connectedAddress = address.some, asServer = mergedServerAddress, actorOpt = peerActor.some)
+          val mergedServerAddress = asServer.orElse(peer.asServer).map(_.copy(peerId = hostId))
+          hostId -> peer.copy(
+            connectedAddress = address.some,
+            asServer = mergedServerAddress,
+            actorOpt = peerActor.some
+          )
       }
     this.copy(peers = peers + peerToAdd)
   }

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
@@ -1313,7 +1313,6 @@ class PeersManagerTest
       (() => client1.remotePeer).expects().anyNumberOfTimes().returns(connectedPeer.pure[F])
 
       (() => client1.remotePeerAsServer).stubs().returns(Async[F].delay(throw new RuntimeException()))
-      PeersManager.Message.OpenedPeerConnection(client1)
 
       (peer1.sendNoWait _)
         .expects(PeerActor.Message.UpdateState(networkLevel = false, applicationLevel = false))


### PR DESCRIPTION
## Purpose
Update remote peerId even if remote peer didn't provide remote peer address

## Approach
Update peerId 

## Testing
Unit tests

## Tickets