### PR TITLE
Run DataStoresInit.repair for Public networks

### DIFF
--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -587,7 +587,9 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
                   header       <- dataStores.headers.getOrRaise(publicBigBang.genesisId).toResource
                   body         <- dataStores.bodies.getOrRaise(publicBigBang.genesisId).toResource
                   transactions <- body.transactionIds.traverse(dataStores.transactions.getOrRaise).toResource
-                } yield FullBlock(header, FullBlockBody(transactions)),
+                  fullBlock = FullBlock(header, FullBlockBody(transactions))
+                  _ <- DataStoresInit.repair[F](dataStores, fullBlock).toResource
+                } yield fullBlock,
                 DataReaders
                   .fromSourcePath[F](publicBigBang.sourcePath)
                   .use(reader =>


### PR DESCRIPTION
## Purpose
- A recent changed introduced DataStoresInit.repair, but this method was only called when initializing a _private_ network
## Approach
- Run `repair` for public networks
## Testing
- N/A
## Tickets
- #BN-1379