### PR TITLE
BodySyntaxValidation Allow All Reward Types

### DIFF
--- a/ledger/src/main/scala/co/topl/ledger/interpreters/BodySyntaxValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/BodySyntaxValidation.scala
@@ -3,15 +3,13 @@ package co.topl.ledger.interpreters
 import cats.data.{EitherT, NonEmptySet, ValidatedNec}
 import cats.effect.Sync
 import cats.implicits._
-import cats.{Foldable, Order, Parallel}
-import co.topl.brambl.models.TransactionId
-import co.topl.brambl.models.TransactionOutputAddress
+import cats.{Foldable, Monoid, Order, Parallel}
 import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.models.{TransactionId, TransactionOutputAddress}
 import co.topl.brambl.validation.algebras.TransactionSyntaxVerifier
 import co.topl.ledger.algebras._
 import co.topl.ledger.models._
 import co.topl.node.models.BlockBody
-import co.topl.brambl.syntax._
 import com.google.protobuf.ByteString
 
 import scala.collection.immutable.SortedSet
@@ -96,29 +94,42 @@ object BodySyntaxValidation {
             if (transactions.isEmpty)
               (BodySyntaxErrors.InvalidReward(rewardTransaction): BodySyntaxError).invalidNec[Unit].pure[F]
             else
-              EitherT
-                .cond[F](
-                  rewardTransaction.inputs.length == 1 &&
-                  rewardTransaction.outputs.length == 1 &&
-                  rewardTransaction.outputs.head.value.value.isLvl,
-                  rewardTransaction.outputs.head.value.value.lvl,
-                  BodySyntaxErrors.InvalidReward(rewardTransaction)
-                )
-                .subflatMap(_.toRight(BodySyntaxErrors.InvalidReward(rewardTransaction)))
-                .map(_.quantity: BigInt)
-                .flatMapF(definedQuantity =>
-                  if (definedQuantity <= 0)
-                    BodySyntaxErrors.InvalidReward(rewardTransaction).asLeft[Unit].pure[F]
-                  else
-                    transactions
-                      .parFoldMapA(rewardCalculator.rewardsOf(_).map(_.lvl))
-                      .map(maxReward =>
-                        Either.cond(definedQuantity <= maxReward, (), BodySyntaxErrors.InvalidReward(rewardTransaction))
-                      )
-                )
-                .leftWiden[BodySyntaxError]
-                .toValidatedNec
+              {
+                def cond(f: => Boolean) =
+                  EitherT.cond[F](f, (), BodySyntaxErrors.InvalidReward(rewardTransaction))
+                for {
+                  _ <- cond(rewardTransaction.inputs.length == 1)
+                  // Prohibit policy/statement creation
+                  _ <- cond(rewardTransaction.groupPolicies.isEmpty)
+                  _ <- cond(rewardTransaction.seriesPolicies.isEmpty)
+                  _ <- cond(rewardTransaction.mintingStatements.isEmpty)
+                  _ <- cond(rewardTransaction.mergingStatements.isEmpty)
+                  _ <- cond(rewardTransaction.splittingStatements.isEmpty)
+                  // Prohibit registrations in Topl rewards
+                  _ <- cond(rewardTransaction.outputs.forall(_.value.value.topl.forall(_.registration.isEmpty)))
+                  // Verify quantities
+                  maximumReward <- EitherT.liftF(transactions.parFoldMapA(rewardCalculator.rewardsOf))
+                  claimedLvls = TransactionRewardCalculator.sumLvls(rewardTransaction.outputs)(_.value)
+                  _ <- cond(maximumReward.lvl >= claimedLvls)
+                  claimedTopls = TransactionRewardCalculator.sumTopls(rewardTransaction.outputs)(_.value)
+                  _ <- cond(maximumReward.topl >= claimedTopls)
+                  claimedAssets = TransactionRewardCalculator.sumAssets(rewardTransaction.outputs)(_.value)
+                  _ <- claimedAssets.toList.traverse { case (id, quantity) =>
+                    cond(maximumReward.assets.get(id).exists(_ >= quantity))
+                  }
+                } yield ()
+              }.leftWiden[BodySyntaxError].toValidatedNec
           )
       }
     }
