### PR TITLE
BN-1505 Stop trust of SlotData from remote peer P1

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -127,7 +127,8 @@ class BlockchainImpl[F[_]: Async: Random: Dns: Stats](
           initialPeers,
           peersStatusChangesTopic,
           remotePeers.offer,
-          currentPeers.set
+          currentPeers.set,
+          p2pBlockchain.cryptoResources.ed25519VRF
         )
         .onFinalize(Logger[F].info("P2P Actor system had been shutdown"))
       _ <- Logger[F].info(s"Exposing server on: ${peerAsServer.fold("")(_.toString)}").toResource

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -22,6 +22,7 @@ import co.topl.typeclasses.implicits._
 import co.topl.node.models.KnownHost
 import co.topl.networking.fsnetwork.P2PShowInstances._
 import co.topl.algebras.Stats
+import co.topl.crypto.signing.Ed25519VRF
 
 object ActorPeerHandlerBridgeAlgebra {
 
@@ -33,7 +34,8 @@ object ActorPeerHandlerBridgeAlgebra {
     remotePeers:             Seq[DisconnectedPeer],
     peersStatusChangesTopic: Topic[F, PeerConnectionChange],
     addRemotePeer:           DisconnectedPeer => F[Unit],
-    hotPeersUpdate:          Set[RemotePeer] => F[Unit]
+    hotPeersUpdate:          Set[RemotePeer] => F[Unit],
+    ed25519VRF:              Resource[F, Ed25519VRF]
   ): Resource[F, BlockchainPeerHandlerAlgebra[F]] = {
     implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName("Bifrost.P2P")
 
@@ -47,7 +49,8 @@ object ActorPeerHandlerBridgeAlgebra {
         networkProperties,
         PeerCreationRequestAlgebra(addRemotePeer),
         peersStatusChangesTopic,
-        hotPeersUpdate
+        hotPeersUpdate,
+        ed25519VRF
       )
 
     networkManager.map(pm => makeAlgebra(pm))

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/BlockApplyError.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/BlockApplyError.scala
@@ -5,6 +5,7 @@ import cats.data.NonEmptyChain
 import co.topl.consensus.models.{BlockHeaderValidationFailure, BlockId}
 import co.topl.ledger.models.BodyValidationError
 import co.topl.models.p2p._
+import org.apache.commons.lang3.exception.ExceptionUtils
 
 sealed abstract class BlockApplyError extends Exception
 
@@ -19,7 +20,8 @@ object BlockApplyError {
     case class UnknownError(ex: Throwable) extends HeaderApplyException {
       this.initCause(ex)
 
-      override def toString: String = show"Unknown error during applying block header due next throwable ${ex.toString}"
+      override def toString: String =
+        show"Error applying block header due next throwable ${ex.toString} ${ExceptionUtils.getStackTrace(ex)}"
     }
   }
 
@@ -34,7 +36,7 @@ object BlockApplyError {
       this.initCause(ex)
 
       override def toString: String =
-        show"Unknown error during applying block body due next throwable ${ex.toString}"
+        show"Error applying block body due next throwable ${ex.toString} ${ExceptionUtils.getStackTrace(ex)}"
     }
   }
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeerActor.scala
@@ -11,7 +11,6 @@ import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.validation.algebras.TransactionSyntaxVerifier
 import co.topl.consensus.algebras.{BlockHeaderToBodyValidationAlgebra, ChainSelectionAlgebra, LocalChainAlgebra}
 import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
-import co.topl.eventtree.ParentChildTree
 import co.topl.ledger.algebras.MempoolAlgebra
 import co.topl.models.p2p._
 import co.topl.networking.KnownHostOps
@@ -126,7 +125,6 @@ object PeerActor {
     slotDataStore:               Store[F, BlockId, SlotData],
     bodyStore:                   Store[F, BlockId, BlockBody],
     transactionStore:            Store[F, TransactionId, IoTransaction],
-    blockIdTree:                 ParentChildTree[F, BlockId],
     headerToBodyValidation:      BlockHeaderToBodyValidationAlgebra[F],
     transactionSyntaxValidation: TransactionSyntaxVerifier[F],
     mempool:                     MempoolAlgebra[F],
@@ -148,7 +146,6 @@ object PeerActor {
         chainSelection,
         slotDataStore,
         bodyStore,
-        blockIdTree,
         commonAncestorF
       )
       body <- networkAlgebra.makePeerBodyFetcher(

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/PeersManager.scala
@@ -852,7 +852,6 @@ object PeersManager {
             state.slotDataStore,
             state.bodyStore,
             state.transactionStore,
-            state.blockIdTree,
             state.headerToBodyValidation,
             state.transactionSyntaxValidation,
             state.mempool,

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
@@ -44,6 +44,7 @@ import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
 import co.topl.algebras.Stats.Implicits._
+import co.topl.crypto.signing.Ed25519VRF
 
 object ActorPeerHandlerBridgeAlgebraTest {
   type F[A] = IO[A]
@@ -295,7 +296,8 @@ class ActorPeerHandlerBridgeAlgebraTest extends CatsEffectSuite with ScalaCheckE
             remotePeers,
             topic,
             addRemotePeer,
-            hotPeersUpdate
+            hotPeersUpdate,
+            Resource.pure(Ed25519VRF.precomputed())
           )
       } yield (algebra, remotePeersStore, mempoolAlgebra)
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/BlockCheckerTest.scala
@@ -13,6 +13,7 @@ import co.topl.consensus.algebras._
 import co.topl.consensus.models.BlockHeaderValidationFailures.NonForwardSlot
 import co.topl.consensus.models._
 import co.topl.crypto.signing.Ed25519VRF
+import co.topl.eventtree.ParentChildTree
 import co.topl.ledger.algebras._
 import co.topl.ledger.models.BodySemanticErrors.TransactionSemanticErrors
 import co.topl.ledger.models.TransactionSemanticErrors.InputDataMismatch
@@ -34,8 +35,9 @@ import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-import scala.concurrent.duration._
+import cats.effect.Resource
 
+import scala.concurrent.duration._
 import scala.collection.mutable
 
 object BlockCheckerTest {
@@ -63,6 +65,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
 
           val slotDataStore = mock[Store[F, BlockId, SlotData]]
           val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val blockIdTree = mock[ParentChildTree[F, BlockId]]
           val bodyStore = mock[Store[F, BlockId, BlockBody]]
           val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
           val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -79,11 +82,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               slotDataStore,
               headerStore,
               bodyStore,
+              blockIdTree,
               headerValidation,
               bodySyntaxValidation,
               bodySemanticValidation,
               bodyAuthorizationValidation,
               chainSelectionAlgebra,
+              Resource.pure(ed255Vrf),
               defaultConfig
             )
             .use { actor =>
@@ -103,6 +108,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           val localChain = mock[LocalChainAlgebra[F]]
           val slotDataStore = mock[Store[F, BlockId, SlotData]]
           val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val blockIdTree = mock[ParentChildTree[F, BlockId]]
           val bodyStore = mock[Store[F, BlockId, BlockBody]]
           val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
           val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -151,11 +157,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               slotDataStore,
               headerStore,
               bodyStore,
+              blockIdTree,
               headerValidation,
               bodySyntaxValidation,
               bodySemanticValidation,
               bodyAuthorizationValidation,
               chainSelectionAlgebra,
+              Resource.pure(ed255Vrf),
               defaultConfig,
               Option(BestChain(NonEmptyChain.one(localSlotData)))
             )
@@ -177,6 +185,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           val localChain = mock[LocalChainAlgebra[F]]
           val slotDataStore = mock[Store[F, BlockId, SlotData]]
           val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val blockIdTree = mock[ParentChildTree[F, BlockId]]
           val bodyStore = mock[Store[F, BlockId, BlockBody]]
           val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
           val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -228,11 +237,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               slotDataStore,
               headerStore,
               bodyStore,
+              blockIdTree,
               headerValidation,
               bodySyntaxValidation,
               bodySemanticValidation,
               bodyAuthorizationValidation,
               chainSelectionAlgebra,
+              Resource.pure(ed255Vrf),
               defaultConfig,
               Option(BestChain(NonEmptyChain.one(remoteSlotData.head)))
             )
@@ -254,6 +265,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           val localChain = mock[LocalChainAlgebra[F]]
           val slotDataStore = mock[Store[F, BlockId, SlotData]]
           val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val blockIdTree = mock[ParentChildTree[F, BlockId]]
           val bodyStore = mock[Store[F, BlockId, BlockBody]]
           val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
           val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -305,11 +317,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               slotDataStore,
               headerStore,
               bodyStore,
+              blockIdTree,
               headerValidation,
               bodySyntaxValidation,
               bodySemanticValidation,
               bodyAuthorizationValidation,
               chainSelectionAlgebra,
+              Resource.pure(ed255Vrf),
               defaultConfig
             )
             .use { actor =>
@@ -330,6 +344,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           val localChain = mock[LocalChainAlgebra[F]]
           val slotDataStore = mock[Store[F, BlockId, SlotData]]
           val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val blockIdTree = mock[ParentChildTree[F, BlockId]]
           val bodyStore = mock[Store[F, BlockId, BlockBody]]
           val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
           val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -388,11 +403,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               slotDataStore,
               headerStore,
               bodyStore,
+              blockIdTree,
               headerValidation,
               bodySyntaxValidation,
               bodySemanticValidation,
               bodyAuthorizationValidation,
               chainSelectionAlgebra,
+              Resource.pure(ed255Vrf),
               defaultConfig,
               bestChain
             )
@@ -415,6 +432,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           val localChain = mock[LocalChainAlgebra[F]]
           val slotDataStore = mock[Store[F, BlockId, SlotData]]
           val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val blockIdTree = mock[ParentChildTree[F, BlockId]]
           val bodyStore = mock[Store[F, BlockId, BlockBody]]
           val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
           val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -464,11 +482,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               slotDataStore,
               headerStore,
               bodyStore,
+              blockIdTree,
               headerValidation,
               bodySyntaxValidation,
               bodySemanticValidation,
               bodyAuthorizationValidation,
               chainSelectionAlgebra,
+              Resource.pure(ed255Vrf),
               defaultConfig,
               Option(BestChain(currentBestChain))
             )
