### PR TITLE
BN-1376 Clear outdated cold peers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,10 +64,12 @@ lazy val dockerSettings = Seq(
     )
   },
   dockerAliases ++= (
-    if (sys.env.get("DOCKER_PUBLISH_DEV_TAG").fold(false)(_.toBoolean)) Seq(
-      DockerAlias(Some("docker.io"), Some("toplprotocol"), "bifrost-node", Some("dev")),
-      DockerAlias(Some("ghcr.io"), Some("topl"), "bifrost-node", Some("dev"))
-    ) else Seq()
+    if (sys.env.get("DOCKER_PUBLISH_DEV_TAG").fold(false)(_.toBoolean))
+      Seq(
+        DockerAlias(Some("docker.io"), Some("toplprotocol"), "bifrost-node", Some("dev")),
+        DockerAlias(Some("ghcr.io"), Some("topl"), "bifrost-node", Some("dev"))
+      )
+    else Seq()
   )
 )
 
@@ -78,9 +80,9 @@ lazy val nodeDockerSettings =
     dockerExposedVolumes += "/bifrost",
     dockerExposedVolumes += "/bifrost-staking",
     dockerEnvVars ++= Map(
-      "BIFROST_APPLICATION_DATA_DIR" -> "/bifrost/data/{genesisBlockId}",
+      "BIFROST_APPLICATION_DATA_DIR"    -> "/bifrost/data/{genesisBlockId}",
       "BIFROST_APPLICATION_STAKING_DIR" -> "/bifrost-staking/{genesisBlockId}",
-      "BIFROST_CONFIG_FILE" -> "/bifrost/config/user.yaml"
+      "BIFROST_CONFIG_FILE"             -> "/bifrost/config/user.yaml"
     )
   )
 
@@ -361,7 +363,11 @@ lazy val tetraByteCodecs = project
   )
   .settings(libraryDependencies ++= Dependencies.munitScalamock ++ Dependencies.protobufSpecs)
   .settings(scalamacrosParadiseSettings)
-  .dependsOn(models % "compile->compile;test->test", byteCodecs % "compile->compile;test->test", nodeCrypto % "compile->compile;test->test")
+  .dependsOn(
+    models     % "compile->compile;test->test",
+    byteCodecs % "compile->compile;test->test",
+    nodeCrypto % "compile->compile;test->test"
+  )
 
 lazy val typeclasses: Project = project
   .in(file("typeclasses"))
@@ -425,7 +431,8 @@ lazy val commonInterpreters = project
     tetraByteCodecs,
     catsUtils,
     eventTree,
-    munitScalamock % "test->test"
+    munitScalamock % "test->test",
+    levelDbStore   % "test->test"
   )
 
 lazy val consensus = project
@@ -452,7 +459,7 @@ lazy val consensus = project
     numerics,
     eventTree,
     commonInterpreters % "compile->test",
-    munitScalamock % "test->test"
+    munitScalamock     % "test->test"
   )
 
 lazy val minting = project
@@ -506,7 +513,7 @@ lazy val networking = project
     eventTree,
     ledger,
     actor,
-    munitScalamock     % "test->test"
+    munitScalamock % "test->test"
   )
 
 lazy val transactionGenerator = project

