### PR TITLE
BN-1424 Added fee based filter

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/Validators.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Validators.scala
@@ -33,7 +33,7 @@ case class Validators[F[_]](
   bodyAuthorization:        BodyAuthorizationValidationAlgebra[F],
   boxState:                 BoxStateAlgebra[F],
   registrationAccumulator:  RegistrationAccumulatorAlgebra[F],
-  rewardCalculator:         TransactionRewardCalculatorAlgebra[F]
+  rewardCalculator:         TransactionRewardCalculatorAlgebra
 )
 
 object Validators {

--- a/blockchain/src/main/scala/co/topl/blockchain/interpreters/EpochDataInterpreter.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/interpreters/EpochDataInterpreter.scala
@@ -74,7 +74,7 @@ object EpochDataEventSourcedState {
     fetchBlockHeader:            BlockId => F[BlockHeader],
     fetchBlockBody:              BlockId => F[BlockBody],
     fetchTransaction:            TransactionId => F[IoTransaction],
-    transactionRewardCalculator: TransactionRewardCalculatorAlgebra[F],
+    transactionRewardCalculator: TransactionRewardCalculatorAlgebra,
     epochBoundaryEventSourcedState: EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
       F
     ], BlockId],
@@ -109,7 +109,7 @@ object EpochDataEventSourcedState {
     fetchBlockHeader:            BlockId => F[BlockHeader],
     fetchBlockBody:              BlockId => F[BlockBody],
     fetchTransaction:            TransactionId => F[IoTransaction],
-    transactionRewardCalculator: TransactionRewardCalculatorAlgebra[F],
+    transactionRewardCalculator: TransactionRewardCalculatorAlgebra,
     epochBoundaryEventSourcedState: EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
       F
     ], BlockId],