+
+  implicit val monoidTransactionRewardQuantities: Monoid[RewardQuantities] = Monoid.instance[RewardQuantities](
+    RewardQuantities(),
+    (q1, q2) =>
+      RewardQuantities(
+        q1.lvl + q2.lvl,
+        q1.topl + q2.topl,
+        (q1.assets.toList ++ q2.assets.toList).groupBy(_._1).view.mapValues(_.map(_._2).sum).toMap
+      )
+  )
 }

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionRewardCalculator.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionRewardCalculator.scala
@@ -29,7 +29,7 @@ object TransactionRewardCalculator {
    * @tparam T an abstract type (SpentTransactionOutput or UnspentTransactionOutput)
    * @return a BigInt sum
    */
-  private def sumLvls[T](containsValues: Iterable[T])(extractValue: T => Value): BigInt =
+  def sumLvls[T](containsValues: Iterable[T])(extractValue: T => Value): BigInt =
     containsValues
       .map(extractValue)
       .flatMap(_.value.lvl)
@@ -44,7 +44,7 @@ object TransactionRewardCalculator {
    * @tparam T an abstract type (SpentTransactionOutput or UnspentTransactionOutput)
    * @return a BigInt sum
    */
-  private def sumTopls[T](containsValues: Iterable[T])(extractValue: T => Value): BigInt =
+  def sumTopls[T](containsValues: Iterable[T])(extractValue: T => Value): BigInt =
     containsValues
       .map(extractValue)
       .flatMap(_.value.topl)
@@ -59,7 +59,7 @@ object TransactionRewardCalculator {
    * @tparam T an abstract type (SpentTransactionOutput or UnspentTransactionOutput)
    * @return a mapping from AssetId to BigInt sum
    */
-  private def sumAssets[T](containsValues: Iterable[T])(extractValue: T => Value): Map[AssetId, BigInt] =
+  def sumAssets[T](containsValues: Iterable[T])(extractValue: T => Value): Map[AssetId, BigInt] =
     containsValues
       .map(extractValue)
       .flatMap(_.value.asset)
@@ -83,7 +83,7 @@ object TransactionRewardCalculator {
    * Determines the excess assets of the given transactions
    * @return a mapping from AssetId to BigInt sum
    */
-  private def diffAssets(transaction: IoTransaction): Map[AssetId, BigInt] = {
+  def diffAssets(transaction: IoTransaction): Map[AssetId, BigInt] = {
     val in = sumAssets(transaction.inputs)(_.value)
     val out = sumAssets(transaction.outputs)(_.value)
     out.foldLeft(in) { case (result, (assetId, quantity)) =>

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BodySyntaxValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BodySyntaxValidationSpec.scala
@@ -4,16 +4,17 @@ import cats.effect.IO
 import cats.implicits._
 import co.topl.brambl.constants.NetworkConstants
 import co.topl.brambl.generators.ModelGenerators._
-import co.topl.brambl.models.box.{Lock, Value}
+import co.topl.brambl.models.box.{FungibilityType, Lock, QuantityDescriptorType, Value}
 import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.models.{LockAddress, TransactionId}
+import co.topl.brambl.models.{GroupId, LockAddress, SeriesId, TransactionId}
 import co.topl.brambl.syntax._
 import co.topl.brambl.validation.TransactionSyntaxError
 import co.topl.brambl.validation.algebras.TransactionSyntaxVerifier
 import co.topl.ledger.algebras.TransactionRewardCalculatorAlgebra
-import co.topl.ledger.models.{BodySyntaxErrors, RewardQuantities}
-import co.topl.node.models.BlockBody
+import co.topl.ledger.models.{AssetId, BodySyntaxErrors, RewardQuantities}
 import co.topl.models.ModelGenerators._
+import co.topl.node.models.BlockBody
+import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
@@ -46,8 +47,12 @@ class BodySyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEffectSuit
   }
 
   test("validation should fail if the reward is incorrect") {
-    PropF.forAllF { transaction: IoTransaction =>
-      withMock {
+    withMock {
+      val transaction = arbitraryIoTransaction.arbitrary.first
+      def test(lvlReward: Option[BigInt], toplReward: Option[BigInt], assetRewards: List[(AssetId, BigInt)])(
+        rewardOutput:  RewardQuantities,
+        expectSuccess: Boolean
+      ) = {
         val lock: Lock = Lock().withPredicate(Lock.Predicate())
 
         val lockAddress: LockAddress =
@@ -58,17 +63,40 @@ class BodySyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEffectSuit
               SpentTransactionOutput(
                 arbitraryTransactionOutputAddress.arbitrary.first,
                 arbitraryAttestation.arbitrary.first,
-                Value().withLvl(Value.LVL(100L))
+                Value.defaultInstance.withLvl(Value.LVL(100L))
               )
             )
           )
           .withOutputs(
             List(
+              lvlReward.map(q =>
+                UnspentTransactionOutput(
+                  lockAddress,
+                  Value.defaultInstance.withLvl(Value.LVL(q))
+                )
+              ),
+              toplReward.map(q =>
+                UnspentTransactionOutput(
+                  lockAddress,
+                  Value.defaultInstance.withTopl(Value.TOPL(q))
+                )
+              )
+            ).flatten ++ assetRewards.map { case (id, q) =>
               UnspentTransactionOutput(
                 lockAddress,
-                Value().withLvl(Value.LVL(100L))
+                Value.defaultInstance.withAsset(
+                  Value.Asset(
+                    id.groupId,
+                    id.seriesId,
+                    q,
+                    id.groupAlloy,
+                    id.seriesAlloy,
+                    id.fungibilityType,
+                    id.quantityDescriptor
+                  )
+                )
               )
-            )
+            }
           )
           .embedId
         val body = BlockBody(List(transaction.id), rewardTx.id.some)
@@ -86,12 +114,65 @@ class BodySyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEffectSuit
             .rewardsOf(_))
             .expects(transaction)
             .once()
-            .returning(RewardQuantities(BigInt(2L), BigInt(0), Map.empty).pure[F])
+            .returning(rewardOutput.pure[F])
           underTest <- BodySyntaxValidation.make[F](fetchTransaction, transactionSyntaxValidation, rewardCalculator)
           result    <- underTest.validate(body)
-          _         <- IO(result.isInvalid).assert
-          _         <- IO(result.swap.toOption.get.toList == List(BodySyntaxErrors.InvalidReward(rewardTx))).assert
+          _         <- IO(result.isValid == expectSuccess).assert
+          _ <- IO(
+            expectSuccess || result.swap.toOption.get.toList == List(BodySyntaxErrors.InvalidReward(rewardTx))
+          ).assert
         } yield ()
+      }
+      test(BigInt(100).some, none, Nil)(RewardQuantities(BigInt(2L), BigInt(0), Map.empty), expectSuccess = false) *>
+      test(BigInt(100).some, none, Nil)(RewardQuantities(BigInt(200L), BigInt(0), Map.empty), expectSuccess = true) *>
+      test(BigInt(100).some, BigInt(100).some, Nil)(
+        RewardQuantities(BigInt(200L), BigInt(0), Map.empty),
+        expectSuccess = false
+      ) *>
+      test(BigInt(100).some, BigInt(100).some, Nil)(
+        RewardQuantities(BigInt(200L), BigInt(100L), Map.empty),
+        expectSuccess = true
+      ) *> {
+        val assetId1 = AssetId(
+          groupId = GroupId(ByteString.copyFrom(Array.fill[Byte](32)(1))).some,
+          seriesId = SeriesId(ByteString.copyFrom(Array.fill[Byte](32)(2))).some,
+          groupAlloy = none,
+          seriesAlloy = none,
+          fungibilityType = FungibilityType.GROUP_AND_SERIES,
+          quantityDescriptor = QuantityDescriptorType.LIQUID
+        )
+        val assetId2 = AssetId(
+          groupId = GroupId(ByteString.copyFrom(Array.fill[Byte](32)(3))).some,
+          seriesId = SeriesId(ByteString.copyFrom(Array.fill[Byte](32)(4))).some,
+          groupAlloy = none,
+          seriesAlloy = none,
+          fungibilityType = FungibilityType.GROUP_AND_SERIES,
+          quantityDescriptor = QuantityDescriptorType.LIQUID
+        )
+        val assetId3 = AssetId(
+          groupId = GroupId(ByteString.copyFrom(Array.fill[Byte](32)(4))).some,
+          seriesId = SeriesId(ByteString.copyFrom(Array.fill[Byte](32)(5))).some,
+          groupAlloy = none,
+          seriesAlloy = none,
+          fungibilityType = FungibilityType.GROUP_AND_SERIES,
+          quantityDescriptor = QuantityDescriptorType.LIQUID
+        )
+        test(none, none, List(assetId1 -> BigInt(100)))(
+          RewardQuantities(BigInt(0), BigInt(0), Map(assetId1 -> BigInt(100), assetId2 -> BigInt(100))),
+          expectSuccess = true
+        ) *>
+        test(none, none, List(assetId1 -> BigInt(100), assetId2 -> BigInt(50)))(
+          RewardQuantities(BigInt(0), BigInt(0), Map(assetId1 -> BigInt(100), assetId2 -> BigInt(100))),
+          expectSuccess = true
+        ) *>
+        test(none, none, List(assetId1 -> BigInt(150), assetId2 -> BigInt(50)))(
+          RewardQuantities(BigInt(0), BigInt(0), Map(assetId1 -> BigInt(100), assetId2 -> BigInt(100))),
+          expectSuccess = false
+        ) *>
+        test(none, none, List(assetId3 -> BigInt(150)))(
+          RewardQuantities(BigInt(0), BigInt(0), Map.empty),
+          expectSuccess = false
+        )
       }
     }
   }


### PR DESCRIPTION
## Purpose
- Previous work modified the RewardsCalculator to calculate rewards for all value types
- This PR modifies the BodySyntaxValidation to also allow rewards for all types
## Approach
- Update BodySyntaxValidation to use helpers from RewardCalculator
## Testing
- New unit tests for TOPL and Asset values
## Tickets
- #BN-1382