### PR TITLE
Added minimum required reputation for keeping peer in HOT state; Added logging

### DIFF
--- a/common-interpreters/src/main/scala/co/topl/interpreters/ContainsCacheStore.scala
+++ b/common-interpreters/src/main/scala/co/topl/interpreters/ContainsCacheStore.scala
@@ -31,10 +31,10 @@ object ContainsCacheStore {
           new Store[F, Key, Value] {
 
             def put(id: Key, t: Value): F[Unit] =
-              (containsCache.put(id)(true, None), underlying.put(id, t)).tupled.void
+              underlying.put(id, t) >> containsCache.put(id)(true)
 
             def remove(id: Key): F[Unit] =
-              (containsCache.put(id)(false, None), underlying.remove(id)).tupled.void
+              containsCache.put(id)(false) >> underlying.remove(id)
 
             def get(id: Key): F[Option[Value]] = underlying.get(id)
 

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -61,12 +61,14 @@ object ApplicationConfig {
       minimumBlockProvidingReputationPeers: Int = 2,
       minimumPerformanceReputationPeers:    Int = 2,
       minimumRequiredReputation:            Double = 0.66,
-      minimumEligibleColdConnections:       Int = 50,
-      maximumEligibleColdConnections:       Int = 100,
-      minimumHotConnections:                Int = 7,
-      maximumWarmConnections:               Int = 12,
-      warmHostsUpdateEveryNBlock:           Double = 4.0,
-      commonAncestorTrackInterval:          FiniteDuration = FiniteDuration(10, SECONDS),
+      // any non-new peer require that reputation to be hot
+      minimumBlockProvidingReputation: Double = 0.15,
+      minimumEligibleColdConnections:  Int = 50,
+      maximumEligibleColdConnections:  Int = 100,
+      minimumHotConnections:           Int = 7,
+      maximumWarmConnections:          Int = 12,
+      warmHostsUpdateEveryNBlock:      Double = 4.0,
+      p2pTrackInterval:                FiniteDuration = FiniteDuration(10, SECONDS),
       // we could try to connect to remote peer again after
       // closeTimeoutFirstDelayInMs * {number of closed connections in last closeTimeoutWindowInMs} ^ 2
       closeTimeoutFirstDelayInMs: Long = 1000,

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/NotifierTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/NotifierTest.scala
@@ -21,7 +21,7 @@ object NotifierTest {
     P2PNetworkConfig(
       NetworkProperties(
         pingPongInterval = FiniteDuration(20, MILLISECONDS),
-        commonAncestorTrackInterval = FiniteDuration(20, MILLISECONDS),
+        p2pTrackInterval = FiniteDuration(20, MILLISECONDS),
         warmHostsUpdateEveryNBlock = 0.01,
         aggressiveP2P = true
       ),
@@ -61,7 +61,7 @@ class NotifierTest extends CatsEffectSuite with ScalaCheckEffectSuite with Async
           defaultP2PConfig.slotDuration.toMillis,
           defaultP2PConfig.peersUpdateInterval.toMillis,
           defaultP2PConfig.networkProperties.pingPongInterval.toMillis,
-          defaultP2PConfig.networkProperties.commonAncestorTrackInterval.toMillis,
+          defaultP2PConfig.networkProperties.p2pTrackInterval.toMillis,
           defaultP2PConfig.aggressiveP2PRequestInterval.toMillis
         ).max
 
@@ -89,7 +89,7 @@ class NotifierTest extends CatsEffectSuite with ScalaCheckEffectSuite with Async
         P2PNetworkConfig(
           NetworkProperties(
             pingPongInterval = FiniteDuration(0, MILLISECONDS),
-            commonAncestorTrackInterval = FiniteDuration(0, MILLISECONDS),
+            p2pTrackInterval = FiniteDuration(0, MILLISECONDS),
             warmHostsUpdateEveryNBlock = 0,
             aggressiveP2P = true
           ),
@@ -140,7 +140,7 @@ class NotifierTest extends CatsEffectSuite with ScalaCheckEffectSuite with Async
           defaultP2PConfig.slotDuration.toMillis,
           defaultP2PConfig.peersUpdateInterval.toMillis,
           defaultP2PConfig.networkProperties.pingPongInterval.toMillis,
-          defaultP2PConfig.networkProperties.commonAncestorTrackInterval.toMillis,
+          defaultP2PConfig.networkProperties.p2pTrackInterval.toMillis,
           defaultP2PConfig.aggressiveP2PRequestInterval.toMillis
         ).max
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
@@ -1002,6 +1002,7 @@ class PeersManagerTest
         .expects(PeerActor.Message.UpdateState(networkLevel = false, applicationLevel = false))
         .returns(().pure[F])
 
+      val minimumBlockProvidingReputation = defaultP2PConfig.networkProperties.minimumBlockProvidingReputation
       val initialPeersMap: Map[HostId, Peer[F]] =
         Map(
           buildSimplePeerEntry(
@@ -1010,7 +1011,7 @@ class PeersManagerTest
             host1Id,
             host1Ra,
             closedTimestamps = Seq(1),
-            blockRep = 0,
+            blockRep = minimumBlockProvidingReputation * defaultP2PConfig.blockNoveltyDecoy * 1.05,
             perfRep = 1.0,
             newRep = 0
           ),


### PR DESCRIPTION
## Purpose
Some remote peer could have great performance reputation but provide no blocks (for example they are syncing for us only), we shall move such peers to COLD state

## Approach
Added minimum required reputation for keeping peer in HOT state

## Testing
Unit tests + Integration tests

## Tickets