### PR TITLE
Docs: Blockchain Core, RPC, P2P

### DIFF
--- a/documentation/docs/concepts/blockchain-core.md
+++ b/documentation/docs/concepts/blockchain-core.md
@@ -1,0 +1,2 @@
+# Blockchain Core
+This module glues together the (Consensus)[consensus] and [Ledger](ledger) modules into a basic framework for blockchain fundamentals. In addition to consensus and ledger, it also holds references to data storage, cryptographic resources, the clock, the block-id tree, validators, and some miscellaneous helpers.

--- a/documentation/docs/concepts/intro.md
+++ b/documentation/docs/concepts/intro.md
@@ -3,5 +3,8 @@ sidebar_position: 1
 ---
 
 # Concepts
-- [Consensus](concepts/consensus)
-- [Ledger](concepts/ledger)
+- [Consensus](consensus)
+- [Ledger](ledger)
+- [Blockchain Core](blockchain-core)
+- [P2P](p2p)
+- [RPC](rpc)

--- a/documentation/docs/concepts/p2p.md
+++ b/documentation/docs/concepts/p2p.md
@@ -1,0 +1,16 @@
+# P2P
+Node-to-node communication is implemented using a custom protocol on top of raw TCP sockets. After some initial handshakes, the remainder of the communcation is performed over a multiplexer with dedicated channels for specific types of communication.
+
+The handshakes consist of:
+- Exchange a "Peer Identity" (a verification key)
+- Exchange network protocol version
+
+Assuming the latest network protocol version, a multiplexer is created with ports dedicated to, but not limited to:
+- The exchange of blocks
+- The exchange of transactions
+- The notification of block and transaction adoptions
+- The exchange of P2P participant information
+
+Each of these channels operate on a request-response model. Request messages are prefixed with a `0` while response messages are prefixed with a `1`. The entire message is framed together with its port number and sent over a shared TCP socket.
+
+Using the combination of multiplexer channels, a `BlockchainPeerClient` is exposed providing higher-level interface to information from the remote peer. The `BlockchainPeerClient` is provided to the actor-based blockchain network framework.

--- a/documentation/docs/concepts/rpc.md
+++ b/documentation/docs/concepts/rpc.md
@@ -1,0 +1,8 @@
+# RPC
+Users interact with the blockchain using the Remote Procedure Call (RPC) layer.  This layer is implemented using gRPC using the specification defined in [Topl/protobuf-specs](https://github.com/Topl/protobuf-specs).
+
+In general, the RPC layer is bound to host `0.0.0.0` at port `9084`. Only gRPC over HTTP/2 is supported directly by the node. To use gRPC-web, a separate proxy like Envoy should be used.
+
+The Node's gRPC layer is implemented using the interface provided by [Blockchain Core](blockchain-core).
+
+Genus's gRPC layer is served using the same port. When running the (legacy) Node-embedded Genus, node traffic flows through the node interpreter while Genus traffic flows through Genus; but it's all served from the same JVM. When running Genus as a standalone server, node traffic is proxied to a remote node instance while Genus traffic is handled by the Genus server.


### PR DESCRIPTION
## Purpose
- Docusaurus pages for Blockchain Core, RPC, P2P
- Also fixed linking (hopefully)
## Approach

## Testing

## Tickets
- #BN-1464