### PR TITLE
BN-1408 Tuning reputation

### DIFF
--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -75,7 +75,7 @@ object ApplicationConfig {
       closeTimeoutFirstDelayInMs: Long = 1000,
       closeTimeoutWindowInMs:     Long = 1000 * 60 * 60 * 24, // 1 day
       aggressiveP2P:              Boolean = true, // always try to found new good remote peers
-      aggressiveP2PCount:         Int = 2 // how many new connection will be opened
+      aggressiveP2PCount:         Int = 1 // how many new connection will be opened
     )
 
     case class KnownPeer(host: String, port: Int)

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/P2PNetworkConfig.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/P2PNetworkConfig.scala
@@ -48,6 +48,17 @@ case class P2PNetworkConfig(networkProperties: NetworkProperties, slotDuration: 
     Math.ceil(networkProperties.expectedSlotsPerBlock * networkProperties.remotePeerNoveltyInExpectedBlocks).toLong
 
   /**
+   * Each header download request increase peer novelty, it allows to keep connection if we sync from scratch.
+   * It is required because of stopping processing new slot data from remote peer during processing already
+   * received slot data, i.e. remote peer block providing reputation will be reduced to 0 over some time.
+   */
+  val maxPeerNovelty: Long =
+    if (slotDuration.toMillis != 0)
+      (1000L * 60 * 30) / slotDuration.toMillis // 30 minutes
+    else
+      remotePeerNoveltyInSlots
+
+  /**
    * How often we update our list of warm hosts
    */
   val peersUpdateInterval: FiniteDuration =

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/P2PShowInstances.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/P2PShowInstances.scala
@@ -81,6 +81,7 @@ trait P2PShowInstances {
     s" PerformanceReputationIdealValue=${config.performanceReputationIdealValue};" ++
     s" PerformanceReputationMaxDelay=${config.performanceReputationMaxDelay} ms;" ++
     s" RemotePeerNoveltyInSlots=${config.remotePeerNoveltyInSlots};" ++
+    s" MaxPeerNovelty=${config.maxPeerNovelty};" ++
     s" WarmHostsUpdateInterval=${config.peersUpdateInterval.toMillis} ms;" ++
     s" AggressiveP2PRequestInterval=${config.aggressiveP2PRequestInterval.toMillis} ms;"
 
@@ -95,8 +96,6 @@ trait P2PShowInstances {
     s" Remote peer=${if (peer.remoteNetworkLevel) "active" else "no active"};" +
     f" Rep: block=${peer.blockRep}%.2f, perf=${peer.perfRep}%.2f, new=${peer.newRep}, mean=${peer.reputation}%.2f;" +
     s" With total ${peer.closedTimestamps.size} closes with" +
-    s" first 5 timestamps ${peer.closedTimestamps.take(5)};" +
-    s" last 5 timestamps ${peer.closedTimestamps.takeRight(5)};" +
     s" last close ${peer.closedTimestamps.lastOption.map(l => Instant.ofEpochMilli(l).toString).getOrElse("none")};" +
     s" >>>"
   }


### PR DESCRIPTION
## Purpose
Reduce unnecessary connection closing to remote peer during sync from scratch due to bad reputation.

## Approach
Receiving block source no longer sets newReputation, instead, it takes maximum value. Limit newRep collected by header request frowarding

## Testing
Unit test + integration test 
## Tickets