@@ -492,6 +512,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           val localChain = mock[LocalChainAlgebra[F]]
           val slotDataStore = mock[Store[F, BlockId, SlotData]]
           val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val blockIdTree = mock[ParentChildTree[F, BlockId]]
           val bodyStore = mock[Store[F, BlockId, BlockBody]]
           val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
           val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -522,11 +543,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               slotDataStore,
               headerStore,
               bodyStore,
+              blockIdTree,
               headerValidation,
               bodySyntaxValidation,
               bodySemanticValidation,
               bodyAuthorizationValidation,
               chainSelectionAlgebra,
+              Resource.pure(ed255Vrf),
               defaultConfig
             )
             .use { actor =>
@@ -546,6 +569,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           val localChain = mock[LocalChainAlgebra[F]]
           val slotDataStore = mock[Store[F, BlockId, SlotData]]
           val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val blockIdTree = mock[ParentChildTree[F, BlockId]]
           val bodyStore = mock[Store[F, BlockId, BlockBody]]
           val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
           val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -565,11 +589,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               slotDataStore,
               headerStore,
               bodyStore,
+              blockIdTree,
               headerValidation,
               bodySyntaxValidation,
               bodySemanticValidation,
               bodyAuthorizationValidation,
               chainSelectionAlgebra,
+              Resource.pure(ed255Vrf),
               defaultConfig
             )
             .use { actor =>
@@ -589,6 +615,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           val localChain = mock[LocalChainAlgebra[F]]
           val slotDataStore = mock[Store[F, BlockId, SlotData]]
           val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val blockIdTree = mock[ParentChildTree[F, BlockId]]
           val bodyStore = mock[Store[F, BlockId, BlockBody]]
           val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
           val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -622,6 +649,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               addedHeader.put(id, header)
               headerStoreData.put(id, header)
               ().pure[F]
+          }
+
+          newIdAndHeaders.foreach { case (id, header) =>
+            val parent = header.parentHeaderId
+            (blockIdTree.associate _).expects(id, parent).returns(().pure[F])
+            val slotData = header.slotData
+            (slotDataStore.put _).expects(id, slotData).returns(().pure[F])
           }
 
           (() => localChain.head).stubs().returning(knownSlotData.pure[F])
