### PR TITLE
TransactionRewardCalculator Return All Value Types

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/interpreters/EpochDataInterpreter.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/interpreters/EpochDataInterpreter.scala
@@ -212,7 +212,7 @@ object EpochDataEventSourcedState {
                 .flatMap(transaction =>
                   (
                     // TODO: Read reward transaction from body
-                    transactionRewardCalculator.rewardOf(transaction),
+                    transactionRewardCalculator.rewardsOf(transaction).map(_.lvl),
                     Sync[F].delay(
                       ContainsImmutable.instances.ioTransactionImmutable.immutableBytes(transaction).value.size()
                     )
@@ -296,7 +296,7 @@ object EpochDataEventSourcedState {
                 .flatMap(transaction =>
                   (
                     // TODO: Read reward transaction from body
-                    transactionRewardCalculator.rewardOf(transaction),
+                    transactionRewardCalculator.rewardsOf(transaction).map(_.lvl),
                     Sync[F].delay(
                       ContainsImmutable.instances.ioTransactionImmutable.immutableBytes(transaction).value.size()
                     )

--- a/blockchain/src/test/scala/co/topl/blockchain/interpreters/EpochDataInterpreterSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/interpreters/EpochDataInterpreterSpec.scala
@@ -16,6 +16,7 @@ import co.topl.consensus.models._
 import co.topl.eventtree.{EventSourcedState, ParentChildTree}
 import co.topl.interpreters.SchedulerClock
 import co.topl.ledger.algebras.TransactionRewardCalculatorAlgebra
+import co.topl.ledger.models.RewardQuantities
 import co.topl.node.models.{BlockBody, FullBlock, FullBlockBody}
 import co.topl.numerics.implicits._
 import co.topl.typeclasses.implicits._
@@ -95,7 +96,11 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
             )
             .toResource
           rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
-          _ = (rewardCalculator.rewardOf(_: IoTransaction)).expects(*).anyNumberOfTimes().returning(BigInt(50).pure[F])
+          _ = (rewardCalculator
+            .rewardsOf(_: IoTransaction))
+            .expects(*)
+            .anyNumberOfTimes()
+            .returning(RewardQuantities(BigInt(50)).pure[F])
           epochBoundaryEss = mock[EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
             F
           ], BlockId]]

--- a/ledger/src/main/scala/co/topl/ledger/algebras/TransactionRewardCalculatorAlgebra.scala
+++ b/ledger/src/main/scala/co/topl/ledger/algebras/TransactionRewardCalculatorAlgebra.scala
@@ -1,14 +1,15 @@
 package co.topl.ledger.algebras
 
 import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.ledger.models.RewardQuantities
 
 trait TransactionRewardCalculatorAlgebra[F[_]] {
 
   /**
-   * Calculates the LVL fee/reward of the given IoTransaction
+   * Calculates the provided rewards of the given transaction.  Any "excess" value is treated as a Reward
    * @param transaction The transaction containing the fee/reward
    * @return a BigInt representing the LVL fee/reward
    */
-  def rewardOf(transaction: IoTransaction): F[BigInt]
+  def rewardsOf(transaction: IoTransaction): F[RewardQuantities]
 
 }

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BodySyntaxValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BodySyntaxValidation.scala
@@ -111,7 +111,7 @@ object BodySyntaxValidation {
                     BodySyntaxErrors.InvalidReward(rewardTransaction).asLeft[Unit].pure[F]
                   else
                     transactions
-                      .parFoldMapA(rewardCalculator.rewardOf)
+                      .parFoldMapA(rewardCalculator.rewardsOf(_).map(_.lvl))
                       .map(maxReward =>
                         Either.cond(definedQuantity <= maxReward, (), BodySyntaxErrors.InvalidReward(rewardTransaction))
                       )

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionRewardCalculator.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionRewardCalculator.scala
@@ -1,19 +1,26 @@
 package co.topl.ledger.interpreters
 
 import cats.effect._
+import cats.implicits._
 import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.ledger.algebras.TransactionRewardCalculatorAlgebra
+import co.topl.ledger.models.{AssetId, RewardQuantities}
 
 /**
- * Implements a TransactionRewardCalculator which returns unclaimed LVLs as a Reward.  If there are no unclaimed LVLs,
- * no Rewards are returned.
- *
- * TOPLs, Assets, and Registrations may not be rewards.
+ * Implements a TransactionRewardCalculator which groups fungible token types and subtracts their output quantities
+ * from the input quantities.
  */
 object TransactionRewardCalculator {
 
   def make[F[_]: Sync]: Resource[F, TransactionRewardCalculatorAlgebra[F]] =
-    Resource.pure(tx => Sync[F].delay((sumLvls(tx.inputs)(_.value) - sumLvls(tx.outputs)(_.value)).max(BigInt(0))))
+    Resource.pure(tx =>
+      (
+        Sync[F].delay((sumLvls(tx.inputs)(_.value) - sumLvls(tx.outputs)(_.value)).max(BigInt(0))),
+        Sync[F].delay((sumTopls(tx.inputs)(_.value) - sumTopls(tx.outputs)(_.value)).max(BigInt(0))),
+        Sync[F].delay(diffAssets(tx))
+      ).mapN(RewardQuantities)
+    )
 
   /**
    * Extracts LVL Box Values from the given collection, and sums the quantities
@@ -29,5 +36,59 @@ object TransactionRewardCalculator {
       .map(_.quantity.value.toByteArray)
       .map(BigInt(_))
       .sum
+
+  /**
+   * Extracts Topl Box Values from the given collection, and sums the quantities
+   * @param containsValues a collection that contains some value T
+   * @param extractValue a function to extract a Value from T
+   * @tparam T an abstract type (SpentTransactionOutput or UnspentTransactionOutput)
+   * @return a BigInt sum
+   */
+  private def sumTopls[T](containsValues: Iterable[T])(extractValue: T => Value): BigInt =
+    containsValues
+      .map(extractValue)
+      .flatMap(_.value.topl)
+      .map(_.quantity.value.toByteArray)
+      .map(BigInt(_))
+      .sum
+
+  /**
+   * Extracts Asset Box Values from the given collection, and sums the quantities based on their respective fungibility
+   * @param containsValues a collection that contains some value T
+   * @param extractValue a function to extract a Value from T
+   * @tparam T an abstract type (SpentTransactionOutput or UnspentTransactionOutput)
+   * @return a mapping from AssetId to BigInt sum
+   */
+  private def sumAssets[T](containsValues: Iterable[T])(extractValue: T => Value): Map[AssetId, BigInt] =
+    containsValues
+      .map(extractValue)
+      .flatMap(_.value.asset)
+      .map(asset =>
+        AssetId(
+          asset.groupId,
+          asset.seriesId,
+          asset.groupAlloy,
+          asset.seriesAlloy,
+          asset.fungibility,
+          asset.quantityDescriptor
+        ) ->
+        BigInt(asset.quantity.value.toByteArray)
+      )
+      .groupBy(_._1)
+      .view
+      .mapValues(_.map(_._2).sum)
+      .toMap
+
+  /**
+   * Determines the excess assets of the given transactions
+   * @return a mapping from AssetId to BigInt sum
+   */
+  private def diffAssets(transaction: IoTransaction): Map[AssetId, BigInt] = {
+    val in = sumAssets(transaction.inputs)(_.value)
+    val out = sumAssets(transaction.outputs)(_.value)
+    out.foldLeft(in) { case (result, (assetId, quantity)) =>
+      result.updatedWith(assetId)(_.map(_ - quantity).filter(_ > 0))
+    }
+  }
 
 }

--- a/ledger/src/main/scala/co/topl/ledger/models/RewardQuantities.scala
+++ b/ledger/src/main/scala/co/topl/ledger/models/RewardQuantities.scala
@@ -1,0 +1,16 @@
+package co.topl.ledger.models
+
+import co.topl.brambl.models.{GroupId, SeriesId}
+import co.topl.brambl.models.box.{FungibilityType, QuantityDescriptorType}
+import co.topl.models.Bytes
+
+case class RewardQuantities(lvl: BigInt = BigInt(0), topl: BigInt = BigInt(0), assets: Map[AssetId, BigInt] = Map.empty)
+
+case class AssetId(
+  groupId:            Option[GroupId],
+  seriesId:           Option[SeriesId],
+  groupAlloy:         Option[Bytes],
+  seriesAlloy:        Option[Bytes],
+  fungibilityType:    FungibilityType,
+  quantityDescriptor: QuantityDescriptorType
+)

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BodySyntaxValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BodySyntaxValidationSpec.scala
@@ -11,7 +11,7 @@ import co.topl.brambl.syntax._
 import co.topl.brambl.validation.TransactionSyntaxError
 import co.topl.brambl.validation.algebras.TransactionSyntaxVerifier
 import co.topl.ledger.algebras.TransactionRewardCalculatorAlgebra
-import co.topl.ledger.models.BodySyntaxErrors
+import co.topl.ledger.models.{BodySyntaxErrors, RewardQuantities}
 import co.topl.node.models.BlockBody
 import co.topl.models.ModelGenerators._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -83,10 +83,10 @@ class BodySyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEffectSuit
             .returning(transaction.validNec[TransactionSyntaxError].toEither.pure[F])
           rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
           _ = (rewardCalculator
-            .rewardOf(_))
+            .rewardsOf(_))
             .expects(transaction)
             .once()
-            .returning(BigInt(2L).pure[F])
+            .returning(RewardQuantities(BigInt(2L), BigInt(0), Map.empty).pure[F])
           underTest <- BodySyntaxValidation.make[F](fetchTransaction, transactionSyntaxValidation, rewardCalculator)
           result    <- underTest.validate(body)
           _         <- IO(result.isInvalid).assert

--- a/minting/src/main/scala/co/topl/minting/interpreters/BlockPacker.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/BlockPacker.scala
@@ -282,7 +282,7 @@ object BlockPacker {
            */
           private def transactionScore(transaction: IoTransaction): F[BigInt] =
             (
-              transactionRewardCalculator.rewardOf(transaction),
+              transactionRewardCalculator.rewardsOf(transaction).map(_.lvl),
               transactionCostCalculator.costOf(transaction)
             ).mapN(_ - _)
 

--- a/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
@@ -204,7 +204,7 @@ object BlockProducer {
      */
     private def insertReward(parentBlockId: BlockId, slot: Slot, base: FullBlockBody): F[FullBlockBody] =
       base.transactions
-        .foldMapM(rewardCalculator.rewardOf)
+        .foldMapM(rewardCalculator.rewardsOf(_).map(_.lvl))
         .flatMap(rewardQuantity =>
           if (rewardQuantity > 0) {
             staker.rewardAddress

--- a/minting/src/test/scala/co/topl/minting/interpreters/BlockPackerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/BlockPackerSpec.scala
@@ -7,7 +7,7 @@ import org.scalamock.munit.AsyncMockFactory
 import cats.effect.IO
 import co.topl.ledger.algebras._
 import co.topl.consensus.models.BlockId
-import co.topl.ledger.models.MempoolGraph
+import co.topl.ledger.models.{MempoolGraph, RewardQuantities}
 import co.topl.brambl.validation.algebras._
 import co.topl.brambl.syntax._
 import co.topl.models.generators.consensus.ModelGenerators
@@ -128,7 +128,11 @@ class BlockPackerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with As
         .once()
         .returning(true.pure[F])
       val rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
-      (rewardCalculator.rewardOf(_: IoTransaction)).expects(*).anyNumberOfTimes().returning(BigInt(100).pure[F])
+      (rewardCalculator
+        .rewardsOf(_: IoTransaction))
+        .expects(*)
+        .anyNumberOfTimes()
+        .returning(RewardQuantities(BigInt(100)).pure[F])
       val costCalculator = mock[TransactionCostCalculator[F]]
       (costCalculator.costOf(_: IoTransaction)).expects(*).anyNumberOfTimes().returning(50L.pure[F])
       val authorizationVerifier = mock[TransactionAuthorizationVerifier[F]]
@@ -229,7 +233,11 @@ class BlockPackerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with As
         .once()
         .returning(true.pure[F])
       val rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
-      (rewardCalculator.rewardOf(_: IoTransaction)).expects(*).anyNumberOfTimes().returning(BigInt(100).pure[F])
+      (rewardCalculator
+        .rewardsOf(_: IoTransaction))
+        .expects(*)
+        .anyNumberOfTimes()
+        .returning(RewardQuantities(BigInt(100)).pure[F])
       val costCalculator = mock[TransactionCostCalculator[F]]
       (costCalculator.costOf(_: IoTransaction)).expects(*).anyNumberOfTimes().returning(50L.pure[F])
       val authorizationVerifier = mock[TransactionAuthorizationVerifier[F]]

--- a/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
@@ -15,6 +15,7 @@ import co.topl.models.ModelGenerators._
 import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.models.generators.node.ModelGenerators._
 import co.topl.brambl.generators.ModelGenerators._
+import co.topl.ledger.models.RewardQuantities
 import co.topl.node.models.{FullBlock, FullBlockBody}
 import fs2._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -79,7 +80,7 @@ class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
             .returning(55L.pure[F])
 
           val rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
-          (rewardCalculator.rewardOf(_)).expects(*).anyNumberOfTimes().returning(BigInt(10L).pure[F])
+          (rewardCalculator.rewardsOf(_)).expects(*).anyNumberOfTimes().returning(RewardQuantities(BigInt(10L)).pure[F])
 
           for {
             clockDeferment   <- IO.deferred[Unit]


### PR DESCRIPTION
## Purpose
- To support future tBTC rewards, a node must be able to collect asset rewards
## Approach
- Modify TransactionRewardCalculator to return a `RewardQuantities` object containing LVL, TOPL, and Asset quantities
- Asset reward quantities are determined using similar fungibility characteristics that are defined in Brambl's TransactionSyntaxVerification
## Testing
- Update unit tests
## Tickets
- #BN-1381
## Notes
- BlockProducers will still only collect LVL rewards until a future ticket