### PR TITLE
Fixng issue with none expired cache

### DIFF
--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BestChain.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BestChain.scala
@@ -11,6 +11,4 @@ case class BestChain(slotData: NonEmptyChain[SlotData]) {
   val lastId: BlockId = last.slotId.blockId
 
   def isLastId(id: BlockId): Boolean = lastId === id
-
-  def getNElementId(n: Int): BlockId = slotData.iterator.drop(n).nextOption().getOrElse(slotData.last).slotId.blockId
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
@@ -195,7 +195,7 @@ object BlockChecker {
   private def requestNextHeaders[F[_]: Async: Logger](state: State[F]): F[Unit] =
     state.bestKnownRemoteSlotDataOpt
       .traverse_ { slotData =>
-        getFirstNMissedInStore(state.headerStore, state.slotDataStore, slotData.getNElementId(chunkSize), chunkSize)
+        getFirstNMissedInStore(state.headerStore, state.slotDataStore, slotData.lastId, chunkSize)
           .logDuration(show"Find N-missing header")
           .flatTap(m => OptionT.liftF(Logger[F].info(show"Send request to get missed headers for blockIds: $m")))
           .map(RequestsProxy.Message.DownloadHeadersRequest(state.bestKnownRemoteSlotDataHost.get, _))

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -125,7 +125,10 @@ object PeerBlockHeaderFetcher {
     newBlockIdsStream
       .evalMap { newBlockId =>
         processBlockId(state, newBlockId)
-          .handleErrorWith(Logger[F].error(_)("Fetching slot data from remote host return error"))
+          .handleErrorWith(
+            Logger[F].error(_)("Fetching slot data from remote host return error") >>
+            state.peersManager.sendNoWait(PeersManager.Message.NonCriticalErrorForHost(state.hostId))
+          )
       }
 
   private def processBlockId[F[_]: Async: Logger](

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -19,6 +19,8 @@ import org.typelevel.log4cats.Logger
 import scodec.Codec
 import scodec.codecs.{cstring, double, int32}
 
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
 package object fsnetwork {
 
   val hostIdBytesLen: Int = 32
@@ -34,8 +36,11 @@ package object fsnetwork {
   val requestCacheSize = 256
   val slotIdResponseCacheSize = 256
 
-  val bodyStoreContainsCacheSize = 32768
   val blockSourceCacheSize = 1024
+
+  // requests in proxy shall be expired, there is no strict guarantee that we will receive responses
+  val proxyBlockDataTTL: FiniteDuration = 1.seconds
+  val proxySlotDataTTL: FiniteDuration = 30.seconds
 
   type BlockHeights[F[_]] = EventSourcedState[F, Long => F[Option[BlockId]], BlockId]
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
@@ -1601,6 +1601,9 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
       val slotData = arbitrarySlotData.arbitrary.first.update(_.slotId.slot.set(5L))
 
       val peersManager = mock[PeersManagerActor[F]]
+      (peersManager.sendNoWait _)
+        .expects(PeersManager.Message.NonCriticalErrorForHost(hostId))
+        .returns(Applicative[F].unit)
 
       val client = mock[BlockchainPeerClient[F]]
       (() => client.remotePeerAdoptions)


### PR DESCRIPTION
## Purpose
The underlying library doesn't correctly set the expiration timer on cache entry by `put` request. Change approach how to expire entries

## Approach
Set entries expired policy on the whole cache level for RequestsProxy instead of every entry

## Testing
Unit tests

## Tickets