### PR TITLE
BlockProducer Collect All Reward Types

### DIFF
--- a/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionRewardCalculator.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionRewardCalculator.scala
@@ -19,7 +19,7 @@ object TransactionRewardCalculator {
         Sync[F].delay((sumLvls(tx.inputs)(_.value) - sumLvls(tx.outputs)(_.value)).max(BigInt(0))),
         Sync[F].delay((sumTopls(tx.inputs)(_.value) - sumTopls(tx.outputs)(_.value)).max(BigInt(0))),
         Sync[F].delay(diffAssets(tx))
-      ).mapN(RewardQuantities)
+      ).mapN(RewardQuantities.apply)
     )
 
   /**

--- a/ledger/src/main/scala/co/topl/ledger/models/RewardQuantities.scala
+++ b/ledger/src/main/scala/co/topl/ledger/models/RewardQuantities.scala
@@ -1,10 +1,51 @@
 package co.topl.ledger.models
 
-import co.topl.brambl.models.{GroupId, SeriesId}
+import cats.implicits._
+import cats.{Monoid, Show}
 import co.topl.brambl.models.box.{FungibilityType, QuantityDescriptorType}
+import co.topl.brambl.models.{GroupId, SeriesId}
 import co.topl.models.Bytes
+import co.topl.typeclasses.implicits._
 
-case class RewardQuantities(lvl: BigInt = BigInt(0), topl: BigInt = BigInt(0), assets: Map[AssetId, BigInt] = Map.empty)
+case class RewardQuantities(
+  lvl:    BigInt = BigInt(0),
+  topl:   BigInt = BigInt(0),
+  assets: Map[AssetId, BigInt] = Map.empty
+) {
+
+  /**
+   * Indicates if this RewardQuantities contains 0-value across all value types.
+   * @return true if there are no rewards
+   */
+  def isEmpty: Boolean =
+    lvl <= 0 && topl <= 0 && assets.forall(_._2 <= 0)
+}
+
+object RewardQuantities {
+
+  implicit val monoidTransactionRewardQuantities: Monoid[RewardQuantities] = Monoid.instance[RewardQuantities](
+    RewardQuantities(),
+    (q1, q2) =>
+      RewardQuantities(
+        q1.lvl + q2.lvl,
+        q1.topl + q2.topl,
+        (q1.assets.toList ++ q2.assets.toList).groupBy(_._1).view.mapValues(_.map(_._2).sum).toMap
+      )
+  )
+
+  implicit val showRewardQuantities: Show[RewardQuantities] = { quantities =>
+    val quantitiesString = (List(
+      "lvl"  -> quantities.lvl,
+      "topl" -> quantities.topl
+    ) ++ quantities.assets.toList.map { case (id, quantity) => id.show -> quantity })
+      .filter(_._2 > 0)
+      .map { case (key, value) =>
+        s"$key=$value"
+      }
+      .mkString(", ")
+    show"Reward($quantitiesString)"
+  }
+}
 
 case class AssetId(
   groupId:            Option[GroupId],
@@ -14,3 +55,15 @@ case class AssetId(
   fungibilityType:    FungibilityType,
   quantityDescriptor: QuantityDescriptorType
 )
+
+object AssetId {
+
+  implicit val showAssetId: Show[AssetId] =
+    assetId =>
+      show"${assetId.groupId.map(_.value)}" +
+      show":${assetId.seriesId.map(_.value)}" +
+      show":${assetId.groupAlloy}" +
+      show":${assetId.seriesAlloy}" +
+      show":${assetId.fungibilityType.toString}" +
+      show":${assetId.quantityDescriptor.toString}"
+}

--- a/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
@@ -1,22 +1,24 @@
 package co.topl.minting.interpreters
 
-import cats.effect.{Async, IO}
 import cats.effect.std.Queue
+import cats.effect.{Async, IO}
 import cats.implicits._
 import co.topl.algebras.ClockAlgebra
-import co.topl.brambl.models.LockAddress
+import co.topl.brambl.generators.ModelGenerators._
+import co.topl.brambl.models.box.{FungibilityType, QuantityDescriptorType}
+import co.topl.brambl.models.{GroupId, LockAddress, SeriesId}
 import co.topl.brambl.syntax._
 import co.topl.catsutils.Iterative
 import co.topl.consensus.models.{BlockHeader, BlockId, SlotData, StakingAddress}
 import co.topl.ledger.algebras.TransactionRewardCalculatorAlgebra
+import co.topl.ledger.models.{AssetId, RewardQuantities}
 import co.topl.minting.algebras.{BlockPackerAlgebra, StakingAlgebra}
 import co.topl.minting.models._
 import co.topl.models.ModelGenerators._
 import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.models.generators.node.ModelGenerators._
-import co.topl.brambl.generators.ModelGenerators._
-import co.topl.ledger.models.RewardQuantities
 import co.topl.node.models.{FullBlock, FullBlockBody}
+import com.google.protobuf.ByteString
 import fs2._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
@@ -79,8 +81,18 @@ class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
             .once()
             .returning(55L.pure[F])
 
+          val assetId1 = AssetId(
+            groupId = GroupId(ByteString.copyFrom(Array.fill[Byte](32)(1))).some,
+            seriesId = SeriesId(ByteString.copyFrom(Array.fill[Byte](32)(2))).some,
+            groupAlloy = none,
+            seriesAlloy = none,
+            fungibilityType = FungibilityType.GROUP_AND_SERIES,
+            quantityDescriptor = QuantityDescriptorType.LIQUID
+          )
+          val rewardQuantities = RewardQuantities(BigInt(10L), BigInt(5L), Map(assetId1 -> BigInt(30L)))
+
           val rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
-          (rewardCalculator.rewardsOf(_)).expects(*).anyNumberOfTimes().returning(RewardQuantities(BigInt(10L)).pure[F])
+          (rewardCalculator.rewardsOf(_)).expects(*).anyNumberOfTimes().returning(rewardQuantities.pure[F])
 
           for {
             clockDeferment   <- IO.deferred[Unit]
@@ -116,9 +128,30 @@ class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
               val rewardTx = result.get.fullBody.rewardTransaction.get
               assert(rewardTx.inputs.length == 1)
               assert(rewardTx.inputs.head.address.id.value == parentSlotData.slotId.blockId.value)
-              assert(rewardTx.outputs.length == 1)
+              assert(rewardTx.outputs.length == 3)
               assert(
-                (rewardTx.outputs.head.value.getLvl.quantity: BigInt) == BigInt(outputBody.transactions.length * 10L)
+                rewardTx.outputs.exists(
+                  _.value.value.lvl.map(_.quantity: BigInt).contains(BigInt(outputBody.transactions.length * 10L))
+                )
+              )
+              assert(
+                rewardTx.outputs.exists(
+                  _.value.value.topl.map(_.quantity: BigInt).contains(BigInt(outputBody.transactions.length * 5L))
+                )
+              )
+              assert(
+                rewardTx.outputs.exists(
+                  _.value.value.asset.exists(a =>
+                    (a.quantity: BigInt) == BigInt(outputBody.transactions.length * 30L)
+                    &&
+                    a.groupId == assetId1.groupId &&
+                    a.seriesId == assetId1.seriesId &&
+                    a.groupAlloy == assetId1.groupAlloy &&
+                    a.seriesAlloy == assetId1.seriesAlloy &&
+                    a.fungibility == assetId1.fungibilityType &&
+                    a.quantityDescriptor == assetId1.quantityDescriptor
+                  )
+                )
               )
             }
             _ <- parents.offer(none)


### PR DESCRIPTION
## Purpose
- The BlockProducer currently only applies rewards of type LVL from the calculated RewardQuantities
- This PR updates the BlockProducer to collect rewards of all types
## Approach
- Update BlockProducer to apply a UTxO for each reward type (LVL, TOPL, Asset)
## Testing
- Update BlockProducerSpec to collect other rewards
## Tickets
- #BN-1383