### PR TITLE
BN-1529 Added network control rpc (disabled by default) for controling network.

### DIFF
--- a/blockchain-core/src/main/scala/co/topl/blockchain/interpreters/NetworkControlRpcServer.scala
+++ b/blockchain-core/src/main/scala/co/topl/blockchain/interpreters/NetworkControlRpcServer.scala
@@ -1,0 +1,50 @@
+package co.topl.blockchain.interpreters
+
+import cats.Show
+import cats.effect.{Async, Resource}
+import co.topl.models.p2p._
+import co.topl.node.services._
+import fs2.concurrent.Topic
+import io.grpc.{Metadata, ServerServiceDefinition}
+import cats.implicits._
+import org.typelevel.log4cats.Logger
+import cats.implicits.showInterpolator
+import co.topl.models.utility.byteStringToByteVector
+
+object NetworkControlRpcServer {
+  implicit val showHostId: Show[HostId] = id => show"${id.id.toBase58}"
+
+  def service[F[_]: Async: Logger](
+    thisHostId:         HostId,
+    networkCommandsOpt: Option[Topic[F, NetworkCommands]]
+  ): Resource[F, ServerServiceDefinition] =
+    NetworkControlRpcFs2Grpc.bindServiceResource(
+      new NetworkControlRpcFs2Grpc[F, Metadata] {
+
+        override def getHostId(request: GetHostIdReq, ctx: Metadata): F[GetHostIdRes] =
+          Logger[F].info(show"Network control: Requested current host id") >>
+          GetHostIdRes(RpcHostId(thisHostId.id)).pure[F]
+
+        override def forgetPeer(request: ForgetPeerReq, ctx: Metadata): F[ForgetPeerRes] = {
+          val command = for {
+            topic <- networkCommandsOpt
+            hostIdToCold = HostId(request.id.id)
+          } yield Logger[F].info(show"Network control: Requested to forget remote peer $hostIdToCold") >>
+          topic.publish1(NetworkCommands.ForgetPeer(hostIdToCold)).as(ForgetPeerRes())
+
+          command.getOrElse(ForgetPeerRes().pure[F])
+        }
+
+        override def addPeer(request: AddPeerReq, ctx: Metadata): F[AddPeerRes] = {
+          val command = for {
+            topic <- networkCommandsOpt
+            hostIdToAdd = request.id.map(rpcHostId => HostId(rpcHostId.id))
+            remoteAddress = RemoteAddress(request.ip, request.port)
+          } yield Logger[F].info(show"Network control: Requested to add remote peer $remoteAddress as known") >>
+          topic.publish1(NetworkCommands.AddPeer(remoteAddress, hostIdToAdd)).as(AddPeerRes())
+
+          command.getOrElse(AddPeerRes().pure[F])
+        }
+      }
+    )
+}

