### PR TITLE
Adding contains cache

### DIFF
--- a/common-interpreters/src/main/scala/co/topl/interpreters/ContainsCacheStore.scala
+++ b/common-interpreters/src/main/scala/co/topl/interpreters/ContainsCacheStore.scala
@@ -1,0 +1,50 @@
+package co.topl.interpreters
+
+import cats.effect.kernel.Sync
+import co.topl.algebras.Store
+import com.github.benmanes.caffeine.cache.Caffeine
+import scalacache.Entry
+import scalacache.caffeine.CaffeineCache
+import cats.implicits._
+
+object ContainsCacheStore {
+
+  /**
+   * Wrap existing store with added cache for "contains" operation
+   * @tparam F parameter type
+   * @tparam Key the underlying Store Key type
+   * @tparam Value the underlying Store Value type
+   * @return a new Store which wraps the underlying Store with Caffeine Cache for contains operations
+   */
+  def make[F[_]: Sync, Key, Value](
+    underlying:        F[Store[F, Key, Value]],
+    containsCacheSize: Long
+  ): F[Store[F, Key, Value]] =
+    underlying.flatMap(underlying =>
+      Sync[F]
+        .delay[CaffeineCache[F, Key, Boolean]](
+          CaffeineCache[F, Key, Boolean](
+            Caffeine.newBuilder.maximumSize(containsCacheSize).build[Key, Entry[Boolean]]
+          )
+        )
+        .map(containsCache =>
+          new Store[F, Key, Value] {
+
+            def put(id: Key, t: Value): F[Unit] =
+              (containsCache.put(id)(true, None), underlying.put(id, t)).tupled.void
+
+            def remove(id: Key): F[Unit] =
+              (containsCache.put(id)(false, None), underlying.remove(id)).tupled.void
+
+            def get(id: Key): F[Option[Value]] = underlying.get(id)
+
+            def contains(id: Key): F[Boolean] =
+              containsCache.cachingF(id)(ttl = None)(Sync[F].defer(underlying.contains(id)))
+          }
+        )
+    )
+
+  implicit class ContainsCacheStoreSyntax[F[_]: Sync, Key, Value](store: Store[F, Key, Value]) {
+    def withCachedContains(containsCacheSize: Long): F[Store[F, Key, Value]] = make(store.pure[F], containsCacheSize)
+  }
+}

--- a/common-interpreters/src/test/scala/co/topl/interpreters/ContainsCacheStoreSpec.scala
+++ b/common-interpreters/src/test/scala/co/topl/interpreters/ContainsCacheStoreSpec.scala
@@ -1,0 +1,41 @@
+package co.topl.interpreters
+
+import cats.effect.IO
+import cats.implicits._
+import co.topl.algebras.Store
+import munit.CatsEffectSuite
+import org.scalamock.munit.AsyncMockFactory
+
+class ContainsCacheStoreSpec extends CatsEffectSuite with AsyncMockFactory {
+  type F[A] = IO[A]
+
+  test("Read, store, and delete cache values") {
+    withMock {
+      for {
+        underlying <- mock[Store[F, Long, String]].pure[F]
+        underTest  <- ContainsCacheStore.make[F, Long, String](underlying.pure[F], 5)
+
+        // check using underlying cache
+        _ = (underlying.get _).expects(5L).once().returning(none[String].pure[F])
+        _ <- underTest.get(5L).assertEquals(None)
+
+        // put information shall be cached
+        _ = (underlying.contains _).expects(6L).never()
+
+        _ = (underlying.put _).expects(6L, "Test").once().returning(().pure[F])
+        _ <- underTest.put(6L, "Test")
+        _ <- underTest.contains(6L).assertEquals(true)
+
+        // remove information shall be cached
+        _ = (underlying.remove _).expects(6L).once().returning(().pure[F])
+        _ <- underTest.remove(6L)
+        _ <- underTest.contains(6L).assertEquals(false)
+
+        // contains information shall be cached
+        _ = (underlying.contains _).expects(7L).once().returning(true.pure[F])
+        _ <- underTest.contains(7L).assertEquals(true)
+        _ <- underTest.contains(7L).assertEquals(true)
+      } yield ()
+    }
+  }
+}

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -161,7 +161,8 @@ object ApplicationConfig {
       blockHeightTree:         Cache.CacheConfig,
       eligibilities:           Cache.CacheConfig,
       epochData:               Cache.CacheConfig,
-      registrationAccumulator: Cache.CacheConfig
+      registrationAccumulator: Cache.CacheConfig,
+      containsCacheSize:       Long = 16384
     )
 
     object Cache {

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
@@ -158,7 +158,6 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               for {
                 updatedState <- actor.send(BlockChecker.Message.RemoteSlotData(hostId, remoteSlotData))
                 _ = assert(updatedState.bestKnownRemoteSlotDataOpt == Option(BestChain(remoteSlotData)))
-                _ = assert(updatedState.bodyStoreCache.underlying.get(localId).get.value)
               } yield ()
             }
         }


### PR DESCRIPTION
## Purpose
In some cases checking missed headers/bodies could take a long time because we hit out of header/body cache thus it requires disk operations. That PR added a cache for speed-up checking missed/present blocks.

## Approach
Added one more layer of cache for "contains" operations. That cache size could have an arbitrary size

## Testing
Unit test + byzantine integration tests

## Tickets