@@ -658,11 +692,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               slotDataStore,
               headerStore,
               bodyStore,
+              blockIdTree,
               headerValidation,
               bodySyntaxValidation,
               bodySemanticValidation,
               bodyAuthorizationValidation,
               chainSelectionAlgebra,
+              Resource.pure(ed255Vrf),
               defaultConfig
             )
             .use { actor =>
@@ -684,6 +720,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           val slotDataStore = mock[Store[F, BlockId, SlotData]]
           val headerStore = mock[Store[F, BlockId, BlockHeader]]
           val bodyStore = mock[Store[F, BlockId, BlockBody]]
+          val blockIdTree = mock[ParentChildTree[F, BlockId]]
           val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
           val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
           val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
@@ -735,11 +772,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               slotDataStore,
               headerStore,
               bodyStore,
+              blockIdTree,
               headerValidation,
               bodySyntaxValidation,
               bodySemanticValidation,
               bodyAuthorizationValidation,
               chainSelectionAlgebra,
+              Resource.pure(ed255Vrf),
               defaultConfig,
               Option(BestChain(bestChain)),
               Option(hostId)
@@ -762,6 +801,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           val localChain = mock[LocalChainAlgebra[F]]
           val slotDataStore = mock[Store[F, BlockId, SlotData]]
           val headerStore = mock[Store[F, BlockId, BlockHeader]]
+          val blockIdTree = mock[ParentChildTree[F, BlockId]]
           val bodyStore = mock[Store[F, BlockId, BlockBody]]
           val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
           val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -794,6 +834,19 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
             addedHeader.put(id, header)
             headerStoreData.put(id, header)
             ().pure[F]
+          }
+
+          newIdAndHeaders.headOption.foreach { case (id, header) =>
+            val parent = header.parentHeaderId
+            (blockIdTree.associate _).expects(id, parent).returns(().pure[F])
+
+            val slotData = header.slotData
+            (slotDataStore.put _).expects(id, slotData).returns(().pure[F])
+          }
+
+          newIdAndHeaders.get(1).foreach { case (id, header) =>
+            val parent = header.parentHeaderId
+            (blockIdTree.associate _).expects(id, parent).returns(().pure[F])
           }
 
           (() => localChain.head).stubs().returning(knownSlotData.pure[F])
