### PR TITLE
Genus: TxO Spender

### DIFF
--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphBlockUpdater.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphBlockUpdater.scala
@@ -6,7 +6,11 @@ import cats.effect._
 import cats.implicits._
 import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.syntax.{groupPolicyAsGroupPolicySyntaxOps, ioTransactionAsTransactionSyntaxOps, seriesPolicyAsSeriesPolicySyntaxOps}
+import co.topl.brambl.syntax.{
+  groupPolicyAsGroupPolicySyntaxOps,
+  ioTransactionAsTransactionSyntaxOps,
+  seriesPolicyAsSeriesPolicySyntaxOps
+}
 import co.topl.genus.services.{BlockData, Txo, TxoState}
 import co.topl.genusLibrary.algebras.{BlockFetcherAlgebra, BlockUpdaterAlgebra, NodeBlockFetcherAlgebra}
 import co.topl.genusLibrary.model.{GE, GEs}

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphTokenFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphTokenFetcher.scala
@@ -16,12 +16,12 @@ object GraphTokenFetcher {
       new TokenFetcherAlgebra[F] {
         def fetchGroupPolicy(groupId: GroupId): F[Either[GE, Option[GroupPolicy]]] =
           EitherT(vertexFetcher.fetchGroupPolicy(groupId))
-            .map(_.map(groupPolicySchema.decodeVertex))
+            .map(_.map(groupPolicySchema.decode))
             .value
 
         override def fetchSeriesPolicy(seriesId: SeriesId): F[Either[GE, Option[Event.SeriesPolicy]]] =
           EitherT(vertexFetcher.fetchSeriesPolicy(seriesId))
-            .map(_.map(seriesPolicySchema.decodeVertex))
+            .map(_.map(seriesPolicySchema.decode))
             .value
 
       }

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphTransactionFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphTransactionFetcher.scala
@@ -4,16 +4,17 @@ import cats.data.EitherT
 import cats.effect.Resource
 import cats.effect.kernel.Async
 import cats.implicits._
-import co.topl.brambl.models.{LockAddress, TransactionId}
 import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.models.{LockAddress, TransactionId}
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
-import co.topl.genus.services.{ChainDistance, ConfidenceFactor, TransactionReceipt, Txo, TxoState}
+import co.topl.genus.services._
 import co.topl.genusLibrary.algebras.{TransactionFetcherAlgebra, VertexFetcherAlgebra}
-import co.topl.genusLibrary.model.GE
+import co.topl.genusLibrary.model.{GE, GEs}
 import co.topl.genusLibrary.orientDb.instances.SchemaBlockHeader
 import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances._
 import co.topl.genusLibrary.orientDb.schema.EdgeSchemaInstances.addressTxoEdge
 import com.tinkerpop.blueprints.{Direction, Vertex}
+
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
@@ -27,7 +28,7 @@ object GraphTransactionFetcher {
           transactionId: TransactionId
         ): F[Either[GE, Option[IoTransaction]]] =
           EitherT(vertexFetcher.fetchTransaction(transactionId))
-            .map(_.map(ioTransactionSchema.decodeVertex))
+            .map(_.map(ioTransactionSchema.decode))
             .value
 
         override def fetchTransactionReceipt(
@@ -45,9 +46,9 @@ object GraphTransactionFetcher {
           res.map {
             _.map {
               case (Some(ioTxV), Some(blockHeaderV)) =>
-                val blockHeader = blockHeaderSchema.decodeVertex(blockHeaderV)
+                val blockHeader = blockHeaderSchema.decode(blockHeaderV)
                 TransactionReceipt(
-                  transaction = ioTransactionSchema.decodeVertex(ioTxV),
+                  transaction = ioTransactionSchema.decode(ioTxV),
                   ConfidenceFactor.defaultInstance,
                   blockId = blockHeader.id,
                   depth = ChainDistance(blockHeader.height)
@@ -62,13 +63,18 @@ object GraphTransactionFetcher {
         override def fetchTransactionByLockAddress(lockAddress: LockAddress, state: TxoState): F[Either[GE, Seq[Txo]]] =
           (for {
             lockAddressVertex <- EitherT(vertexFetcher.fetchLockAddress(lockAddress))
-            txos <- EitherT.fromEither[F](
-              lockAddressVertex
-                .map(_.getVertices(Direction.OUT, addressTxoEdge.label).asScala.map(txoSchema.decodeVertex).toSeq)
-                .map(_.filter(_.state.value == state.value))
-                .getOrElse(Seq.empty)
-                .asRight[GE]
-            )
+            txos <-
+              EitherT.fromEither[F](
+                Try(
+                  lockAddressVertex.toSeq
+                    .flatMap(_.getVertices(Direction.OUT, addressTxoEdge.label).asScala)
+                    .map(txoSchema.decode)
+                    .filter(_.state.value == state.value)
+                ).toEither
+                  .leftMap[GE](tx =>
+                    GEs.InternalMessageCause("GraphTransactionFetcher:fetchTransactionByLockAddress", tx)
+                  )
+              )
           } yield txos).value
       }
 

--- a/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcher.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/interpreter/GraphVertexFetcher.scala
@@ -75,7 +75,7 @@ object GraphVertexFetcher {
                 orientGraph.command(new OSQLSynchQuery[OrientVertex](queryString)).execute()
 
               query.asScala.headOption
-                .map(blockHeaderSchema.decodeVertex)
+                .map(blockHeaderSchema.decode)
                 .map(_.height)
                 .map(_ - depth)
                 .map(height =>

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransaction.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaIoTransaction.scala
@@ -21,6 +21,7 @@ object SchemaIoTransaction {
     val Size = "size"
     val TransactionIndex = "transactionIdIndex"
     val IsReward = "isReward"
+    val ParentBlock = "blockId"
   }
 
   private[genusLibrary] def size(ioTransaction: IoTransaction): Long =
@@ -54,7 +55,7 @@ object SchemaIoTransaction {
           notNull = true
         )
         .withIndex[IoTransaction](Field.TransactionIndex, Field.TransactionId)
-        .withLink(SchemaBlockHeader.Field.BlockId, OType.LINK, SchemaBlockHeader.Field.SchemaName),
+        .withLink(Field.ParentBlock, OType.LINK, SchemaBlockHeader.Field.SchemaName),
       v => IoTransaction.parseFrom(v(Field.Transaction): Array[Byte])
     )
 

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaTxo.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaTxo.scala
@@ -27,8 +27,6 @@ object SchemaTxo {
     val SpendingTransaction = "spendingTransaction"
     // This is the _property_
     val SpendingInputIndex = "spendingInputIndex"
-    // This is the _index_ of the above property
-    val SpendingInputIndexIndex = "spendingInputIndexIndex"
   }
 
   def make(): VertexSchema[Txo] =
@@ -71,8 +69,7 @@ object SchemaTxo {
           mandatory = false,
           readOnly = false,
           notNull = false
-        )
-        .withIndex[Txo](Field.SpendingInputIndexIndex, Field.SpendingInputIndex),
+        ),
       v =>
         Txo(
           transactionOutput = UnspentTransactionOutput.parseFrom(v(Field.TransactionOutput): Array[Byte]),

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaTxo.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/instances/SchemaTxo.scala
@@ -1,11 +1,15 @@
 package co.topl.genusLibrary.orientDb.instances
 
-import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
+import co.topl.brambl.models.{TransactionInputAddress, TransactionOutputAddress}
+import co.topl.brambl.syntax._
 import co.topl.genus.services.{Txo, TxoState}
+import co.topl.genusLibrary.orientDb.instances.VertexSchemaInstances.instances._
 import co.topl.genusLibrary.orientDb.schema.OIndexable.Instances.txo
 import co.topl.genusLibrary.orientDb.schema.OTyped.Instances._
 import co.topl.genusLibrary.orientDb.schema.{GraphDataEncoder, VertexSchema}
+import com.orientechnologies.orient.core.metadata.schema.OType
+import com.tinkerpop.blueprints.Vertex
 
 object SchemaTxo {
 
@@ -20,6 +24,11 @@ object SchemaTxo {
     val OutputAddress = "outputAddress"
     val TxoId = "txoId"
     val TxoIndex = "txoIndex"
+    val SpendingTransaction = "spendingTransaction"
+    // This is the _property_
+    val SpendingInputIndex = "spendingInputIndex"
+    // This is the _index_ of the above property
+    val SpendingInputIndexIndex = "spendingInputIndexIndex"
   }
 
   def make(): VertexSchema[Txo] =
@@ -54,12 +63,32 @@ object SchemaTxo {
           readOnly = true,
           notNull = true
         )
-        .withIndex[Txo](Field.TxoIndex, Field.TxoId),
+        .withIndex[Txo](Field.TxoIndex, Field.TxoId)
+        .withLink(Field.SpendingTransaction, OType.LINK, SchemaIoTransaction.Field.SchemaName)
+        .withProperty(
+          Field.SpendingInputIndex,
+          txo => txo.spender.map(s => java.lang.Integer.valueOf(s.inputAddress.index)).orNull,
+          mandatory = false,
+          readOnly = false,
+          notNull = false
+        )
+        .withIndex[Txo](Field.SpendingInputIndexIndex, Field.SpendingInputIndex),
       v =>
         Txo(
           transactionOutput = UnspentTransactionOutput.parseFrom(v(Field.TransactionOutput): Array[Byte]),
           state = TxoState.fromValue(v(Field.State): Int),
-          outputAddress = TransactionOutputAddress.parseFrom(v(Field.OutputAddress): Array[Byte])
+          outputAddress = TransactionOutputAddress.parseFrom(v(Field.OutputAddress): Array[Byte]),
+          spender = Option(v.vertex.getProperty[java.lang.Integer](SchemaTxo.Field.SpendingInputIndex))
+            .flatMap(index =>
+              Option(v.vertex.getProperty[Vertex](SchemaTxo.Field.SpendingTransaction))
+                .map(ioTransactionSchema.decode)
+                .map { tx =>
+                  val input = tx.inputs(index)
+                  val inputAddress =
+                    TransactionInputAddress(input.address.network, input.address.ledger, index, tx.id)
+                  Txo.Spender(inputAddress, input)
+                }
+            )
         )
     )
 

--- a/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/GraphDataEncoder.scala
+++ b/genus-library/src/main/scala/co/topl/genusLibrary/orientDb/schema/GraphDataEncoder.scala
@@ -35,7 +35,7 @@ case class GraphDataEncoder[T] private (
     notNull:   Boolean
   ): GraphDataEncoder[T] =
     copy(
-      encode = t => encode(t).updated(name, extract(t)),
+      encode = t => encode(t).updatedWith(name)(_ => Option(extract(t))),
       properties = properties.incl(Property(name, OTyped[V].oType, mandatory, readOnly, notNull))
     )
 

--- a/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphTokenFetcherTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/interpreter/GraphTokenFetcherTest.scala
@@ -57,17 +57,6 @@ class GraphTokenFetcherTest extends CatsEffectSuite with ScalaCheckEffectSuite w
           vertexFetcher <- mock[VertexFetcherAlgebra[F]].pure[F].toResource
           vertex        <- mock[Vertex].pure[F].toResource
 
-          _ = (vertex.getPropertyKeys _)
-            .expects()
-            .once()
-            .returning(
-              java.util.Set.of(
-                SchemaGroupPolicy.Field.Label,
-                SchemaGroupPolicy.Field.RegistrationUtxo,
-                SchemaGroupPolicy.Field.FixedSeries
-              )
-            )
-
           groupPolicy = GroupPolicy("fooboo", address, Some(seriesId))
 
           _ = (vertexFetcher.fetchGroupPolicy _)
@@ -139,21 +128,6 @@ class GraphTokenFetcherTest extends CatsEffectSuite with ScalaCheckEffectSuite w
         val res = for {
           vertexFetcher <- mock[VertexFetcherAlgebra[F]].pure[F].toResource
           vertex        <- mock[Vertex].pure[F].toResource
-
-          _ = (vertex.getPropertyKeys _)
-            .expects()
-            .once()
-            .returning(
-              java.util.Set.of(
-                SchemaSeriesPolicy.Field.Label,
-                SchemaSeriesPolicy.Field.TokenSupply,
-                SchemaSeriesPolicy.Field.RegistrationUtxo,
-                SchemaSeriesPolicy.Field.QuantityDescriptor,
-                SchemaSeriesPolicy.Field.Fungibility,
-                SchemaSeriesPolicy.Field.EphemeralMetadataScheme,
-                SchemaSeriesPolicy.Field.PermanentMetadataScheme
-              )
-            )
 
           seriesPolicy = SeriesPolicy(
             label = "fooboo",

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/GraphBlockUpdaterFixtureTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/GraphBlockUpdaterFixtureTest.scala
@@ -12,12 +12,11 @@ import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.models.generators.node.ModelGenerators._
 import co.topl.node.models.FullBlockBody
 import fs2.Stream
-
-import java.util.concurrent.TimeUnit
 import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.jdk.CollectionConverters.IterableHasAsScala
 
@@ -79,20 +78,19 @@ class GraphBlockUpdaterFixtureTest
           dbTx <- oThread.delay(odbFactory.getTx).toResource
 
           graphBlockUpdater <- GraphBlockUpdater.make[F](dbTx, blockFetcher, nodeBlockFetcher)
-          _                 <- graphBlockUpdater.insert(blockData).toResource
+          _                 <- graphBlockUpdater.insert(blockData).rethrow.toResource
 
-          blockHeaderVertex = dbTx.getBlockHeader(blockData.header)
-          _ = assert(blockHeaderVertex.isDefined)
-          _ <- assertIOBoolean(oThread.delay(dbTx.getBlockHeader(blockData.header).isDefined)).toResource
-          _ <- assertIOBoolean(oThread.delay(dbTx.getBody(blockHeaderVertex.get).isDefined)).toResource
+          _ <- oThread
+            .delay(dbTx.getBlockHeader(blockData.header).flatMap(dbTx.getBody))
+            .map(_.isDefined)
+            .assert
+            .toResource
 
-          _ <- graphBlockUpdater.remove(blockData).toResource
+          _ <- graphBlockUpdater.remove(blockData).rethrow.toResource
 
           // When we remove headerVertex, the canonicalHead schema is not updated, insertions handle it
           // When we remove txoVertex, lockAddress schema is not updated, because lockAddress references many txo
           // Eventually could create an orphan lockAddress, it is not a problem cause some future txo will reference it
-          blockHeaderVertex = dbTx.getBlockHeader(blockData.header)
-          _ = assert(blockHeaderVertex.isEmpty)
           _ <- assertIOBoolean(oThread.delay(dbTx.getBlockHeader(blockData.header).isEmpty)).toResource
           _ <- assertIOBoolean(oThread.delay(dbTx.getVerticesOfClass(blockBodySchema.name).asScala.isEmpty)).toResource
           _ <- assertIOBoolean(

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaCanonicalHeadTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaCanonicalHeadTest.scala
@@ -99,7 +99,7 @@ class SchemaCanonicalHeadTest
         blockHeaderVertex
       ).toResource
 
-      blockHeaderDecoded = blockHeaderSchema.decodeVertex(blockHeaderFromCanonicalHead)
+      blockHeaderDecoded = blockHeaderSchema.decode(blockHeaderFromCanonicalHead)
       _ <- assertIOBoolean((blockHeader == blockHeaderDecoded).pure[F]).toResource
 
     } yield ()

--- a/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaGroupPolicyTest.scala
+++ b/genus-library/src/test/scala/co/topl/genusLibrary/orientDb/instances/SchemaGroupPolicyTest.scala
@@ -107,7 +107,7 @@ class SchemaGroupPolicyTest
             groupPolicy.fixedSeries.get.value.toByteArray.toSeq
       )
 
-      groupPolicyDecoded = groupPolicySchema.decodeVertex(vertex_test_1)
+      groupPolicyDecoded = groupPolicySchema.decode(vertex_test_1)
       _ = assert(groupPolicyDecoded == groupPolicy)
 
       registrationUtxo = TransactionOutputAddress(1, 1, 1, transactionId)
@@ -146,7 +146,7 @@ class SchemaGroupPolicyTest
           Array.empty[Byte].toSeq
       )
 
-      groupPolicyDecoded = groupPolicySchema.decodeVertex(vertex_test_2)
+      groupPolicyDecoded = groupPolicySchema.decode(vertex_test_2)
       _ = assert(groupPolicyDecoded == groupPolicyWithNoneSeries)
 
     } yield ()

--- a/minting/src/test/resources/logback-test.xml
+++ b/minting/src/test/resources/logback-test.xml
@@ -14,11 +14,7 @@
         <appender-ref ref="STDOUT" />
     </appender>
 
-    <logger name="co.topl" level="INFO" />
-    <logger name="Bifrost.BlockProducer" level="WARN" />
-
-
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val orientDbVersion = "3.2.26"
   val ioGrpcVersion = "1.60.1"
   val http4sVersion = "0.23.25"
-  val protobufSpecsVersion = "2.0.0-beta1" // scala-steward:off
+  val protobufSpecsVersion = "2.0.0-beta1+1-066694a4-SNAPSHOT" // scala-steward:off
   val bramblScVersion = "2.0.0-beta2+2-8e98ff76-SNAPSHOT" // scala-steward:off
 
   val catsSlf4j =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val orientDbVersion = "3.2.26"
   val ioGrpcVersion = "1.60.1"
   val http4sVersion = "0.23.25"
-  val protobufSpecsVersion = "2.0.0-beta1+1-066694a4-SNAPSHOT" // scala-steward:off
+  val protobufSpecsVersion = "2.0.0-beta2" // scala-steward:off
   val bramblScVersion = "2.0.0-beta2+2-8e98ff76-SNAPSHOT" // scala-steward:off
 
   val catsSlf4j =


### PR DESCRIPTION
## Purpose
- To support the Bridge use-case, clients would benefit from knowing which Transaction (Input) spent a particular Transaction Output
## Approach
- Use new field in TxO `spender`
- When applying or unapplying a block, update the spender fields of spent TxOs
## Testing
- New unit test
- Ran local node from `dev`, then relaunched with new changes.  Node was able to run as expected.
## Tickets
- #BN-1414
## TODO
- [protobuf-specs](https://github.com/Topl/protobuf-specs/pull/97) should be merged