### PR TITLE
BN-1331 Added option to not expose remote peers to other nodes by id / ip(s)

### DIFF
--- a/byzantine-it/src/test/scala/co/topl/byzantine/ChainSelectionTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/ChainSelectionTest.scala
@@ -60,7 +60,7 @@ class ChainSelectionTest extends IntegrationSuite {
                 .use(
                   _.adoptedHeaders
                     .takeWhile(_.slot < TestNodeConfig.epochSlotLength)
-                    .timeout(4.minutes)
+                    .timeout(9.minutes)
                     .compile
                     .lastOrError
                 )

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -79,7 +79,18 @@ object ApplicationConfig {
       // do not try to open aggressively connection to remote peer if we have closed N connection(s) to them recently
       aggressiveP2PMaxCloseEvent: Int = 3,
       defaultTimeout:             FiniteDuration = 3.seconds,
-      chunkSize:                  Int = 1
+      chunkSize:                  Int = 1,
+      // If remote peer have ip address in that list then that peer will not be exposed to other peers
+      // Examples of supported ip addresses description:
+      // 10.*.65-67.0/24 (first octet is "10", second octet is any, third octet in range 65-67, subnet mask is 24)
+      // If subnet mask is used then first address in subnet shall be set, otherwise subnet mask will not be applied
+      // In that case next addresses will be filtered: 10.45.67.0, 10.0.65.80, 10.255.66.200.
+      // Next address is not filtered: 10.45.64.255
+      // Could be used if current node serves as proxy, and we don't want to expose any node behind proxy
+      doNotExposeIps: List[String] = List.empty,
+      // If remote peer have id in that list then that peer will not be exposed to other peers
+      // Could be used if current node serves as proxy, and we don't want to expose any node behind proxy
+      doNotExposeIds: List[String] = List.empty
     )
 
     case class KnownPeer(host: String, port: Int)

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerFilter.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerFilter.scala
@@ -1,0 +1,21 @@
+package co.topl.networking.fsnetwork
+
+import co.topl.models.p2p.HostId
+
+import scala.util.Try
+import inet.ipaddr.IPAddressString
+
+class PeerFilter(ipFilters: Seq[String], idFilters: Seq[HostId]) {
+  private val filterAddresses: Seq[IPAddressString] = ipFilters.flatMap(s => Try(new IPAddressString(s)).toOption)
+
+  def remotePeerIsAcceptable(peer: RemotePeer): Boolean =
+    !(idFiltered(peer) || addressFiltered(peer))
+
+  private def idFiltered(peer: RemotePeer): Boolean =
+    idFilters.contains(peer.peerId)
+
+  private def addressFiltered(peer: RemotePeer): Boolean =
+    Try(new IPAddressString(peer.address.host))
+      .map(ipAddress => filterAddresses.exists(_.contains(ipAddress)))
+      .fold(_ => true, identity)
+}

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
@@ -672,7 +672,7 @@ object PeersManager {
       hotPeersServers <- state.peersHandler.getHotPeers.values.flatMap(_.asServer).pure[F]
       _               <- Logger[F].debug(show"Resolve ip(s) to hostnames for hot peers ${hotPeersServers.toList}")
       hotPeersAsHosts <- hotPeersServers.toSeq.parTraverse(_.reverseResolving())
-      _               <- Logger[F].debug(show"Got hot peers hostnames $hotPeersAsHosts")
+      _               <- Logger[F].debug(show"No filtered hot peers hostnames $hotPeersAsHosts")
       filteredHosts   <- hotPeersAsHosts.filter(state.peerFilter.remotePeerIsAcceptable).pure[F]
       _               <- Logger[F].debug(show"Filtered hot peers hostnames $filteredHosts")
       _               <- state.hotPeersUpdate(filteredHosts.toSet)

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerFilterTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerFilterTest.scala
@@ -1,0 +1,86 @@
+package co.topl.networking.fsnetwork
+
+import co.topl.models.p2p._
+import co.topl.networking.fsnetwork._
+import com.google.protobuf.ByteString
+import munit.FunSuite
+
+class PeerFilterTest extends FunSuite {
+
+  private def ipToPeer(ip: String) = RemotePeer(HostId(ByteString.copyFrom("host".getBytes)), RemoteAddress(ip, 0))
+
+  test("non ip address is not filtered by default") {
+    val underTest = new PeerFilter(Seq("10.45.67.89", "9.45.67.89/32"), Seq.empty)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("wrongIpAddress")), true)
+  }
+
+  test("HotPeers filter IP single addresses") {
+    val underTest = new PeerFilter(Seq("10.45.67.89", "9.45.67.89/32"), Seq.empty)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.89")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.90")), true)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("9.45.67.89")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("9.45.67.90")), true)
+  }
+
+  test("HotPeers filter IP based on subnet 1") {
+    val underTest = new PeerFilter(Seq("10.45.67.0/24"), Seq.empty)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.89")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.0")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.255")), false)
+
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.68.89")), true)
+  }
+
+  test("HotPeers filter IP based on subnet 2") {
+    val underTest = new PeerFilter(Seq("10.45.67.0/255.255.255.0"), Seq.empty)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.89")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.0")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.255")), false)
+
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.68.89")), true)
+  }
+
+  test("HotPeers filter IP based on mask character") {
+    val underTest = new PeerFilter(Seq("10.45.67.*"), Seq.empty)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.89")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.0")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.255")), false)
+
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.68.89")), true)
+  }
+
+  test("HotPeers filter IP based on range") {
+    val underTest = new PeerFilter(Seq("10.45.67.0-255"), Seq.empty)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.89")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.0")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.255")), false)
+
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.68.89")), true)
+  }
+
+  test("HotPeers filter IP based on complex usage") {
+    val underTest = new PeerFilter(Seq("10.*.65-67.0/24"), Seq.empty)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.67.1")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.0.65.80")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.255.66.200")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.64.255")), true)
+
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.45.65.0")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.0.65.80")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.0.65.200")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("10.0.68.255")), true)
+
+    assertEquals(underTest.remotePeerIsAcceptable(ipToPeer("34.45.68.89")), true)
+  }
+
+  private def stringToHostId(id:     String) = HostId(ByteString.copyFrom(id.getBytes))
+  private def stringToRemotePeer(id: String) = RemotePeer(stringToHostId(id), RemoteAddress("", 0))
+
+  test("HotPeers filter peerId") {
+    val underTest = new PeerFilter(Seq.empty, Seq(stringToHostId("first"), stringToHostId("second")))
+    assertEquals(underTest.remotePeerIsAcceptable(stringToRemotePeer("first")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(stringToRemotePeer("not-first")), true)
+    assertEquals(underTest.remotePeerIsAcceptable(stringToRemotePeer("second")), false)
+    assertEquals(underTest.remotePeerIsAcceptable(stringToRemotePeer("not-second")), true)
+  }
+}

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -41,7 +41,7 @@ bifrost {
       // In that case next addresses will be filtered: 10.45.67.0, 10.0.65.80, 10.255.66.200.
       // Next address is not filtered: 10.45.64.255
       // Could be used if current node serves as proxy, and we don`t want to expose any node behind proxy
-      do-not-expose-ips = ["127.0.0.0/8"]
+      do-not-expose-ips = ["127.0.0.0/8", "127.*.*.*"]
     }
   }
   // Settings for RPC/gRPC

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -6,7 +6,7 @@ bifrost {
     directory = "/tmp/bifrost/data/{genesisBlockId}"
     // The data storage engine to use for node operations
     // Options: `levelDb-jni` and `levelDb-java`
-    // Note: if `levelDb-jni` is selected but can't be loaded, it will fallback to levelDb-java
+    // Note: if `levelDb-jni` is selected but can`t be loaded, it will fallback to levelDb-java
     // Note: `levelDb-jni` is much faster but may not work on all systems
     database-type = "levelDb-jni"
   }