@@ -859,11 +912,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               slotDataStore,
               headerStore,
               bodyStore,
+              blockIdTree,
               headerValidation,
               bodySyntaxValidation,
               bodySemanticValidation,
               bodyAuthorizationValidation,
               chainSelectionAlgebra,
+              Resource.pure(ed255Vrf),
               defaultConfig,
               bestChain = Option(BestChain(NonEmptyChain.fromSeq(newIdAndHeaders.map(d => headerToSlotData(d._2))).get))
             )
@@ -890,6 +945,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           val slotDataStore = mock[Store[F, BlockId, SlotData]]
           val headerStore = mock[Store[F, BlockId, BlockHeader]]
           val bodyStore = mock[Store[F, BlockId, BlockBody]]
+          val blockIdTree = mock[ParentChildTree[F, BlockId]]
           val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
           val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
           val bodySemanticValidation = mock[BodySemanticValidationAlgebra[F]]
@@ -921,6 +977,17 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
             addedHeader.put(id, header)
             headerStoreData.put(id, header)
             ().pure[F]
+          }
+          newIdAndHeaders.headOption.foreach { case (id, header) =>
+            val parent = header.parentHeaderId
+            (blockIdTree.associate _).expects(id, parent).returns(().pure[F])
+            val slotData = header.slotData
+            (slotDataStore.put _).expects(id, slotData).returns(().pure[F])
+          }
+
+          newIdAndHeaders.get(1).foreach { case (id, header) =>
+            val parent = header.parentHeaderId
+            (blockIdTree.associate _).expects(id, parent).returns(().pure[F])
           }
 
           (() => localChain.head).stubs().returning(knownSlotData.pure[F])
@@ -978,11 +1045,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
               slotDataStore,
               headerStore,
               bodyStore,
+              blockIdTree,
               headerValidation,
               bodySyntaxValidation,
               bodySemanticValidation,
               bodyAuthorizationValidation,
               chainSelectionAlgebra,
+              Resource.pure(ed255Vrf),
               defaultConfig,
               bestChain = Option(BestChain(NonEmptyChain.fromSeq(newIdAndHeaders.map(d => headerToSlotData(d._2))).get))
             )
@@ -1005,6 +1074,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         val localChain = mock[LocalChainAlgebra[F]]
         val slotDataStore = mock[Store[F, BlockId, SlotData]]
         val headerStore = mock[Store[F, BlockId, BlockHeader]]
+        val blockIdTree = mock[ParentChildTree[F, BlockId]]
         val bodyStore = mock[Store[F, BlockId, BlockBody]]
         val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
         val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -1029,11 +1099,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
             slotDataStore,
             headerStore,
             bodyStore,
+            blockIdTree,
             headerValidation,
             bodySyntaxValidation,
             bodySemanticValidation,
             bodyAuthorizationValidation,
             chainSelectionAlgebra,
