### PR TITLE
BN-1332 Considering transaction received for mempool for reputation for remote peer

### DIFF
--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -60,7 +60,11 @@ object ApplicationConfig {
       remotePeerNoveltyInExpectedBlocks:    Double = 2.0,
       minimumBlockProvidingReputationPeers: Int = 2,
       minimumPerformanceReputationPeers:    Int = 2,
-      minimumRequiredReputation:            Double = 0.66,
+      // every slot we update txMempoolReputation as
+      // newReputation = (currentReputation * (txImpactValue - 1) + txMempoolReputationForLastSlot) / txImpactValue
+      txImpactRatio:                   Int = 1000,
+      minimumTxMempoolReputationPeers: Int = 2,
+      minimumRequiredReputation:       Double = 0.66,
       // any non-new peer require that reputation to be hot
       minimumBlockProvidingReputation: Double = 0.15,
       minimumEligibleColdConnections:  Int = 50,

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/NetworkAlgebra.scala
@@ -116,7 +116,8 @@ trait NetworkAlgebra[F[_]] {
     transactionSyntaxValidation: TransactionSyntaxVerifier[F],
     transactionStore:            Store[F, TransactionId, IoTransaction],
     mempool:                     MempoolAlgebra[F],
-    peersManager:                PeersManagerActor[F]
+    peersManager:                PeersManagerActor[F],
+    localChainAlgebra:           LocalChainAlgebra[F]
   ): Resource[F, PeerMempoolTransactionSyncActor[F]]
 }
 
