### PR TITLE
Publish Genus Docker Image

### DIFF
--- a/.github/workflows/_docker_publish_dev.yml
+++ b/.github/workflows/_docker_publish_dev.yml
@@ -44,7 +44,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images to registries
-        run: DOCKER_PUBLISH_DEV_TAG=true sbt node/Docker/publish
+        run: DOCKER_PUBLISH_DEV_TAG=true sbt node/Docker/publish genus/Docker/publish
 
       # Then publish other iamges to GCP Artifact Registry
       - id: "auth"

--- a/.github/workflows/_docker_publish_release.yml
+++ b/.github/workflows/_docker_publish_release.yml
@@ -30,4 +30,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images to registries
-        run: DOCKER_PUBLISH_LATEST_TAG=true sbt node/Docker/publish
+        run: DOCKER_PUBLISH_LATEST_TAG=true sbt node/Docker/publish genus/Docker/publish


### PR DESCRIPTION
## Purpose
- Genus is a separately deployable application, but its image is not yet available on DockerHub
## Approach
- Enable publishing genus whenever the node is published
## Testing
N/A
## Tickets
- #BN-1430