### PR TITLE
BN-1524 Download multiply slot data instead one-by-one if long slot data chain sync is required

### DIFF
--- a/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/co/topl/blockchain/Blockchain.scala
@@ -142,7 +142,8 @@ class BlockchainImpl[F[_]: Async: Random: Dns: Stats](
         p2pBlockchain,
         () => peerAsServer.map(kp => KnownHost(localPeer.p2pVK, kp.host, kp.port)),
         () => currentPeers.get,
-        peersStatusChangesTopic
+        peersStatusChangesTopic,
+        networkProperties.slotDataParentDepth
       ) _
       _ <- BlockchainNetwork
         .make[F](

--- a/config/src/main/scala/co/topl/config/ApplicationConfig.scala
+++ b/config/src/main/scala/co/topl/config/ApplicationConfig.scala
@@ -94,7 +94,11 @@ object ApplicationConfig {
       doNotExposeIps: List[String] = List.empty,
       // If remote peer have id in that list then that peer will not be exposed to other peers
       // Could be used if current node serves as proxy, and we don't want to expose any node behind proxy
-      doNotExposeIds: List[String] = List.empty
+      doNotExposeIds: List[String] = List.empty,
+
+      // How many parents shall be returned for getRemoteSlotDataWithParents request
+      // Increasing number lead to fast sync from scratch from that peer but increased network usage
+      slotDataParentDepth: Int = 25
     )
 
     case class KnownPeer(host: String, port: Int)

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainMultiplexedBuffers.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainMultiplexedBuffers.scala
@@ -23,7 +23,8 @@ case class BlockchainMultiplexedBuffers[F[_]](
   headers:              MultiplexedBuffer[F, BlockId, Option[BlockHeader]],
   bodies:               MultiplexedBuffer[F, BlockId, Option[BlockBody]],
   transactions:         MultiplexedBuffer[F, TransactionId, Option[IoTransaction]],
-  appLevel:             MultiplexedBuffer[F, Boolean, Unit]
+  appLevel:             MultiplexedBuffer[F, Boolean, Unit],
+  slotDataAndParents:   MultiplexedBuffer[F, (BlockId, BlockId), Option[List[SlotData]]]
 )
 
 object BlockchainMultiplexedBuffers {
@@ -41,7 +42,8 @@ object BlockchainMultiplexedBuffers {
       MultiplexedBuffer.make[F, BlockId, Option[BlockHeader]],
       MultiplexedBuffer.make[F, BlockId, Option[BlockBody]],
       MultiplexedBuffer.make[F, TransactionId, Option[IoTransaction]],
-      MultiplexedBuffer.make[F, Boolean, Unit]
+      MultiplexedBuffer.make[F, Boolean, Unit],
+      MultiplexedBuffer.make[F, (BlockId, BlockId), Option[List[SlotData]]]
     ).mapN(BlockchainMultiplexedBuffers.apply[F])
 
 }

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainMultiplexerId.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainMultiplexerId.scala
@@ -24,6 +24,7 @@ object BlockchainMultiplexerId {
       case 19 => RemotePeerServerRequest.some
       case 20 => PingRequest.some
       case 21 => AppLevelRequest.some
+      case 22 => SlotDataAndParentsRequest.some
       case _  => none
     }
 
@@ -39,4 +40,5 @@ object BlockchainMultiplexerId {
   case object RemotePeerServerRequest extends BlockchainMultiplexerId(19)
   case object PingRequest extends BlockchainMultiplexerId(20)
   case object AppLevelRequest extends BlockchainMultiplexerId(21)
+  case object SlotDataAndParentsRequest extends BlockchainMultiplexerId(22)
 }

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerClient.scala
@@ -56,6 +56,15 @@ trait BlockchainPeerClient[F[_]] {
   def getRemoteSlotData(id: BlockId): F[Option[SlotData]]
 
   /**
+   * A Lookup to retrieve a remote SlotData by ID defined by "to" parameter and N parents for that slot.
+   * @param to requested slot data id
+   * @param from stop building parents if slot data id is equal to that parameter
+   * @return slot data (to, from) OR (fromParent(N), ..., fromParent(1), from) where number is parent index, i.e.
+   *         fromParent(2) is parent of parent of slot data with id "from"
+   */
+  def getRemoteSlotDataWithParents(from: BlockId, to: BlockId): F[Option[List[SlotData]]]
+
+  /**
    * A Lookup to retrieve a remote slot data by ID, or throw specified Error
    */
   def getSlotDataOrError[E <: Throwable](id: BlockId, error: => E)(implicit MonadThrow: MonadThrow[F]): F[SlotData] =

--- a/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServerAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/blockchain/BlockchainPeerServerAlgebra.scala
@@ -14,6 +14,7 @@ trait BlockchainPeerServerAlgebra[F[_]] {
   def localBlockAdoptions: F[Stream[F, BlockId]]
   def localTransactionNotifications: F[Stream[F, TransactionId]]
   def getLocalSlotData(id:              BlockId): F[Option[SlotData]]
+  def requestSlotDataAndParents(from:   BlockId, to: BlockId): F[Option[List[SlotData]]]
   def getLocalHeader(id:                BlockId): F[Option[BlockHeader]]
   def getLocalBody(id:                  BlockId): F[Option[BlockBody]]
   def getLocalTransaction(id:           TransactionId): F[Option[IoTransaction]]

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -108,6 +108,9 @@ class BlockchainPeerClientCloseHook[F[_]: Monad](underlying: BlockchainPeerClien
 
   override def getRemoteSlotData(id: BlockId): F[Option[SlotData]] = underlying.getRemoteSlotData(id)
 
+  override def getRemoteSlotDataWithParents(from: BlockId, to: BlockId): F[Option[List[SlotData]]] =
+    underlying.getRemoteSlotDataWithParents(from, to)
+
   override def getRemoteHeader(id: BlockId): F[Option[BlockHeader]] = underlying.getRemoteHeader(id)
 
   override def getRemoteBody(id: BlockId): F[Option[BlockBody]] = underlying.getRemoteBody(id)
@@ -135,4 +138,5 @@ class BlockchainPeerClientCloseHook[F[_]: Monad](underlying: BlockchainPeerClien
     currentHeight:           () => F[Long]
   )(implicit syncF: Sync[F], loggerF: Logger[F]): F[BlockId] =
     underlying.findCommonAncestor(getLocalBlockIdAtHeight, currentHeight)
+
 }

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/P2PShowInstances.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/P2PShowInstances.scala
@@ -96,6 +96,12 @@ trait P2PShowInstances {
     (objToString.productElementNames zip objToString.productIterator)
       .map { case (paramName, param) => s"$paramName=$param, " }
       .foldLeft("")(_ + _)
+
+  implicit val SlotDataToSyncShow: Show[SlotDataToSync] = {
+    case SlotDataToSync.Empty           => "slot data sync empty"
+    case SlotDataToSync.Chain(from, to) => show"slot data sync chain ${from.slotId.blockId}:${to.slotId.blockId}"
+    case SlotDataToSync.One(toSync)     => show"slot data sync one ${toSync.slotId.blockId}"
+  }
 }
 
 object P2PShowInstances extends P2PShowInstances

--- a/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/co/topl/networking/fsnetwork/package.scala
@@ -183,4 +183,24 @@ package object fsnetwork {
       else
         Applicative[F].unit
   }
+
+  sealed trait SlotDataToSync {
+    def lastOrElse(slotData: SlotData): SlotData
+  }
+
+  object SlotDataToSync {
+
+    case object Empty extends SlotDataToSync {
+      override def lastOrElse(slotData: SlotData): SlotData = slotData
+    }
+
+    case class Chain(from: SlotData, to: SlotData) extends SlotDataToSync {
+      override def lastOrElse(slotData: SlotData): SlotData = to
+    }
+
+    case class One(toSync: SlotData) extends SlotDataToSync {
+      override def lastOrElse(slotData: SlotData): SlotData = toSync
+    }
+  }
+
 }

--- a/networking/src/main/scala/co/topl/networking/legacy/v0/LegacyBlockchainSocketHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/legacy/v0/LegacyBlockchainSocketHandler.scala
@@ -196,7 +196,7 @@ object LegacyBlockchainSocketHandler {
 
           def closeConnection(): F[Unit] = close
 
-          def getRemoteSlotDataWithParents(to: BlockId, from: BlockId): F[Option[List[SlotData]]] =
+          def getRemoteSlotDataWithParents(from: BlockId, to: BlockId): F[Option[List[SlotData]]] =
             getRemoteSlotData(to).map(_.map(List(_)))
         }
 

--- a/networking/src/main/scala/co/topl/networking/legacy/v0/LegacyBlockchainSocketHandler.scala
+++ b/networking/src/main/scala/co/topl/networking/legacy/v0/LegacyBlockchainSocketHandler.scala
@@ -195,6 +195,9 @@ object LegacyBlockchainSocketHandler {
             appNotifyCallback(networkLevel).void
 
           def closeConnection(): F[Unit] = close
+
+          def getRemoteSlotDataWithParents(to: BlockId, from: BlockId): F[Option[List[SlotData]]] =
+            getRemoteSlotData(to).map(_.map(List(_)))
         }
 
         subHandlers =

--- a/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
+++ b/networking/src/test/scala/co/topl/networking/blockchain/BlockchainClientSpec.scala
@@ -59,6 +59,8 @@ class BlockchainClientSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
           override def notifyAboutThisNetworkLevel(networkLevel: Boolean): F[Unit] = ???
 
           override def closeConnection(): F[Unit] = ???
+
+          override def getRemoteSlotDataWithParents(from: BlockId, to: BlockId): F[Option[List[SlotData]]] = ???
         }
 
         val blockHeights =

--- a/node-it/src/test/scala/co/topl/node/NodeNetworkControlTest.scala
+++ b/node-it/src/test/scala/co/topl/node/NodeNetworkControlTest.scala
@@ -147,7 +147,7 @@ class NodeNetworkControlTest extends CatsEffectSuite {
 
 
               // check there is no consensus
-              secondHeight = firstHeight + 2
+              secondHeight = firstHeight + 4
               _ <- rpcClients.parTraverse(fetchUntilHeight(_, secondHeight)).toResource
               idsAtTargetHeight2 <- rpcClients
                 .traverse(client =>

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -8,7 +8,7 @@ import co.topl.models._
 import co.topl.models.utility._
 import co.topl.node.models.KnownHost
 import scodec.Codec
-import scodec.codecs.{discriminated, lazily, utf8_32}
+import scodec.codecs._
 import shapeless.{::, HList, HNil}
 
 /**
@@ -154,10 +154,31 @@ trait TetraScodecCodecs {
       stakingAddressCodec // address
   ).as[UnsignedBlockHeader]
 
+  implicit val slotIdCodec: Codec[SlotId] = (
+    longCodec :: // slot
+      blockIdCodec :: // blockId
+      unknownFieldSetCodec
+  ).as[SlotId]
+
+  implicit val slotDataCodec: Codec[SlotData] = (
+    slotIdCodec :: // slotId
+      slotIdCodec :: // parentSlotId
+      byteStringCodecSized(64) :: // rho
+      byteStringCodecSized(32) :: // eta
+      longCodec :: // height
+      unknownFieldSetCodec // unknownFields
+  ).as[SlotData]
+
   implicit val knownHostCodec: Codec[KnownHost] = (
     byteStringCodec ::
       utf8_32 ::
       intCodec ::
       unknownFieldSetCodec
   ).as[KnownHost]
+
+  implicit def pairCodec[A: Codec, B: Codec]: Codec[(A, B)] =
+    (
+      implicitly[Codec[A]] ::
+        implicitly[Codec[B]]
+    ).as[(A, B)]
 }

--- a/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraTransmittableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/co/topl/codecs/bytes/tetra/TetraTransmittableCodecs.scala
@@ -6,6 +6,8 @@ import co.topl.consensus.models.BlockId
 import co.topl.models.utility.Ratio
 import com.google.protobuf.ByteString
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
+import scodec.Codec
+import scodec.codecs._
 
 import scala.util.Try
 
@@ -41,6 +43,12 @@ trait TetraTransmittableCodecs {
       (longCodec :: optionCodec[BlockId])
         .as[(Long, Option[BlockId])]
     )
+
+  implicit def listTransmittable[A: Codec]: Transmittable[List[A]] =
+    Transmittable.instanceFromCodec(list[A](implicitly[Codec[A]]))
+
+  implicit def pairTransmittable[A: Codec, B: Codec]: Transmittable[(A, B)] =
+    Transmittable.instanceFromCodec(pairCodec[A, B])
 
   implicit def optionalTransmittable[T: Transmittable]: Transmittable[Option[T]] =
     new Transmittable[Option[T]] {


### PR DESCRIPTION
## Purpose
If the node is far behind from remote peer then syncing slot data from the remote peer could take a lot of time because every request will suffer from network latency. To avoid that in some cases we could request many slot data from remote peer at the same time

## Approach
Add `getRemoteSlotDataWithParents(from, to)` request to the server which could be described like "give me as many slot data as possible between `from` and `to`" which could be used for fast building slot data chain. Client will repeat that request until chain `from` to `to` is built.

## Testing
Unit test + integration tests

## Tickets
BN-1524