@@ -291,7 +292,8 @@ class NetworkAlgebraImpl[F[_]: Async: Parallel: Logger: DnsResolver: ReverseDnsR
     transactionSyntaxValidation: TransactionSyntaxVerifier[F],
     transactionStore:            Store[F, TransactionId, IoTransaction],
     mempool:                     MempoolAlgebra[F],
-    peersManager:                PeersManagerActor[F]
+    peersManager:                PeersManagerActor[F],
+    localChainAlgebra:           LocalChainAlgebra[F]
   ): Resource[F, PeerMempoolTransactionSyncActor[F]] =
     PeerMempoolTransactionSync.makeActor(
       hostId,
@@ -299,6 +301,7 @@ class NetworkAlgebraImpl[F[_]: Async: Parallel: Logger: DnsResolver: ReverseDnsR
       transactionSyntaxValidation,
       transactionStore,
       mempool,
-      peersManager
+      peersManager,
+      localChainAlgebra
     )
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersHandler.scala
@@ -61,7 +61,7 @@ case class PeersHandler[F[_]: Async: Logger](
   def getRemotePeers: Set[KnownRemotePeer] =
     peers
       .filterNot(_._2.state == PeerState.Banned)
-      .collect { case (_, Peer(_, _, _, Some(server), _, _, blockProvidingRep, performanceRep, _, lastOpen)) =>
+      .collect { case (_, Peer(_, _, _, Some(server), _, _, blockProvidingRep, performanceRep, _, _, lastOpen)) =>
         KnownRemotePeer(server.peerId, server.address, blockProvidingRep, performanceRep, lastOpen)
       }
       .toSet
@@ -86,7 +86,6 @@ case class PeersHandler[F[_]: Async: Logger](
             _                       <- Logger[F].info(show"Move $host from ${oldPeer.state} to ${newPeer.state}")
           } yield host -> newPeer
         }
-
     updateF.map(update => this.copy(peers = peers ++ update))
   }
 
@@ -109,7 +108,7 @@ case class PeersHandler[F[_]: Async: Logger](
 
   private def updateReputation(oldPeer: Peer[F], newPeer: Peer[F]): Peer[F] =
     if (oldPeer.state.isActive && !newPeer.state.isActive) {
-      newPeer.copy(perfRep = 0.0, blockRep = 0.0, newRep = 0)
+      newPeer.copy(perfRep = 0.0, blockRep = 0.0, newRep = 0, mempoolTxRep = 0)
     } else if (!oldPeer.state.applicationLevel && newPeer.state.applicationLevel) {
       newPeer.copy(newRep = networkConfig.remotePeerNoveltyInSlots)
     } else { newPeer }
@@ -168,6 +167,7 @@ case class PeersHandler[F[_]: Async: Logger](
             0,
             0,
             0,
+            0,
             openTimestamp.some
           )
         case Some(peer) =>
@@ -197,6 +197,7 @@ case class PeersHandler[F[_]: Async: Logger](
               initialBlockReputation,
               initialPerfReputation,
               0,
+              0,
               timestamp
             )
           case Some(peer) => id -> peer.copy(asServer = RemotePeer(id, ra).some)
@@ -210,17 +211,19 @@ case class PeersHandler[F[_]: Async: Logger](
     peersToChange.flatMap(id => peers.get(id).map(peer => id -> peer))
 
   def copyWithUpdatedReputation(
-    perfRepMap:    Map[HostId, HostReputationValue] = Map.empty,
-    blockRepMap:   Map[HostId, HostReputationValue] = Map.empty,
-    noveltyRepMap: Map[HostId, Long] = Map.empty
+    perfRepMap:      Map[HostId, HostReputationValue] = Map.empty,
+    blockRepMap:     Map[HostId, HostReputationValue] = Map.empty,
+    noveltyRepMap:   Map[HostId, Long] = Map.empty,
+    mempoolTxRepMap: Map[HostId, Double] = Map.empty
   ): PeersHandler[F] = {
-    val toUpdate = perfRepMap.keySet ++ blockRepMap.keySet ++ noveltyRepMap.keySet
+    val toUpdate = perfRepMap.keySet ++ blockRepMap.keySet ++ noveltyRepMap.keySet ++ mempoolTxRepMap.keySet
     val newPeers =
       getAffectedPeers(toUpdate).map { case (id, peer) =>
         val perfRep = perfRepMap.getOrElse(id, peer.perfRep)
         val blockRep = blockRepMap.getOrElse(id, peer.blockRep)
         val newRep = noveltyRepMap.getOrElse(id, peer.newRep)
-        id -> peer.copy(perfRep = perfRep, blockRep = blockRep, newRep = newRep)
+        val mempoolTxRep = mempoolTxRepMap.getOrElse(id, peer.mempoolTxRep)
+        id -> peer.copy(perfRep = perfRep, blockRep = blockRep, newRep = newRep, mempoolTxRep = mempoolTxRep)
       }.toMap
 
     this.copy(peers = peers ++ newPeers)
@@ -282,6 +285,7 @@ case class Peer[F[_]: Logger](
   blockRep:                  HostReputationValue,
   perfRep:                   HostReputationValue,
   newRep:                    Long,
+  mempoolTxRep:              Double,
   activeConnectionTimestamp: Option[Long]
 ) {
   def couldOpenConnection: Boolean = asServer.isDefined || actorOpt.isDefined

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
@@ -138,7 +138,8 @@ object ActorPeerHandlerBridgeAlgebraTest {
 
     override def remove(transactionId: TransactionId): F[Unit] = transactions.update(_ - transactionId)
 
-    override def contains(blockId: BlockId, transactionId: TransactionId): F[Boolean] = ???
+    override def contains(blockId: BlockId, transactionId: TransactionId): F[Boolean] =
+      transactions.get.map(_.contains(transactionId))
 
     def contains(transactionId: TransactionId): F[Boolean] = transactions.get.map(_.contains(transactionId))
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerMempoolTransactionSyncTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerMempoolTransactionSyncTest.scala
@@ -3,6 +3,7 @@ package co.topl.networking.fsnetwork
 import cats.data.NonEmptyChain
 import cats.{Applicative, MonadThrow}
 import cats.effect.IO
+import cats.effect.Sync
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalamock.munit.AsyncMockFactory
 import cats.implicits._
@@ -14,8 +15,11 @@ import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
 import co.topl.brambl.validation.TransactionSyntaxError
 import co.topl.brambl.validation.TransactionSyntaxError.EmptyInputs
 import co.topl.brambl.validation.algebras.TransactionSyntaxVerifier
+import co.topl.consensus.algebras.LocalChainAlgebra
+import co.topl.consensus.models.SlotData
 import co.topl.ledger.algebras.MempoolAlgebra
 import co.topl.models.ModelGenerators.GenHelper
+import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.models.p2p._
 import co.topl.networking.blockchain.BlockchainPeerClient
 import co.topl.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError
@@ -25,6 +29,9 @@ import co.topl.networking.fsnetwork.TestHelper.{arbitraryHost, BlockBodyOrTransa
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import fs2.Stream
+
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.duration._
 
 object PeerMempoolTransactionSyncTest {
   type F[A] = IO[A]
@@ -44,21 +51,26 @@ class PeerMempoolTransactionSyncTest extends CatsEffectSuite with ScalaCheckEffe
   implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName[F](this.getClass.getName)
 
   val hostId: HostId = arbitraryHost.arbitrary.first
+  val headBlock: SlotData = arbitrarySlotData.arbitrary.first
 
   test("Transaction notification shall be started and missed transaction shall be requested") {
     withMock {
       val client = mock[BlockchainPeerClient[F]]
       val transactionSyntaxValidation = mock[TransactionSyntaxVerifier[F]]
       val mempool = mock[MempoolAlgebra[F]]
+      (mempool.contains _).expects(headBlock.slotId.blockId, *).anyNumberOfTimes().returns(false.pure[F])
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val peersManager = mock[PeersManagerActor[F]]
+      val localChain = mock[LocalChainAlgebra[F]]
+      (localChain.head _).expects().anyNumberOfTimes().returns(headBlock.pure[F])
 
       val totalTransactions = 10
       val transactions = Seq.fill(totalTransactions)(arbitraryIoTransaction.arbitrary.first).map(_.embedId)
-      val (missedTransaction, transactionInStore) = transactions.splitAt(totalTransactions / 2)
+      val (missedTransaction, transactionInStore) = transactions.splitAt(totalTransactions / 2 + 1)
 
+      val txSentFlag: AtomicBoolean = new AtomicBoolean(false)
       (() => client.remoteTransactionNotifications).expects().once().onCall { () =>
-        Stream.emits(transactions.map(_.id)).covary[F].pure[F]
+        Stream.emits(transactions.map(_.id)).covary[F].pure[F] <* Sync[F].delay(txSentFlag.set(true))
       }
 
       val missedMap = missedTransaction.map(tx => tx.id -> tx).toMap
@@ -81,11 +93,82 @@ class PeerMempoolTransactionSyncTest extends CatsEffectSuite with ScalaCheckEffe
         (transactionStore.contains _).expects(tx.id).once().returns(true.pure[F])
       }
 
+      (peersManager.sendNoWait _)
+        .expects(PeersManager.Message.ReceivedTransactionsCount(hostId, missedTransaction.size))
+        .returns(Applicative[F].unit)
+
+      val timeout = FiniteDuration(1000, MILLISECONDS)
+
       PeerMempoolTransactionSync
-        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager)
+        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager, localChain)
         .use { actor =>
           for {
             state <- actor.send(PeerMempoolTransactionSync.Message.StartActor)
+            _     <- Sync[F].untilM_(Sync[F].sleep(timeout))(Sync[F].delay(txSentFlag.get()))
+            state <- actor.send(PeerMempoolTransactionSync.Message.CollectTransactionsRep)
+            _     <- state.fetchingFiber.get.join
+          } yield ()
+        }
+    }
+  }
+
+  test("Transaction notification shall be started and missed transaction shall be requested") {
+    withMock {
+      val client = mock[BlockchainPeerClient[F]]
+      val transactionSyntaxValidation = mock[TransactionSyntaxVerifier[F]]
+      val mempool = mock[MempoolAlgebra[F]]
+
+      val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
+      val peersManager = mock[PeersManagerActor[F]]
+      val localChain = mock[LocalChainAlgebra[F]]
+      (localChain.head _).expects().anyNumberOfTimes().returns(headBlock.pure[F])
+
+      val totalTransactions = 10
+      val transactions = Seq.fill(totalTransactions)(arbitraryIoTransaction.arbitrary.first).map(_.embedId)
+      val (missedTransaction, transactionInMempool) = transactions.splitAt(totalTransactions / 2 + 1)
+
+      val txSentFlag: AtomicBoolean = new AtomicBoolean(false)
+      (() => client.remoteTransactionNotifications).expects().once().onCall { () =>
+        Stream.emits(transactions.map(_.id)).covary[F].pure[F] <* Sync[F].delay(txSentFlag.set(true))
+      }
+
+      val missedMap = missedTransaction.map(tx => tx.id -> tx).toMap
+      missedTransaction.map { tx =>
+        (transactionStore.contains _).expects(tx.id).once().returns(false.pure[F])
+        (client
+          .getRemoteTransactionOrError(_: TransactionId, _: BlockBodyOrTransactionError)(_: MonadThrow[F]))
+          .expects(*, *, *)
+          .once()
+          .onCall {
+            case (id: TransactionId, _: BlockBodyOrTransactionErrorByName @unchecked, _: MonadThrow[F] @unchecked) =>
+              missedMap(id).pure[F]
+          }
+        (transactionSyntaxValidation.validate _).expects(tx).once().returns(Either.right(tx).pure[F])
+        (transactionStore.put _).expects(tx.id, tx).once().returns(Applicative[F].unit)
+        (mempool.add _).expects(tx.id).once().returns(true.pure[F])
+      }
+
+      (transactionStore.contains _).expects(*).anyNumberOfTimes().returns(false.pure[F])
+      transactionInMempool.map { tx =>
+        (mempool.contains _).expects(headBlock.slotId.blockId, tx.id).once.returns(true.pure[F])
+      }
+      missedTransaction.map { tx =>
+        (mempool.contains _).expects(headBlock.slotId.blockId, tx.id).once.returns(false.pure[F])
+      }
+
+      (peersManager.sendNoWait _)
+        .expects(PeersManager.Message.ReceivedTransactionsCount(hostId, missedTransaction.size))
+        .returns(Applicative[F].unit)
+
+      val timeout = FiniteDuration(1000, MILLISECONDS)
+
+      PeerMempoolTransactionSync
+        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager, localChain)
+        .use { actor =>
+          for {
+            state <- actor.send(PeerMempoolTransactionSync.Message.StartActor)
+            _     <- Sync[F].untilM_(Sync[F].sleep(timeout))(Sync[F].delay(txSentFlag.get()))
+            state <- actor.send(PeerMempoolTransactionSync.Message.CollectTransactionsRep)
             _     <- state.fetchingFiber.get.join
           } yield ()
         }
@@ -99,6 +182,9 @@ class PeerMempoolTransactionSyncTest extends CatsEffectSuite with ScalaCheckEffe
       val mempool = mock[MempoolAlgebra[F]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val peersManager = mock[PeersManagerActor[F]]
+      val localChain = mock[LocalChainAlgebra[F]]
+      (localChain.head _).expects().anyNumberOfTimes().returns(headBlock.pure[F])
+      (mempool.contains _).expects(headBlock.slotId.blockId, *).anyNumberOfTimes().returns(false.pure[F])
 
       val totalTransactions = 1
       val transactions = Seq.fill(totalTransactions)(arbitraryIoTransaction.arbitrary.first).map(_.embedId)
@@ -132,7 +218,7 @@ class PeerMempoolTransactionSyncTest extends CatsEffectSuite with ScalaCheckEffe
       }
 
       PeerMempoolTransactionSync
-        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager)
+        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager, localChain)
         .use { actor =>
           for {
             state <- actor.send(PeerMempoolTransactionSync.Message.StartActor)
@@ -149,6 +235,9 @@ class PeerMempoolTransactionSyncTest extends CatsEffectSuite with ScalaCheckEffe
       val mempool = mock[MempoolAlgebra[F]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val peersManager = mock[PeersManagerActor[F]]
+      val localChain = mock[LocalChainAlgebra[F]]
+      (localChain.head _).expects().anyNumberOfTimes().returns(headBlock.pure[F])
+      (mempool.contains _).expects(headBlock.slotId.blockId, *).anyNumberOfTimes().returns(false.pure[F])
 
       val totalTransactions = 1
       val transactions = Seq.fill(totalTransactions)(arbitraryIoTransaction.arbitrary.first).map(_.embedId)
@@ -177,7 +266,7 @@ class PeerMempoolTransactionSyncTest extends CatsEffectSuite with ScalaCheckEffe
       }
 
       PeerMempoolTransactionSync
-        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager)
+        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager, localChain)
         .use { actor =>
           for {
             state <- actor.send(PeerMempoolTransactionSync.Message.StartActor)
@@ -194,6 +283,9 @@ class PeerMempoolTransactionSyncTest extends CatsEffectSuite with ScalaCheckEffe
       val mempool = mock[MempoolAlgebra[F]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val peersManager = mock[PeersManagerActor[F]]
+      val localChain = mock[LocalChainAlgebra[F]]
+      (localChain.head _).expects().anyNumberOfTimes().returns(headBlock.pure[F])
+      (mempool.contains _).expects(headBlock.slotId.blockId, *).anyNumberOfTimes().returns(false.pure[F])
 
       val totalTransactions = 10
       val transactions = Seq.fill(totalTransactions)(arbitraryIoTransaction.arbitrary.first).map(_.embedId)
@@ -227,7 +319,7 @@ class PeerMempoolTransactionSyncTest extends CatsEffectSuite with ScalaCheckEffe
       }
 
       PeerMempoolTransactionSync
-        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager)
+        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager, localChain)
         .use { actor =>
           for {
             state <- actor.send(PeerMempoolTransactionSync.Message.StartActor)
@@ -244,13 +336,16 @@ class PeerMempoolTransactionSyncTest extends CatsEffectSuite with ScalaCheckEffe
       val mempool = mock[MempoolAlgebra[F]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val peersManager = mock[PeersManagerActor[F]]
+      val localChain = mock[LocalChainAlgebra[F]]
+      (localChain.head _).expects().anyNumberOfTimes().returns(headBlock.pure[F])
+      (mempool.contains _).expects(headBlock.slotId.blockId, *).anyNumberOfTimes().returns(false.pure[F])
 
       (() => client.remoteTransactionNotifications).expects().once().onCall { () =>
         Stream.fromOption[F](Option.empty[TransactionId]).pure[F]
       }
 
       PeerMempoolTransactionSync
-        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager)
+        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager, localChain)
         .use { actor =>
           for {
             state1 <- actor.send(PeerMempoolTransactionSync.Message.StartActor)
@@ -271,13 +366,16 @@ class PeerMempoolTransactionSyncTest extends CatsEffectSuite with ScalaCheckEffe
       val mempool = mock[MempoolAlgebra[F]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
       val peersManager = mock[PeersManagerActor[F]]
+      val localChain = mock[LocalChainAlgebra[F]]
+      (localChain.head _).expects().anyNumberOfTimes().returns(headBlock.pure[F])
+      (mempool.contains _).expects(headBlock.slotId.blockId, *).anyNumberOfTimes().returns(false.pure[F])
 
       (() => client.remoteTransactionNotifications).expects().once().onCall { () =>
         Stream.fromOption[F](Option.empty[TransactionId]).pure[F]
       }
 
       PeerMempoolTransactionSync
-        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager)
+        .makeActor(hostId, client, transactionSyntaxValidation, transactionStore, mempool, peersManager, localChain)
         .use { actor =>
           for {
             state1 <- actor.send(PeerMempoolTransactionSync.Message.StartActor)


### PR DESCRIPTION
## Purpose
Remote peer could be a good provider for mempool transactions but provide no blocks for some reason. We could be interested in such remote nodes as well. Separate transaction reputation had been added to keep such remote peers 


## Approach
Save the number of received transactions per slot and send them to PeerManager to update the reputation of remote peer transactions. Use that reputation for saving hot peers.

## Testing
Unit test + integration tests


## Tickets
BN-1332