--- a/common-interpreters/src/main/scala/co/topl/interpreters/ContainsCacheStore.scala
+++ b/common-interpreters/src/main/scala/co/topl/interpreters/ContainsCacheStore.scala
@@ -31,10 +31,10 @@ object ContainsCacheStore {
           new Store[F, Key, Value] {
 
             def put(id: Key, t: Value): F[Unit] =
-              underlying.put(id, t) >> containsCache.put(id)(true)
+              underlying.put(id, t) >> underlying.contains(id).flatMap(containsCache.put(id)(_))
 
             def remove(id: Key): F[Unit] =
-              containsCache.put(id)(false) >> underlying.remove(id)
+              underlying.remove(id) >> underlying.contains(id).flatMap(containsCache.put(id)(_))
 
             def get(id: Key): F[Option[Value]] = underlying.get(id)
 

--- a/common-interpreters/src/test/scala/co/topl/interpreters/ContainsCacheStoreSpec.scala
+++ b/common-interpreters/src/test/scala/co/topl/interpreters/ContainsCacheStoreSpec.scala
@@ -1,41 +1,81 @@
 package co.topl.interpreters
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import cats.implicits._
 import co.topl.algebras.Store
+import co.topl.algebras.testInterpreters.NoOpLogger
+import co.topl.db.leveldb.{LevelDbStore, SpecKey, SpecValue}
+import fs2.io.file.{Files, Path}
 import munit.CatsEffectSuite
 import org.scalamock.munit.AsyncMockFactory
+import org.typelevel.log4cats.Logger
 
 class ContainsCacheStoreSpec extends CatsEffectSuite with AsyncMockFactory {
   type F[A] = IO[A]
 
   test("Read, store, and delete cache values") {
     withMock {
-      for {
-        underlying <- mock[Store[F, Long, String]].pure[F]
-        underTest  <- ContainsCacheStore.make[F, Long, String](underlying.pure[F], 5)
+      inSequence {
+        for {
+          underlying <- mock[Store[F, Long, String]].pure[F]
+          underTest  <- ContainsCacheStore.make[F, Long, String](underlying.pure[F], 5)
 
-        // check using underlying cache
-        _ = (underlying.get _).expects(5L).once().returning(none[String].pure[F])
-        _ <- underTest.get(5L).assertEquals(None)
+          // check using underlying cache
+          _ = (underlying.get _).expects(5L).once().returning(none[String].pure[F])
+          _ <- underTest.get(5L).assertEquals(None)
 
-        // put information shall be cached
-        _ = (underlying.contains _).expects(6L).never()
+          // put information shall be cached
+          _ = (underlying.put _).expects(6L, "Test").once().returning(().pure[F])
+          _ = (underlying.contains _).expects(6L).once().returning(true.pure[F])
+          _ <- underTest.put(6L, "Test")
+          _ <- underTest.contains(6L).assertEquals(true)
+          _ <- underTest.contains(6L).assertEquals(true)
 
-        _ = (underlying.put _).expects(6L, "Test").once().returning(().pure[F])
-        _ <- underTest.put(6L, "Test")
-        _ <- underTest.contains(6L).assertEquals(true)
+          // remove information shall be cached
+          _ = (underlying.remove _).expects(6L).once().returning(().pure[F])
+          _ = (underlying.contains _).expects(6L).once().returning(false.pure[F])
+          _ <- underTest.remove(6L)
+          _ <- underTest.contains(6L).assertEquals(false)
+          _ <- underTest.contains(6L).assertEquals(false)
 
-        // remove information shall be cached
-        _ = (underlying.remove _).expects(6L).once().returning(().pure[F])
-        _ <- underTest.remove(6L)
-        _ <- underTest.contains(6L).assertEquals(false)
-
-        // contains information shall be cached
-        _ = (underlying.contains _).expects(7L).once().returning(true.pure[F])
-        _ <- underTest.contains(7L).assertEquals(true)
-        _ <- underTest.contains(7L).assertEquals(true)
-      } yield ()
+          // contains information shall be cached
+          _ = (underlying.contains _).expects(7L).once().returning(true.pure[F])
+          _ <- underTest.contains(7L).assertEquals(true)
+          _ <- underTest.contains(7L).assertEquals(true)
+        } yield ()
+      }
     }
   }
+
+  implicit val logger: Logger[F] = new NoOpLogger[F]
+
+  ResourceFixture[Path](Resource.make(Files[F].createTempDirectory)(Files[F].deleteRecursively))
+    .test("Check multi thread") { testPath =>
+      def parWriting(store: Store[F, SpecKey, SpecValue], key: SpecKey, thr: Int): F[Unit] =
+        for {
+          values <- (1 to thr).toList.map(t => SpecValue(key.id, t)).pure[F]
+          _ <- values.map { value =>
+            store
+              .contains(key)
+              .ifM(
+                ifTrue = ().pure[F],
+                ifFalse = store.put(key, value)
+              )
+          }.parUnorderedSequence
+        } yield ()
+
+      LevelDbStore.makeFactory[F]().flatMap(LevelDbStore.makeDb[F](testPath, _)).use { dbUnderTest =>
+        for {
+          leveldb        <- LevelDbStore.make[F, SpecKey, SpecValue](dbUnderTest)
+          cacheStore     <- CacheStore.make[F, SpecKey, SpecKey, SpecValue](leveldb.pure[F], identity)
+          threadsN       <- 5.pure[F]
+          elements       <- 100000.pure[F]
+          containsCached <- ContainsCacheStore.make[F, SpecKey, SpecValue](cacheStore.pure[F], elements)
+          keys           <- (1 to elements).map(id => SpecKey(id.toString)).toList.pure[F]
+          _              <- keys.map(key => parWriting(containsCached, key, threadsN)).parSequence
+          _              <- keys.map(key => containsCached.get(key).map(_.isDefined).assert).parSequence
+        } yield ()
+      }
+
+    }
 }

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -65,6 +65,7 @@ object ApplicationConfig {
       minimumBlockProvidingReputation: Double = 0.15,
       minimumEligibleColdConnections:  Int = 50,
       maximumEligibleColdConnections:  Int = 100,
+      clearColdIfNotActiveForInMs:     Long = 7 * 24 * 60 * 60 * 1000, // 7 days
       minimumHotConnections:           Int = 7,
       maximumWarmConnections:          Int = 12,
       warmHostsUpdateEveryNBlock:      Double = 4.0,

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
@@ -157,7 +157,7 @@ object NetworkManager {
     val remoteAddressMap = remoteAddress.map { ra =>
       val id =
         ra.p2pVK.map(HostId).getOrElse(HostId(ByteString.copyFrom(Random.nextBytes(hostIdBytesLen))))
-      ra.remoteAddress -> KnownRemotePeer(id, ra.remoteAddress, 0, 0)
+      ra.remoteAddress -> KnownRemotePeer(id, ra.remoteAddress, 0, 0, None)
     }.toMap
     val remotePeersMap = remotePeers.map(p => p.address -> p).toMap
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -140,7 +140,7 @@ object PeerBlockHeaderFetcher {
     blockId: BlockId
   ): F[Unit] =
     for {
-      hostId <- state.hostId.pure[F]
+      hostId <- state.hostIdString.pure[F]
 
       _          <- Logger[F].info(show"Got blockId: $blockId from peer $hostId")
       (from, to) <- slotDataToSync(state, blockId)
@@ -171,7 +171,7 @@ object PeerBlockHeaderFetcher {
           betterChain.some.pure[F]
         case CompareResult.RemoteIsWorseByDensity =>
           Logger[F].info(show"Ignoring tip $blockId from peer $hostId because of the density rule") >>
-          state.requestsProxy.sendNoWait(RequestsProxy.Message.BadKLookbackSlotData(hostId)) >>
+          state.requestsProxy.sendNoWait(RequestsProxy.Message.BadKLookbackSlotData(state.hostId)) >>
           None.pure[F]
         case CompareResult.RemoteIsWorseByHeight =>
           Logger[F].info(show"Ignoring tip $blockId because other better or equal block had been adopted") >>
@@ -317,7 +317,7 @@ object PeerBlockHeaderFetcher {
       (sd: SlotData) => state.slotDataStore.contains(sd.slotId.blockId)
     )(from.slotId.blockId)
       .handleErrorWith { error =>
-        Logger[F].error(show"Failed to get remote slot data due to ${error.toString}") >>
+        Logger[F].error(show"Failed to get slot data from ${state.hostIdString} due to ${error.toString}") >>
         List.empty[SlotData].pure[F] // TODO send information about error
       }
   }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -86,7 +86,7 @@ object PeerBlockHeaderFetcher {
     val initialState =
       State(
         hostId,
-        show"hostId",
+        show"$hostId",
         client,
         requestsProxy,
         peersManager,

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -17,7 +17,7 @@ import co.topl.typeclasses.implicits._
 import com.github.benmanes.caffeine.cache.Cache
 import org.typelevel.log4cats.Logger
 import scodec.Codec
-import scodec.codecs.{cstring, double, int32}
+import scodec.codecs.{cstring, double, int32, vlong}
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
@@ -173,17 +173,18 @@ package object fsnetwork {
   )
 
   case class KnownRemotePeer(
-    peerId:          HostId,
-    address:         RemoteAddress,
-    blockReputation: HostReputationValue,
-    perfReputation:  HostReputationValue
+    peerId:              HostId,
+    address:             RemoteAddress,
+    blockReputation:     HostReputationValue,
+    perfReputation:      HostReputationValue,
+    lastOpenedTimestamp: Option[Long]
   )
 
   private val hostIdCodec: Codec[HostId] = byteStringCodec.as[HostId]
   private val remoteAddressCodec: Codec[RemoteAddress] = (cstring :: int32).as[RemoteAddress]
 
   implicit val peerToAddCodec: Codec[KnownRemotePeer] =
-    (hostIdCodec :: remoteAddressCodec :: double :: double).as[KnownRemotePeer]
+    (hostIdCodec :: remoteAddressCodec :: double :: double :: optionCodec[Long](vlong)).as[KnownRemotePeer]
 
   implicit class LoggerOps[F[_]: Applicative](logger: Logger[F]) {
 


### PR DESCRIPTION
## Purpose
We could store outdated peers and try to connect to them. Remove outdated cold peers, i.e. peers with active connection more than seven days

## Approach
Update special timestamp when connection is opened, also update that time during active connection, if that timestamp is older than seven days and cold peers are not active then remove such peer

## Testing
Unit test + integration tests

## Tickets