### PR TITLE
Peer no longer could stuck in warm state, fixed possible leak of connection

### DIFF
--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
@@ -1489,10 +1489,14 @@ class PeersManagerTest
       val host6Id = arbitraryHost.arbitrary.first
       val host6Ra = RemoteAddress("6", 6)
       val peer6 = mockPeerActor[F]()
+      val client6 = mock[BlockchainPeerClient[F]]
+      (() => client6.closeConnection()).stubs().returning(Applicative[F].unit)
 
       val host7Id = arbitraryHost.arbitrary.first
       val host7Ra = RemoteAddress("7", 7)
       val peer7 = mockPeerActor[F]()
+      val client7 = mock[BlockchainPeerClient[F]]
+      (() => client7.closeConnection()).stubs().returning(Applicative[F].unit)
 
       val initialPeersMap = Map(
         buildSimplePeerEntry(
@@ -1580,15 +1584,11 @@ class PeersManagerTest
             _ = assert(stateHost5.peersHandler(host5Id).state == PeerState.Hot)
             _ = assert(stateHost5.peersHandler(host5Id).closedTimestamps == Seq(5))
             _ = assert(stateHost5.peersHandler(host5Id).asServer == client5RemotePort)
-            stateHost6 <- actor.send(
-              buildOpenedPeerConnectionMessage(mock[BlockchainPeerClient[F]], ConnectedPeer(host6Ra, host6Id.id))
-            )
+            stateHost6 <- actor.send(buildOpenedPeerConnectionMessage(client6, ConnectedPeer(host6Ra, host6Id.id)))
             _ = assert(stateHost6.peersHandler(host6Id).state == PeerState.Cold)
             _ = assert(stateHost6.peersHandler(host6Id).closedTimestamps == Seq(6))
             _ = assert(stateHost6.peersHandler(host6Id).asServer.isEmpty)
-            stateHost7 <- actor.send(
-              buildOpenedPeerConnectionMessage(mock[BlockchainPeerClient[F]], ConnectedPeer(host7Ra, host7Id.id))
-            )
+            stateHost7 <- actor.send(buildOpenedPeerConnectionMessage(client7, ConnectedPeer(host7Ra, host7Id.id)))
             _ = assert(stateHost7.peersHandler(host7Id).state == PeerState.Warm)
             _ = assert(stateHost7.peersHandler(host7Id).closedTimestamps == Seq(7))
             _ = assert(stateHost7.peersHandler(host7Id).asServer.isEmpty)


### PR DESCRIPTION
## Purpose
1. Previously if peers A,B,C had the same actual remote peer address (but different peer id) then connection open request had been done only for one peer. It could lead to stucking other peers in WARM state. Now we do open connection request for the all peers, thus all peers will change their status correctly
2. Fix possible leak of connection is established to remote peer with connection

## Approach
Do all open connection request, fix possible connection leak

## Testing
Unit tests

## Tickets