@@ -34,6 +34,14 @@ bifrost {
     // Additional network properties
     network-properties {
       ping-pong-interval = 300 seconds
+      // If remote peer have ip address in that list then that peer will not be exposed to other peers
+      // Examples of supported ip addresses description:
+      // 10.*.65-67.0/24 (first octet is "10", second octet is any, third octet in range 65-67, subnet mask is 24)
+      // If subnet mask is used then first address in subnet shall be set, otherwise subnet mask will not be applied
+      // In that case next addresses will be filtered: 10.45.67.0, 10.0.65.80, 10.255.66.200.
+      // Next address is not filtered: 10.45.64.255
+      // Could be used if current node serves as proxy, and we don`t want to expose any node behind proxy
+      do-not-expose-ips = ["127.0.0.0/8"]
     }
   }
   // Settings for RPC/gRPC
@@ -131,7 +139,7 @@ bifrost {
     // How frequently should the NTP server be called
     refresh-interval = 30 minutes
     // How long to wait for a response from the NTP server
-    // (If the NTP server takes a long time to respond, the result isn't particularly useful)
+    // (If the NTP server takes a long time to respond, the result isn`t particularly useful)
     timeout = 1 second
   }
   version-info {
@@ -147,7 +155,7 @@ genus {
   // The _base_ directory in which genus_db data is stored
   // optionally if OrientDB Studio was previously installed required, the genus_db storage should be a child of ¨database¨ folder
   // Example = "../../orientdb-community-3.2.18/databases/genus_db"
-  // If an empty string is provided, the node's data directory will be used
+  // If an empty string is provided, the node`s data directory will be used
   orient-db-directory = ""
 
   // see https://orientdb.com/docs/last/security/OrientDB-Security-Guide.html

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -124,6 +124,8 @@ object Dependencies {
     "co.topl" %% "protobuf-fs2" % protobufSpecsVersion
   )
 
+  val ipaddress = "com.github.seancfoley" % "ipaddress" % "5.5.0"
+
   // For NTP-UDP
   val commonsNet = "commons-net" % "commons-net" % "3.10.0"
 
@@ -212,7 +214,7 @@ object Dependencies {
     Dependencies.mUnitTest ++ Dependencies.catsEffect
 
   lazy val networking: Seq[ModuleID] =
-    Dependencies.mUnitTest ++ Dependencies.catsEffect
+    Dependencies.mUnitTest ++ Dependencies.catsEffect ++ Seq(ipaddress)
 
   lazy val transactionGenerator: Seq[ModuleID] =
     Dependencies.mUnitTest ++ Dependencies.catsEffect ++ Seq(Dependencies.fs2Core)


### PR DESCRIPTION
## Purpose
BN-1331 Added option to not expose remote peers to other nodes by id / ip(s)

## Approach
Added special class which filter out remote peers before updating the current hot peers list

## Testing
Unit tests

## Tickets
BN-1331