+            Resource.pure(ed255Vrf),
             defaultConfig
           )
           .use { actor =>
@@ -1054,6 +1126,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         val localChain = mock[LocalChainAlgebra[F]]
         val slotDataStore = mock[Store[F, BlockId, SlotData]]
         val headerStore = mock[Store[F, BlockId, BlockHeader]]
+        val blockIdTree = mock[ParentChildTree[F, BlockId]]
         val bodyStore = mock[Store[F, BlockId, BlockBody]]
         val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
         val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -1135,11 +1208,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
             slotDataStore,
             headerStore,
             bodyStore,
+            blockIdTree,
             headerValidation,
             bodySyntaxValidation,
             bodySemanticValidation,
             bodyAuthorizationValidation,
             chainSelectionAlgebra,
+            Resource.pure(ed255Vrf),
             defaultConfig
           )
           .use { actor =>
@@ -1160,6 +1235,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
         val localChain = mock[LocalChainAlgebra[F]]
         val slotDataStore = mock[Store[F, BlockId, SlotData]]
         val headerStore = mock[Store[F, BlockId, BlockHeader]]
+        val blockIdTree = mock[ParentChildTree[F, BlockId]]
         val bodyStore = mock[Store[F, BlockId, BlockBody]]
         val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
         val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -1250,11 +1326,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
             slotDataStore,
             headerStore,
             bodyStore,
+            blockIdTree,
             headerValidation,
             bodySyntaxValidation,
             bodySemanticValidation,
             bodyAuthorizationValidation,
             chainSelectionAlgebra,
+            Resource.pure(ed255Vrf),
             defaultConfig,
             Option(BestChain(NonEmptyChain.one(lastBlockSlotData)))
           )
@@ -1274,6 +1352,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
+      val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -1387,11 +1466,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           slotDataStore,
           headerStore,
           bodyStore,
+          blockIdTree,
           headerValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
           chainSelectionAlgebra,
+          Resource.pure(ed255Vrf),
           defaultConfig,
           Option(BestChain(NonEmptyChain.one(allIdSlotDataHeaderBlock.last._2))),
           Option(hostId)
@@ -1415,6 +1496,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
+      val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -1526,11 +1608,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           slotDataStore,
           headerStore,
           bodyStore,
+          blockIdTree,
           headerValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
           chainSelectionAlgebra,
+          Resource.pure(ed255Vrf),
           defaultConfig,
           Option(BestChain(NonEmptyChain.one(allIdSlotDataHeaderBlock.last._2))),
           Option(hostId)
@@ -1554,6 +1638,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
+      val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -1671,11 +1756,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           slotDataStore,
           headerStore,
           bodyStore,
+          blockIdTree,
           headerValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
           chainSelectionAlgebra,
+          Resource.pure(ed255Vrf),
           defaultConfig,
           Option(BestChain(NonEmptyChain.fromSeq(allIdSlotDataHeaderBlock.map(_._2)).get)),
           Option(hostId)
@@ -1694,6 +1781,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
+      val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -1813,11 +1901,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           slotDataStore,
           headerStore,
           bodyStore,
+          blockIdTree,
           headerValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
           chainSelectionAlgebra,
+          Resource.pure(ed255Vrf),
           defaultConfig,
           Option(BestChain(NonEmptyChain.fromSeq(allIdSlotDataHeaderBlock.map(_._2)).get)),
           Option(hostId)
@@ -1836,6 +1926,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
+      val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -1855,11 +1946,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           slotDataStore,
           headerStore,
           bodyStore,
+          blockIdTree,
           headerValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
           chainSelectionAlgebra,
+          Resource.pure(ed255Vrf),
           defaultConfig,
           Option(BestChain(currentBestChain)),
           Option(hostId)
@@ -1882,6 +1975,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
+      val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -1902,11 +1996,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           slotDataStore,
           headerStore,
           bodyStore,
+          blockIdTree,
           headerValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
           chainSelectionAlgebra,
+          Resource.pure(ed255Vrf),
           defaultConfig,
           Option(BestChain(currentBestChain)),
           Option(hostId)
@@ -1929,6 +2025,7 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
       val localChain = mock[LocalChainAlgebra[F]]
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val headerStore = mock[Store[F, BlockId, BlockHeader]]
+      val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val bodyStore = mock[Store[F, BlockId, BlockBody]]
       val headerValidation = mock[BlockHeaderValidationAlgebra[F]]
       val bodySyntaxValidation = mock[BodySyntaxValidationAlgebra[F]]
@@ -1948,11 +2045,13 @@ class BlockCheckerTest extends CatsEffectSuite with ScalaCheckEffectSuite with A
           slotDataStore,
           headerStore,
           bodyStore,
