### PR TITLE
BN-1470 Chunk size for downloading remote block data now is parameter

### DIFF
--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -78,7 +78,8 @@ object ApplicationConfig {
       aggressiveP2PCount:         Int = 1, // how many new connection will be opened
       // do not try to open aggressively connection to remote peer if we have closed N connection(s) to them recently
       aggressiveP2PMaxCloseEvent: Int = 3,
-      defaultTimeout:             FiniteDuration = 3.seconds
+      defaultTimeout:             FiniteDuration = 3.seconds,
+      chunkSize:                  Int = 1
     )
 
     case class KnownPeer(host: String, port: Int)

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
@@ -55,7 +55,8 @@ trait NetworkAlgebra[F[_]] {
     bodySyntaxValidation:        BodySyntaxValidationAlgebra[F],
     bodySemanticValidation:      BodySemanticValidationAlgebra[F],
     bodyAuthorizationValidation: BodyAuthorizationValidationAlgebra[F],
-    chainSelectionAlgebra:       ChainSelectionAlgebra[F, SlotData]
+    chainSelectionAlgebra:       ChainSelectionAlgebra[F, SlotData],
+    p2pNetworkConfig:            P2PNetworkConfig
   ): Resource[F, BlockCheckerActor[F]]
 
   def makeRequestsProxy(
@@ -176,7 +177,8 @@ class NetworkAlgebraImpl[F[_]: Async: Parallel: Logger: DnsResolver: ReverseDnsR
     bodySyntaxValidation:        BodySyntaxValidationAlgebra[F],
     bodySemanticValidation:      BodySemanticValidationAlgebra[F],
     bodyAuthorizationValidation: BodyAuthorizationValidationAlgebra[F],
-    chainSelectionAlgebra:       ChainSelectionAlgebra[F, SlotData]
+    chainSelectionAlgebra:       ChainSelectionAlgebra[F, SlotData],
+    p2pNetworkConfig:            P2PNetworkConfig
   ): Resource[F, BlockCheckerActor[F]] =
     BlockChecker.makeActor(
       requestsProxy,
@@ -188,7 +190,8 @@ class NetworkAlgebraImpl[F[_]: Async: Parallel: Logger: DnsResolver: ReverseDnsR
       bodySyntaxValidation,
       bodySemanticValidation,
       bodyAuthorizationValidation,
-      chainSelectionAlgebra
+      chainSelectionAlgebra,
+      p2pNetworkConfig
     )
 
   override def makeRequestsProxy(

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkManager.scala
@@ -71,7 +71,8 @@ object NetworkManager {
         blockchain.validators.bodySyntax,
         blockchain.validators.bodySemantics,
         blockchain.validators.bodyAuthorization,
-        blockchain.consensus.chainSelection
+        blockchain.consensus.chainSelection,
+        p2pNetworkConfig
       )
 
       _ <- Resource.liftK(requestsProxy.sendNoWait(RequestsProxy.Message.SetupBlockChecker(blocksChecker)))

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -310,7 +310,7 @@ object PeerBlockHeaderFetcher {
     state.slotDataStore.get(blockId).flatMap {
       case Some(sd) => sd.pure[F]
       case None =>
-        Logger[F].info(show"Fetching remote SlotData id=$blockId from peer ${state.hostIdString}") >>
+        Logger[F].info(show"Fetching SlotData id=$blockId from peer ${state.hostIdString}") >>
         Async[F].cede >>
         state.client
           .getSlotDataOrError(blockId, new NoSuchElementException(blockId.toString))
@@ -403,7 +403,7 @@ object PeerBlockHeaderFetcher {
   ): F[List[(BlockId, Either[BlockHeaderDownloadError, UnverifiedBlockHeader])]] =
     Stream
       .foldable[F, NonEmptyChain, BlockId](blockIds)
-      .parEvalMapUnbounded(downloadHeader(client, hostId, _))
+      .evalMap(downloadHeader(client, hostId, _))
       .compile
       .toList
 

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -23,10 +23,6 @@ package object fsnetwork {
 
   val hostIdBytesLen: Int = 32
 
-  // how many block/headers could be requested from remote host in the same time,
-  // TODO shall be dynamically changed based by host reputation, i.e. bigger value for trusted host
-  val chunkSize = 1
-
   val requestCacheSize = 256
   val slotIdResponseCacheSize = 256
 


### PR DESCRIPTION
## Purpose
Make it possible to configure chunk size for downloading block data like headers and bodies

## Approach

## Testing
Unit tests + Integration tests + sync with topl-net

## Tickets
BN-1470


**Delete everything after and including this line after you are done reading and understand what to put for each section**

>### Purpose
>
>*State in plain words what the scope of the pull request and what problem it is trying to solve*
>
>### Approach
>
>*Enumerate the steps you took to create the code/changes contained in this pull request*
>
>### Testing
>
>*Specify all unit, integration, or end-to-end testing that is contained in this pull request*
>
>### Tickets
>
>*List tickets if any that are connected to this pull request in the following format:*
>
>_* closes #1234_