### PR TITLE
[BN-1479]: Fix High Cardinality Labels for Bifrost Metrics

### DIFF
--- a/consensus/src/main/scala/co/topl/consensus/interpreters/LocalChain.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/LocalChain.scala
@@ -13,7 +13,6 @@ import fs2.concurrent.Topic
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.typelevel.log4cats._
 import co.topl.algebras.Stats
-import io.circe.syntax._
 
 object LocalChain {
 
@@ -46,8 +45,8 @@ object LocalChain {
             Stats[F].recordGauge(
               "bifrost_block_adoptions",
               "Block adoptions",
-              Map("block_id" -> (show"${slotData.slotId.blockId}").asJson),
-              slotData.height.asJson
+              Map(),
+              slotData.height
             ) >>
             EitherT(adoptionsTopic.publish1(slotData.slotId.blockId))
               .leftMap(_ => new IllegalStateException("LocalChain topic unexpectedly closed"))

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/LocalChain.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/LocalChain.scala
@@ -43,10 +43,16 @@ object LocalChain {
             onAdopted(slotData.slotId.blockId) >>
             headRef.set(slotData) >>
             Stats[F].recordGauge(
-              "bifrost_block_adoptions",
+              "bifrost_block_adoptions_height",
               "Block adoptions",
               Map(),
               slotData.height
+            ) >>
+            Stats[F].recordGauge(
+              "bifrost_block_adoptions_slot",
+              "Block adoptions",
+              Map(),
+              slotData.slotId.slot
             ) >>
             EitherT(adoptionsTopic.publish1(slotData.slotId.blockId))
               .leftMap(_ => new IllegalStateException("LocalChain topic unexpectedly closed"))

--- a/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
@@ -139,7 +139,7 @@ object BlockProducer {
             Stats[F].recordHistogram(
               "bifrost_blocks_minted",
               "Blocks minted",
-              Map("block_id" -> show"${block.header}}"),
+              Map(),
               block.header.height
             )
           )

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -176,7 +176,7 @@ kamon {
   environment.service = "bifrost"
 
   trace.join-remote-parents-with-same-span-id = yes
-  metric.tick-interval = 5 seconds
+  metric.tick-interval = 30 seconds
 
   modules {
     process-metrics.enabled = no


### PR DESCRIPTION
## Purpose
Storing the `block_id` as a label for our Prometheus metrics causes huge memory increases due to high cardinality. (from less than 1GB to  over 10GB).

We are just using the value from the gauge to calculate the block height, so this is not currently needed.

## Approach
* Remove `block_id` labels.
* Standardize metric tick-interval to be 30 seconds (default for Prometheus).
* Remove unnecessary `asJson` (we have an implicit for this).

## Testing
Tested on local Prometheus stack. Observed graphs still worked normally.

## Tickets
* BN-1476