### PR TITLE
Block Packer Improvements

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/interpreters/BlockchainPeerServer.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/interpreters/BlockchainPeerServer.scala
@@ -37,7 +37,7 @@ object BlockchainPeerServer {
     newTransactionIds:       Topic[F, TransactionId],
     peerStatus:              Topic[F, PeerConnectionChange],
     blockIdBufferSize:       Int = 8,
-    transactionIdBufferSize: Int = 64
+    transactionIdBufferSize: Int = 512
   )(peer: ConnectedPeer): Resource[F, BlockchainPeerServerAlgebra[F]] =
     (
       DroppingTopic(newBlockIds, blockIdBufferSize).flatMap(_.subscribeAwaitUnbounded),

--- a/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
+++ b/networking/src/main/scala/co/topl/networking/TypedProtocolSetFactory.scala
@@ -197,7 +197,7 @@ object TypedProtocolSetFactory {
             initialState = TypedProtocol.CommonStates.None,
             outboundMessages = Stream.eval(clientSignalPromise.get) >>
               notifications
-                .dropOldest(64)
+                .dropOldest(512)
                 .evalTap(data => Logger[F].debug(show"Notifying peer of data=$data"))
                 .map(TypedProtocol.CommonMessages.Push(_))
                 .map(OutboundMessage(_)),
@@ -212,7 +212,7 @@ object TypedProtocolSetFactory {
     ): F[(Byte => TypedSubHandler[F, CommonStates.None.type], Stream[F, T])] =
       for {
         startSignal <- Deferred[F, OutboundMessage]
-        queue       <- Queue.circularBuffer[F, T](64)
+        queue       <- Queue.circularBuffer[F, T](512)
         stream =
           // A Notification Client must send a `Start` message to the server before it will start
           // pushing notifications. We can signal this message to the server once the returned Source here requests

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerMempoolTransactionSync.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerMempoolTransactionSync.scala
@@ -97,7 +97,7 @@ object PeerMempoolTransactionSync {
   ): Stream[F, Unit] =
     transactionIdsStream
       .evalFilterNotAsync(maxConcurrent)(state.transactionStore.contains)
-      .parEvalMapUnordered(maxConcurrent)(processTransactionId(state))
+      .evalMap(processTransactionId(state))
 
   private def processTransactionId[F[_]: Async: Logger](state: State[F])(id: TransactionId): F[Unit] = {
     val fetchingTransaction =

--- a/networking/src/main/scala/co/topl/networking/typedprotocols/TypedProtocolInstance.scala
+++ b/networking/src/main/scala/co/topl/networking/typedprotocols/TypedProtocolInstance.scala
@@ -68,7 +68,7 @@ case class TypedProtocolInstance[F[_]] private (
       }
       .value
 
-  final private val MessageQueueSize = 16
+  final private val MessageQueueSize = 512
 
   /**
    * Produces an "Applier" which enqueues each message.  A background fiber processes these queues in the background

--- a/typeclasses/src/main/scala/co/topl/typeclasses/ShowInstances.scala
+++ b/typeclasses/src/main/scala/co/topl/typeclasses/ShowInstances.scala
@@ -58,7 +58,8 @@ trait ShowInstances {
       show")"
 
   implicit val showNodeBlockBody: Show[BlockBody] =
-    body => show"Body(transactionIds=${body.transactionIds}, reward=${body.rewardTransactionId})"
+    body =>
+      show"Body(transactionIds=[${body.transactionIds.length}]${body.transactionIds}, reward=${body.rewardTransactionId})"
 
   implicit val showBoxId: Show[TransactionOutputAddress] =
     boxId => show"${boxId.id}.outputs[${boxId.index}]"


### PR DESCRIPTION
## Purpose
- If the mempool grows large in size, the BlockPacker produces empty blocks
## Approach
- Update BlockPacker to emit partial blocks
- Add parallelism to BlockPacker
- Disable parallelism on P2P transaction processing
- Update queue/buffer sizes for P2P messages
- Update TransactionGenerator to create "wide" transaction graphs (previously "deep", which is less realistic)
## Testing
- Modified `NodeAppTransactionsTest` to produce a larger mempool 
## Tickets
- #BN-1448