### PR TITLE
Improve speed of searching first N missed headers in BlockChecker

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BestChain.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BestChain.scala
@@ -11,4 +11,6 @@ case class BestChain(slotData: NonEmptyChain[SlotData]) {
   val lastId: BlockId = last.slotId.blockId
 
   def isLastId(id: BlockId): Boolean = lastId === id
+
+  def getNElementId(n: Int): BlockId = slotData.iterator.drop(n).nextOption().getOrElse(slotData.last).slotId.blockId
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
@@ -195,7 +195,7 @@ object BlockChecker {
   private def requestNextHeaders[F[_]: Async: Logger](state: State[F]): F[Unit] =
     state.bestKnownRemoteSlotDataOpt
       .traverse_ { slotData =>
-        getFirstNMissedInStore(state.headerStore, state.slotDataStore, slotData.lastId, chunkSize)
+        getFirstNMissedInStore(state.headerStore, state.slotDataStore, slotData.getNElementId(chunkSize), chunkSize)
           .logDuration(show"Find N-missing header")
           .flatTap(m => OptionT.liftF(Logger[F].info(show"Send request to get missed headers for blockIds: $m")))
           .map(RequestsProxy.Message.DownloadHeadersRequest(state.bestKnownRemoteSlotDataHost.get, _))


### PR DESCRIPTION
## Purpose
Improve speed of searching first missed N headers

## Approach
Instead of checking long BestSlotData chain we check only first N elements, where N is requested missed headers size

## Testing
Unit tests

## Tickets