### PR TITLE
BlockPacker: Validate Transaction Data

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,3 +1,4 @@
 -Xmx4G
 -Xms1G
 -Xss32M
+-Dstorage.diskCache.bufferSize=1024

--- a/blockchain/src/main/scala/co/topl/blockchain/Validators.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Validators.scala
@@ -71,7 +71,6 @@ object Validators {
       transactionSyntaxValidation = TransactionSyntaxInterpreter.make[F]()
       transactionSemanticValidation <- TransactionSemanticValidation
         .make[F](dataStores.transactions.getOrRaise, boxState)
-        .toResource
       transactionAuthorizationValidation = TransactionAuthorizationInterpreter.make[F]()
       rewardCalculator <- TransactionRewardCalculator.make[F]
       bodySyntaxValidation <- BodySyntaxValidation

--- a/ledger/src/main/scala/co/topl/ledger/implicits/LedgerShowInstances.scala
+++ b/ledger/src/main/scala/co/topl/ledger/implicits/LedgerShowInstances.scala
@@ -1,0 +1,57 @@
+package co.topl.ledger.implicits
+
+import cats.Show
+import cats.implicits._
+import co.topl.brambl.syntax._
+import co.topl.brambl.validation.{TransactionAuthorizationError, TransactionSyntaxError}
+import co.topl.ledger.models._
+import co.topl.quivr.runtime.QuivrRuntimeError
+import co.topl.typeclasses.implicits._
+
+trait LedgerShowInstances {
+
+  implicit val showTransactionSyntaxError: Show[TransactionSyntaxError] =
+    _.getClass.getName
+
+  implicit val showTransactionSemanticError: Show[TransactionSemanticError] =
+    _.getClass.getName
+
+  implicit val showQuivrRuntimeError: Show[QuivrRuntimeError] =
+    _.getClass.getName
+
+  implicit val showAuthorizationError: Show[TransactionAuthorizationError] = {
+    case TransactionAuthorizationError.AuthorizationFailed(errors) => errors.mkString_("[", ", ", "]")
+    case TransactionAuthorizationError.Contextual(error)           => show"Contextual($error)"
+    case TransactionAuthorizationError.Permanent(error)            => show"Permanent($error)"
+  }
+
+  implicit val showBodySyntaxError: Show[BodySyntaxError] = {
+    case BodySyntaxErrors.TransactionSyntaxErrors(t, e) =>
+      show"TransactionSyntaxErrors(${t.id}, $e)"
+    case BodySyntaxErrors.DoubleSpend(_) =>
+      show"DoubleSpend"
+    case BodySyntaxErrors.InvalidReward(_) =>
+      show"InvalidReward"
+  }
+
+  implicit val showBodySemanticError: Show[BodySemanticError] = {
+    case BodySemanticErrors.TransactionSemanticErrors(t, e) =>
+      show"TransactionSemanticError(${t.id}, $e)"
+    case BodySemanticErrors.TransactionRegistrationError(_) =>
+      "TransactionRegistrationError"
+    case BodySemanticErrors.RewardTransactionError(_) =>
+      "RewardTransactionError"
+  }
+
+  implicit val showBodyAuthorizationError: Show[BodyAuthorizationError] = {
+    case BodyAuthorizationErrors.TransactionAuthorizationErrors(t, e) =>
+      show"TransactionAuthorizationError(${t.id}, $e)"
+  }
+
+  implicit val showBodyValidationError: Show[BodyValidationError] = {
+    case e: BodySyntaxError        => e.show
+    case e: BodySemanticError      => e.show
+    case e: BodyAuthorizationError => e.show
+  }
+
+}

--- a/ledger/src/main/scala/co/topl/ledger/implicits/package.scala
+++ b/ledger/src/main/scala/co/topl/ledger/implicits/package.scala
@@ -1,0 +1,3 @@
+package co.topl.ledger
+
+package object implicits extends LedgerShowInstances {}

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSemanticValidation.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionSemanticValidation.scala
@@ -1,17 +1,16 @@
 package co.topl.ledger.interpreters
 
+import cats.Monad
 import cats.data.{EitherT, NonEmptyChain, Validated, ValidatedNec}
 import cats.effect._
 import cats.implicits._
-import cats.{Applicative, Functor, Monad}
+import co.topl.algebras.ContextlessValidationAlgebra
 import co.topl.brambl.common.ContainsEvidence
 import co.topl.brambl.common.ContainsEvidence.blake2bEvidenceFromImmutable
 import co.topl.brambl.common.ContainsImmutable.instances._
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.box.Lock
-import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.models.transaction.Schedule
-import co.topl.brambl.models.transaction.SpentTransactionOutput
+import co.topl.brambl.models.transaction.{IoTransaction, Schedule, SpentTransactionOutput}
 import co.topl.consensus.models.BlockId
 import co.topl.ledger.algebras._
 import co.topl.ledger.models._
@@ -22,39 +21,54 @@ object TransactionSemanticValidation {
   def make[F[_]: Async](
     fetchTransaction: TransactionId => F[IoTransaction],
     boxState:         BoxStateAlgebra[F]
-  ): F[TransactionSemanticValidationAlgebra[F]] =
-    Sync[F].delay(
-      new TransactionSemanticValidationAlgebra[F] {
+  ): Resource[F, TransactionSemanticValidationAlgebra[F]] =
+    (makeDataValidation(fetchTransaction), makeContextualValidation(boxState))
+      .mapN((v1, v2) =>
+        new TransactionSemanticValidationAlgebra[F] {
 
-        /**
-         * Validate the semantics of a transaction by verifying
-         *  - for each input, the claimed value/proposition matches the data defined in the spent output
-         *  - for each input, the referenced output is still spendable
-         */
-        def validate(
-          context: TransactionValidationContext
-        )(transaction: IoTransaction): F[ValidatedNec[TransactionSemanticError, IoTransaction]] =
-          AugmentedBoxState
-            .make(boxState)(
-              context.prefix.foldLeft(AugmentedBoxState.StateAugmentation.empty)(_.augment(_))
-            )
-            .flatMap(boxState =>
-              transaction.inputs
-                // Stop validating after the first error
-                .foldM(transaction.validNec[TransactionSemanticError]) {
-                  case (Validated.Valid(_), input) =>
-                    Async[F].cede >>
-                    (
-                      EitherT(scheduleValidation[F](context.slot)(transaction.datum.event.schedule).map(_.toEither)) >>
-                      EitherT(dataValidation(fetchTransaction)(input).map(_.toEither)) >>
-                      EitherT(spendableValidation(boxState)(context.parentHeaderId)(input).map(_.toEither))
-                    ).toNestedValidatedNec.value
-                      .map(_.leftMap(_.flatten).as(transaction))
-                  case (invalid, _) => invalid.pure[F]
-                }
-            )
+          override def validate(
+            context: TransactionValidationContext
+          )(t: IoTransaction): F[ValidatedNec[TransactionSemanticError, IoTransaction]] =
+            v1.validate(t).flatMap {
+              case Validated.Valid(_) => v2.validate(context)(t)
+              case e                  => e.pure[F]
+            }
+        }
+      )
+
+  def makeDataValidation[F[_]: Monad](
+    fetchTransaction: TransactionId => F[IoTransaction]
+  ): Resource[F, TransactionSemanticDataValidation[F]] =
+    Resource.pure(new TransactionSemanticDataValidation(fetchTransaction))
+
+  def makeContextualValidation[F[_]: Async](
+    boxState: BoxStateAlgebra[F]
+  ): Resource[F, TransactionSemanticContextualValidation[F]] =
+    Resource.pure(new TransactionSemanticContextualValidation(boxState))
+
+}
+
+/**
+ * Verifies that each claimed input value+attestation matches the information saved in the referenced output
+ */
+class TransactionSemanticDataValidation[F[_]: Monad](
+  fetchTransaction: TransactionId => F[IoTransaction]
+) extends ContextlessValidationAlgebra[F, TransactionSemanticError, IoTransaction] {
+
+  /**
+   * Determines the validity of the given value, scoped without any contextual information
+   * (i.e. if T is a Transaction, there is no context about previous transactions or blocks)
+   * Usually used for syntactic validation purposes.
+   */
+  override def validate(transaction: IoTransaction): F[ValidatedNec[TransactionSemanticError, IoTransaction]] =
+    transaction.inputs
+      // Stop validating after the first error
+      .foldM(transaction.validNec[TransactionSemanticError]) {
+        case (Validated.Valid(_), input) =>
+          dataValidation(input).map(_.as(transaction))
+        case (e, _) =>
+          e.pure[F]
       }
-    )
 
   /**
    * Does the box value included on the input of _this_ transaction match the value on the output of the spent transaction?
@@ -62,9 +76,9 @@ object TransactionSemanticValidation {
    * Does the proposition's evidence included on the input of _this_ transaction match the evidence associated
    * with the Spending Address which owns the box being spent?
    */
-  private def dataValidation[F[_]: Functor](
-    fetchTransaction: TransactionId => F[IoTransaction]
-  )(input: SpentTransactionOutput): F[Validated[NonEmptyChain[TransactionSemanticError], Unit]] =
+  private def dataValidation(
+    input: SpentTransactionOutput
+  ): F[Validated[NonEmptyChain[TransactionSemanticError], Unit]] =
     fetchTransaction(input.address.id)
       .map(spentTransaction =>
         // Did the output referenced by this input ever exist?  (Not a spend-ability check, just existence)
@@ -84,13 +98,44 @@ object TransactionSemanticValidation {
           )
           .void
       )
+}
+
+class TransactionSemanticContextualValidation[F[_]: Async](boxState: BoxStateAlgebra[F])
+    extends TransactionSemanticValidationAlgebra[F] {
+
+  /**
+   * Validate the semantics of a transaction by verifying
+   *  - for each input, the claimed value/proposition matches the data defined in the spent output
+   *  - for each input, the referenced output is still spendable
+   */
+  def validate(
+    context: TransactionValidationContext
+  )(transaction: IoTransaction): F[ValidatedNec[TransactionSemanticError, IoTransaction]] =
+    AugmentedBoxState
+      .make(boxState)(
+        context.prefix.foldLeft(AugmentedBoxState.StateAugmentation.empty)(_.augment(_))
+      )
+      .flatMap(boxState =>
+        transaction.inputs
+          // Stop validating after the first error
+          .foldM(transaction.validNec[TransactionSemanticError]) {
+            case (Validated.Valid(_), input) =>
+              Async[F].cede >>
+              (
+                EitherT(scheduleValidation(context.slot)(transaction.datum.event.schedule).map(_.toEither)) >>
+                EitherT(spendableValidation(boxState)(context.parentHeaderId)(input).map(_.toEither))
+              ).toNestedValidatedNec.value
+                .map(_.leftMap(_.flatten).as(transaction))
+            case (invalid, _) => invalid.pure[F]
+          }
+      )
 
   /**
    * Does the box referenced in the input still exist in a "spendable" state?
    */
-  private def spendableValidation[F[_]: Monad](
-    boxState: BoxStateAlgebra[F]
-  )(blockId: BlockId)(input: SpentTransactionOutput): F[ValidatedNec[TransactionSemanticError, Unit]] =
+  private def spendableValidation(boxState: BoxStateAlgebra[F])(
+    blockId: BlockId
+  )(input: SpentTransactionOutput): F[ValidatedNec[TransactionSemanticError, Unit]] =
     boxState
       .boxExistsAt(blockId)(input.address)
       .ifM(
@@ -101,7 +146,7 @@ object TransactionSemanticValidation {
   /**
    * Is this Transaction valid at the provided Slot?
    */
-  private def scheduleValidation[F[_]: Applicative](
+  private def scheduleValidation(
     slot: Slot
   )(schedule: Schedule): F[ValidatedNec[TransactionSemanticError, Unit]] =
     Validated
@@ -111,5 +156,4 @@ object TransactionSemanticValidation {
         TransactionSemanticErrors.UnsatisfiedSchedule(slot, schedule): TransactionSemanticError
       )
       .pure[F]
-
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockChecker.scala
@@ -10,6 +10,7 @@ import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.consensus.algebras._
 import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
 import co.topl.ledger.algebras._
+import co.topl.ledger.implicits._
 import co.topl.ledger.interpreters.QuivrContext
 import co.topl.ledger.models.{BodyValidationError, StaticBodyValidationContext}
 import co.topl.networking.fsnetwork.BlockChecker.Message._

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockDownloadError.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockDownloadError.scala
@@ -7,7 +7,7 @@ import co.topl.brambl.validation.TransactionSyntaxError
 import co.topl.consensus.models.BlockId
 import co.topl.models.TxRoot
 import co.topl.typeclasses.implicits._
-import co.topl.networking.fsnetwork.P2PShowInstances._
+import co.topl.ledger.implicits._
 
 sealed abstract class BlockDownloadError extends Exception {
   def notCritical: Boolean

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/P2PShowInstances.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/P2PShowInstances.scala
@@ -2,16 +2,13 @@ package co.topl.networking.fsnetwork
 
 import cats.Show
 import cats.implicits.showInterpolator
-import co.topl.brambl.validation.TransactionSyntaxError
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.config.ApplicationConfig.Bifrost.NetworkProperties
 import co.topl.consensus.models._
-import co.topl.ledger.models._
 import co.topl.models.utility.byteStringToByteVector
 import co.topl.networking.fsnetwork.NetworkQualityError._
 import co.topl.networking.fsnetwork.PeersManager.Message.PingPongMessagePing
 import co.topl.networking.p2p.ConnectedPeer
-import co.topl.networking.p2p.RemoteAddress.showRemoteAddress
 import co.topl.node.models._
 import co.topl.typeclasses.implicits._
 import java.time._
@@ -23,25 +20,10 @@ trait P2PShowInstances {
 
   implicit val showConnectedPeer: Show[ConnectedPeer] = cp => cp.toString
 
-  implicit val showTransactionSyntaxError: Show[TransactionSyntaxError] =
-    Show.fromToString
-
   implicit val showBlockHeaderValidationFailure: Show[BlockHeaderValidationFailure] =
     Show.fromToString
 
-  implicit val showBodySyntaxError: Show[BodySyntaxError] =
-    Show.fromToString
-
-  implicit val showBodySemanticError: Show[BodySemanticError] =
-    Show.fromToString
-
-  implicit val showBodyAuthorizationError: Show[BodyAuthorizationError] =
-    Show.fromToString
-
   implicit val showHeaderToBodyError: Show[BlockHeaderToBodyValidationFailure] =
-    Show.fromToString
-
-  implicit val showBodyValidationError: Show[BodyValidationError] =
     Show.fromToString
 
   implicit val showKnownHostReq: Show[CurrentKnownHostsReq] = req => s"CurrentKnownHostsReq(maxCount=${req.maxCount})"


### PR DESCRIPTION
## Purpose
- The BlockPacker does not check to see if a Transaction's Inputs contain valid data (Values)
- This allows the BlockProducer to produce an invalid block (which is rejected locally by the node)
## Approach
- Split TransactionSemanticValidation into data validation and context validation
- Create BlockPackerValidation
- Use TransactionSemanticDataValidation in BlockPacker
## Testing
- New unit test
## Tickets
- #BN-1444