+          blockIdTree,
           headerValidation,
           bodySyntaxValidation,
           bodySemanticValidation,
           bodyAuthorizationValidation,
           chainSelectionAlgebra,
+          Resource.pure(ed255Vrf),
           defaultConfig,
           Option(BestChain(currentBestChain)),
           Option(hostId)

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerActorTest.scala
@@ -13,7 +13,6 @@ import co.topl.brambl.validation.algebras.TransactionSyntaxVerifier
 import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import co.topl.consensus.algebras.{BlockHeaderToBodyValidationAlgebra, ChainSelectionAlgebra, LocalChainAlgebra}
 import co.topl.consensus.models.{BlockId, SlotData}
-import co.topl.eventtree.ParentChildTree
 import co.topl.ledger.algebras.MempoolAlgebra
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.models.generators.consensus.ModelGenerators._
@@ -51,7 +50,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
     slotDataStore:                   Store[F, BlockId, SlotData],
     bodyDataStore:                   Store[F, BlockId, BlockBody],
     transactionStore:                Store[F, TransactionId, IoTransaction],
-    blockIdTree:                     ParentChildTree[F, BlockId],
     headerToBodyValidation:          BlockHeaderToBodyValidationAlgebra[F],
     transactionSyntaxValidation:     TransactionSyntaxVerifier[F],
     mempool:                         MempoolAlgebra[F],
@@ -93,7 +91,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
     slotDataStore:                   Store[F, BlockId, SlotData] = mock[Store[F, BlockId, SlotData]],
     bodyDataStore:                   Store[F, BlockId, BlockBody] = mock[Store[F, BlockId, BlockBody]],
     transactionStore:            Store[F, TransactionId, IoTransaction] = mock[Store[F, TransactionId, IoTransaction]],
-    blockIdTree:                 ParentChildTree[F, BlockId] = mock[ParentChildTree[F, BlockId]],
     headerToBodyValidation:      BlockHeaderToBodyValidationAlgebra[F] = mock[BlockHeaderToBodyValidationAlgebra[F]],
     transactionSyntaxValidation: TransactionSyntaxVerifier[F] = mock[TransactionSyntaxVerifier[F]],
     mempool:                     MempoolAlgebra[F] = mock[MempoolAlgebra[F]]
@@ -107,7 +104,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       slotDataStore,
       bodyDataStore,
       transactionStore,
-      blockIdTree,
       headerToBodyValidation,
       transactionSyntaxValidation,
       mempool,
@@ -132,7 +128,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
         peerActorMockData.slotDataStore,
         peerActorMockData.bodyDataStore,
         peerActorMockData.transactionStore,
-        peerActorMockData.blockIdTree,
         peerActorMockData.headerToBodyValidation,
         peerActorMockData.transactionSyntaxValidation,
         peerActorMockData.mempool,
@@ -171,7 +166,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
     val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
     (() => blockHeaderFetcher.id).expects().anyNumberOfTimes().returns(1)
     (networkAlgebra.makePeerHeaderFetcher _)
