### PR TITLE
Dependency Updates

### DIFF
--- a/byzantine-it/src/test/scala/co/topl/byzantine/ChainSelectionTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/ChainSelectionTest.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
  */
 class ChainSelectionTest extends IntegrationSuite {
 
-  override def munitTimeout: Duration = 12.minutes
+  override def munitIOTimeout: Duration = 12.minutes
 
   test("Disconnected nodes can forge independently and later sync up to a proper chain") {
     val bigBang = Instant.now().plusSeconds(30)

--- a/byzantine-it/src/test/scala/co/topl/byzantine/IntegrationSuite.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/IntegrationSuite.scala
@@ -12,6 +12,6 @@ trait IntegrationSuite extends CatsEffectSuite {
 
   implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromClass[F](this.getClass)
 
-  override def munitTimeout: Duration = 10.minutes
+  override def munitIOTimeout: Duration = 10.minutes
 
 }

--- a/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/MultiNodeTest.scala
@@ -36,7 +36,7 @@ import scala.concurrent.duration._
 class MultiNodeTest extends IntegrationSuite {
   import MultiNodeTest._
 
-  override def munitTimeout: Duration = 15.minutes
+  override def munitIOTimeout: Duration = 15.minutes
   // This many nodes will be launched for this test.  All but one of the nodes will be launched immediately as
   // genesis stakers.  The final node will be launched later in the test.
   // When running on GitHub Actions, only 3 nodes can run on one machine.

--- a/byzantine-it/src/test/scala/co/topl/byzantine/TransactionTest.scala
+++ b/byzantine-it/src/test/scala/co/topl/byzantine/TransactionTest.scala
@@ -24,7 +24,7 @@ class TransactionTest extends IntegrationSuite {
 
   type RpcClient = NodeRpc[F, Stream[F, *]]
 
-  override val munitTimeout: Duration = 3.minutes
+  override val munitIOTimeout: Duration = 3.minutes
 
   /**
    * Submits many transactions to a group of running node and verifies the transactions are confirmed

--- a/genus/src/test/scala/co/topl/genus/orientDb/GraphBlockUpdaterFixtureTest.scala
+++ b/genus/src/test/scala/co/topl/genus/orientDb/GraphBlockUpdaterFixtureTest.scala
@@ -33,7 +33,7 @@ class GraphBlockUpdaterFixtureTest
       .withMaxSize(3)
       .withMinSuccessfulTests(5)
 
-  override def munitTimeout: Duration =
+  override def munitIOTimeout: Duration =
     new FiniteDuration(10, TimeUnit.SECONDS)
 
   orientDbFixture.test("Insert and remove genesis block") { case (odbFactory, implicit0(oThread: OrientThread[F])) =>

--- a/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/BlockProducerSpec.scala
@@ -31,7 +31,7 @@ import co.topl.algebras.Stats.Implicits._
 class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   type F[A] = IO[A]
 
-  override val munitTimeout: FiniteDuration = 10.seconds
+  override val munitIOTimeout: FiniteDuration = 10.seconds
 
   override def scalaCheckTestParameters =
     super.scalaCheckTestParameters

--- a/minting/src/test/scala/co/topl/minting/interpreters/OperationalKeyMakerSpec.scala
+++ b/minting/src/test/scala/co/topl/minting/interpreters/OperationalKeyMakerSpec.scala
@@ -31,7 +31,7 @@ import scala.util.Random
 
 class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
-  override def munitTimeout: Duration = new FiniteDuration(2, TimeUnit.MINUTES)
+  override def munitIOTimeout: Duration = new FiniteDuration(2, TimeUnit.MINUTES)
 
   type F[A] = cats.effect.IO[A]
 

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainPeerServerSpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainPeerServerSpec.scala
@@ -37,7 +37,7 @@ class BlockchainPeerServerSpec extends CatsEffectSuite with ScalaCheckEffectSuit
   private val dummyRewardCalc: TransactionRewardCalculatorAlgebra = (_: IoTransaction) => RewardQuantities()
   private val dummyCostCalc: TransactionCostCalculator = (tx: IoTransaction) => tx.inputs.size
 
-  override val munitTimeout: FiniteDuration = 5.seconds
+  override val munitIOTimeout: FiniteDuration = 5.seconds
 
   test("serve slot data") {
     PropF.forAllF { slotData: SlotData =>

--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration._
 
 class NodeAppTest extends CatsEffectSuite {
 
-  override val munitTimeout: Duration = 3.minutes
+  override val munitIOTimeout: Duration = 3.minutes
 
   test("Two block-producing nodes that maintain consensus") {
     // Allow the nodes to produce/adopt blocks until reaching this height

--- a/node-it/src/test/scala/co/topl/node/NodeAppTransactionsTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTransactionsTest.scala
@@ -34,7 +34,7 @@ class NodeAppTransactionsTest extends CatsEffectSuite {
 
   type RpcClient = NodeRpc[F, Stream[F, *]]
 
-  override val munitTimeout: Duration = 3.minutes
+  override val munitIOTimeout: Duration = 3.minutes
 
   val maxMempoolSize = 1024 * 20
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,21 +2,21 @@ import sbt._
 
 object Dependencies {
 
-  val circeVersion = "0.14.6"
-  val kamonVersion = "2.7.1"
+  val circeVersion = "0.14.7"
+  val kamonVersion = "2.7.2"
   val simulacrumVersion = "1.0.1"
   val catsCoreVersion = "2.10.0"
   val catsEffectVersion = "3.5.4"
-  val fs2Version = "3.9.4"
-  val logback = "1.5.3"
+  val fs2Version = "3.10.2"
+  val logback = "1.5.6"
   val orientDbVersion = "3.2.29"
-  val ioGrpcVersion = "1.62.2"
+  val ioGrpcVersion = "1.64.0"
   val http4sVersion = "0.23.26"
-  val protobufSpecsVersion = "2.0.0-beta3" // scala-steward:off
-  val bramblScVersion = "2.0.0-beta3+3-de74a6dd-SNAPSHOT" // scala-steward:off
+  val protobufSpecsVersion = "2.0.0-beta3"
+  val bramblScVersion = "2.0.0-beta3+3-de74a6dd-SNAPSHOT"
 
   val catsSlf4j =
-    "org.typelevel" %% "log4cats-slf4j" % "2.6.0"
+    "org.typelevel" %% "log4cats-slf4j" % "2.7.0"
 
   val logging: Seq[ModuleID] = Seq(
     "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.5",
@@ -26,14 +26,14 @@ object Dependencies {
     catsSlf4j
   )
 
-  val scalamockBase = "org.scalamock" %% "scalamock" % "5.2.0"
+  val scalamockBase = "org.scalamock" %% "scalamock" % "6.0.0"
   val scalamock = scalamockBase        % Test
 
   private val mUnitTestBase: Seq[ModuleID] = Seq(
-    "org.scalameta" %% "munit"                   % "0.7.29",
-    "org.scalameta" %% "munit-scalacheck"        % "0.7.29",
-    "org.typelevel" %% "munit-cats-effect-3"     % "1.0.7",
-    "org.typelevel" %% "scalacheck-effect-munit" % "1.0.4",
+    "org.scalameta" %% "munit"                   % "1.0.0",
+    "org.scalameta" %% "munit-scalacheck"        % "1.0.0",
+    "org.typelevel" %% "munit-cats-effect"       % "2.0.0",
+    "org.typelevel" %% "scalacheck-effect-munit" % "2.0-9366e44",
     scalamockBase
   )
 
@@ -75,7 +75,7 @@ object Dependencies {
   )
 
   val externalCrypto: Seq[ModuleID] = Seq(
-    "org.bouncycastle" % "bcprov-jdk18on" % "1.77"
+    "org.bouncycastle" % "bcprov-jdk18on" % "1.78.1"
   )
 
   val levelDb: Seq[ModuleID] = Seq(
@@ -90,10 +90,10 @@ object Dependencies {
   )
 
   val mainargs = Seq(
-    "com.lihaoyi" %% "mainargs" % "0.6.2"
+    "com.lihaoyi" %% "mainargs" % "0.6.3"
   )
 
-  val fastparse = "com.lihaoyi" %% "fastparse" % "3.0.2"
+  val fastparse = "com.lihaoyi" %% "fastparse" % "3.1.0"
 
   val monocle: Seq[ModuleID] = Seq(
     "com.github.julien-truffaut" %% "monocle-core"  % "3.0.0-M6",
@@ -105,7 +105,7 @@ object Dependencies {
   val fs2ReactiveStreams = "co.fs2"        %% "fs2-reactive-streams" % fs2Version
   val pureConfig = "com.github.pureconfig" %% "pureconfig"           % "0.17.6"
   val circeYaml = "io.circe"               %% "circe-yaml"           % "1.15.0"
-  val kubernetes = "io.kubernetes"          % "client-java"          % "19.0.0"
+  val kubernetes = "io.kubernetes"          % "client-java"          % "20.0.1"
 
   val http4s = Seq(
     "org.http4s" %% "http4s-ember-client" % http4sVersion,
@@ -168,7 +168,7 @@ object Dependencies {
       fs2IO,
       pureConfig,
       kubernetes,
-      "com.google.cloud" % "google-cloud-storage" % "2.35.0"
+      "com.google.cloud" % "google-cloud-storage" % "2.36.1"
     )
 
   lazy val actor: Seq[sbt.ModuleID] = fs2All

--- a/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/interpreters/K8sSimulationController.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/co/topl/testnetsimulationorchestrator/interpreters/K8sSimulationController.scala
@@ -22,9 +22,7 @@ object K8sSimulationController {
       implicit0(logger: Logger[F]) <- Resource.eval(Slf4jLogger.fromName("Bifrost.K8sSimulationController"))
     } yield new SimulationController[F] {
 
-      def terminate: F[Unit] = withCallback[V1Status](
-        api.deleteNamespaceAsync(namespace, null, null, null, null, null, null, _)
-      ).void
+      def terminate: F[Unit] = withCallback[V1Status](api.deleteNamespace(namespace).executeAsync).void
 
       private def createDeferredCallback[T]: Resource[F, (ApiCallback[T], F[T])] =
         for {


### PR DESCRIPTION
## Purpose
- kubernetes SDK introduces a breaking change, which blocks scala-steward from continuing
## Approach
- Update kubernetes SDK usage to account for breaking change
- Update some other dependencies
## Testing
- `preparePR` locally
## Tickets
- #BN-1511