### PR TITLE
Refresh `TxO` Vertex

### DIFF
--- a/genus/src/main/scala/co/topl/genus/interpreter/GraphVertexFetcher.scala
+++ b/genus/src/main/scala/co/topl/genus/interpreter/GraphVertexFetcher.scala
@@ -188,8 +188,15 @@ object GraphVertexFetcher {
                   transactionOutputAddress.id.value.toByteArray :+ transactionOutputAddress.index.byteValue
                 )
                 .asScala
+                .headOption
+                .map {
+                  case o: OrientVertex =>
+                    o.reload()
+                    o
+                  case o =>
+                    o
+                }
             ).toEither
-              .map(_.headOption)
               .leftMap[GE](tx => GEs.InternalMessageCause("GraphVertexFetcher:fetchTxo", tx))
           )
 


### PR DESCRIPTION
## Purpose
- OrientDB has a built-in cache.  When a Vertex is updated in one DB instance, it may not be reflected in another (even if the DB instances target the same underlying DB)
## Approach
- The TxO vertex is the only one that may be "updated", so modify `fetchTxo` to call `OrientVertex#reload()`
## Testing
- Verified locally that the stale TxO state no longer appears
- Re-ran Brambl-CLI integration tests, and this particular issue seems to be fixed (though there are others to be investigated still)
## Tickets
N/A