-      .expects(*, *, *, *, *, *, *, *, *, *)
+      .expects(*, *, *, *, *, *, *, *, *)
       .returns(
         // simulate real header fetcher behaviour on finalizing
         Resource
@@ -605,7 +600,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val bodyDataStore = mock[Store[F, BlockId, BlockBody]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val transactionSyntaxValidation = mock[TransactionSyntaxVerifier[F]]
       val mempool = mock[MempoolAlgebra[F]]
@@ -626,7 +620,7 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val networkAlgebra = mock[NetworkAlgebra[F]]
       val blockHeaderFetcher = mock[PeerBlockHeaderFetcherActor[F]]
       (networkAlgebra.makePeerHeaderFetcher _)
-        .expects(*, *, *, *, *, *, *, *, *, *)
+        .expects(*, *, *, *, *, *, *, *, *)
         .returns(Resource.pure(blockHeaderFetcher))
 
       val blockBodyFetcher = mock[PeerBlockBodyFetcherActor[F]]
@@ -648,7 +642,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           slotDataStore,
           bodyDataStore,
           transactionStore,
-          blockIdTree,
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,
@@ -669,7 +662,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
       val bodyDataStore = mock[Store[F, BlockId, BlockBody]]
       val transactionStore = mock[Store[F, TransactionId, IoTransaction]]
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
       val headerToBodyValidation = mock[BlockHeaderToBodyValidationAlgebra[F]]
       val client = mock[BlockchainPeerClient[F]]
       val transactionSyntaxValidation = mock[TransactionSyntaxVerifier[F]]
@@ -701,7 +693,6 @@ class PeerActorTest extends CatsEffectSuite with ScalaCheckEffectSuite with Asyn
           slotDataStore,
           bodyDataStore,
           transactionStore,
-          blockIdTree,
           headerToBodyValidation,
           transactionSyntaxValidation,
           mempool,

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
@@ -9,7 +9,6 @@ import co.topl.algebras.{ClockAlgebra, Store}
 import co.topl.codecs.bytes.tetra.instances._
 import co.topl.consensus.algebras.{ChainSelectionAlgebra, LocalChainAlgebra}
 import co.topl.consensus.models.{BlockHeader, BlockId, SlotData}
-import co.topl.eventtree.ParentChildTree
 import co.topl.models.ModelGenerators.GenHelper
 import co.topl.models.generators.consensus.ModelGenerators._
 import co.topl.models.p2p._
@@ -90,8 +89,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-
       val clock = mock[ClockAlgebra[F]]
 
       val commonAncestorF = mock[(BlockchainPeerClient[F], LocalChainAlgebra[F]) => F[BlockId]]
@@ -106,7 +103,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           defaultBodyStorage,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -152,8 +148,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-
       val clock = mock[ClockAlgebra[F]]
 
       val commonAncestorF = mock[(BlockchainPeerClient[F], LocalChainAlgebra[F]) => F[BlockId]]
@@ -168,7 +162,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           defaultBodyStorage,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -222,8 +215,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-
       val clock = mock[ClockAlgebra[F]]
 
       val commonAncestorF = mock[(BlockchainPeerClient[F], LocalChainAlgebra[F]) => F[BlockId]]
@@ -238,7 +229,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           defaultBodyStorage,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -298,8 +288,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
 
       val slotDataStore = mock[Store[F, BlockId, SlotData]]
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-
       val clock = mock[ClockAlgebra[F]]
 
       val commonAncestorF = mock[(BlockchainPeerClient[F], LocalChainAlgebra[F]) => F[BlockId]]
@@ -314,7 +302,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           defaultBodyStorage,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -388,9 +375,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           slotDataStoreMap(id).pure[F]
         }
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).rep(remoteSlotDataCount).returning(().pure[F])
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -410,7 +394,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -497,9 +480,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           slotDataStoreMap(id).pure[F]
         }
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).rep(remoteSlotDataCount - enoughHeightDelta).returning(().pure[F])
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -519,7 +499,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           chainSelection,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -600,8 +579,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           slotDataStoreMap(id).pure[F]
         }
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -621,7 +598,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           chainSelection,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -699,9 +675,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           slotDataStoreMap(id).pure[F]
         }
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -721,7 +694,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -789,9 +761,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           slotDataStoreMap(id).pure[F]
         }
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).once().returning(().pure[F])
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -810,7 +779,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -880,9 +848,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           slotDataStoreMap(id).pure[F]
         }
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).twice().returning(().pure[F])
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -905,7 +870,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -973,9 +937,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           slotDataStoreMap(id).pure[F]
         }
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -995,7 +956,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -1072,9 +1032,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           slotDataStoreMap(id).pure[F]
         }
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -1097,7 +1054,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -1170,9 +1126,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           slotDataStoreMap(id).pure[F]
         }
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -1194,7 +1147,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -1237,8 +1189,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
         .anyNumberOfTimes()
         .returning(slotData.pure[F])
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -1260,7 +1210,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -1312,8 +1261,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
         .anyNumberOfTimes()
         .returning(remoteKnownHead.pure[F])
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -1334,7 +1281,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -1413,9 +1359,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           slotDataStoreMap(id).pure[F]
         }
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -1435,7 +1378,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -1511,9 +1453,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           slotDataStoreMap(id).pure[F]
         }
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -1533,7 +1472,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -1608,9 +1546,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           slotDataStoreMap(id).pure[F]
         }
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-      (blockIdTree.associate _).expects(*, *).anyNumberOfTimes().returning(().pure[F])
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot).expects().anyNumberOfTimes().returning(2L.pure[F])
 
@@ -1630,7 +1565,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )
@@ -1677,8 +1611,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
         .once()
         .returning(none[SlotData].pure[F])
 
-      val blockIdTree = mock[ParentChildTree[F, BlockId]]
-
       val clock = mock[ClockAlgebra[F]]
       (() => clock.globalSlot)
         .expects()
