### PR TITLE
Block Packer Completion Case

### DIFF
--- a/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
+++ b/minting/src/main/scala/co/topl/minting/interpreters/BlockProducer.scala
@@ -203,8 +203,7 @@ object BlockProducer {
      */
     private def packBlock(parentId: BlockId, height: Long, untilSlot: Slot): F[FullBlockBody] =
       OptionT(
-        blockPacker
-          .blockImprover(parentId, height, untilSlot)
+        (blockPacker.blockImprover(parentId, height, untilSlot) ++ Stream.never)
           .interruptWhen(
             constructionPermit >>
             clock.delayedUntilSlot(untilSlot) >>


### PR DESCRIPTION
## Purpose
- If the BlockPacker is able to complete processing for a non-empty mempool, it will complete the stream
- If the stream completes, the BlockProducer will immediately make the block, skipping the regtest permit and the slot delay
## Approach
- In BlockProducer, add `Stream.never` to the `BlockPacker#blockImprover` call to force the stream to never complete
## Testing
- Verified locally that broadcasting a TX in regtest mode does not make a new block
## Tickets
- #BN-1540