### PR TITLE
Socket "readExactly" Helper

### DIFF
--- a/networking/src/main/scala/co/topl/networking/p2p/PeerVersion.scala
+++ b/networking/src/main/scala/co/topl/networking/p2p/PeerVersion.scala
@@ -3,6 +3,7 @@ package co.topl.networking.p2p
 import cats.data.{EitherT, OptionT}
 import cats.effect.Async
 import cats.implicits._
+import co.topl.networking._
 import com.google.protobuf.ByteString
 import fs2.Chunk
 import fs2.io.net.Socket
@@ -21,7 +22,7 @@ object PeerVersion {
     (
       for {
         _ <- EitherT.liftF(socket.write(Chunk.byteBuffer(localVersion.asReadOnlyByteBuffer())))
-        remoteVersion <- OptionT(socket.read(localVersion.size()))
+        remoteVersion <- OptionT(socket.readExactly(localVersion.size()))
           .toRight(ExtractionException.VersionNotProvided)
           .leftWiden[ExtractionException]
           .map(_.toArray)

--- a/networking/src/main/scala/co/topl/networking/package.scala
+++ b/networking/src/main/scala/co/topl/networking/package.scala
@@ -1,9 +1,14 @@
 package co.topl
 
+import cats.Monad
+import cats.data.OptionT
+import cats.implicits._
 import co.topl.models.p2p._
 import co.topl.networking.fsnetwork.RemotePeer
 import co.topl.node.models.KnownHost
 import com.comcast.ip4s.{IpAddress, SocketAddress}
+import fs2.Chunk
+import fs2.io.net.Socket
 
 import java.net.InetAddress
 import java.nio.ByteBuffer
@@ -33,5 +38,24 @@ package object networking {
 
   implicit class SocketAddressOps(address: SocketAddress[IpAddress]) {
     def asRemoteAddress: RemoteAddress = RemoteAddress(address.host.toUriString, address.port.value)
+  }
+
+  implicit class SocketOps[F[_]](val socket: Socket[F]) extends AnyVal {
+
+    /**
+     * Calling Socket.read(numberOfBytes) may not return all `numberOfBytes`. This situation needs to be checked,
+     * and additional bytes should be requested until the expected number of bytes are received.
+     * @param length the total number of bytes desired
+     * @return a chunk of bytes with the desired length, or None if the socket is closed
+     */
+    def readExactly(length: Int)(implicit monadF: Monad[F]): F[Option[Chunk[Byte]]] =
+      (length, Chunk.empty[Byte]).tailRecM { case (remaining, acc) =>
+        OptionT(socket.read(remaining))
+          .fold(none[Chunk[Byte]].asRight[(Int, Chunk[Byte])])(bytes =>
+            if (bytes.size < remaining) Left((remaining - bytes.size, acc ++ bytes))
+            else Right(Some(acc ++ bytes))
+          )
+      }
+
   }
 }


### PR DESCRIPTION
## Purpose
- Socket.read may not produce all of the requested bytes
- The consumer assumes all bytes are available, so parsing is likely to fail
- This situation is only likely to happen when crossing physical network boundaries (i.e. local to GCP), but not in local connections
## Approach
- Add a helper which polls the socket (similar to the `readN` implementation but returning an Option instead)
## Testing
- `preparePR`
- This isn't something that is easily reproducible locally
## Tickets
- #BN-1543