--- a/build.sbt
+++ b/build.sbt
@@ -735,6 +735,7 @@ lazy val nodeIt = project
   )
   .dependsOn(
     node,
+    models % "test->compile",
     transactionGenerator % "test->compile"
   )
 

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -100,7 +100,7 @@ object ApplicationConfig {
     case class KnownPeer(host: String, port: Int)
 
     @Lenses
-    case class RPC(bindHost: String, bindPort: Int)
+    case class RPC(bindHost: String, bindPort: Int, networkControl: Boolean = false)
 
     @Lenses
     case class Mempool(defaultExpirationSlots: Long, protection: MempoolProtection = MempoolProtection())

--- a/models/src/main/scala/co/topl/models/p2p/package.scala
+++ b/models/src/main/scala/co/topl/models/p2p/package.scala
@@ -6,7 +6,6 @@ import cats.implicits._
 package object p2p {
 
   case class RemoteAddress(host: String, port: Int) {
-
     override def toString: String = show"$host:$port"
   }
 
@@ -17,4 +16,12 @@ package object p2p {
 
   type HostReputationValue =
     Double // will be more complex, to get high reputation host shall fulfill different criteria
+
+  sealed trait NetworkCommands
+
+  object NetworkCommands {
+    case class ForgetPeer(hostId: HostId) extends NetworkCommands
+    case class AddPeer(remoteAddress: RemoteAddress, remotepeerIdOpt: Option[HostId]) extends NetworkCommands
+  }
+
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -35,7 +35,8 @@ object ActorPeerHandlerBridgeAlgebra {
     peersStatusChangesTopic: Topic[F, PeerConnectionChange],
     addRemotePeer:           DisconnectedPeer => F[Unit],
     hotPeersUpdate:          Set[RemotePeer] => F[Unit],
-    ed25519VRF:              Resource[F, Ed25519VRF]
+    ed25519VRF:              Resource[F, Ed25519VRF],
+    networkCommands:         Topic[F, NetworkCommands]
   ): Resource[F, BlockchainPeerHandlerAlgebra[F]] = {
     implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName("Bifrost.P2P")
 
@@ -50,7 +51,8 @@ object ActorPeerHandlerBridgeAlgebra {
         PeerCreationRequestAlgebra(addRemotePeer),
         peersStatusChangesTopic,
         hotPeersUpdate,
-        ed25519VRF
+        ed25519VRF,
+        networkCommands
       )
 
     networkManager.map(pm => makeAlgebra(pm))

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/P2PShowInstances.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/P2PShowInstances.scala
@@ -69,8 +69,8 @@ trait P2PShowInstances {
     s" AggressiveP2PRequestInterval=${config.aggressiveP2PRequestInterval.toMillis} ms;"
 
   implicit def showPeer[F[_]]: Show[Peer[F]] = { peer: Peer[F] =>
-    val connectionAddress = peer.connectedAddress.map(ra => show"$ra").getOrElse("absent")
-    val serverAddress = peer.asServer.map(rp => show"$rp").getOrElse("absent")
+    val connectionAddress = peer.connectedAddress.fold("absent")(ra => show"$ra")
+    val serverAddress = peer.asServer.fold("absent")(rp => show"$rp")
     "<<< Peer" +
     show" Connected address=$connectionAddress;" +
     show" Server address=$serverAddress;" +

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
@@ -296,6 +296,7 @@ class ActorPeerHandlerBridgeAlgebraTest extends CatsEffectSuite with ScalaCheckE
           b
         }
 
+        networkCommandsTopic <- Resource.make(Topic[F, NetworkCommands])(_.close.void)
         algebra <- ActorPeerHandlerBridgeAlgebra
           .make[F](
             hostId,
@@ -305,7 +306,8 @@ class ActorPeerHandlerBridgeAlgebraTest extends CatsEffectSuite with ScalaCheckE
             topic,
             addRemotePeer,
             hotPeersUpdate,
-            Resource.pure(Ed25519VRF.precomputed())
+            Resource.pure(Ed25519VRF.precomputed()),
+            networkCommandsTopic
           )
       } yield (algebra, remotePeersStore, mempoolAlgebra)
 

--- a/networking/src/test/scala/co/topl/networking/fsnetwork/PeerMempoolTransactionSyncTest.scala
+++ b/networking/src/test/scala/co/topl/networking/fsnetwork/PeerMempoolTransactionSyncTest.scala
@@ -150,10 +150,10 @@ class PeerMempoolTransactionSyncTest extends CatsEffectSuite with ScalaCheckEffe
 
       (transactionStore.contains _).expects(*).anyNumberOfTimes().returns(false.pure[F])
       transactionInMempool.map { tx =>
-        (mempool.contains _).expects(headBlock.slotId.blockId, tx.id).once.returns(true.pure[F])
+        (mempool.contains _).expects(headBlock.slotId.blockId, tx.id).once().returns(true.pure[F])
       }
       missedTransaction.map { tx =>
-        (mempool.contains _).expects(headBlock.slotId.blockId, tx.id).once.returns(false.pure[F])
+        (mempool.contains _).expects(headBlock.slotId.blockId, tx.id).once().returns(false.pure[F])
       }
 
       (peersManager.sendNoWait _)

--- a/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeAppTest.scala
@@ -112,8 +112,8 @@ class NodeAppTest extends CatsEffectSuite {
           .parMapN(_.race(_).map(_.merge).flatMap(_.embedNever))
           .flatMap(nodeCompletion =>
             nodeCompletion.toResource.race(for {
-              rpcClientA <- NodeGrpc.Client.make[F]("127.0.0.2", 9151, tls = false)
-              rpcClientB <- NodeGrpc.Client.make[F]("localhost", 9153, tls = false)
+              rpcClientA      <- NodeGrpc.Client.make[F]("127.0.0.2", 9151, tls = false)
+              rpcClientB      <- NodeGrpc.Client.make[F]("localhost", 9153, tls = false)
               rpcClients = List(rpcClientA, rpcClientB)
               implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeAppTest").toResource
               _                            <- rpcClients.parTraverse(_.waitForRpcStartUp).toResource
@@ -121,8 +121,8 @@ class NodeAppTest extends CatsEffectSuite {
               genusTxServiceA              <- TransactionServiceFs2Grpc.stubResource[F](genusChannelA)
               genusBlockServiceA           <- BlockServiceFs2Grpc.stubResource[F](genusChannelA)
               _                            <- awaitGenusReady(genusBlockServiceA).timeout(45.seconds).toResource
-              wallet <- makeWallet(genusTxServiceA)
-              _      <- IO(wallet.spendableBoxes.nonEmpty).assert.toResource
+              wallet                       <- makeWallet(genusTxServiceA)
+              _                            <- IO(wallet.spendableBoxes.nonEmpty).assert.toResource
               implicit0(random: Random[F]) <- SecureRandom.javaSecuritySecureRandom[F].toResource
               // Construct two competing graphs of transactions.
               // Graph 1 has higher fees and should be included in the chain

--- a/node-it/src/test/scala/co/topl/node/NodeNetworkControlTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeNetworkControlTest.scala
@@ -1,0 +1,177 @@
+package co.topl.node
+
+import cats.data.OptionT
+import cats.effect._
+import cats.effect.implicits._
+import cats.implicits._
+import co.topl.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
+import co.topl.consensus.models.BlockId
+import co.topl.genus.services._
+import co.topl.grpc.NodeGrpc
+import co.topl.interpreters.NodeRpcOps.clientAsNodeRpcApi
+import co.topl.node.Util._
+import co.topl.typeclasses.implicits._
+import fs2.io.file.{Files, Path}
+import fs2.{io => _}
+import munit._
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import scala.concurrent.duration._
+
+
+class NodeNetworkControlTest extends CatsEffectSuite {
+
+  override val munitIOTimeout: Duration = 3.minutes
+
+  val nodeAIp = "127.0.0.2"
+  val nodeAP2PPort = 9150
+  val nodeARpcPort = 9151
+
+  val nodeBIp = "localhost"
+  val nodeBP2PPort = 9152
+  val nodeBRpcPort = 9153
+
+  test("Two block-producing nodes that maintain consensus") {
+    def configNodeA(dataDir: Path, stakingDir: Path, genesisBlockId: BlockId, genesisSourcePath: String): String =
+      s"""
+         |bifrost:
+         |  data:
+         |    directory: $dataDir
+         |  staking:
+         |    directory: $stakingDir
+         |  p2p:
+         |    bind-port: $nodeAP2PPort
+         |    public-port: $nodeAP2PPort
+         |  rpc:
+         |    bind-port: $nodeARpcPort
+         |    network-control: true
+         |  big-bang:
+         |    type: public
+         |    genesis-id: ${genesisBlockId.show}
+         |    source-path: $genesisSourcePath
+         |  mempool:
+         |    protection:
+         |      enabled: false
+         |genus:
+         |  enable: true
+         |""".stripMargin
+
+    def configNodeB(dataDir: Path, stakingDir: Path, genesisBlockId: BlockId, genesisSourcePath: String): String =
+      s"""
+         |bifrost:
+         |  data:
+         |    directory: $dataDir
+         |  staking:
+         |    directory: $stakingDir
+         |  p2p:
+         |    bind-port: $nodeBP2PPort
+         |    public-port: $nodeBP2PPort
+         |    known-peers: $nodeAIp:$nodeAP2PPort
+         |  rpc:
+         |    bind-port: $nodeBRpcPort
+         |    network-control: true
+         |  big-bang:
+         |    type: public
+         |    genesis-id: ${genesisBlockId.show}
+         |    source-path: $genesisSourcePath
+         |  mempool:
+         |    protection:
+         |      enabled: false
+         |genus:
+         |  enable: false
+         |""".stripMargin
+
+    val resource =
+      for {
+        testnetConfig     <- createTestnetConfig.toResource
+        genesisServerPort <- serveGenesisBlock(testnetConfig.genesis)
+        genesisSourcePath = s"http://localhost:$genesisServerPort/${testnetConfig.genesis.header.id.show}"
+        configALocation <- (
+          Files.forAsync[F].tempDirectory,
+          Files
+            .forAsync[F]
+            .tempDirectory
+            .evalTap(saveStaker(_)(testnetConfig.stakers.head._1, testnetConfig.stakers.head._2))
+        ).tupled
+          .map { case (dataDir, stakingDir) =>
+            configNodeA(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath)
+          }
+          .flatMap(saveLocalConfig(_, "nodeA"))
+          .map(_.toString)
+        configBLocation <- (
+          Files.forAsync[F].tempDirectory,
+          Files
+            .forAsync[F]
+            .tempDirectory
+            .evalTap(saveStaker(_)(testnetConfig.stakers(1)._1, testnetConfig.stakers(1)._2))
+        ).tupled
+          .map { case (dataDir, stakingDir) =>
+            configNodeB(dataDir, stakingDir, testnetConfig.genesis.header.id, genesisSourcePath)
+          }
+          .flatMap(serveConfig(_, "nodeB.yaml"))
+        // Run the nodes in separate fibers, but use the fibers' outcomes as an error signal to
+        // the test by racing the computation
+        _ <- (launch(configALocation), launch(configBLocation))
+          .parMapN(_.race(_).map(_.merge).flatMap(_.embedNever))
+          .flatMap(nodeCompletion =>
+            nodeCompletion.toResource.race(for {
+              rpcClientA      <- NodeGrpc.Client.make[F](nodeAIp, nodeARpcPort, tls = false)
+              rpcClientB      <- NodeGrpc.Client.make[F](nodeBIp, nodeBRpcPort, tls = false)
+              networkControlA <- NetworkControlClient.make[F](nodeAIp, nodeARpcPort, tls = false)
+              networkControlB <- NetworkControlClient.make[F](nodeBIp, nodeBRpcPort, tls = false)
+              rpcClients = List(rpcClientA, rpcClientB)
+              implicit0(logger: Logger[F]) <- Slf4jLogger.fromName[F]("NodeNetworkControlTest").toResource
+              _                            <- rpcClients.parTraverse(_.waitForRpcStartUp).toResource
+              genusChannelA                <- co.topl.grpc.makeChannel[F](nodeAIp, nodeARpcPort, tls = false)
+              genusTxServiceA              <- TransactionServiceFs2Grpc.stubResource[F](genusChannelA)
+              genusBlockServiceA           <- BlockServiceFs2Grpc.stubResource[F](genusChannelA)
+              _                            <- awaitGenusReady(genusBlockServiceA).timeout(45.seconds).toResource
+              wallet                       <- makeWallet(genusTxServiceA)
+              _                            <- IO(wallet.spendableBoxes.nonEmpty).assert.toResource
+
+              // check consensus
+              firstHeight = 3
+              _ <- rpcClients.parTraverse(fetchUntilHeight(_, firstHeight)).toResource
+              idsAtTargetHeight <- rpcClients
+                .traverse(client =>
+                  OptionT(client.blockIdAtHeight(firstHeight)).getOrRaise(new IllegalStateException)
+                )
+                .toResource
+              _ <- IO(idsAtTargetHeight.toSet.size == 1).assert.toResource
+              //forget nodes
+              hostA                        <- networkControlA.getHostId().toResource
+              hostB                        <- networkControlB.getHostId().toResource
+              _ <- networkControlA.forgetPeer(hostB).toResource
+              _ <- networkControlB.forgetPeer(hostA).toResource
+
+
+              // check there is no consensus
+              secondHeight = firstHeight + 2
+              _ <- rpcClients.parTraverse(fetchUntilHeight(_, secondHeight)).toResource
+              idsAtTargetHeight2 <- rpcClients
+                .traverse(client =>
+                  OptionT(client.blockIdAtHeight(secondHeight)).getOrRaise(new IllegalStateException)
+                )
+                .toResource
+              _ <- IO(idsAtTargetHeight2.toSet.size == 2).assert.toResource
+
+              //remind nodes
+              _ <- networkControlB.addPeer(nodeAIp, nodeAP2PPort, hostA.some).toResource
+              _ <- networkControlA.addPeer(nodeBIp, nodeBP2PPort, hostA.some).toResource
+
+              // check there is consensus
+              thirdHeight = secondHeight + 2
+              _ <- rpcClients.parTraverse(fetchUntilHeight(_, thirdHeight)).toResource
+              idsAtTargetHeight3 <- rpcClients
+                .traverse(client =>
+                  OptionT(client.blockIdAtHeight(thirdHeight)).getOrRaise(new IllegalStateException)
+                )
+                .toResource
+              _ <- IO(idsAtTargetHeight3.toSet.size == 1).assert.toResource
+            } yield ())
+          )
+      } yield ()
+    resource.use_
+  }
+}

--- a/node/src/main/scala/co/topl/node/NodeApp.scala
+++ b/node/src/main/scala/co/topl/node/NodeApp.scala
@@ -614,6 +614,7 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
           p2pConfig.knownPeers,
           appConfig.bifrost.rpc.bindHost,
           appConfig.bifrost.rpc.bindPort,
+          appConfig.bifrost.rpc.networkControl,
           genusServices ::: healthServices,
           (p2pConfig.publicHost, p2pConfig.publicPort).mapN(KnownPeer),
           p2pConfig.networkProperties,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val orientDbVersion = "3.2.29"
   val ioGrpcVersion = "1.64.0"
   val http4sVersion = "0.23.26"
-  val protobufSpecsVersion = "2.0.0-beta3+2-17b46622-SNAPSHOT"
+  val protobufSpecsVersion = "2.0.0-beta3+3-bd44cc82-SNAPSHOT"
   val bramblScVersion = "2.0.0-beta3+3-de74a6dd-SNAPSHOT"
 
   val catsSlf4j =


### PR DESCRIPTION
## Purpose
For testing purposes, we need to be able to control the network on the node.
Right now, it supports three commands: het host id, forget remote host, add known remote host

## Approach
Add RPC for network controlling

## Testing
Unit tests + integration test

## Tickets
BN-1529