### PR TITLE
Tuning Aggressive P2P: open hot connection by aggressive p2p only if connection have less than N closed connection events

### DIFF
--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -75,7 +75,9 @@ object ApplicationConfig {
       closeTimeoutFirstDelayInMs: Long = 1000,
       closeTimeoutWindowInMs:     Long = 1000 * 60 * 60 * 24, // 1 day
       aggressiveP2P:              Boolean = true, // always try to found new good remote peers
-      aggressiveP2PCount:         Int = 1 // how many new connection will be opened
+      aggressiveP2PCount:         Int = 1, // how many new connection will be opened
+      // do not try to open aggressively connection to remote peer if we have closed N connection(s) to them recently
+      aggressiveP2PMaxCloseEvent: Int = 3
     )
 
     case class KnownPeer(host: String, port: Int)


### PR DESCRIPTION
## Purpose
Aggressive P2P could exhaust our warm connection pool by constantly connect to other node. To prevent that, we connect to other node (by aggressive timer) only if we have a few "close event"

## Approach
Filter warm peers by select only if such warm peer have close timestamp count less than is set in config

## Testing
Unit test + integration test


## Tickets
*