### PR TITLE
Regtest Mode

### DIFF
--- a/blockchain-core/src/main/scala/co/topl/blockchain/interpreters/RegtestRpcServer.scala
+++ b/blockchain-core/src/main/scala/co/topl/blockchain/interpreters/RegtestRpcServer.scala
@@ -1,0 +1,22 @@
+package co.topl.blockchain.interpreters
+
+import cats.implicits._
+import cats.effect.{Async, Resource, Sync}
+import co.topl.node.services._
+import io.grpc.{Metadata, ServerServiceDefinition}
+
+/**
+ * Serves the RPC(s) needed to operate the node in "regtest" mode
+ */
+object RegtestRpcServer {
+
+  def service[F[_]: Async](instructMakeBlock: F[Unit]): Resource[F, ServerServiceDefinition] =
+    RegtestRpcFs2Grpc.bindServiceResource(
+      new RegtestRpcFs2Grpc[F, Metadata] {
+
+        override def makeBlocks(request: MakeBlocksReq, ctx: Metadata): F[MakeBlocksRes] =
+          Sync[F].defer(instructMakeBlock.replicateA(request.quantity)).as(MakeBlocksRes())
+      }
+    )
+
+}

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -140,7 +140,8 @@ object ApplicationConfig {
         timestamp:        Long = System.currentTimeMillis() + 5_000L,
         stakerCount:      Int,
         stakes:           Option[List[BigInt]],
-        localStakerIndex: Option[Int]
+        localStakerIndex: Option[Int],
+        regtestEnabled:   Boolean = false
       ) extends BigBang
 
       @Lenses

--- a/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
@@ -115,7 +115,8 @@ class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with 
               staker,
               clock,
               blockPacker,
-              rewardCalculator
+              rewardCalculator,
+              ().pure[F]
             )
             resultFiber <- Async[F].start(Stream.force(underTest.blocks).enqueueNoneTerminated(results).compile.drain)
             _ = (clock.delayedUntilSlot(_)).expects(vrfHit.slot).once().returning(clockDeferment.get)

--- a/node/src/main/scala/co/topl/node/ApplicationConfigOps.scala
+++ b/node/src/main/scala/co/topl/node/ApplicationConfigOps.scala
@@ -70,7 +70,8 @@ object ApplicationConfigOps {
     if (
       cmdArgs.runtime.testnetArgs.testnetTimestamp.nonEmpty ||
       cmdArgs.runtime.testnetArgs.testnetStakerCount.nonEmpty ||
-      cmdArgs.runtime.testnetArgs.testnetStakerIndex.nonEmpty
+      cmdArgs.runtime.testnetArgs.testnetStakerIndex.nonEmpty ||
+      cmdArgs.runtime.testnetArgs.regtest.value
     ) {
       val bigBangConfig =
         simpleArgApplications.bifrost.bigBang match {
@@ -78,7 +79,8 @@ object ApplicationConfigOps {
             p.copy(
               timestamp = cmdArgs.runtime.testnetArgs.testnetTimestamp.getOrElse(p.timestamp),
               stakerCount = cmdArgs.runtime.testnetArgs.testnetStakerCount.getOrElse(p.stakerCount),
-              localStakerIndex = cmdArgs.runtime.testnetArgs.testnetStakerIndex.orElse(p.localStakerIndex)
+              localStakerIndex = cmdArgs.runtime.testnetArgs.testnetStakerIndex.orElse(p.localStakerIndex),
+              regtestEnabled = cmdArgs.runtime.testnetArgs.regtest.value
             )
           case p => p
         }

--- a/node/src/main/scala/co/topl/node/Args.scala
+++ b/node/src/main/scala/co/topl/node/Args.scala
@@ -106,7 +106,11 @@ object Args {
     @arg(
       doc = "The index of the staker to launch."
     )
-    testnetStakerIndex: Option[Int] = None
+    testnetStakerIndex: Option[Int] = None,
+    @arg(
+      doc = "Enables a testing mode for the node."
+    )
+    regtest: Flag
   )
 
   @main @Lenses

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -608,7 +608,11 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
           appConfig.bifrost.rpc.bindPort,
           genusServices ::: healthServices,
           (p2pConfig.publicHost, p2pConfig.publicPort).mapN(KnownPeer),
-          p2pConfig.networkProperties
+          p2pConfig.networkProperties,
+          appConfig.bifrost.bigBang match {
+            case p: ApplicationConfig.Bifrost.BigBangs.Private => p.regtestEnabled
+            case _                                             => false
+          }
         )
         .parProduct(genusOpt.traverse(Replicator.background[F]).void)
         .parProduct(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val orientDbVersion = "3.2.29"
   val ioGrpcVersion = "1.62.2"
   val http4sVersion = "0.23.26"
-  val protobufSpecsVersion = "2.0.0-beta2" // scala-steward:off
+  val protobufSpecsVersion = "2.0.0-beta3" // scala-steward:off
   val bramblScVersion = "2.0.0-beta3+3-de74a6dd-SNAPSHOT" // scala-steward:off
 
   val catsSlf4j =


### PR DESCRIPTION
## Purpose
- Adds the ability to control the timing of block production via RPC
## Approach
- Use a queue to store "MakeBlock" commands
- Tap into the BlockProducer's "wait" period for its eligibility slot. Dequeue element to control delay.
- Add RPC server to enqueue MakeBlock commands 
## Testing
- Ran locally and observed block creation via RPC
## Tickets
- #BN-1477