@@ -1702,7 +1634,6 @@ class PeerBlockHeaderFetcherTest extends CatsEffectSuite with ScalaCheckEffectSu
           defaultChainSelectionAlgebra,
           slotDataStore,
           bodyStore,
-          blockIdTree,
           clock,
           commonAncestorF
         )

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeersManagerTest.scala
@@ -1317,7 +1317,7 @@ class PeersManagerTest
       val peer2 = mockPeerActor[F]()
 
       (networkAlgebra.makePeer _)
-        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(
           Resource
@@ -1333,7 +1333,7 @@ class PeersManagerTest
       (peer1.sendNoWait _).expects(PeerActor.Message.CloseConnectionForActor).returns(Applicative[F].unit)
 
       (networkAlgebra.makePeer _)
-        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer2))
       (peer2.sendNoWait _)
@@ -1385,7 +1385,7 @@ class PeersManagerTest
       val peer1 = mockPeerActor[F]()
 
       (networkAlgebra.makePeer _)
-        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(
           Resource
@@ -1432,7 +1432,7 @@ class PeersManagerTest
       val peer1 = mockPeerActor[F]()
 
       (networkAlgebra.makePeer _)
-        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(
           Resource
@@ -1608,7 +1608,7 @@ class PeersManagerTest
       val host1Ra = RemoteAddress("1", 1)
       val peer1 = mockPeerActor[F]()
       (networkAlgebra.makePeer _)
-        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer1))
       (peer1.sendNoWait _)
@@ -1624,7 +1624,7 @@ class PeersManagerTest
       val host2Ra = RemoteAddress("2", 2)
       val peer2 = mockPeerActor[F]()
       (networkAlgebra.makePeer _)
-        .expects(host2Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host2Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer2))
       (peer2.sendNoWait _)
@@ -1639,7 +1639,7 @@ class PeersManagerTest
       val host3Ra = RemoteAddress("3", 3)
       val peer3 = mockPeerActor[F]()
       (networkAlgebra.makePeer _)
-        .expects(host3Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host3Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer3))
       (peer3.sendNoWait _)
@@ -1659,7 +1659,7 @@ class PeersManagerTest
       val host5Ra = RemoteAddress("5", 5)
       val peer5 = mockPeerActor[F]()
       (networkAlgebra.makePeer _)
-        .expects(host5Id, *, *, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host5Id, *, *, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(Resource.pure(peer5))
       (peer5.sendNoWait _)
@@ -3450,7 +3450,7 @@ class PeersManagerTest
       val peer1 = mockPeerActor[F]()
 
       (networkAlgebra.makePeer _)
-        .expects(host1Id, *, client1, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1Id, *, client1, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(
           Resource
@@ -3504,7 +3504,7 @@ class PeersManagerTest
       val host2Id = arbitraryHost.arbitrary.first
 
       (networkAlgebra.makePeer _)
-        .expects(host1Id, *, client1, *, *, *, *, *, *, *, *, *, *, *, *)
+        .expects(host1Id, *, client1, *, *, *, *, *, *, *, *, *, *, *)
         .once()
         .returns(
           Resource

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -126,6 +126,8 @@ object Dependencies {
 
   val ipaddress = "com.github.seancfoley" % "ipaddress" % "5.5.0"
 
+  val apacheCommonLang = "org.apache.commons" % "commons-lang3" % "3.0"
+
   // For NTP-UDP
   val commonsNet = "commons-net" % "commons-net" % "3.10.0"
 
@@ -214,7 +216,7 @@ object Dependencies {
     Dependencies.mUnitTest ++ Dependencies.catsEffect
 
   lazy val networking: Seq[ModuleID] =
-    Dependencies.mUnitTest ++ Dependencies.catsEffect ++ Seq(ipaddress)
+    Dependencies.mUnitTest ++ Dependencies.catsEffect ++ Seq(ipaddress, apacheCommonLang)
 
   lazy val transactionGenerator: Seq[ModuleID] =
     Dependencies.mUnitTest ++ Dependencies.catsEffect ++ Seq(Dependencies.fs2Core)


### PR DESCRIPTION
## Purpose
Stop build parent-child tree from slot data; do not use slot data received from remote peer to calculate ETA

## Approach
Associate block parent-child only after receiving header from a remote peer; update slot data based on actual header rather than use slot data from a remote peer.

## Testing
Unit tests + integration tests

## Tickets
BN-1505