@@ -212,7 +212,7 @@ object EpochDataEventSourcedState {
                 .flatMap(transaction =>
                   (
                     // TODO: Read reward transaction from body
-                    transactionRewardCalculator.rewardsOf(transaction).map(_.lvl),
+                    transactionRewardCalculator.rewardsOf(transaction).pure[F].map(_.lvl),
                     Sync[F].delay(
                       ContainsImmutable.instances.ioTransactionImmutable.immutableBytes(transaction).value.size()
                     )
@@ -235,7 +235,7 @@ object EpochDataEventSourcedState {
     fetchBlockHeader:            BlockId => F[BlockHeader],
     fetchBlockBody:              BlockId => F[BlockBody],
     fetchTransaction:            TransactionId => F[IoTransaction],
-    transactionRewardCalculator: TransactionRewardCalculatorAlgebra[F]
+    transactionRewardCalculator: TransactionRewardCalculatorAlgebra
   ) extends ((State[F], BlockId) => F[State[F]]) {
 
     def apply(state: State[F], blockId: BlockId): F[State[F]] =
@@ -296,7 +296,7 @@ object EpochDataEventSourcedState {
                 .flatMap(transaction =>
                   (
                     // TODO: Read reward transaction from body
-                    transactionRewardCalculator.rewardsOf(transaction).map(_.lvl),
+                    transactionRewardCalculator.rewardsOf(transaction).pure[F].map(_.lvl),
                     Sync[F].delay(
                       ContainsImmutable.instances.ioTransactionImmutable.immutableBytes(transaction).value.size()
                     )

--- a/blockchain/src/test/scala/co/topl/blockchain/interpreters/BlockchainPeerServerSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/interpreters/BlockchainPeerServerSpec.scala
@@ -17,6 +17,7 @@ import org.scalacheck.effect.PropF
 import cats.implicits._
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.validation.algebras.TransactionCostCalculator
 import co.topl.ledger.models.{MempoolGraph, RewardQuantities}
 import co.topl.networking.NetworkGen._
 import co.topl.networking.fsnetwork.RemotePeer
@@ -32,6 +33,7 @@ class BlockchainPeerServerSpec extends CatsEffectSuite with ScalaCheckEffectSuit
   type F[A] = IO[A]
 
   private val dummyRewardCalc: TransactionRewardCalculatorAlgebra = (_: IoTransaction) => RewardQuantities()
+  private val dummyCostCalc: TransactionCostCalculator = (tx: IoTransaction) => tx.inputs.size
 
   override val munitTimeout: FiniteDuration = 5.seconds
 
@@ -221,7 +223,8 @@ class BlockchainPeerServerSpec extends CatsEffectSuite with ScalaCheckEffectSuit
             ),
             Map.empty,
             Map.empty,
-            dummyRewardCalc
+            dummyRewardCalc,
+            dummyCostCalc
           )
           val mempool = mock[MempoolAlgebra[F]]
           (mempool.read _).expects(head.slotId.blockId).once().returning(currentMempool.pure[F])

--- a/blockchain/src/test/scala/co/topl/blockchain/interpreters/EpochDataInterpreterSpec.scala
+++ b/blockchain/src/test/scala/co/topl/blockchain/interpreters/EpochDataInterpreterSpec.scala
@@ -95,12 +95,12 @@ class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuit
               block.fullBody.allTransactions.traverse(tx => transactionStore.put(tx.id, tx))
             )
             .toResource
-          rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
+          rewardCalculator = mock[TransactionRewardCalculatorAlgebra]
           _ = (rewardCalculator
             .rewardsOf(_: IoTransaction))
             .expects(*)
             .anyNumberOfTimes()
-            .returning(RewardQuantities(BigInt(50)).pure[F])
+            .returning(RewardQuantities(BigInt(50)))
           epochBoundaryEss = mock[EventSourcedState[F, EpochBoundariesEventSourcedState.EpochBoundaries[
             F
           ], BlockId]]

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -89,13 +89,25 @@ object ApplicationConfig {
     case class Mempool(defaultExpirationSlots: Long, protection: MempoolProtection = MempoolProtection())
 
     case class MempoolProtection(
-      enabled: Boolean = false,
-      // do not perform checks if number of transactions in mempool less than that value
-      noCheckIfLess: Long = 10,
+      enabled:        Boolean = false,
+      maxMempoolSize: Long = 1024 * 1024 * 20, // 20 Mb
+
+      // do not perform mempool checks
+      // if (protectionEnabledThresholdPercent / 100 * maxMempoolSize) is less than curren mempool size
+      protectionEnabledThresholdPercent: Double = 10,
+
       // during semantic check we will include all transactions from memory pool in context
-      // if total tx count in memory pool is less that that value
-      useMempoolForSemanticIfLess: Long = 100
-    )
+      // if (useMempoolForSemanticThresholdPercent / 100 * maxMempoolSize) is less than curren mempool size
+      useMempoolForSemanticThresholdPercent: Double = 40,
+
+      // during semantic check we will include all transactions from memory pool in context
+      // if (feeFilterThresholdPercent / 100 * maxMempoolSize) is less than curren mempool size
+      feeFilterThresholdPercent: Double = 50
+    ) {
+      val protectionEnabledThreshold = toMultiplier(protectionEnabledThresholdPercent) * maxMempoolSize
+      val useMempoolForSemanticThreshold = toMultiplier(useMempoolForSemanticThresholdPercent) * maxMempoolSize
+      val feeFilterThreshold = toMultiplier(feeFilterThresholdPercent) * maxMempoolSize
+    }
 
     sealed abstract class BigBang
 

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -89,8 +89,9 @@ object ApplicationConfig {
     case class Mempool(defaultExpirationSlots: Long, protection: MempoolProtection = MempoolProtection())
 
     case class MempoolProtection(
-      enabled:        Boolean = false,
-      maxMempoolSize: Long = 1024 * 1024 * 20, // 20 Mb
+      enabled: Boolean = false,
+      // Use size in some abstract units which are used in co.topl.brambl.validation.algebras.TransactionCostCalculator
+      maxMempoolSize: Long = 1024 * 1024 * 20,
 
       // do not perform mempool checks
       // if (protectionEnabledThresholdPercent / 100 * maxMempoolSize) is less than curren mempool size

--- a/config/src/main/scala/co/topl/config/package.scala
+++ b/config/src/main/scala/co/topl/config/package.scala
@@ -1,0 +1,9 @@
+package co.topl
+
+package object config {
+
+  // scalastyle:off magic.number
+  def toMultiplier(percent: Double): Double =
+    percent.max(0).min(100) / 100
+  // scalastyle:on magic.number
+}

--- a/ledger/src/main/scala/co/topl/ledger/algebras/TransactionRewardCalculatorAlgebra.scala
+++ b/ledger/src/main/scala/co/topl/ledger/algebras/TransactionRewardCalculatorAlgebra.scala
@@ -3,13 +3,13 @@ package co.topl.ledger.algebras
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.ledger.models.RewardQuantities
 
-trait TransactionRewardCalculatorAlgebra[F[_]] {
+trait TransactionRewardCalculatorAlgebra {
 
   /**
    * Calculates the provided rewards of the given transaction.  Any "excess" value is treated as a Reward
    * @param transaction The transaction containing the fee/reward
    * @return a BigInt representing the LVL fee/reward
    */
-  def rewardsOf(transaction: IoTransaction): F[RewardQuantities]
+  def rewardsOf(transaction: IoTransaction): RewardQuantities
 
 }

--- a/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionRewardCalculator.scala
+++ b/ledger/src/main/scala/co/topl/ledger/interpreters/TransactionRewardCalculator.scala
@@ -1,7 +1,6 @@
 package co.topl.ledger.interpreters
 
 import cats.effect._
-import cats.implicits._
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.ledger.algebras.TransactionRewardCalculatorAlgebra
@@ -13,13 +12,13 @@ import co.topl.ledger.models.{AssetId, RewardQuantities}
  */
 object TransactionRewardCalculator {
 
-  def make[F[_]: Sync]: Resource[F, TransactionRewardCalculatorAlgebra[F]] =
+  def make[F[_]: Sync]: Resource[F, TransactionRewardCalculatorAlgebra] =
     Resource.pure(tx =>
-      (
-        Sync[F].delay((sumLvls(tx.inputs)(_.value) - sumLvls(tx.outputs)(_.value)).max(BigInt(0))),
-        Sync[F].delay((sumTopls(tx.inputs)(_.value) - sumTopls(tx.outputs)(_.value)).max(BigInt(0))),
-        Sync[F].delay(diffAssets(tx))
-      ).mapN(RewardQuantities.apply)
+      RewardQuantities(
+        (sumLvls(tx.inputs)(_.value) - sumLvls(tx.outputs)(_.value)).max(BigInt(0)),
+        (sumTopls(tx.inputs)(_.value) - sumTopls(tx.outputs)(_.value)).max(BigInt(0)),
+        diffAssets(tx)
+      )
     )
 
   /**

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/BodySyntaxValidationSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/BodySyntaxValidationSpec.scala
@@ -37,7 +37,7 @@ class BodySyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEffectSuit
             .returning(
               (TransactionSyntaxError.EmptyInputs: TransactionSyntaxError).invalidNec[IoTransaction].toEither.pure[F]
             )
-          rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
+          rewardCalculator = mock[TransactionRewardCalculatorAlgebra]
           underTest <- BodySyntaxValidation.make[F](fetchTransaction, transactionSyntaxValidation, rewardCalculator)
           result    <- underTest.validate(body)
           _         <- IO(result.isInvalid).assert
@@ -109,12 +109,12 @@ class BodySyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEffectSuit
             .expects(transaction)
             .once()
             .returning(transaction.validNec[TransactionSyntaxError].toEither.pure[F])
-          rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
+          rewardCalculator = mock[TransactionRewardCalculatorAlgebra]
           _ = (rewardCalculator
             .rewardsOf(_))
             .expects(transaction)
             .once()
-            .returning(rewardOutput.pure[F])
+            .returning(rewardOutput)
           underTest <- BodySyntaxValidation.make[F](fetchTransaction, transactionSyntaxValidation, rewardCalculator)
           result    <- underTest.validate(body)
           _         <- IO(result.isValid == expectSuccess).assert
@@ -207,7 +207,7 @@ class BodySyntaxValidationSpec extends CatsEffectSuite with ScalaCheckEffectSuit
         fetchTransaction <- mockFunction[TransactionId, F[IoTransaction]].pure[F]
         _ = fetchTransaction.expects(rewardTx.id).once().returning(rewardTx.pure[F])
         transactionSyntaxValidation = mock[TransactionSyntaxVerifier[F]]
-        rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
+        rewardCalculator = mock[TransactionRewardCalculatorAlgebra]
         underTest <- BodySyntaxValidation.make[F](fetchTransaction, transactionSyntaxValidation, rewardCalculator)
         result    <- underTest.validate(body)
         _         <- IO(result.isInvalid).assert

--- a/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionRewardCalculatorSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/interpreters/TransactionRewardCalculatorSpec.scala
@@ -22,7 +22,7 @@ class TransactionRewardCalculatorSpec extends CatsEffectSuite with ScalaCheckEff
     val testResource =
       for {
         underTest <- TransactionRewardCalculator.make[F]
-        rewards   <- underTest.rewardsOf(tx).toResource
+        rewards   <- underTest.rewardsOf(tx).pure[F].toResource
         _         <- IO(rewards.lvl).assertEquals(BigInt(0)).toResource
         _         <- IO(rewards.topl).assertEquals(BigInt(0)).toResource
         _         <- IO(rewards.assets).assertEquals(Map.empty[AssetId, BigInt]).toResource
@@ -68,7 +68,7 @@ class TransactionRewardCalculatorSpec extends CatsEffectSuite with ScalaCheckEff
     val testResource =
       for {
         underTest <- TransactionRewardCalculator.make[F]
-        rewards   <- underTest.rewardsOf(tx).toResource
+        rewards   <- underTest.rewardsOf(tx).pure[F].toResource
         _         <- IO(rewards.lvl).assertEquals(BigInt(1200)).toResource
         _         <- IO(rewards.topl).assertEquals(BigInt(60)).toResource
         _ <- IO(rewards.assets)
@@ -106,7 +106,7 @@ class TransactionRewardCalculatorSpec extends CatsEffectSuite with ScalaCheckEff
     val testResource =
       for {
         underTest <- TransactionRewardCalculator.make[F]
-        rewards   <- underTest.rewardsOf(tx).toResource
+        rewards   <- underTest.rewardsOf(tx).pure[F].toResource
         _         <- IO(rewards.lvl).assertEquals(BigInt(0)).toResource
         _         <- IO(rewards.topl).assertEquals(BigInt(0)).toResource
         _         <- IO(rewards.assets).assertEquals(Map.empty[AssetId, BigInt]).toResource

--- a/ledger/src/test/scala/co/topl/ledger/models/MempoolGraphSpec.scala
+++ b/ledger/src/test/scala/co/topl/ledger/models/MempoolGraphSpec.scala
@@ -6,6 +6,7 @@ import co.topl.brambl.models.box.{Attestation, Value}
 import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import co.topl.brambl.models.{Datum, LockAddress, LockId, TransactionOutputAddress}
 import co.topl.brambl.syntax._
+import co.topl.ledger.algebras.TransactionRewardCalculatorAlgebra
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalamock.munit.AsyncMockFactory
@@ -31,6 +32,8 @@ class MempoolGraphSpec extends CatsEffectSuite with ScalaCheckEffectSuite with A
       )
       .embedId
 
+  private val dummyRewardCalc: TransactionRewardCalculatorAlgebra = (_: IoTransaction) => RewardQuantities()
+
   test("add and remove a transaction") {
     val tx1 =
       IoTransaction(datum = Datum.IoTransaction.defaultInstance)
@@ -45,8 +48,8 @@ class MempoolGraphSpec extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .embedId
 
     for {
-      graph1 <- MempoolGraph.empty.add(tx1).pure[F]
-      _      <- IO(graph1.transactions(tx1.id)).assertEquals(tx1)
+      graph1 <- MempoolGraph.empty(dummyRewardCalc).add(tx1).pure[F]
+      _      <- IO(graph1.transactions(tx1.id)).assertEquals(IoTransactionEx(tx1, RewardQuantities()))
       _      <- IO(graph1.unresolved(tx1.id).toList).assertEquals(List(0))
       _      <- IO(graph1.spenders(tx1.id).isEmpty).assert
       (graph2, removed) = graph1.removeSubtree(tx1)
@@ -54,7 +57,7 @@ class MempoolGraphSpec extends CatsEffectSuite with ScalaCheckEffectSuite with A
       _ <- IO(graph2.transactions.isEmpty).assert
       _ <- IO(graph2.spenders.isEmpty).assert
       _ <- IO(graph2.unresolved.isEmpty).assert
-      _ <- IO(graph2).assertEquals(MempoolGraph.empty)
+      _ <- IO(graph2).assertEquals(MempoolGraph.empty(dummyRewardCalc))
       graph3 = graph1.removeSingle(tx1)
       _ <- IO(graph3).assertEquals(graph2)
     } yield ()
@@ -96,7 +99,7 @@ class MempoolGraphSpec extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .embedId
 
     for {
-      graph1 <- MempoolGraph.empty.add(tx1).add(tx2).add(tx3).pure[F]
+      graph1 <- MempoolGraph.empty(dummyRewardCalc).add(tx1).add(tx2).add(tx3).pure[F]
       _      <- IO(graph1.unresolved(tx1.id).toList).assertEquals(List(0))
       _      <- IO(graph1.unresolved(tx2.id).toList).assertEquals(List(1))
       _      <- IO(!graph1.unresolved.contains(tx3.id)).assert
@@ -112,7 +115,7 @@ class MempoolGraphSpec extends CatsEffectSuite with ScalaCheckEffectSuite with A
       _ <- IO(graph3.spenders(tx1.id)(0).isEmpty).assert
       (graph4, removed3) = graph1.removeSubtree(tx1)
       _ <- IO(removed3).assertEquals(Set(tx1, tx2, tx3))
-      _ <- IO(graph4).assertEquals(MempoolGraph.empty)
+      _ <- IO(graph4).assertEquals(MempoolGraph.empty(dummyRewardCalc))
     } yield ()
 
   }
@@ -168,7 +171,7 @@ class MempoolGraphSpec extends CatsEffectSuite with ScalaCheckEffectSuite with A
         .embedId
 
     for {
-      graph1 <- MempoolGraph.empty.add(tx1).add(tx2).add(tx2a).add(tx3).pure[F]
+      graph1 <- MempoolGraph.empty(dummyRewardCalc).add(tx1).add(tx2).add(tx2a).add(tx3).pure[F]
       _      <- IO(graph1.unresolved(tx1.id).toList).assertEquals(List(0))
       _      <- IO(graph1.unresolved(tx2.id).toList).assertEquals(List(1))
       _      <- IO(graph1.unresolved(tx2a.id).toList).assertEquals(List(0))
@@ -189,7 +192,7 @@ class MempoolGraphSpec extends CatsEffectSuite with ScalaCheckEffectSuite with A
       _ <- IO(graph4.spenders(tx1.id)).assertEquals(Map(0 -> Set((tx2.id, 0))))
       (graph5, removed4) = graph1.removeSubtree(tx1)
       _ <- IO(removed4).assertEquals(Set(tx1, tx2, tx2a, tx3))
-      _ <- IO(graph5).assertEquals(MempoolGraph.empty)
+      _ <- IO(graph5).assertEquals(MempoolGraph.empty(dummyRewardCalc))
     } yield ()
 
   }

--- a/minting/src/main/scala/co/topl/minting/interpreters/BlockPacker.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/BlockPacker.scala
@@ -34,7 +34,7 @@ object BlockPacker {
     mempool:                     MempoolAlgebra[F],
     boxState:                    BoxStateAlgebra[F],
     transactionRewardCalculator: TransactionRewardCalculatorAlgebra,
-    transactionCostCalculator:   TransactionCostCalculator[F],
+    transactionCostCalculator:   TransactionCostCalculator,
     blockPackerValidation:       BlockPackerValidation[F],
     registrationAccumulator:     RegistrationAccumulatorAlgebra[F],
     emptyMempoolPollPeriod:      FiniteDuration = 1.second
@@ -55,7 +55,7 @@ object BlockPacker {
     mempool:                     MempoolAlgebra[F],
     boxState:                    BoxStateAlgebra[F],
     transactionRewardCalculator: TransactionRewardCalculatorAlgebra,
-    transactionCostCalculator:   TransactionCostCalculator[F],
+    transactionCostCalculator:   TransactionCostCalculator,
     blockPackerValidation:       BlockPackerValidation[F],
     registrationAccumulator:     RegistrationAccumulatorAlgebra[F],
     emptyMempoolPollPeriod:      FiniteDuration
@@ -272,10 +272,8 @@ object BlockPacker {
            * Calculate the score (reward - cost) of the given transaction
            */
           private def transactionScore(transaction: IoTransaction): F[BigInt] =
-            (
-              transactionRewardCalculator.rewardsOf(transaction).pure[F].map(_.lvl),
-              transactionCostCalculator.costOf(transaction)
-            ).parMapN(_ - _)
+            (transactionRewardCalculator.rewardsOf(transaction).lvl - transactionCostCalculator.costOf(transaction))
+              .pure[F]
 
           /**
            * Accumulate the score of the given transaction, as well as all dependent transactions

--- a/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
@@ -46,7 +46,7 @@ object BlockProducer {
     staker:           StakingAlgebra[F],
     clock:            ClockAlgebra[F],
     blockPacker:      BlockPackerAlgebra[F],
-    rewardCalculator: TransactionRewardCalculatorAlgebra[F]
+    rewardCalculator: TransactionRewardCalculatorAlgebra
   ): F[BlockProducerAlgebra[F]] =
     (staker.address, Ref.of(0L)).mapN((address, lastUsedSlotRef) =>
       new Impl[F](address, parentHeaders, staker, clock, blockPacker, rewardCalculator, lastUsedSlotRef)
@@ -58,7 +58,7 @@ object BlockProducer {
     staker:           StakingAlgebra[F],
     clock:            ClockAlgebra[F],
     blockPacker:      BlockPackerAlgebra[F],
-    rewardCalculator: TransactionRewardCalculatorAlgebra[F],
+    rewardCalculator: TransactionRewardCalculatorAlgebra,
     lastUsedSlotRef:  Ref[F, Slot]
   ) extends BlockProducerAlgebra[F] {
 
@@ -205,7 +205,7 @@ object BlockProducer {
      */
     private def insertReward(parentBlockId: BlockId, slot: Slot, base: FullBlockBody): F[FullBlockBody] =
       base.transactions
-        .foldMapM(rewardCalculator.rewardsOf)
+        .foldMapM(t => rewardCalculator.rewardsOf(t).pure[F])
         .flatMap(rewardQuantities =>
           if (!rewardQuantities.isEmpty) {
             staker.rewardAddress

--- a/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
@@ -91,8 +91,8 @@ class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
           )
           val rewardQuantities = RewardQuantities(BigInt(10L), BigInt(5L), Map(assetId1 -> BigInt(30L)))
 
-          val rewardCalculator = mock[TransactionRewardCalculatorAlgebra[F]]
-          (rewardCalculator.rewardsOf(_)).expects(*).anyNumberOfTimes().returning(rewardQuantities.pure[F])
+          val rewardCalculator = mock[TransactionRewardCalculatorAlgebra]
+          (rewardCalculator.rewardsOf(_)).expects(*).anyNumberOfTimes().returning(rewardQuantities)
 
           for {
             clockDeferment   <- IO.deferred[Unit]

--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -128,7 +128,7 @@ class NodeAppTest extends CatsEffectSuite {
               // Graph 1 has higher fees and should be included in the chain
               transactionGenerator1 <-
                 Fs2TransactionGenerator
-                  .make[F](wallet, _ => 1000L.pure[F], Fs2TransactionGenerator.emptyMetadata[F])
+                  .make[F](wallet, _ => 1000L, Fs2TransactionGenerator.emptyMetadata[F])
                   .toResource
               transactionGraph1 <- Stream
                 .force(transactionGenerator1.generateTransactions)
@@ -140,7 +140,7 @@ class NodeAppTest extends CatsEffectSuite {
               // Graph 2 has lower fees, so the Block Packer should never choose them
               transactionGenerator2 <-
                 Fs2TransactionGenerator
-                  .make[F](wallet, _ => 10L.pure[F], Fs2TransactionGenerator.randomMetadata[F])
+                  .make[F](wallet, _ => 10L, Fs2TransactionGenerator.randomMetadata[F])
                   .toResource
               transactionGraph2 <- Stream
                 .force(transactionGenerator2.generateTransactions)

--- a/node-it/src/test/scala/co/topl/node/NodeAppTransactionsTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTransactionsTest.scala
@@ -8,6 +8,7 @@ import co.topl.algebras.NodeRpc
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.syntax._
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
+import co.topl.codecs.bytes.typeclasses.Transmittable
 import co.topl.consensus.models.BlockId
 import co.topl.genus.services._
 import co.topl.grpc.NodeGrpc
@@ -20,7 +21,10 @@ import fs2.{io => _, _}
 import munit._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-
+import co.topl.codecs.bytes.typeclasses.Transmittable
+import co.topl.codecs.bytes.tetra.instances._
+import cats.data.Chain
+import co.topl.ledger.models._
 import scala.concurrent.duration._
 
 // scalastyle:off magic.number
@@ -32,13 +36,15 @@ class NodeAppTransactionsTest extends CatsEffectSuite {
 
   override val munitTimeout: Duration = 3.minutes
 
+  val maxMempoolSize = 1024 * 20
+
   def configNodeA(
     dataDir:                     Path,
     stakingDir:                  Path,
     genesisBlockId:              BlockId,
     genesisSourcePath:           String,
     rpcPort:                     Int,
-    useMempoolForSemanticIfLess: Int = 100
+    useMempoolForSemanticIfLess: Double = 100
   ): String =
     s"""
        |bifrost:
@@ -58,8 +64,9 @@ class NodeAppTransactionsTest extends CatsEffectSuite {
        |  mempool:
        |    protection:
        |      enabled: true
-       |      no-check-if-less: 0
-       |      use-mempool-for-semantic-if-less: $useMempoolForSemanticIfLess
+       |      protection-enabled-threshold-percent: 0
+       |      max-mempool-size: $maxMempoolSize
+       |      use-mempool-for-semantic-threshold-percent: $useMempoolForSemanticIfLess
        |genus:
        |  enable: true
        |""".stripMargin
@@ -71,7 +78,7 @@ class NodeAppTransactionsTest extends CatsEffectSuite {
     genesisSourcePath:           String,
     rpcPort:                     Int,
     NodeAIp:                     String,
-    useMempoolForSemanticIfLess: Int = 100
+    useMempoolForSemanticIfLess: Double = 100
   ): String =
     s"""
        |bifrost:
@@ -92,203 +99,205 @@ class NodeAppTransactionsTest extends CatsEffectSuite {
        |  mempool:
        |    protection:
        |      enabled: true
-       |      no-check-if-less: 0
-       |      use-mempool-for-semantic-if-less: $useMempoolForSemanticIfLess
+       |      protection-enabled-threshold-percent: 0
+       |      max-mempool-size: $maxMempoolSize
+       |      use-mempool-for-semantic-threshold-percent: $useMempoolForSemanticIfLess
        |genus:
        |  enable: false
        |""".stripMargin
 
-  test("Enabled memory pool protection, accept and broadcast transaction chain, tx in mempool is considered") {
-
-    val height: Int = 3
-    val rpcPortA: Int = 1951
-    val rpcPortB: Int = 1953
-
-    val resource =
-      for {
-        testnetConfig     <- createTestnetConfig.toResource
-        genesisServerPort <- serveGenesisBlock(testnetConfig.genesis)
-        genesisSourcePath = s"http://localhost:$genesisServerPort/${testnetConfig.genesis.header.id.show}"
-        configALocation <- (
-          Files.forAsync[F].tempDirectory,
-          Files
-            .forAsync[F]
-            .tempDirectory
-            .evalTap(saveStaker(_)(testnetConfig.stakers(0)._1, testnetConfig.stakers(0)._2))
-        ).tupled
-          .map { case (dataDir, stakingDir) =>
-            configNodeA(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortA)
-          }
-          .flatMap(saveLocalConfig(_, "nodeA"))
-          .map(_.toString)
-        configBLocation <- (
-          Files.forAsync[F].tempDirectory,
-          Files
-            .forAsync[F]
-            .tempDirectory
-            .evalTap(saveStaker(_)(testnetConfig.stakers(1)._1, testnetConfig.stakers(1)._2))
-        ).tupled
-          .map { case (dataDir, stakingDir) =>
-            configNodeB(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortB, "127.0.0.2")
-          }
-          .flatMap(serveConfig(_, "nodeB.yaml"))
-        // Run the nodes in separate fibers, but use the fibers' outcomes as an error signal to
-        // the test by racing the computation
-        _ <- (launch(configALocation), launch(configBLocation))
-          .parMapN(_.race(_).map(_.merge).flatMap(_.embedNever))
-          .flatMap(nodeCompletion =>
-            nodeCompletion.toResource.race(for {
-              rpcClientA <- NodeGrpc.Client.make[F]("127.0.0.2", rpcPortA, tls = false)
-              rpcClientB <- NodeGrpc.Client.make[F]("127.0.0.3", rpcPortB, tls = false)
-              rpcClients = List(rpcClientA, rpcClientB)
-              implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeAppTest").toResource
-              _                            <- rpcClients.parTraverse(_.waitForRpcStartUp).toResource
-              genusChannelA                <- co.topl.grpc.makeChannel[F]("127.0.0.2", rpcPortA, tls = false)
-              genusTxServiceA              <- TransactionServiceFs2Grpc.stubResource[F](genusChannelA)
-              genusBlockServiceA           <- BlockServiceFs2Grpc.stubResource[F](genusChannelA)
-              _                            <- awaitGenusReady(genusBlockServiceA).timeout(45.seconds).toResource
-              wallet                       <- makeWallet(genusTxServiceA)
-              _                            <- IO(wallet.spendableBoxes.nonEmpty).assert.toResource
-              implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F].toResource
-
-              transactionGenerator <-
-                Fs2TransactionGenerator
-                  .make[F](wallet, _ => 1000L.pure[F], Fs2TransactionGenerator.emptyMetadata[F])
-                  .toResource
-              transactionGraph <- Stream
-                .force(transactionGenerator.generateTransactions)
-                .take(10)
-                .compile
-                .toList
-                .toResource
-              _ <- IO(transactionGraph.sizeIs == 10).assert.toResource
-
-              _ <- rpcClients.parTraverse(fetchUntilHeight(_, height)).toResource
-              // Broadcast transactions to the node
-              _ <- Stream
-                .emits(transactionGraph)
-                .covaryAll[F, IoTransaction]
-                .evalMap(tx => rpcClientA.broadcastTransaction(tx))
-                .compile
-                .drain
-                .toResource
-
-              // Verify that the transactions were confirmed by both nodes
-              _ <- rpcClients
-                .parTraverse(client =>
-                  Async[F].timeout(confirmTransactions(client)(transactionGraph.map(_.id).toSet), 60.seconds)
-                )
-                .toResource
-
-            } yield ())
-          )
-      } yield ()
-    resource.use_
-  }
-
-  test("Enabled memory pool protection, send tx chain to different nodes, thus only head tx will be accepted") {
-
-    val height: Int = 3
-    val rpcPortA: Int = 1961
-    val rpcPortB: Int = 1963
-
-    val resource =
-      for {
-        testnetConfig     <- createTestnetConfig.toResource
-        genesisServerPort <- serveGenesisBlock(testnetConfig.genesis)
-        genesisSourcePath = s"http://localhost:$genesisServerPort/${testnetConfig.genesis.header.id.show}"
-        configALocation <- (
-          Files.forAsync[F].tempDirectory,
-          Files
-            .forAsync[F]
-            .tempDirectory
-            .evalTap(saveStaker(_)(testnetConfig.stakers(0)._1, testnetConfig.stakers(0)._2))
-        ).tupled
-          .map { case (dataDir, stakingDir) =>
-            configNodeA(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortA)
-          }
-          .flatMap(saveLocalConfig(_, "nodeA"))
-          .map(_.toString)
-        configBLocation <- (
-          Files.forAsync[F].tempDirectory,
-          Files
-            .forAsync[F]
-            .tempDirectory
-            .evalTap(saveStaker(_)(testnetConfig.stakers(1)._1, testnetConfig.stakers(1)._2))
-        ).tupled
-          .map { case (dataDir, stakingDir) =>
-            configNodeB(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortB, "127.0.0.4")
-          }
-          .flatMap(serveConfig(_, "nodeB.yaml"))
-        // Run the nodes in separate fibers, but use the fibers' outcomes as an error signal to
-        // the test by racing the computation
-        _ <- (launch(configALocation), launch(configBLocation))
-          .parMapN(_.race(_).map(_.merge).flatMap(_.embedNever))
-          .flatMap(nodeCompletion =>
-            nodeCompletion.toResource.race(for {
-              rpcClientA <- NodeGrpc.Client.make[F]("127.0.0.4", rpcPortA, tls = false)
-              rpcClientB <- NodeGrpc.Client.make[F]("127.0.0.5", rpcPortB, tls = false)
-              rpcClients = List(rpcClientA, rpcClientB)
-              implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeAppTest").toResource
-              _                            <- rpcClients.parTraverse(_.waitForRpcStartUp).toResource
-              genusChannelA                <- co.topl.grpc.makeChannel[F]("127.0.0.4", rpcPortA, tls = false)
-              genusTxServiceA              <- TransactionServiceFs2Grpc.stubResource[F](genusChannelA)
-              genusBlockServiceA           <- BlockServiceFs2Grpc.stubResource[F](genusChannelA)
-              _                            <- awaitGenusReady(genusBlockServiceA).timeout(45.seconds).toResource
-              implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F].toResource
-
-              _ <- rpcClients.parTraverse(fetchUntilHeight(_, height)).toResource
-
-              wallet <- makeWallet(genusTxServiceA)
-              _      <- IO(wallet.spendableBoxes.nonEmpty).assert.toResource
-              transactionGenerator <-
-                Fs2TransactionGenerator
-                  .make[F](wallet, _ => 1000L.pure[F], Fs2TransactionGenerator.emptyMetadata[F])
-                  .toResource
-              transactionGraph <- Stream
-                .force(transactionGenerator.generateTransactions)
-                .take(20)
-                .compile
-                .toList
-                .toResource
-              _ <- Logger[F].info(show"Generated txs: ${transactionGraph.map(_.id)}").toResource
-
-              // send txs chain to different nodes,
-              // most of them will be rejected because "parent" tx is sent to other node
-              _ <-
-                Stream
-                  .repeatEval(random.elementOf(rpcClients))
-                  .zip(Stream.evalSeq(random.shuffleList(transactionGraph)))
-                  .evalMap { case (client, tx) => client.broadcastTransaction(tx) }
-                  .compile
-                  .drain
-                  .toResource
-
-              // verify that first transaction had been confirmed
-              _ <- Async[F].timeout(fetchUntilTx(rpcClientB, transactionGraph.head.id), 30.seconds).toResource
-              _ <- rpcClients
-                .parTraverse(client =>
-                  Async[F].timeout(confirmTransactions(client)(Set(transactionGraph.head.id)), 30.seconds)
-                )
-                .toResource
-
-              // verify that last transaction had not been confirmed
-              _ <- rpcClients
-                .parTraverse(verifyNotConfirmed(_)(Set(transactionGraph.last.id)))
-                .toResource
-
-            } yield ())
-          )
-      } yield ()
-    resource.use_
-  }
+//  test("Enabled memory pool protection, accept and broadcast transaction chain, tx in mempool is considered") {
+//
+//    val height: Int = 3
+//    val rpcPortA: Int = 1951
+//    val rpcPortB: Int = 1953
+//
+//    val resource =
+//      for {
+//        testnetConfig     <- createTestnetConfig.toResource
+//        genesisServerPort <- serveGenesisBlock(testnetConfig.genesis)
+//        genesisSourcePath = s"http://localhost:$genesisServerPort/${testnetConfig.genesis.header.id.show}"
+//        configALocation <- (
+//          Files.forAsync[F].tempDirectory,
+//          Files
+//            .forAsync[F]
+//            .tempDirectory
+//            .evalTap(saveStaker(_)(testnetConfig.stakers(0)._1, testnetConfig.stakers(0)._2))
+//        ).tupled
+//          .map { case (dataDir, stakingDir) =>
+//            configNodeA(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortA)
+//          }
+//          .flatMap(saveLocalConfig(_, "nodeA"))
+//          .map(_.toString)
+//        configBLocation <- (
+//          Files.forAsync[F].tempDirectory,
+//          Files
+//            .forAsync[F]
+//            .tempDirectory
+//            .evalTap(saveStaker(_)(testnetConfig.stakers(1)._1, testnetConfig.stakers(1)._2))
+//        ).tupled
+//          .map { case (dataDir, stakingDir) =>
+//            configNodeB(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortB, "127.0.0.2")
+//          }
+//          .flatMap(serveConfig(_, "nodeB.yaml"))
+//        // Run the nodes in separate fibers, but use the fibers' outcomes as an error signal to
+//        // the test by racing the computation
+//        _ <- (launch(configALocation), launch(configBLocation))
+//          .parMapN(_.race(_).map(_.merge).flatMap(_.embedNever))
+//          .flatMap(nodeCompletion =>
+//            nodeCompletion.toResource.race(for {
+//              rpcClientA <- NodeGrpc.Client.make[F]("127.0.0.2", rpcPortA, tls = false)
+//              rpcClientB <- NodeGrpc.Client.make[F]("127.0.0.3", rpcPortB, tls = false)
+//              rpcClients = List(rpcClientA, rpcClientB)
+//              implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeAppTest").toResource
+//              _                            <- rpcClients.parTraverse(_.waitForRpcStartUp).toResource
+//              genusChannelA                <- co.topl.grpc.makeChannel[F]("127.0.0.2", rpcPortA, tls = false)
+//              genusTxServiceA              <- TransactionServiceFs2Grpc.stubResource[F](genusChannelA)
+//              genusBlockServiceA           <- BlockServiceFs2Grpc.stubResource[F](genusChannelA)
+//              _                            <- awaitGenusReady(genusBlockServiceA).timeout(45.seconds).toResource
+//              wallet                       <- makeWallet(genusTxServiceA)
+//              _                            <- IO(wallet.spendableBoxes.nonEmpty).assert.toResource
+//              implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F].toResource
+//
+//              transactionGenerator <-
+//                Fs2TransactionGenerator
+//                  .make[F](wallet, _ => 1000L.pure[F], Fs2TransactionGenerator.emptyMetadata[F])
+//                  .toResource
+//              transactionGraph <- Stream
+//                .force(transactionGenerator.generateTransactions)
+//                .take(10)
+//                .compile
+//                .toList
+//                .toResource
+//              _ <- IO(transactionGraph.sizeIs == 10).assert.toResource
+//
+//              _ <- rpcClients.parTraverse(fetchUntilHeight(_, height)).toResource
+//              // Broadcast transactions to the node
+//              _ <- Stream
+//                .emits(transactionGraph)
+//                .covaryAll[F, IoTransaction]
+//                .evalMap(tx => rpcClientA.broadcastTransaction(tx))
+//                .compile
+//                .drain
+//                .toResource
+//
+//              // Verify that the transactions were confirmed by both nodes
+//              _ <- rpcClients
+//                .parTraverse(client =>
+//                  Async[F].timeout(confirmTransactions(client)(transactionGraph.map(_.id).toSet), 60.seconds)
+//                )
+//                .toResource
+//
+//            } yield ())
+//          )
+//      } yield ()
+//    resource.use_
+//  }
+//
+//  test("Enabled memory pool protection, send tx chain to different nodes, thus only head tx will be accepted") {
+//
+//    val height: Int = 3
+//    val rpcPortA: Int = 1961
+//    val rpcPortB: Int = 1963
+//
+//    val resource =
+//      for {
+//        testnetConfig     <- createTestnetConfig.toResource
+//        genesisServerPort <- serveGenesisBlock(testnetConfig.genesis)
+//        genesisSourcePath = s"http://localhost:$genesisServerPort/${testnetConfig.genesis.header.id.show}"
+//        configALocation <- (
+//          Files.forAsync[F].tempDirectory,
+//          Files
+//            .forAsync[F]
+//            .tempDirectory
+//            .evalTap(saveStaker(_)(testnetConfig.stakers(0)._1, testnetConfig.stakers(0)._2))
+//        ).tupled
+//          .map { case (dataDir, stakingDir) =>
+//            configNodeA(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortA)
+//          }
+//          .flatMap(saveLocalConfig(_, "nodeA"))
+//          .map(_.toString)
+//        configBLocation <- (
+//          Files.forAsync[F].tempDirectory,
+//          Files
+//            .forAsync[F]
+//            .tempDirectory
+//            .evalTap(saveStaker(_)(testnetConfig.stakers(1)._1, testnetConfig.stakers(1)._2))
+//        ).tupled
+//          .map { case (dataDir, stakingDir) =>
+//            configNodeB(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortB, "127.0.0.4")
+//          }
+//          .flatMap(serveConfig(_, "nodeB.yaml"))
+//        // Run the nodes in separate fibers, but use the fibers' outcomes as an error signal to
+//        // the test by racing the computation
+//        _ <- (launch(configALocation), launch(configBLocation))
+//          .parMapN(_.race(_).map(_.merge).flatMap(_.embedNever))
+//          .flatMap(nodeCompletion =>
+//            nodeCompletion.toResource.race(for {
+//              rpcClientA <- NodeGrpc.Client.make[F]("127.0.0.4", rpcPortA, tls = false)
+//              rpcClientB <- NodeGrpc.Client.make[F]("127.0.0.5", rpcPortB, tls = false)
+//              rpcClients = List(rpcClientA, rpcClientB)
+//              implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeAppTest").toResource
+//              _                            <- rpcClients.parTraverse(_.waitForRpcStartUp).toResource
+//              genusChannelA                <- co.topl.grpc.makeChannel[F]("127.0.0.4", rpcPortA, tls = false)
+//              genusTxServiceA              <- TransactionServiceFs2Grpc.stubResource[F](genusChannelA)
+//              genusBlockServiceA           <- BlockServiceFs2Grpc.stubResource[F](genusChannelA)
+//              _                            <- awaitGenusReady(genusBlockServiceA).timeout(45.seconds).toResource
+//              implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F].toResource
+//
+//              _ <- rpcClients.parTraverse(fetchUntilHeight(_, height)).toResource
+//
+//              wallet <- makeWallet(genusTxServiceA)
+//              _      <- IO(wallet.spendableBoxes.nonEmpty).assert.toResource
+//              transactionGenerator <-
+//                Fs2TransactionGenerator
+//                  .make[F](wallet, _ => 1000L.pure[F], Fs2TransactionGenerator.emptyMetadata[F])
+//                  .toResource
+//              transactionGraph <- Stream
+//                .force(transactionGenerator.generateTransactions)
+//                .take(20)
+//                .compile
+//                .toList
+//                .toResource
+//              _ <- Logger[F].info(show"Generated txs: ${transactionGraph.map(_.id)}").toResource
+//
+//              // send txs chain to different nodes,
+//              // most of them will be rejected because "parent" tx is sent to other node
+//              _ <-
+//                Stream
+//                  .repeatEval(random.elementOf(rpcClients))
+//                  .zip(Stream.evalSeq(random.shuffleList(transactionGraph)))
+//                  .evalMap { case (client, tx) => client.broadcastTransaction(tx) }
+//                  .compile
+//                  .drain
+//                  .toResource
+//
+//              // verify that first transaction had been confirmed
+//              _ <- Async[F].timeout(fetchUntilTx(rpcClientB, transactionGraph.head.id), 30.seconds).toResource
+//              _ <- rpcClients
+//                .parTraverse(client =>
+//                  Async[F].timeout(confirmTransactions(client)(Set(transactionGraph.head.id)), 30.seconds)
+//                )
+//                .toResource
+//
+//              // verify that last transaction had not been confirmed
+//              _ <- rpcClients
+//                .parTraverse(verifyNotConfirmed(_)(Set(transactionGraph.last.id)))
+//                .toResource
+//
+//            } yield ())
+//          )
+//      } yield ()
+//    resource.use_
+//  }
 
   test("Enabled memory pool protection consider only first N transaction for semantic check") {
     val height: Int = 3
     val rpcPortA: Int = 1971
     val rpcPortB: Int = 1973
 
-    val useMempoolForSemanticIfLess = 100
+    val useMempoolForSemanticIfLess: Double = 10
+    val useMempoolForSemanticIfLessSize = maxMempoolSize * (useMempoolForSemanticIfLess / 100)
 
     val resource =
       for {
@@ -359,15 +368,32 @@ class NodeAppTransactionsTest extends CatsEffectSuite {
                 Fs2TransactionGenerator
                   .make[F](wallet, _ => 10L.pure[F], Fs2TransactionGenerator.emptyMetadata[F])
                   .toResource
+              // get transactions of such size that last transaction
+              // shall no longer take in consideration transactions im memory pool
               transactionGraph <- Stream
                 .force(transactionGenerator.generateTransactions)
-                .take(useMempoolForSemanticIfLess * 2)
+                .map(tx => IoTransactionEx(tx, RewardQuantities()))
+                .scan((Chain.empty[IoTransactionEx], 0L)) { case ((txs, totalSize), tx) =>
+                  (txs.append(tx), totalSize + tx.size)
+                }
+                .takeWhile { case (txs, totalSize) =>
+                  (totalSize - txs.lastOption.fold(0L)(_.size)) < useMempoolForSemanticIfLessSize
+                }
+                .last
+                .evalTap{txs =>
+                  val fr = txs.get
+                  Logger[F].info(s"total size: ${fr._2}") >>
+                  Logger[F].info(show"${fr._1.map(tx => (tx.tx.id, tx.size))}")
+                }
+                .map(_.get._1.map(_.tx))
                 .compile
-                .toList
+                .last.map(_.get)
+                .map(_.toList)
                 .toResource
 
               _ <- Logger[F].info(show"Generated txs: ${transactionGraph.map(_.id).zipWithIndex}").toResource
-              _ <- IO(transactionGraph.length).assertEquals(useMempoolForSemanticIfLess * 2).toResource
+              _ <- Logger[F].info(show"EXTENDED: ${transactionGraph.map(tx => IoTransactionEx(tx, RewardQuantities())).map(tx => (tx.tx.id, tx.size))}").toResource
+
               // Broadcast _all_ of the good transactions to the nodes
               _ <- Stream
                 .emits(transactionGraph)
@@ -378,7 +404,7 @@ class NodeAppTransactionsTest extends CatsEffectSuite {
                 .toResource
 
               _ <- Async[F]
-                .timeout(fetchUntilTx(rpcClientB, transactionGraph(useMempoolForSemanticIfLess - 1).id), 70.seconds)
+                .timeout(fetchUntilTx(rpcClientB, transactionGraph.init.last.id), 70.seconds)
                 .toResource
               _ <- rpcClients
                 .parTraverse(verifyNotConfirmed(_)(Set(transactionGraph.last.id)))

--- a/node-it/src/test/scala/co/topl/node/NodeAppTransactionsTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTransactionsTest.scala
@@ -24,7 +24,11 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import co.topl.codecs.bytes.typeclasses.Transmittable
 import co.topl.codecs.bytes.tetra.instances._
 import cats.data.Chain
+import co.topl.brambl.validation.{TransactionCostCalculatorInterpreter, TransactionCostConfig}
+import co.topl.brambl.validation.algebras.TransactionCostCalculator
 import co.topl.ledger.models._
+import co.topl.models.Bytes
+
 import scala.concurrent.duration._
 
 // scalastyle:off magic.number
@@ -37,6 +41,9 @@ class NodeAppTransactionsTest extends CatsEffectSuite {
   override val munitTimeout: Duration = 3.minutes
 
   val maxMempoolSize = 1024 * 20
+
+  val sizeCalculator: TransactionCostCalculator =
+    TransactionCostCalculatorInterpreter.make[F](TransactionCostConfig())
 
   def configNodeA(
     dataDir:                     Path,
@@ -106,190 +113,190 @@ class NodeAppTransactionsTest extends CatsEffectSuite {
        |  enable: false
        |""".stripMargin
 
-//  test("Enabled memory pool protection, accept and broadcast transaction chain, tx in mempool is considered") {
-//
-//    val height: Int = 3
-//    val rpcPortA: Int = 1951
-//    val rpcPortB: Int = 1953
-//
-//    val resource =
-//      for {
-//        testnetConfig     <- createTestnetConfig.toResource
-//        genesisServerPort <- serveGenesisBlock(testnetConfig.genesis)
-//        genesisSourcePath = s"http://localhost:$genesisServerPort/${testnetConfig.genesis.header.id.show}"
-//        configALocation <- (
-//          Files.forAsync[F].tempDirectory,
-//          Files
-//            .forAsync[F]
-//            .tempDirectory
-//            .evalTap(saveStaker(_)(testnetConfig.stakers(0)._1, testnetConfig.stakers(0)._2))
-//        ).tupled
-//          .map { case (dataDir, stakingDir) =>
-//            configNodeA(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortA)
-//          }
-//          .flatMap(saveLocalConfig(_, "nodeA"))
-//          .map(_.toString)
-//        configBLocation <- (
-//          Files.forAsync[F].tempDirectory,
-//          Files
-//            .forAsync[F]
-//            .tempDirectory
-//            .evalTap(saveStaker(_)(testnetConfig.stakers(1)._1, testnetConfig.stakers(1)._2))
-//        ).tupled
-//          .map { case (dataDir, stakingDir) =>
-//            configNodeB(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortB, "127.0.0.2")
-//          }
-//          .flatMap(serveConfig(_, "nodeB.yaml"))
-//        // Run the nodes in separate fibers, but use the fibers' outcomes as an error signal to
-//        // the test by racing the computation
-//        _ <- (launch(configALocation), launch(configBLocation))
-//          .parMapN(_.race(_).map(_.merge).flatMap(_.embedNever))
-//          .flatMap(nodeCompletion =>
-//            nodeCompletion.toResource.race(for {
-//              rpcClientA <- NodeGrpc.Client.make[F]("127.0.0.2", rpcPortA, tls = false)
-//              rpcClientB <- NodeGrpc.Client.make[F]("127.0.0.3", rpcPortB, tls = false)
-//              rpcClients = List(rpcClientA, rpcClientB)
-//              implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeAppTest").toResource
-//              _                            <- rpcClients.parTraverse(_.waitForRpcStartUp).toResource
-//              genusChannelA                <- co.topl.grpc.makeChannel[F]("127.0.0.2", rpcPortA, tls = false)
-//              genusTxServiceA              <- TransactionServiceFs2Grpc.stubResource[F](genusChannelA)
-//              genusBlockServiceA           <- BlockServiceFs2Grpc.stubResource[F](genusChannelA)
-//              _                            <- awaitGenusReady(genusBlockServiceA).timeout(45.seconds).toResource
-//              wallet                       <- makeWallet(genusTxServiceA)
-//              _                            <- IO(wallet.spendableBoxes.nonEmpty).assert.toResource
-//              implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F].toResource
-//
-//              transactionGenerator <-
-//                Fs2TransactionGenerator
-//                  .make[F](wallet, _ => 1000L.pure[F], Fs2TransactionGenerator.emptyMetadata[F])
-//                  .toResource
-//              transactionGraph <- Stream
-//                .force(transactionGenerator.generateTransactions)
-//                .take(10)
-//                .compile
-//                .toList
-//                .toResource
-//              _ <- IO(transactionGraph.sizeIs == 10).assert.toResource
-//
-//              _ <- rpcClients.parTraverse(fetchUntilHeight(_, height)).toResource
-//              // Broadcast transactions to the node
-//              _ <- Stream
-//                .emits(transactionGraph)
-//                .covaryAll[F, IoTransaction]
-//                .evalMap(tx => rpcClientA.broadcastTransaction(tx))
-//                .compile
-//                .drain
-//                .toResource
-//
-//              // Verify that the transactions were confirmed by both nodes
-//              _ <- rpcClients
-//                .parTraverse(client =>
-//                  Async[F].timeout(confirmTransactions(client)(transactionGraph.map(_.id).toSet), 60.seconds)
-//                )
-//                .toResource
-//
-//            } yield ())
-//          )
-//      } yield ()
-//    resource.use_
-//  }
-//
-//  test("Enabled memory pool protection, send tx chain to different nodes, thus only head tx will be accepted") {
-//
-//    val height: Int = 3
-//    val rpcPortA: Int = 1961
-//    val rpcPortB: Int = 1963
-//
-//    val resource =
-//      for {
-//        testnetConfig     <- createTestnetConfig.toResource
-//        genesisServerPort <- serveGenesisBlock(testnetConfig.genesis)
-//        genesisSourcePath = s"http://localhost:$genesisServerPort/${testnetConfig.genesis.header.id.show}"
-//        configALocation <- (
-//          Files.forAsync[F].tempDirectory,
-//          Files
-//            .forAsync[F]
-//            .tempDirectory
-//            .evalTap(saveStaker(_)(testnetConfig.stakers(0)._1, testnetConfig.stakers(0)._2))
-//        ).tupled
-//          .map { case (dataDir, stakingDir) =>
-//            configNodeA(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortA)
-//          }
-//          .flatMap(saveLocalConfig(_, "nodeA"))
-//          .map(_.toString)
-//        configBLocation <- (
-//          Files.forAsync[F].tempDirectory,
-//          Files
-//            .forAsync[F]
-//            .tempDirectory
-//            .evalTap(saveStaker(_)(testnetConfig.stakers(1)._1, testnetConfig.stakers(1)._2))
-//        ).tupled
-//          .map { case (dataDir, stakingDir) =>
-//            configNodeB(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortB, "127.0.0.4")
-//          }
-//          .flatMap(serveConfig(_, "nodeB.yaml"))
-//        // Run the nodes in separate fibers, but use the fibers' outcomes as an error signal to
-//        // the test by racing the computation
-//        _ <- (launch(configALocation), launch(configBLocation))
-//          .parMapN(_.race(_).map(_.merge).flatMap(_.embedNever))
-//          .flatMap(nodeCompletion =>
-//            nodeCompletion.toResource.race(for {
-//              rpcClientA <- NodeGrpc.Client.make[F]("127.0.0.4", rpcPortA, tls = false)
-//              rpcClientB <- NodeGrpc.Client.make[F]("127.0.0.5", rpcPortB, tls = false)
-//              rpcClients = List(rpcClientA, rpcClientB)
-//              implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeAppTest").toResource
-//              _                            <- rpcClients.parTraverse(_.waitForRpcStartUp).toResource
-//              genusChannelA                <- co.topl.grpc.makeChannel[F]("127.0.0.4", rpcPortA, tls = false)
-//              genusTxServiceA              <- TransactionServiceFs2Grpc.stubResource[F](genusChannelA)
-//              genusBlockServiceA           <- BlockServiceFs2Grpc.stubResource[F](genusChannelA)
-//              _                            <- awaitGenusReady(genusBlockServiceA).timeout(45.seconds).toResource
-//              implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F].toResource
-//
-//              _ <- rpcClients.parTraverse(fetchUntilHeight(_, height)).toResource
-//
-//              wallet <- makeWallet(genusTxServiceA)
-//              _      <- IO(wallet.spendableBoxes.nonEmpty).assert.toResource
-//              transactionGenerator <-
-//                Fs2TransactionGenerator
-//                  .make[F](wallet, _ => 1000L.pure[F], Fs2TransactionGenerator.emptyMetadata[F])
-//                  .toResource
-//              transactionGraph <- Stream
-//                .force(transactionGenerator.generateTransactions)
-//                .take(20)
-//                .compile
-//                .toList
-//                .toResource
-//              _ <- Logger[F].info(show"Generated txs: ${transactionGraph.map(_.id)}").toResource
-//
-//              // send txs chain to different nodes,
-//              // most of them will be rejected because "parent" tx is sent to other node
-//              _ <-
-//                Stream
-//                  .repeatEval(random.elementOf(rpcClients))
-//                  .zip(Stream.evalSeq(random.shuffleList(transactionGraph)))
-//                  .evalMap { case (client, tx) => client.broadcastTransaction(tx) }
-//                  .compile
-//                  .drain
-//                  .toResource
-//
-//              // verify that first transaction had been confirmed
-//              _ <- Async[F].timeout(fetchUntilTx(rpcClientB, transactionGraph.head.id), 30.seconds).toResource
-//              _ <- rpcClients
-//                .parTraverse(client =>
-//                  Async[F].timeout(confirmTransactions(client)(Set(transactionGraph.head.id)), 30.seconds)
-//                )
-//                .toResource
-//
-//              // verify that last transaction had not been confirmed
-//              _ <- rpcClients
-//                .parTraverse(verifyNotConfirmed(_)(Set(transactionGraph.last.id)))
-//                .toResource
-//
-//            } yield ())
-//          )
-//      } yield ()
-//    resource.use_
-//  }
+  test("Enabled memory pool protection, accept and broadcast transaction chain, tx in mempool is considered") {
+
+    val height: Int = 3
+    val rpcPortA: Int = 1951
+    val rpcPortB: Int = 1953
+
+    val resource =
+      for {
+        testnetConfig     <- createTestnetConfig.toResource
+        genesisServerPort <- serveGenesisBlock(testnetConfig.genesis)
+        genesisSourcePath = s"http://localhost:$genesisServerPort/${testnetConfig.genesis.header.id.show}"
+        configALocation <- (
+          Files.forAsync[F].tempDirectory,
+          Files
+            .forAsync[F]
+            .tempDirectory
+            .evalTap(saveStaker(_)(testnetConfig.stakers(0)._1, testnetConfig.stakers(0)._2))
+        ).tupled
+          .map { case (dataDir, stakingDir) =>
+            configNodeA(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortA)
+          }
+          .flatMap(saveLocalConfig(_, "nodeA"))
+          .map(_.toString)
+        configBLocation <- (
+          Files.forAsync[F].tempDirectory,
+          Files
+            .forAsync[F]
+            .tempDirectory
+            .evalTap(saveStaker(_)(testnetConfig.stakers(1)._1, testnetConfig.stakers(1)._2))
+        ).tupled
+          .map { case (dataDir, stakingDir) =>
+            configNodeB(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortB, "127.0.0.2")
+          }
+          .flatMap(serveConfig(_, "nodeB.yaml"))
+        // Run the nodes in separate fibers, but use the fibers' outcomes as an error signal to
+        // the test by racing the computation
+        _ <- (launch(configALocation), launch(configBLocation))
+          .parMapN(_.race(_).map(_.merge).flatMap(_.embedNever))
+          .flatMap(nodeCompletion =>
+            nodeCompletion.toResource.race(for {
+              rpcClientA <- NodeGrpc.Client.make[F]("127.0.0.2", rpcPortA, tls = false)
+              rpcClientB <- NodeGrpc.Client.make[F]("127.0.0.3", rpcPortB, tls = false)
+              rpcClients = List(rpcClientA, rpcClientB)
+              implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeAppTest").toResource
+              _                            <- rpcClients.parTraverse(_.waitForRpcStartUp).toResource
+              genusChannelA                <- co.topl.grpc.makeChannel[F]("127.0.0.2", rpcPortA, tls = false)
+              genusTxServiceA              <- TransactionServiceFs2Grpc.stubResource[F](genusChannelA)
+              genusBlockServiceA           <- BlockServiceFs2Grpc.stubResource[F](genusChannelA)
+              _                            <- awaitGenusReady(genusBlockServiceA).timeout(45.seconds).toResource
+              wallet                       <- makeWallet(genusTxServiceA)
+              _                            <- IO(wallet.spendableBoxes.nonEmpty).assert.toResource
+              implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F].toResource
+
+              transactionGenerator <-
+                Fs2TransactionGenerator
+                  .make[F](wallet, _ => 1000L, Fs2TransactionGenerator.emptyMetadata[F])
+                  .toResource
+              transactionGraph <- Stream
+                .force(transactionGenerator.generateTransactions)
+                .take(10)
+                .compile
+                .toList
+                .toResource
+              _ <- IO(transactionGraph.sizeIs == 10).assert.toResource
+
+              _ <- rpcClients.parTraverse(fetchUntilHeight(_, height)).toResource
+              // Broadcast transactions to the node
+              _ <- Stream
+                .emits(transactionGraph)
+                .covaryAll[F, IoTransaction]
+                .evalMap(tx => rpcClientA.broadcastTransaction(tx))
+                .compile
+                .drain
+                .toResource
+
+              // Verify that the transactions were confirmed by both nodes
+              _ <- rpcClients
+                .parTraverse(client =>
+                  Async[F].timeout(confirmTransactions(client)(transactionGraph.map(_.id).toSet), 60.seconds)
+                )
+                .toResource
+
+            } yield ())
+          )
+      } yield ()
+    resource.use_
+  }
+
+  test("Enabled memory pool protection, send tx chain to different nodes, thus only head tx will be accepted") {
+
+    val height: Int = 3
+    val rpcPortA: Int = 1961
+    val rpcPortB: Int = 1963
+
+    val resource =
+      for {
+        testnetConfig     <- createTestnetConfig.toResource
+        genesisServerPort <- serveGenesisBlock(testnetConfig.genesis)
+        genesisSourcePath = s"http://localhost:$genesisServerPort/${testnetConfig.genesis.header.id.show}"
+        configALocation <- (
+          Files.forAsync[F].tempDirectory,
+          Files
+            .forAsync[F]
+            .tempDirectory
+            .evalTap(saveStaker(_)(testnetConfig.stakers(0)._1, testnetConfig.stakers(0)._2))
+        ).tupled
+          .map { case (dataDir, stakingDir) =>
+            configNodeA(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortA)
+          }
+          .flatMap(saveLocalConfig(_, "nodeA"))
+          .map(_.toString)
+        configBLocation <- (
+          Files.forAsync[F].tempDirectory,
+          Files
+            .forAsync[F]
+            .tempDirectory
+            .evalTap(saveStaker(_)(testnetConfig.stakers(1)._1, testnetConfig.stakers(1)._2))
+        ).tupled
+          .map { case (dataDir, stakingDir) =>
+            configNodeB(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath, rpcPortB, "127.0.0.4")
+          }
+          .flatMap(serveConfig(_, "nodeB.yaml"))
+        // Run the nodes in separate fibers, but use the fibers' outcomes as an error signal to
+        // the test by racing the computation
+        _ <- (launch(configALocation), launch(configBLocation))
+          .parMapN(_.race(_).map(_.merge).flatMap(_.embedNever))
+          .flatMap(nodeCompletion =>
+            nodeCompletion.toResource.race(for {
+              rpcClientA <- NodeGrpc.Client.make[F]("127.0.0.4", rpcPortA, tls = false)
+              rpcClientB <- NodeGrpc.Client.make[F]("127.0.0.5", rpcPortB, tls = false)
+              rpcClients = List(rpcClientA, rpcClientB)
+              implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeAppTest").toResource
+              _                            <- rpcClients.parTraverse(_.waitForRpcStartUp).toResource
+              genusChannelA                <- co.topl.grpc.makeChannel[F]("127.0.0.4", rpcPortA, tls = false)
+              genusTxServiceA              <- TransactionServiceFs2Grpc.stubResource[F](genusChannelA)
+              genusBlockServiceA           <- BlockServiceFs2Grpc.stubResource[F](genusChannelA)
+              _                            <- awaitGenusReady(genusBlockServiceA).timeout(45.seconds).toResource
+              implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F].toResource
+
+              _ <- rpcClients.parTraverse(fetchUntilHeight(_, height)).toResource
+
+              wallet <- makeWallet(genusTxServiceA)
+              _      <- IO(wallet.spendableBoxes.nonEmpty).assert.toResource
+              transactionGenerator <-
+                Fs2TransactionGenerator
+                  .make[F](wallet, _ => 1000L, Fs2TransactionGenerator.emptyMetadata[F])
+                  .toResource
+              transactionGraph <- Stream
+                .force(transactionGenerator.generateTransactions)
+                .take(20)
+                .compile
+                .toList
+                .toResource
+              _ <- Logger[F].info(show"Generated txs: ${transactionGraph.map(_.id)}").toResource
+
+              // send txs chain to different nodes,
+              // most of them will be rejected because "parent" tx is sent to other node
+              _ <-
+                Stream
+                  .repeatEval(random.elementOf(rpcClients))
+                  .zip(Stream.evalSeq(random.shuffleList(transactionGraph)))
+                  .evalMap { case (client, tx) => client.broadcastTransaction(tx) }
+                  .compile
+                  .drain
+                  .toResource
+
+              // verify that first transaction had been confirmed
+              _ <- Async[F].timeout(fetchUntilTx(rpcClientB, transactionGraph.head.id), 30.seconds).toResource
+              _ <- rpcClients
+                .parTraverse(client =>
+                  Async[F].timeout(confirmTransactions(client)(Set(transactionGraph.head.id)), 30.seconds)
+                )
+                .toResource
+
+              // verify that last transaction had not been confirmed
+              _ <- rpcClients
+                .parTraverse(verifyNotConfirmed(_)(Set(transactionGraph.last.id)))
+                .toResource
+
+            } yield ())
+          )
+      } yield ()
+    resource.use_
+  }
 
   test("Enabled memory pool protection consider only first N transaction for semantic check") {
     val height: Int = 3
@@ -366,13 +373,13 @@ class NodeAppTransactionsTest extends CatsEffectSuite {
 
               transactionGenerator <-
                 Fs2TransactionGenerator
-                  .make[F](wallet, _ => 10L.pure[F], Fs2TransactionGenerator.emptyMetadata[F])
+                  .make[F](wallet, _ => 10L, Fs2TransactionGenerator.emptyMetadata[F])
                   .toResource
               // get transactions of such size that last transaction
               // shall no longer take in consideration transactions im memory pool
               transactionGraph <- Stream
                 .force(transactionGenerator.generateTransactions)
-                .map(tx => IoTransactionEx(tx, RewardQuantities()))
+                .map(tx => IoTransactionEx(tx, RewardQuantities(), sizeCalculator.costOf(tx)))
                 .scan((Chain.empty[IoTransactionEx], 0L)) { case ((txs, totalSize), tx) =>
                   (txs.append(tx), totalSize + tx.size)
                 }
@@ -380,19 +387,17 @@ class NodeAppTransactionsTest extends CatsEffectSuite {
                   (totalSize - txs.lastOption.fold(0L)(_.size)) < useMempoolForSemanticIfLessSize
                 }
                 .last
-                .evalTap{txs =>
+                .evalTap { txs =>
                   val fr = txs.get
                   Logger[F].info(s"total size: ${fr._2}") >>
                   Logger[F].info(show"${fr._1.map(tx => (tx.tx.id, tx.size))}")
                 }
                 .map(_.get._1.map(_.tx))
                 .compile
-                .last.map(_.get)
+                .last
+                .map(_.get)
                 .map(_.toList)
                 .toResource
-
-              _ <- Logger[F].info(show"Generated txs: ${transactionGraph.map(_.id).zipWithIndex}").toResource
-              _ <- Logger[F].info(show"EXTENDED: ${transactionGraph.map(tx => IoTransactionEx(tx, RewardQuantities())).map(tx => (tx.tx.id, tx.size))}").toResource
 
               // Broadcast _all_ of the good transactions to the nodes
               _ <- Stream

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -466,7 +466,8 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
         currentEventIdGetterSetters.mempool.set,
         clock,
         id => Logger[F].info(show"Expiring transaction id=$id"),
-        appConfig.bifrost.mempool.defaultExpirationSlots
+        appConfig.bifrost.mempool.defaultExpirationSlots,
+        transactionRewardCalculator
       )
 
       protectedMempool <- MempoolProtected.make(
@@ -475,6 +476,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
         validatorsP2P.transactionAuthorization,
         currentEventIdGetterSetters.canonicalHead.get().flatMap(dataStores.headers.getOrRaise),
         dataStores.transactions.getOrRaise,
+        transactionRewardCalculator,
         appConfig.bifrost.mempool.protection
       )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val ioGrpcVersion = "1.62.2"
   val http4sVersion = "0.23.26"
   val protobufSpecsVersion = "2.0.0-beta2" // scala-steward:off
-  val bramblScVersion = "2.0.0-beta3" // scala-steward:off
+  val bramblScVersion = "2.0.0-beta3+3-de74a6dd-SNAPSHOT" // scala-steward:off
 
   val catsSlf4j =
     "org.typelevel" %% "log4cats-slf4j" % "2.6.0"

--- a/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/app/Orchestrator.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/app/Orchestrator.scala
@@ -239,7 +239,7 @@ object Orchestrator
       transactionStream <- Fs2TransactionGenerator
         .make[F](
           wallet,
-          TransactionCostCalculatorInterpreter.make(TransactionCostConfig()),
+          TransactionCostCalculatorInterpreter.make[F](TransactionCostConfig()),
           Fs2TransactionGenerator.randomMetadata[F]
         )
         .flatMap(_.generateTransactions)

--- a/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/TransactionGeneratorApp.scala
+++ b/transaction-generator/src/main/scala/co/topl/transactiongenerator/app/TransactionGeneratorApp.scala
@@ -95,7 +95,7 @@ object TransactionGeneratorApp
     transactionStream: Stream[F, IoTransaction],
     client:            NodeRpc[F, Stream[F, *]],
     targetTps:         Double,
-    costCalculator:    TransactionCostCalculator[F]
+    costCalculator:    TransactionCostCalculator
   ) =
     transactionStream
       // Send 1 transaction per _this_ duration
@@ -106,6 +106,7 @@ object TransactionGeneratorApp
         client.broadcastTransaction(transaction) >>
         costCalculator
           .costOf(transaction)
+          .pure[F]
           .flatTap(cost => Logger[F].info(show"Broadcasted transaction id=${transaction.id} cost=$cost"))
       )
       .onError { case e =>


### PR DESCRIPTION
## Purpose
To prevent spam of transactions with low fee, fee-per-kb based filter is introduced

## Approach
If total size of transactions (including transaction to check) reaches the threshold then check the transaction fee-per-kb. If fee is not enough then reject transaction. Formula for minimum fee calculation is next:
          if (freeMempoolSizePercent == 0) Double.MaxValue
          else (meanFeePerKByteInMempool / freeMempoolSizePercent) - meanFeePerKByteInMempool 
if 80% of mempool is free then 25% of mean fee per Kb is required 
if 60% of mempool is free then 66% of mean fee per Kb is required 
if 50% of mempool is free then 100% of mean fee per Kb is required
if 40% of mempool is free then 150% of mean fee per Kb is required
if 30% of mempool is free then 233% of mean fee per Kb is required

By default fee-based filter is enabled if 50% of memory pool is filled

## Testing
TBD

## Tickets
