### PR TITLE
BN-1509 Introducing parameter: slot gap leader election

### DIFF
--- a/blockchain-core/src/main/scala/co/topl/blockchain/BigBang.scala
+++ b/blockchain-core/src/main/scala/co/topl/blockchain/BigBang.scala
@@ -171,11 +171,13 @@ object BigBang {
 
   def updateProposalToProtocol(proposal: Value.UpdateProposal): Either[String, ApplicationConfig.Bifrost.Protocol] =
     for {
-      fEffective              <- proposal.fEffective.toRight("Missing fEffective")
-      vrfLddCutoff            <- proposal.vrfLddCutoff.toRight("Missing vrfLddCutoff")
-      vrfPrecision            <- proposal.vrfPrecision.toRight("Missing vrfPrecision")
-      vrfBaselineDifficulty   <- proposal.vrfBaselineDifficulty.toRight("Missing vrfBaselineDifficulty")
-      vrfAmplitude            <- proposal.vrfAmplitude.toRight("Missing vrfAmplitude")
+      fEffective            <- proposal.fEffective.toRight("Missing fEffective")
+      vrfLddCutoff          <- proposal.vrfLddCutoff.toRight("Missing vrfLddCutoff")
+      vrfPrecision          <- proposal.vrfPrecision.toRight("Missing vrfPrecision")
+      vrfBaselineDifficulty <- proposal.vrfBaselineDifficulty.toRight("Missing vrfBaselineDifficulty")
+      vrfAmplitude          <- proposal.vrfAmplitude.toRight("Missing vrfAmplitude")
+      // TODO Temporary solution shall be changed as soon as we relaunch toplnet
+      slotGapLeaderElection <- proposal.slotGapLeaderElection.toRight("Missing slotGapLeaderElection").recover(_ => 0L)
       chainSelectionKLookback <- proposal.chainSelectionKLookback.toRight("Missing chainSelectionKLookback")
       slotDuration            <- proposal.slotDuration.toRight("Missing slotDuration")
       forwardBiasedSlotWindow <- proposal.forwardBiasedSlotWindow.toRight("Missing forwardBiasedSlotWindow")
@@ -191,6 +193,7 @@ object BigBang {
       vrfPrecision,
       vrfBaselineDifficulty,
       vrfAmplitude,
+      slotGapLeaderElection,
       chainSelectionKLookback,
       slotDuration,
       forwardBiasedSlotWindow,
@@ -216,6 +219,7 @@ object BigBang {
       forwardBiasedSlotWindow = protocol.forwardBiasedSlotWindow.some,
       operationalPeriodsPerEpoch = protocol.operationalPeriodsPerEpoch.some,
       kesKeyHours = protocol.kesKeyHours.some,
-      kesKeyMinutes = protocol.kesKeyMinutes.some
+      kesKeyMinutes = protocol.kesKeyMinutes.some,
+      slotGapLeaderElection = protocol.slotGapLeaderElection.some
     )
 }

--- a/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/PrivateTestnet.scala
@@ -162,6 +162,7 @@ object PrivateTestnet {
       vrfPrecision = 40,
       vrfBaselineDifficulty = Ratio(5, 100),
       vrfAmplitude = Ratio(50, 100),
+      slotGapLeaderElection = 0,
       chainSelectionKLookback = 5184,
       slotDuration = 1.seconds,
       forwardBiasedSlotWindow = 50,

--- a/blockchain/src/main/scala/co/topl/blockchain/PublicTestnet.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/PublicTestnet.scala
@@ -14,6 +14,7 @@ object PublicTestnet {
       vrfPrecision = 40,
       vrfBaselineDifficulty = co.topl.models.utility.Ratio(5, 100),
       vrfAmplitude = co.topl.models.utility.Ratio(50, 100),
+      slotGapLeaderElection = 0,
       chainSelectionKLookback = 5184,
       slotDuration = 1.seconds,
       forwardBiasedSlotWindow = 50,

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -163,6 +163,7 @@ object ApplicationConfig {
       vrfPrecision:               Int,
       vrfBaselineDifficulty:      Ratio,
       vrfAmplitude:               Ratio,
+      slotGapLeaderElection:      Long,
       chainSelectionKLookback:    Long,
       slotDuration:               FiniteDuration,
       forwardBiasedSlotWindow:    Slot,

--- a/consensus/src/main/scala/co/topl/consensus/interpreters/LeaderElectionValidation.scala
+++ b/consensus/src/main/scala/co/topl/consensus/interpreters/LeaderElectionValidation.scala
@@ -68,7 +68,7 @@ object LeaderElectionValidation {
     CaffeineCache[F, (Ratio, Slot), Ratio].map(cache =>
       new LeaderElectionValidationAlgebra[F] {
 
-        override def getThreshold(relativeStake: Ratio, slotDiff: Slot): F[Ratio] =
+        override def getThreshold(relativeStake: Ratio, slotDiff: Long): F[Ratio] =
           cache.cachingF((relativeStake, slotDiff))(ttl = None)(
             Sync[F].defer(
               alg.getThreshold(relativeStake, slotDiff)
@@ -96,7 +96,7 @@ object LeaderElectionValidation {
        * If slotDiff > lddCutoff, substitute (lddCutoff + 1) for the slotDiff since the result should
        * always be constant
        */
-      def getThreshold(relativeStake: Ratio, slotDiff: Epoch): F[Ratio] =
+      def getThreshold(relativeStake: Ratio, slotDiff: Long): F[Ratio] =
         if (slotDiff > lddCutoff) alg.getThreshold(relativeStake, lddCutoff + 1)
         else alg.getThreshold(relativeStake, slotDiff)
 

--- a/consensus/src/test/scala/co/topl/consensus/interpreters/BlockHeaderValidationSpec.scala
+++ b/consensus/src/test/scala/co/topl/consensus/interpreters/BlockHeaderValidationSpec.scala
@@ -72,6 +72,7 @@ class BlockHeaderValidationSpec extends CatsEffectSuite with ScalaCheckEffectSui
         .mapN((blake2b512, exp, log1p) =>
           LeaderElectionValidation.make[F](
             VrfConfig(lddCutoff = 0, precision = 16, baselineDifficulty = Ratio(1, 15), amplitude = Ratio(2, 5)),
+            0,
             blake2b512,
             exp,
             log1p

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -80,6 +80,7 @@ bifrost {
       vrf-precision = 40
       vrf-baseline-difficulty = "5/100"
       vrf-amplitude = "50/100"
+      slot-gap-leader-election = 0
       chain-selection-k-lookback = 5184
       slot-duration = 1000 milli
       forward-biased-slot-window = 50

--- a/node/src/main/scala/co/topl/node/cli/InitNetworkHelpers.scala
+++ b/node/src/main/scala/co/topl/node/cli/InitNetworkHelpers.scala
@@ -186,6 +186,11 @@ object InitNetworkHelpers {
             List("1/2"),
             PublicTestnet.DefaultProtocol.vrfAmplitude.show
           )
+          slotGapLeaderElection <- readDefaultedOptional[F, Long](
+            "slot-gap-leader-election",
+            List("0"),
+            PublicTestnet.DefaultProtocol.slotGapLeaderElection.show
+          )
           chainSelectionKLookback <- readDefaultedOptional[F, Long](
             "chain-selection-k-lookback",
             List("500"),
@@ -228,7 +233,8 @@ object InitNetworkHelpers {
           forwardBiasedSlotWindow.some,
           operationalPeriodsPerEpoch.some,
           kesKeyHours.some,
-          kesKeyMinutes.some
+          kesKeyMinutes.some,
+          slotGapLeaderElection.some
         ),
       ifNo = StageResultT.liftF(PublicTestnet.DefaultUpdateProposal.pure[F])
     )

--- a/node/src/main/scala/co/topl/node/cli/ProposalCommand.scala
+++ b/node/src/main/scala/co/topl/node/cli/ProposalCommand.scala
@@ -50,6 +50,7 @@ private class ProposalCommandImpl[F[_]: Async](implicit c: Console[F]) {
       operationalPeriodsPerEpoch <- readOptionalParameter[F, Long]("operational-periods-per-epoch", List("2"))
       kesKeyHours                <- readOptionalParameter[F, Int]("kes-key-hours", List("2"))
       kesKeyMinutes              <- readOptionalParameter[F, Int]("kes-key-minutes", List("9"))
+      slotGapLeaderElection      <- readOptionalParameter[F, Long]("slot-gap-leader-election", List("0"))
 
       proposal = UpdateProposal(
         label,
@@ -63,7 +64,8 @@ private class ProposalCommandImpl[F[_]: Async](implicit c: Console[F]) {
         forwardBiasedSlotWindow,
         operationalPeriodsPerEpoch,
         kesKeyHours,
-        kesKeyMinutes
+        kesKeyMinutes,
+        slotGapLeaderElection
       )
 
       lockAddress <- readParameter[F, LockAddress](

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val orientDbVersion = "3.2.29"
   val ioGrpcVersion = "1.64.0"
   val http4sVersion = "0.23.26"
-  val protobufSpecsVersion = "2.0.0-beta3"
+  val protobufSpecsVersion = "2.0.0-beta3+2-17b46622-SNAPSHOT"
   val bramblScVersion = "2.0.0-beta3+3-de74a6dd-SNAPSHOT"
 
   val catsSlf4j =


### PR DESCRIPTION
## Purpose
Add ability to intentionally slow down consensus by injecting a gap of non-eligibility after a block is minted. We call this the ‘slot gap’, and it allows us to prevent minting new blocks until the last block has propagated throughout the network.

## Approach
Check parameter during leader election if required slot data is not elapsed then return 0 as current threshold.

## Testing
Unit tests

## Tickets
BN-1509